### PR TITLE
docs: fix quickstart inaccuracies found in end-to-end audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center"><strong>Make database extraction boring.</strong></p>
 
-<p align="center">One Rust binary, ~10 MB. Extracts PostgreSQL and MySQL to Parquet/CSV — locally, on S3, GCS, or Azure Blob — without holding long queries open on your production database. Resumable, auditable, source-safe.</p>
+<p align="center">One Rust binary, ~14 MB. Extracts PostgreSQL and MySQL to Parquet/CSV — locally, on S3, GCS, or Azure Blob — without holding long queries open on your production database. Resumable, auditable, source-safe.</p>
 
 > Not sure if Rivet fits your problem? [docs/who-is-this-for.md](docs/who-is-this-for.md) is a 60-second fit-check.
 
@@ -107,7 +107,8 @@ Exposed read-only surfaces:
 Works out-of-the-box with [Claude Desktop](https://claude.ai/), [Claude Code](https://claude.ai/code), and any MCP-compatible client. Runs as a separate binary — never requires write access to the source database.
 
 ```bash
-rivet-mcp --source-env DATABASE_URL
+export DATABASE_URL="postgresql://..."
+rivet-mcp        # reads DATABASE_URL from the environment
 ```
 
 Add to your MCP client config:

--- a/demo/setup_demo_tables.sql
+++ b/demo/setup_demo_tables.sql
@@ -80,6 +80,9 @@ SELECT
     CASE WHEN (i % 3) = 0 THEN NULL ELSE (TIMESTAMP '2024-06-01' + (i * INTERVAL '45 seconds'))::timestamp END AS updated_at
 FROM generate_series(1, 100000) AS s(i);
 ALTER TABLE logs_archive ADD PRIMARY KEY (id);
+-- created_at is always populated; mark it NOT NULL so discovery's auto-coalesce
+-- hint fires (best cursor `updated_at` is nullable, NOT NULL sibling `created_at`).
+ALTER TABLE logs_archive ALTER COLUMN created_at SET NOT NULL;
 CREATE INDEX idx_logs_archive_created ON logs_archive(created_at);
 
 -- 6) email_queue — 20k rows, pending/sent, no timestamp cursor.

--- a/docs/pilot/demo-quickstart.md
+++ b/docs/pilot/demo-quickstart.md
@@ -34,7 +34,8 @@ A scripted, reproducible end-to-end demo that exercises every post-Epic feature 
   cargo build --release --bin rivet --bin seed
   ```
 
-- `python3` and `jq` (both used only for pretty-printing JSON artifacts below).
+- `python3` and `jq` (used for pretty-printing JSON artifacts below). The §5
+  Parquet-schema peek also needs `pyarrow` (`pip install pyarrow`).
 
 Container quick check:
 
@@ -65,6 +66,15 @@ cargo run --release --bin seed -- --target postgres \
     --sparse-chunk-demo --sparse-chunk-rows 500 --sparse-chunk-id-gap 5000 \
     --coalesce-rows 5000 --coalesce-null-ratio 0.35
 ```
+
+> **Base schema first.** The seeder *fills* the bundled dev tables (`users`,
+> `orders`, `events`, `page_views`, `content_items`) — it does not create them.
+> They are created by `dev/postgres/init.sql` (and `dev/mysql/init.sql`), which
+> the bundled `docker compose` runs automatically the first time each container
+> initializes. So this works against the bundled `rivet` database out of the box.
+> If you point `--pg-url` / `--mysql-url` at a **fresh** database instead, apply
+> that `init.sql` there first, or the seeder's `TRUNCATE` fails with
+> `relation "content_items" does not exist`.
 
 Verify the landscape (PostgreSQL):
 
@@ -149,8 +159,9 @@ PY
 
 Expected:
 - **Wave 1** (score 76–88) — indexed-cursor incrementals: `events`, `sessions`, `transactions`.
-- **Wave 3** — small full exports.
-- **Wave 4** — heavy chunked exports; `audit_log` lowest (reconcile_required + chunking_heavy + degraded verdict).
+- **Wave 2** — `orders_coalesce` (composite-cursor incremental).
+- **Wave 3** — small full exports plus the lighter chunked ones (`metric_samples`, `page_views`).
+- **Wave 4** — the heaviest chunked exports at the bottom: `audit_log` and `logs_archive` (reconcile_required + chunking_heavy + degraded verdict).
 - Warning: `Source group 'replica_primary': 3 exports share this source — stagger large runs`.
 
 ---
@@ -173,7 +184,7 @@ grep -E '"password":\s*"[^"]+"' plan_events.json || echo "✅ no plaintext passw
 ../target/release/rivet apply plan_events.json
 ```
 
-Expected: `40209 rows, success`, a Parquet in `out/`, and `last_cursor` advanced.
+Expected: `40000 rows, success`, a Parquet in `out/`, and `last_cursor` advanced.
 
 ---
 
@@ -266,7 +277,7 @@ export DATABASE_URL='mysql://rivet:rivet@localhost:3306/rivet'
 
 A few MySQL notes:
 - The same `source_group` warnings fire when 3+ exports share a replica.
-- `rivet preflight` gives weaker cursor signals on MySQL than on PostgreSQL (MySQL `EXPLAIN` doesn't always annotate `type=range` for indexed incrementals), so scores tilt slightly lower. This is an observable difference, not a bug.
+- `rivet check` gives weaker cursor signals on MySQL than on PostgreSQL (MySQL `EXPLAIN` doesn't always annotate `type=range` for indexed incrementals), so some scores shift. This is an observable difference, not a bug.
 - Composite cursor SQL uses backticks (`` `updated_at` ``) instead of double-quoted identifiers — same contract, different dialect (ADR-0007 CC9).
 
 ---


### PR DESCRIPTION
Ran all three quickstarts (README 30-second, getting-started, demo) end to end against rivet 0.7.9 in an isolated database and corrected the mismatches:

- README: rivet-mcp reads DATABASE_URL from the env; it has no `--source-env` flag, so the documented command errored. Binary size ~10 MB -> ~14 MB.
- demo setup: mark logs_archive.created_at NOT NULL so discovery's auto-coalesce hint fires as section 1 promises (CREATE TABLE AS dropped the constraint; the MySQL fixture already had it).
- demo section 0: note the seeder fills but does not create the base dev tables; a fresh database needs dev/{postgres,mysql}/init.sql first, otherwise the seeder's TRUNCATE fails with `relation "content_items" does not exist`.
- demo section 2: correct the wave summary (Wave 2 orders_coalesce; audit_log is not strictly the lowest score).
- demo section 3: apply yields 40000 rows (exact fast-seed), not 40209.
- demo section 5: note the Parquet schema peek needs pyarrow.
- demo section 7: `rivet preflight` -> `rivet check` (no such subcommand).