### PR TITLE
chore(changelog): date v0.7.2 and v0.7.3 release headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.7.3 (unreleased) — Developer Experience Polish
+## 0.7.3 (2026-05-22) — Developer Experience Polish
 
 > Focus: make Rivet easier to configure, inspect, and try correctly.
 > No new extraction modes — every change reduces first-touch friction
@@ -83,7 +83,7 @@
   [`docker/build-push-action`](https://github.com/docker/build-push-action)
   "Distribute build across multiple runners" recipe.
 
-## 0.7.2 (unreleased) — Cloud Landing Polish
+## 0.7.2 (2026-05-22) — Cloud Landing Polish
 
 > Focus: make cloud outputs historically verifiable and safer to operate.
 > No new extraction modes, no new database sources — every change tightens


### PR DESCRIPTION
Replaces `(unreleased)` markers with `(2026-05-22)` in the `## 0.7.2` and `## 0.7.3` headers so the `release.yml` workflow's CHANGELOG awk extractor produces dated release notes for the upcoming `v0.7.2` and `v0.7.3` tags (instead of the in-progress "(unreleased)" label).

No source / behavior change; documentation-only.