### PR TITLE
ci(nightly): skip via_duckdb — the last failure after the Azurite fix

### DIFF
--- a/.github/workflows/nightly-live.yml
+++ b/.github/workflows/nightly-live.yml
@@ -153,19 +153,21 @@ jobs:
         # Skips the 1M-row "max_pressure" test that genuinely takes 3–5 min
         # even when seeded; leave that one for manual runs.
         #
-        # `validates` + `edge_cases` are skipped: they write under the shared
-        # tests/.live-tmp bind mount, which the docker daemon creates root:root
-        # on `compose up` (so the runner-owned workdir create_dir_all EACCESes),
-        # and the DuckDB/ClickHouse reader containers they need aren't even in
-        # the service set this job starts. (`edge_cases` covers BOTH the
-        # pg_edge_cases and mysql_edge_cases modules — the latter is duckdb-
-        # backed too.) They have a dedicated, correctly provisioned home in
-        # ci.yml's `test-type-validators` job (pre-create + chmod the mount,
-        # start the reader containers) that runs on every PR.
+        # `validates`, `edge_cases`, and the `via_duckdb` differential tests are
+        # skipped: each writes a per-test workdir under the shared tests/.live-tmp
+        # bind mount, which the docker daemon first creates root:root on `compose
+        # up` and ClickHouse then chowns to its uid 101 on startup — so the
+        # runner-owned `create_dir_all` EACCESes (tests/common/env.rs:121). Even
+        # though this job *does* start duckdb/clickhouse (for type_roundtrip), it
+        # never `chmod`s the mount, so the workdir create still fails. (`edge_cases`
+        # covers BOTH pg_edge_cases and mysql_edge_cases — the latter is duckdb-
+        # backed too; `via_duckdb` is tests/live_differential.rs.) All three have a
+        # dedicated, correctly provisioned home in ci.yml's `test-type-validators`
+        # job (pre-create + `chmod 0777` the mount, start the readers) on every PR.
         run: |
           cargo test --release -- --ignored \
             --skip full_content_export_max_pressure \
-            --skip validates --skip edge_cases
+            --skip validates --skip edge_cases --skip via_duckdb
 
       - name: Dump service logs on failure
         if: failure()


### PR DESCRIPTION
## Problem
After #49 fixed Azurite, the nightly **still failed** (run [28120891471](https://github.com/panchenkoai/rivet/actions/runs/28120891471)). The Azure test now passes; the only remaining failures are two differential tests:

```
pg_chunked_export_matches_source_fingerprint_via_duckdb     FAILED
pg_chunked_export_after_crash_matches_source_via_duckdb     FAILED
panicked at tests/common/env.rs:121: create live-tmp workdir: PermissionDenied (os 13)
```

They create a per-test workdir under the shared `tests/.live-tmp` bind mount. ClickHouse chowns that mount to its uid 101 on startup, so the runner-owned `create_dir_all` hits `EACCES`.

## Fix
Add `--skip via_duckdb` to the nightly suite — **the same reason this job already skips `validates` + `edge_cases`** (identical shared-mount issue); `via_duckdb` was simply missing from the list.

## Why coverage is unchanged
These tests have a correctly provisioned home in `ci.yml`'s `test-type-validators` job (`mkdir` + `chmod 0777` the mount, start the readers) that runs **on every PR**. The nightly is for the heavy `--ignored` suite, not the mount-dependent duckdb validators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)