### PR TITLE
ci(nightly): start Azurite — fixes 8+ days of nightly failures

### DIFF
--- a/.github/workflows/nightly-live.yml
+++ b/.github/workflows/nightly-live.yml
@@ -69,7 +69,7 @@ jobs:
         # them the `--ignored` run fails 13 tests with `No such object:
         # rivet-duckdb` / `ClickHouse reachable on 127.0.0.1:8123` (pyarrow_*
         # cases also go through the shared rivet-duckdb exec helper).
-        run: docker compose --profile pool --profile loaders --profile cdc up -d postgres mysql mssql minio fake-gcs toxiproxy pgbouncer proxysql duckdb clickhouse postgres-cdc mysql-cdc mssql-cdc
+        run: docker compose --profile pool --profile loaders --profile cdc up -d postgres mysql mssql minio fake-gcs azurite toxiproxy pgbouncer proxysql duckdb clickhouse postgres-cdc mysql-cdc mssql-cdc
 
       - name: Wait for services
         run: |
@@ -83,6 +83,10 @@ jobs:
           # 6033 is the client-facing MySQL protocol port; 6032 admin comes
           # up first but we wait for 6033 so backend wiring is in place.
           for i in $(seq 1 30); do (exec 3<>/dev/tcp/127.0.0.1/6033) 2>/dev/null && break || sleep 1; done
+          echo "Waiting for Azurite..."
+          # Blob emulator on :10000 — cloud_multipart_azure_* needs it. It was missing
+          # from `up` here (ci.yml has it) and panicked the whole nightly suite nightly.
+          for i in $(seq 1 30); do (exec 3<>/dev/tcp/127.0.0.1/10000) 2>/dev/null && break || sleep 1; done
           echo "Waiting for ClickHouse..."
           # HTTP :8123/ping — the type_roundtrip clickhouse_load tests connect here.
           for i in $(seq 1 30); do curl -sf localhost:8123/ping >/dev/null 2>&1 && break || sleep 2; done


### PR DESCRIPTION
## Problem
**Nightly Live has failed every night for 8+ days** (2026-06-17 … 2026-06-24) on a single test:
`cloud_multipart_azure_rotation_distinct_keys_and_all_rows`, which panics at `require_alive(Azurite)`:

```
live test requires Azurite reachable on 127.0.0.1:10000.
hint: service `azurite` in docker-compose.yaml (blob :10000)
```

The Azure blob emulator was **missing from the nightly `up` command** — every other service is there, `azurite` was dropped.

## Fix
Add `azurite` to the service list + a `:10000` readiness wait, matching `ci.yml`.

## Why this is correct
`ci.yml` brings up `azurite` in the same list **and** runs this exact test (it's in the broad `cargo test -- --ignored` with no skip for it) — and ci's latest runs are green. This PR just replicates ci's working setup in nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)