### PR TITLE
Release 0.16.0: plan→apply cycle (wave-ordered, cost-gated, resumable) + operator UX (#53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,66 @@
 # Changelog
 
+## 0.16.0 (2026-06-28) — the plan→apply cycle: wave-ordered, cost-gated, resumable execution
+
+`rivet plan` becomes executable. It already scored and waved your exports; now `rivet apply <config>`
+runs them — wave by wave, lowest priority first, with a barrier between waves and cost-gated within-wave
+parallelism. This closes the OSS engine's loop: `init` → `plan` (annotates the config in place) →
+[review/edit] → `apply`. This release also ships the operator-UX and verify-depth work that was merged in
+#53 but never released (v0.15.0 cherry-picked only the always-on checksum from it).
+
+### Added — the plan → apply cycle
+
+- **`rivet apply <config>.yaml` runs exports wave-by-wave.** `rivet plan` writes a `wave:` and
+  `parallel_safe:` onto each export (in place, comments and field order preserved); `apply` runs them in
+  ascending `wave:` order with a barrier between waves. Tables are independent, so a failed export does
+  **not** block its wave-mates — `apply` collects failures, runs the rest, and exits non-zero
+  (continue/isolate). A `.json` path still means the sealed single-artifact replay.
+- **Cost-gated within-wave parallelism** (`--parallel-export-processes`, or `parallel_export_processes:
+  true`). The cheap exports — `parallel_safe: true` (cost class `Low`, and not flagged
+  `isolate_on_source`) — run concurrently as separate processes; a heavier export runs alone in its wave
+  (it already chunk-parallelizes internally), so two big tables never multiply load on the source.
+- **`rivet apply <config> --resume`** skips exports a prior run already completed (`_SUCCESS` present)
+  and resumes incomplete chunked exports from their checkpoints, so recovering a partially-failed run
+  does not redo the tables that already succeeded.
+- **`rivet plan` writes the advisory schedule into the config** and prints a compact one-line-per-export
+  table (Wave | Export | Strategy | Rows | Verdict). `rivet init`'s next-steps surface the plan→apply path.
+
+### Added — operator UX & verify (#53)
+
+- **Graded `rivet validate --depth light|sample|full`** with stable `RIVET_VERIFY_*` error codes — one
+  per failure variant (JSON `code` + the pretty `[CODE]` prefix).
+- **Memory-aware `rivet check` verdict** — an unindexed large scan is DEGRADED (not UNSAFE) when the
+  estimated peak RSS fits the budget; **`check --json`** emits the per-export verdict / strategy /
+  warnings / recommended profile + parallel, not just the type report.
+- **`rivet plan` explains the strategy** — why this mode, chunk geometry, parallelism, RSS-budget fit,
+  resumability and memory risk.
+- **Signed releases** — keyless cosign (Sigstore).
+
+### Changed — multi-export console UX
+
+- **Strict aligned card table.** Per-export cards render as a table: the name plus every metric column
+  (rows / files / size / duration / RSS) is fixed-width and aligned, and the name column is seeded
+  wave-wide so it stays aligned across the cost gate's separate safe/lone batches.
+- **Chunk progress ticks per source batch, not only per chunk** — a wide first chunk (e.g. 250k rows /
+  90 MB) no longer reads as idle while it streams; the bar shows rows/rate climbing throughout the read.
+- **Captured child stderr goes to a file artifact** (`rivet-child-stderr-<ts>.log`) with a one-line
+  console pointer, instead of flooding the run summary with every child's per-export log.
+
+### Fixed
+
+- **Chunked boundary probes no longer force a full scan.** The NULL-key guard is a presence probe
+  (`SELECT 1 … WHERE col IS NULL LIMIT 1`, `TOP 1` on SQL Server) instead of `COUNT(*) - COUNT(col)` —
+  the planner returns nothing without scanning for a `NOT NULL` column, and stops at the first NULL
+  otherwise. A plain `SELECT <cols> FROM <table>` projection now probes the bare table (index-only)
+  instead of wrapping the wide query in a subquery.
+
+### Internal
+
+- Test-infra consolidation (#53). plan→apply pre-PR review fixes (orphaned doc-comment, table-geometry
+  split across two files, `parallel_safe` now respecting the campaign's `isolate_on_source`). Live tests:
+  a failed wave isolates its successors; `--resume` skips completed exports. A "measure cold, don't
+  theorize" performance-diagnosis rule added to `CLAUDE.md`.
+
 ## 0.15.0 (2026-06-25) — always-on value-integrity checksum
 
 Every export now cross-checks its data end-to-end, on by default. An always-on per-column `xxh3`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,3 +105,26 @@ that a crash before the checkpoint re-reads rather than loses). Each
 engine resumes by a different mechanism (MySQL binlog checkpoint file,
 PostgreSQL slot advance, SQL Server from-LSN), so one engine passing
 proves nothing about another. Never infer resume from capture.
+
+## Performance diagnosis: measure cold, don't theorize
+
+A "why is this slow?" answer reasoned from the code is a hypothesis, not a
+finding — and on the *same* symptom this repo's plausible hypothesis was wrong
+three times running. A reported "~12s of idle before the first chunk" on a
+chunked `content_items` export was blamed, in order, on a window function
+(wrong — `ROW_NUMBER` only runs for `chunk_dense`), on the `SELECT … FROM
+(<wide query>)` boundary-probe wrap (wrong — PostgreSQL pushes the `min`/`max`
+into the index: 0.1 ms), and on the `COUNT(*) - COUNT(col)` null-key check
+(wrong — index-only, 90 ms warm). The real cause, found only by running the
+binary **cold** with elapsed-time-prefixed `RUST_LOG` output, was the first
+chunk reading 92 MB of wide rows with **no progress feedback** — not a query at
+all. Each wrong guess shipped a real fix (they were genuine improvements) that
+did nothing for the actual symptom.
+
+Process rule: **for any latency claim, reproduce it and read the timeline before
+proposing a fix.** Restart the source (`docker restart rivet-postgres-1`) for a
+cold cache; run the real binary with per-line elapsed timestamps and let the
+trace name the slow step; `EXPLAIN (ANALYZE, BUFFERS)` the exact SQL rivet emits
+rather than guessing the plan. A fix shipped against an unmeasured hypothesis is
+a guess wearing a diff — each of the three wrong guesses above cost a build +
+install + dogfood round-trip that a 20-second cold trace would have skipped.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rivet-cli"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Branch commands: `rivet apply` (replay a saved plan, **or** run a config's expor
 
 For a first run, `rivet init + rivet run` is enough. The full workflow is for production pipelines where "it ran" is not sufficient — you need a verifiable record of what was written.
 
-**Many tables, one command.** For a config with several exports, `rivet plan` assigns each a `wave:` (a priority band by size / strategy / risk) and writes it back into the config; `rivet apply rivet.yaml` then runs them wave by wave, lowest first, with a barrier between waves. With `parallel_export_processes: true`, keyset-chunkable exports within a wave run as concurrent processes while full-scan ones run alone — see [docs/getting-started.md § 5](docs/getting-started.md#5--many-tables-plan-once-apply-by-waves).
+**Many tables, one command.** For a config with several exports, `rivet plan` assigns each a `wave:` (a priority band by size / strategy / risk) and writes it back into the config; `rivet apply rivet.yaml` then runs them wave by wave, lowest first, with a barrier between waves. With `parallel_export_processes: true` (or `rivet apply --parallel-export-processes`), the cheap (low-cost) exports within a wave run as concurrent processes while heavier ones — which already chunk-parallelize internally — run alone; see [docs/getting-started.md § 5](docs/getting-started.md#5--many-tables-plan-once-apply-by-waves).
 
 ## Stateless deployment
 

--- a/README.md
+++ b/README.md
@@ -211,9 +211,11 @@ rivet run       # execute the plan; checkpoint each chunk
 rivet validate  # verify row counts and manifest against the destination
 ```
 
-Branch commands: `rivet apply` (apply a saved plan), `rivet reconcile` (compare manifest vs destination), `rivet repair` (re-upload orphaned chunks), `rivet state` (inspect progression and checkpoints).
+Branch commands: `rivet apply` (replay a saved plan, **or** run a config's exports wave-by-wave), `rivet reconcile` (compare manifest vs destination), `rivet repair` (re-upload orphaned chunks), `rivet state` (inspect progression and checkpoints).
 
 For a first run, `rivet init + rivet run` is enough. The full workflow is for production pipelines where "it ran" is not sufficient — you need a verifiable record of what was written.
+
+**Many tables, one command.** For a config with several exports, `rivet plan` assigns each a `wave:` (a priority band by size / strategy / risk) and writes it back into the config; `rivet apply rivet.yaml` then runs them wave by wave, lowest first, with a barrier between waves. With `parallel_export_processes: true`, keyset-chunkable exports within a wave run as concurrent processes while full-scan ones run alone — see [docs/getting-started.md § 5](docs/getting-started.md#5--many-tables-plan-once-apply-by-waves).
 
 ## Stateless deployment
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -149,10 +149,10 @@ rivet apply rivet.yaml          # a .yaml path → wave-ordered execution
 
 ### Parallel within a wave — only where it's safe
 
-Add `parallel_export_processes: true` and, within each wave, **keyset-chunkable** exports (`mode: chunked` with a `chunk_column` — bounded, index-backed scans) run concurrently as separate processes. Full / incremental / time-window / CDC exports scan or stream the table, so each runs **alone** to avoid stacking pressure on the source. Every child still self-throttles on source pressure + memory (the adaptive governor), so a whole wave at once stays bounded.
+Add `parallel_export_processes: true` (or pass `rivet apply --parallel-export-processes`) and, within each wave, the **cheap** exports — the ones `rivet plan` marked `parallel_safe: true` (cost class `Low`, under ~100K rows) — run concurrently as separate processes. A heavier export already chunk-parallelizes its own ranges *internally*, so it runs **alone** in its wave: two big tables at once would multiply the load on the source. Every child still self-throttles on source pressure + memory (the adaptive governor), so a whole wave at once stays bounded.
 
 ```yaml
-parallel_export_processes: true   # top-level: parallelize keyset exports within each wave
+parallel_export_processes: true   # top-level: parallelize the cheap (parallel_safe) exports within each wave
 ```
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -121,6 +121,42 @@ Subsequent `rivet run` invocations will only fetch rows with `updated_at >` the 
 
 ---
 
+## 5 · Many tables: plan once, apply by waves
+
+When a config has several exports, `rivet plan` assigns each one a **wave** — a priority band derived from its size, chunking strategy, and risk ([ADR-0006](adr/0006-source-aware-prioritization.md)) — and writes it back into the config as a `wave:` field you can see and hand-edit:
+
+```bash
+rivet plan -c rivet.yaml        # writes `wave: N` onto every export, in place
+```
+
+```yaml
+exports:
+  - name: users
+    wave: 1        # small / cheap → runs first
+    # …
+  - name: events
+    wave: 3        # large → runs later
+    # …
+```
+
+`rivet apply` then runs the whole config **wave by wave**, lowest first, with a barrier between waves — every export in wave 1 finishes before wave 2 starts. Exports with no `wave:` run last:
+
+```bash
+rivet apply rivet.yaml          # a .yaml path → wave-ordered execution
+```
+
+(A `.json` path still means the sealed single-artifact replay — see [reference/cli.md § rivet apply](reference/cli.md#rivet-apply).) The plan *suggests* the waves; you stay in control — hand-edit `wave:` and `apply` respects your order.
+
+### Parallel within a wave — only where it's safe
+
+Add `parallel_export_processes: true` and, within each wave, **keyset-chunkable** exports (`mode: chunked` with a `chunk_column` — bounded, index-backed scans) run concurrently as separate processes. Full / incremental / time-window / CDC exports scan or stream the table, so each runs **alone** to avoid stacking pressure on the source. Every child still self-throttles on source pressure + memory (the adaptive governor), so a whole wave at once stays bounded.
+
+```yaml
+parallel_export_processes: true   # top-level: parallelize keyset exports within each wave
+```
+
+---
+
 ## When something is wrong
 
 Rivet tries to fail early and say exactly what to fix — most mistakes are caught at `check` / `doctor` time, before a single row is read.

--- a/docs/pilot/pilot-walkthrough.md
+++ b/docs/pilot/pilot-walkthrough.md
@@ -149,6 +149,8 @@ A single-export plan prints a `Priority` block; a multi-export plan adds a `Camp
 rivet plan -c pilot.yaml --format json -o plan.json
 ```
 
+For a multi-export config, `plan` also writes the assigned `wave:` and `parallel_safe:` fields back into the config **in place** (preserving your comments and field order) — visible, hand-editable, and consumed by `rivet apply <config>` in Step 4. The plan *suggests* the schedule; you stay in control.
+
 **What the plan guarantees (PA1–PA8):**
 - PA1 — the artifact is the sole input to `apply`.
 - PA3 — apply bails on plans older than 24h (override with `--force`).
@@ -157,15 +159,24 @@ rivet plan -c pilot.yaml --format json -o plan.json
 
 ---
 
-## Step 4 — Run (or apply the sealed plan)
+## Step 4 — Run, or apply by wave
 
-Either run live:
+Three ways to execute, by how much orchestration you want.
+
+**Run live** — straightforward, config order, no waves:
 
 ```bash
 rivet run -c pilot.yaml --validate
 ```
 
-…or apply the plan for an auditable split between "what will happen" and "do it":
+**Apply the whole config wave-by-wave** — `rivet plan` (Step 3) wrote a `wave:` onto each export; apply runs them lowest-wave first, with a barrier between waves. Tables are independent, so a failed export does **not** block its wave-mates: apply collects the failure, runs the rest, and exits non-zero. Add `--parallel-export-processes` to run the cheap (`parallel_safe`) exports within a wave concurrently — the heavy ones still run alone (they chunk-parallelize internally):
+
+```bash
+rivet apply pilot.yaml                          # wave-ordered, sequential
+rivet apply pilot.yaml --parallel-export-processes   # + within-wave parallelism for cheap exports
+```
+
+**Apply a sealed single-export artifact** — the auditable split between "what will happen" and "do it":
 
 ```bash
 rivet apply plan.json

--- a/docs/pilot/production-checklist.md
+++ b/docs/pilot/production-checklist.md
@@ -90,6 +90,8 @@ Key guarantees:
 - Plans older than 1 hour emit a warning; older than 24 hours require `--force`
 - For incremental exports, `apply` rejects the artifact if the cursor has advanced since plan time (another run completed in between)
 
+**Many tables in one run.** For a config with several exports, `rivet plan -c rivet.yaml` also writes a `wave:` and `parallel_safe:` onto each export, and `rivet apply rivet.yaml` runs them **wave by wave** (lowest first), with a barrier between waves. Tables are independent, so a failed export does not block its wave-mates — apply collects failures, runs the rest, and exits non-zero. Add `--parallel-export-processes` to run the cheap (`parallel_safe`) exports within a wave concurrently. See [getting-started § 5](../getting-started.md#5--many-tables-plan-once-apply-by-waves).
+
 > **Security note:** `plan.json` embeds the resolved source connection config. Plaintext `password:` values and `scheme://user:pass@` userinfo are stripped by ADR-0005 PA9; references (`password_env:` / `url_env:` / `url_file:`) are preserved so the apply environment can re-resolve them. Plans still contain query SQL, schema and cursor state — treat them as sensitive.
 
 See [CLI reference](../reference/cli.md) and [ADR-0005](../adr/0005-plan-apply-contracts.md) for the full contract specification.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -287,7 +287,11 @@ rivet plan  -c rivet.yaml
 rivet apply rivet.yaml
 ```
 
-A failing export does not stop its wave-mates: failures are collected and the run exits non-zero with the most stop-worthy error (data-integrity > schema-drift > retryable). `partition_by` exports are not expanded in this path yet — use `rivet run` for those.
+A failing export does not stop its wave-mates: failures are collected and the run exits non-zero with the most stop-worthy error (data-integrity > schema-drift > retryable).
+
+**Resuming after a partial failure.** Re-run with `rivet apply <config>.yaml --resume`: exports a prior run already completed (their destination carries a `_SUCCESS` marker) are **skipped**, and an incomplete chunked export continues from its checkpoint — so recovering a run that failed mid-way does not redo the tables that already succeeded. Without `--resume`, a re-run re-exports everything.
+
+`partition_by` exports are not expanded in this path yet — use `rivet run` for those.
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -228,18 +228,19 @@ The JSON artifact (`--format json`) contains:
 
 ## `rivet apply`
 
-Execute a previously-generated plan artifact.
+Execute a sealed plan artifact, **or** run a config's exports wave-by-wave. The mode is chosen by the path's extension:
 
-`rivet apply` deserializes the artifact, validates staleness and cursor integrity, then executes the export using the pre-computed chunk boundaries from the artifact — no `SELECT min/max` queries are run against the source.
+- **`.json`** → a sealed [`PlanArtifact`](#rivet-plan): deserialize, validate staleness + cursor integrity, then execute the single export using the artifact's pre-computed chunk boundaries — no `SELECT min/max` queries against the source.
+- **`.yaml` / `.yml`** → a config: run every export **wave by wave** in ascending `wave:` order (the wave each export was assigned by `rivet plan`). See [Wave-ordered execution](#wave-ordered-execution-yaml-config) below.
 
 ```bash
-rivet apply <PLAN_FILE> [OPTIONS]
+rivet apply <PLAN_FILE | CONFIG> [OPTIONS]
 ```
 
 | Argument/Flag | Type | Description |
 |---|---|---|
-| `PLAN_FILE` | string | Path to plan JSON file **(required)** |
-| `--force` | bool | Skip staleness check (allow plans older than 24 h) |
+| `PLAN_FILE` / `CONFIG` | string | Path to a plan JSON artifact, or a YAML config for wave-ordered execution **(required)** |
+| `--force` | bool | Skip staleness check (allow plans older than 24 h) — JSON-artifact mode only |
 
 ### Staleness rules
 
@@ -273,6 +274,20 @@ rivet apply plan.json --force
 ### State location
 
 `rivet apply` opens `.rivet_state.db` from the directory containing the plan file. Place the plan file alongside the config file, or in the same directory, to ensure the correct state database is used.
+
+### Wave-ordered execution (YAML config)
+
+`rivet apply <config>.yaml` runs every export in the config **wave by wave**, lowest `wave:` first, with a barrier between waves — every export in wave 1 finishes before wave 2 starts. Exports with no `wave:` run last. `rivet plan` writes the `wave:` field onto each export (you can hand-edit it; apply respects your order).
+
+**Within-wave parallelism.** With `parallel_export_processes: true` in the config, exports within a wave that paginate by a keyset chunk column (`mode: chunked` with a `chunk_column`) run concurrently as separate processes. Full / incremental / time-window / CDC exports scan or stream the table, so each runs **alone** in the wave to avoid stacking source pressure; each child still self-throttles via the adaptive governor. Without the flag, every export runs sequentially.
+
+```bash
+# plan assigns waves → you review/edit → apply executes them, lowest wave first
+rivet plan  -c rivet.yaml
+rivet apply rivet.yaml
+```
+
+A failing export does not stop its wave-mates: failures are collected and the run exits non-zero with the most stop-worthy error (data-integrity > schema-drift > retryable). `partition_by` exports are not expanded in this path yet — use `rivet run` for those.
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -277,9 +277,9 @@ rivet apply plan.json --force
 
 ### Wave-ordered execution (YAML config)
 
-`rivet apply <config>.yaml` runs every export in the config **wave by wave**, lowest `wave:` first, with a barrier between waves — every export in wave 1 finishes before wave 2 starts. Exports with no `wave:` run last. `rivet plan` writes the `wave:` field onto each export (you can hand-edit it; apply respects your order).
+`rivet apply <config>.yaml` runs every export in the config **wave by wave**, lowest `wave:` first, with a barrier between waves — every export in wave 1 finishes before wave 2 starts. Exports with no `wave:` run last. `rivet plan` writes the `wave:` and `parallel_safe:` fields onto each export (you can hand-edit them; apply respects your order).
 
-**Within-wave parallelism.** With `parallel_export_processes: true` in the config, exports within a wave that paginate by a keyset chunk column (`mode: chunked` with a `chunk_column`) run concurrently as separate processes. Full / incremental / time-window / CDC exports scan or stream the table, so each runs **alone** in the wave to avoid stacking source pressure; each child still self-throttles via the adaptive governor. Without the flag, every export runs sequentially.
+**Within-wave parallelism.** With `parallel_export_processes: true` in the config (or `rivet apply --parallel-export-processes`), the **cheap** exports within a wave — those `rivet plan` marked `parallel_safe: true` (cost class `Low`, < ~100K rows) — run concurrently as separate processes. A heavier export already chunk-parallelizes its own ranges internally, so it runs **alone** in its wave; two large tables at once would multiply load on the source. Each child still self-throttles via the adaptive governor. Without the flag, every export runs sequentially. `parallel_safe` also respects the campaign's `isolate_on_source` — a cheap export on a contended shared source still runs alone.
 
 ```bash
 # plan assigns waves → you review/edit → apply executes them, lowest wave first

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -123,6 +123,8 @@ Each entry in the `exports` list defines one export job.
 | `verify` | `size` \| `content` | no | `size` | Integrity depth required of `--validate`. `content` checks every part's MD5 against the store's listing (no download) and **fails** validation for any part only size-verified — e.g. a part too large to upload as a single PUT (lower `max_file_size` so it fits) or a backend that exposes no checksum (local FS, streamed multipart). See [Verification depth](#verification-depth) below. |
 | `skip_empty` | boolean | no | `false` | Skip file creation if 0 rows |
 | `max_file_size` | string | no | — | Split output: `"256MB"`, `"1GB"`, etc. |
+| `wave` | integer | no | — | Advisory execution wave (1 = highest priority, runs first). Written by `rivet plan` from the source-aware prioritization score ([ADR-0006](../adr/0006-source-aware-prioritization.md)); consumed by `rivet apply <config>`, which runs exports wave-by-wave in ascending order (no `wave:` runs last). Hand-editable; a later `rivet plan` refreshes it. |
+| `parallel_safe` | boolean | no | — | Whether this export is cheap enough (cost class `Low`, < ~100K rows, and not `isolate_on_source`) to run concurrently with its wave-mates under `rivet apply --parallel-export-processes`. Written by `rivet plan`; a heavier export runs alone in its wave (it already chunk-parallelizes internally). Hand-editable. |
 | `meta_columns` | object | no | — | Extra columns added to output |
 | `quality` | object | no | — | Data quality checks |
 | `tuning` | object | no | — | Per-export tuning overrides |

--- a/schemas/latest/rivet.schema.json
+++ b/schemas/latest/rivet.schema.json
@@ -495,6 +495,22 @@
           "minimum": 0,
           "default": 1
         },
+        "wave": {
+          "description": "Advisory execution wave (1 = highest priority, run first). Written by\n`rivet plan` from the source-aware prioritization score (see ADR-0006)\nand consumed by `rivet apply`, which runs exports wave-by-wave in\nascending order. `None` = unscheduled (apply treats it as the last wave).\nOperators may hand-edit it; a later `rivet plan` refreshes it in place.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
+        },
+        "parallel_safe": {
+          "description": "Whether this export is cheap enough to run concurrently with its\nwave-mates under `rivet apply --parallel-export-processes`. Written by\n`rivet plan` (true when the source-aware cost class is `Low`, i.e.\n< ~100K rows); a heavier table already chunk-parallelizes internally, so\ntwo of them at once would overload the source. `None`/`false` → the\nexport runs alone within its wave. Operators may hand-edit it; a later\n`rivet plan` refreshes it in place.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "time_column": {
           "type": [
             "string",

--- a/schemas/latest/rivet.schema.json
+++ b/schemas/latest/rivet.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Rivet config (rivet-cli 0.15.0)",
+  "title": "Rivet config (rivet-cli 0.16.0)",
   "description": "Top-level Rivet configuration root.\n\nOperators write this struct as YAML (typically `rivet.yaml`).  The\n`JsonSchema` derive is the source of truth for the `schemas/rivet.schema.json`\nartifact and the `rivet schema config` command's output (v0.7.3 P0).",
   "type": "object",
   "properties": {

--- a/schemas/rivet.schema.json
+++ b/schemas/rivet.schema.json
@@ -495,6 +495,22 @@
           "minimum": 0,
           "default": 1
         },
+        "wave": {
+          "description": "Advisory execution wave (1 = highest priority, run first). Written by\n`rivet plan` from the source-aware prioritization score (see ADR-0006)\nand consumed by `rivet apply`, which runs exports wave-by-wave in\nascending order. `None` = unscheduled (apply treats it as the last wave).\nOperators may hand-edit it; a later `rivet plan` refreshes it in place.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
+        },
+        "parallel_safe": {
+          "description": "Whether this export is cheap enough to run concurrently with its\nwave-mates under `rivet apply --parallel-export-processes`. Written by\n`rivet plan` (true when the source-aware cost class is `Low`, i.e.\n< ~100K rows); a heavier table already chunk-parallelizes internally, so\ntwo of them at once would overload the source. `None`/`false` → the\nexport runs alone within its wave. Operators may hand-edit it; a later\n`rivet plan` refreshes it in place.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "time_column": {
           "type": [
             "string",

--- a/schemas/rivet.schema.json
+++ b/schemas/rivet.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Rivet config (rivet-cli 0.15.0)",
+  "title": "Rivet config (rivet-cli 0.16.0)",
   "description": "Top-level Rivet configuration root.\n\nOperators write this struct as YAML (typically `rivet.yaml`).  The\n`JsonSchema` derive is the source of truth for the `schemas/rivet.schema.json`\nartifact and the `rivet schema config` command's output (v0.7.3 P0).",
   "type": "object",
   "properties": {

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -303,6 +303,12 @@ pub enum Commands {
         /// chunk-parallelize internally — still run one at a time.
         #[arg(long)]
         parallel_export_processes: bool,
+        /// Config-wave mode: skip exports a prior run already completed
+        /// (`_SUCCESS` present) and resume incomplete chunked exports from their
+        /// checkpoints, so a re-run after a partial failure does not redo
+        /// finished tables. Independent tables are never re-exported.
+        #[arg(long)]
+        resume: bool,
         /// Skip staleness check (allow plans older than 24 h)
         #[arg(long)]
         force: bool,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -297,11 +297,12 @@ pub enum Commands {
         /// ascending `wave:` order — the wave each export was assigned by
         /// `rivet plan`.
         plan_file: String,
-        /// Run keyset-chunkable exports within each wave concurrently, as separate
-        /// processes (same as `parallel_export_processes: true` in the config).
-        /// Config-wave mode only; full / non-keyset exports still run one at a time.
+        /// Run the cheap (low-cost) exports within each wave concurrently, as
+        /// separate processes (same as `parallel_export_processes: true` in the
+        /// config). Config-wave mode only; heavier exports — which already
+        /// chunk-parallelize internally — still run one at a time.
         #[arg(long)]
-        parallel: bool,
+        parallel_export_processes: bool,
         /// Skip staleness check (allow plans older than 24 h)
         #[arg(long)]
         force: bool,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -290,9 +290,14 @@ pub enum Commands {
         #[arg(long, default_value = "pretty")]
         format: PlanFormat,
     },
-    /// Execute a previously-generated plan artifact
+    /// Execute a sealed plan artifact, or run a config's exports wave-by-wave
     Apply {
-        /// Path to plan JSON file produced by `rivet plan`
+        /// A plan JSON artifact from `rivet plan` (sealed single-export replay),
+        /// OR a YAML config (`.yaml`/`.yml`) to run its exports wave-by-wave in
+        /// ascending `wave:` order — the wave each export was assigned by
+        /// `rivet plan`. With `parallel_export_processes: true` in the config,
+        /// keyset-chunkable exports within a wave run concurrently; the rest run
+        /// one at a time.
         plan_file: String,
         /// Skip staleness check (allow plans older than 24 h)
         #[arg(long)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -295,10 +295,13 @@ pub enum Commands {
         /// A plan JSON artifact from `rivet plan` (sealed single-export replay),
         /// OR a YAML config (`.yaml`/`.yml`) to run its exports wave-by-wave in
         /// ascending `wave:` order — the wave each export was assigned by
-        /// `rivet plan`. With `parallel_export_processes: true` in the config,
-        /// keyset-chunkable exports within a wave run concurrently; the rest run
-        /// one at a time.
+        /// `rivet plan`.
         plan_file: String,
+        /// Run keyset-chunkable exports within each wave concurrently, as separate
+        /// processes (same as `parallel_export_processes: true` in the config).
+        /// Config-wave mode only; full / non-keyset exports still run one at a time.
+        #[arg(long)]
+        parallel: bool,
         /// Skip staleness check (allow plans older than 24 h)
         #[arg(long)]
         force: bool,

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -159,8 +159,9 @@ pub fn dispatch(cli: Cli) -> Result<()> {
         Commands::Apply {
             plan_file,
             parallel_export_processes,
+            resume,
             force,
-        } => pipeline::run_apply_command(&plan_file, force, parallel_export_processes),
+        } => pipeline::run_apply_command(&plan_file, force, parallel_export_processes, resume),
         Commands::Validate {
             config,
             export,

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -156,7 +156,11 @@ pub fn dispatch(cli: Cli) -> Result<()> {
             output,
             format,
         } => dispatch_plan(config, export, params, output, format),
-        Commands::Apply { plan_file, force } => pipeline::run_apply_command(&plan_file, force),
+        Commands::Apply {
+            plan_file,
+            parallel,
+            force,
+        } => pipeline::run_apply_command(&plan_file, force, parallel),
         Commands::Validate {
             config,
             export,

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -158,9 +158,9 @@ pub fn dispatch(cli: Cli) -> Result<()> {
         } => dispatch_plan(config, export, params, output, format),
         Commands::Apply {
             plan_file,
-            parallel,
+            parallel_export_processes,
             force,
-        } => pipeline::run_apply_command(&plan_file, force, parallel),
+        } => pipeline::run_apply_command(&plan_file, force, parallel_export_processes),
         Commands::Validate {
             config,
             export,

--- a/src/config/export.rs
+++ b/src/config/export.rs
@@ -125,6 +125,16 @@ pub struct ExportConfig {
     /// Operators may hand-edit it; a later `rivet plan` refreshes it in place.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub wave: Option<u32>,
+
+    /// Whether this export is cheap enough to run concurrently with its
+    /// wave-mates under `rivet apply --parallel-export-processes`. Written by
+    /// `rivet plan` (true when the source-aware cost class is `Low`, i.e.
+    /// < ~100K rows); a heavier table already chunk-parallelizes internally, so
+    /// two of them at once would overload the source. `None`/`false` → the
+    /// export runs alone within its wave. Operators may hand-edit it; a later
+    /// `rivet plan` refreshes it in place.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parallel_safe: Option<bool>,
     pub time_column: Option<String>,
     #[serde(default = "default_time_column_type")]
     pub time_column_type: TimeColumnType,
@@ -543,6 +553,7 @@ pub(crate) fn sample_export(name: &str) -> ExportConfig {
         chunk_by_key: None,
         parallel: 1,
         wave: None,
+        parallel_safe: None,
         time_column: None,
         time_column_type: TimeColumnType::Timestamp,
         days_window: None,

--- a/src/config/export.rs
+++ b/src/config/export.rs
@@ -123,11 +123,6 @@ pub struct ExportConfig {
     /// and consumed by `rivet apply`, which runs exports wave-by-wave in
     /// ascending order. `None` = unscheduled (apply treats it as the last wave).
     /// Operators may hand-edit it; a later `rivet plan` refreshes it in place.
-    ///
-    /// `allow(dead_code)`: `plan` writes it through the YAML text and it is
-    /// deserialized here, but no Rust code *reads* the field until `rivet apply`
-    /// consumes it (plan→apply cycle step 2). Drop the allow when that lands.
-    #[allow(dead_code)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub wave: Option<u32>,
     pub time_column: Option<String>,

--- a/src/config/export.rs
+++ b/src/config/export.rs
@@ -117,6 +117,19 @@ pub struct ExportConfig {
     pub chunk_by_key: Option<String>,
     #[serde(default = "default_parallel")]
     pub parallel: usize,
+
+    /// Advisory execution wave (1 = highest priority, run first). Written by
+    /// `rivet plan` from the source-aware prioritization score (see ADR-0006)
+    /// and consumed by `rivet apply`, which runs exports wave-by-wave in
+    /// ascending order. `None` = unscheduled (apply treats it as the last wave).
+    /// Operators may hand-edit it; a later `rivet plan` refreshes it in place.
+    ///
+    /// `allow(dead_code)`: `plan` writes it through the YAML text and it is
+    /// deserialized here, but no Rust code *reads* the field until `rivet apply`
+    /// consumes it (plan→apply cycle step 2). Drop the allow when that lands.
+    #[allow(dead_code)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wave: Option<u32>,
     pub time_column: Option<String>,
     #[serde(default = "default_time_column_type")]
     pub time_column_type: TimeColumnType,
@@ -534,6 +547,7 @@ pub(crate) fn sample_export(name: &str) -> ExportConfig {
         chunk_by_days: None,
         chunk_by_key: None,
         parallel: 1,
+        wave: None,
         time_column: None,
         time_column_type: TimeColumnType::Timestamp,
         days_window: None,

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -419,6 +419,11 @@ fn next_steps_block(path: &str, provenance: &SourceProvenance) -> String {
          2. rivet check  -c {path}            # column-type & schema report\n  \
          3. rivet run    -c {path} --validate # export, then verify row counts\n"
     ));
+    s.push_str(&format!(
+        "\nOr seal a reviewable plan, then apply it (runs many tables by priority wave):\n  \
+         rivet plan  -c {path}     # assigns waves + writes a reviewable plan\n  \
+         rivet apply {path}        # runs wave-by-wave (parallel where safe)\n"
+    ));
     s
 }
 

--- a/src/init/yaml_scaffold.rs
+++ b/src/init/yaml_scaffold.rs
@@ -39,7 +39,7 @@ pub(super) fn generate_config(
     let mut lines = config_header_lines(st, &header, unbounded, provenance);
     lines.push("exports:".to_string());
     lines.extend(export_block_lines(info, st, dest, mode_override));
-    Ok(lines.join("\n") + "\n")
+    Ok(wrap_comments(&(lines.join("\n") + "\n")))
 }
 
 pub(super) fn generate_schema_config(
@@ -64,7 +64,90 @@ pub(super) fn generate_schema_config(
     for info in infos {
         lines.extend(export_block_lines(info, st, dest, mode_override));
     }
-    Ok(lines.join("\n") + "\n")
+    Ok(wrap_comments(&(lines.join("\n") + "\n")))
+}
+
+/// Maximum column width for scaffolded comment lines.
+const COMMENT_WRAP_WIDTH: usize = 100;
+
+/// Word-wrap every comment in the scaffolded YAML so no line exceeds
+/// [`COMMENT_WRAP_WIDTH`]. A standalone comment (`<indent># text`) wraps onto
+/// continuation comment lines at the same indent; an inline comment
+/// (`key: value  # text`) keeps as much as fits after the value and wraps the
+/// rest onto standalone comment lines at the line's indent. Lines with no
+/// comment — or whose `#` sits inside a quoted scalar (a generated SQL `query:`
+/// or any quoted value) — are left byte-for-byte untouched, so values are never
+/// split.
+fn wrap_comments(yaml: &str) -> String {
+    let mut out = String::with_capacity(yaml.len());
+    for line in yaml.split_inclusive('\n') {
+        let nl = line.ends_with('\n');
+        let content = line.strip_suffix('\n').unwrap_or(line);
+        if content.chars().count() <= COMMENT_WRAP_WIDTH {
+            out.push_str(line);
+            continue;
+        }
+        match comment_split(content) {
+            Some((prefix, comment)) => {
+                let indent: String = content.chars().take_while(|c| *c == ' ').collect();
+                out.push_str(&wrap_comment(prefix, &indent, comment));
+                if nl {
+                    out.push('\n');
+                }
+            }
+            None => out.push_str(line),
+        }
+    }
+    out
+}
+
+/// Split a line at the start of a YAML comment that is NOT inside a quoted
+/// scalar → `(prefix, comment_text)`, where `prefix` is everything up to (not
+/// including) the `#` and `comment_text` is the comment with its `#` and one
+/// leading space stripped. `None` if the line carries no such comment.
+fn comment_split(line: &str) -> Option<(&str, &str)> {
+    let trimmed = line.trim_start();
+    if let Some(rest) = trimmed.strip_prefix('#') {
+        let prefix = &line[..line.len() - trimmed.len()];
+        return Some((prefix, rest.trim_start()));
+    }
+    let (mut in_s, mut in_d) = (false, false);
+    let bytes = line.as_bytes();
+    for i in 0..bytes.len() {
+        match bytes[i] {
+            b'\'' if !in_d => in_s = !in_s,
+            b'"' if !in_s => in_d = !in_d,
+            b'#' if !in_s && !in_d && i > 0 && bytes[i - 1] == b' ' => {
+                return Some((&line[..i], line[i + 1..].trim_start()));
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Greedily word-wrap `comment` so the first line is `prefix# …` and each
+/// continuation line is `indent# …`, none exceeding [`COMMENT_WRAP_WIDTH`]
+/// (except a single word longer than the budget, which takes its own line).
+fn wrap_comment(prefix: &str, indent: &str, comment: &str) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    let mut cur = format!("{prefix}# ");
+    let mut has_word = false;
+    for word in comment.split_whitespace() {
+        let extra = usize::from(has_word) + word.chars().count();
+        if has_word && cur.chars().count() + extra > COMMENT_WRAP_WIDTH {
+            lines.push(cur);
+            cur = format!("{indent}# {word}");
+        } else {
+            if has_word {
+                cur.push(' ');
+            }
+            cur.push_str(word);
+        }
+        has_word = true;
+    }
+    lines.push(cur);
+    lines.join("\n")
 }
 
 fn config_header_lines(
@@ -638,6 +721,58 @@ fn memory_capped_parallel(suggested: usize, avg_row_bytes: i64, budget_mb: u64) 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn wrap_long_standalone_comment_by_words() {
+        let yaml = "exports:\n    # auto: this is a very long generated comment that goes well beyond one hundred columns so it has to wrap onto several lines\n    mode: full\n";
+        let out = wrap_comments(yaml);
+        for l in out.lines() {
+            assert!(l.chars().count() <= COMMENT_WRAP_WIDTH, "over width: {l:?}");
+        }
+        assert!(
+            out.starts_with("exports:\n    # auto: "),
+            "first comment line kept"
+        );
+        assert!(
+            out.contains("\n    # "),
+            "continuation comment at the same indent"
+        );
+        assert!(out.contains("    mode: full\n"), "value line untouched");
+    }
+
+    #[test]
+    fn wrap_leaves_quoted_value_with_hash_untouched() {
+        let long = "x".repeat(140);
+        let yaml = format!("    query: \"SELECT '{long}' -- not # a real comment\"\n");
+        assert_eq!(
+            wrap_comments(&yaml),
+            yaml,
+            "a quoted scalar containing # must stay byte-identical"
+        );
+    }
+
+    #[test]
+    fn wrap_long_inline_comment_continues_below() {
+        let yaml = "    chunk_checkpoint: true  # record per-chunk progress so the resume command can finish a crashed run without redoing work\n";
+        let out = wrap_comments(yaml);
+        for l in out.lines() {
+            assert!(l.chars().count() <= COMMENT_WRAP_WIDTH, "over width: {l:?}");
+        }
+        assert!(
+            out.starts_with("    chunk_checkpoint: true  # "),
+            "value + first comment chunk stay inline"
+        );
+        assert!(
+            out.contains("\n    # "),
+            "continuation comment at line indent"
+        );
+    }
+
+    #[test]
+    fn wrap_leaves_short_comment_untouched() {
+        let yaml = "    mode: full  # full table scan\n";
+        assert_eq!(wrap_comments(yaml), yaml);
+    }
     use crate::init::{ColumnInfo, TableInfo};
 
     /// Cost+engine-aware parallelism (REPORT_full_vs_parallel.md): the wide

--- a/src/pipeline/apply_cmd.rs
+++ b/src/pipeline/apply_cmd.rs
@@ -19,13 +19,18 @@ use crate::state::StateStore;
 use super::chunked::ChunkSource;
 use super::summary::ApplyContext;
 
-/// Entry point for `rivet apply <plan-file> [--force]`.
-pub fn run_apply_command(plan_file: &str, force: bool) -> Result<()> {
+/// Entry point for `rivet apply <plan-file> [--parallel] [--force]`.
+pub fn run_apply_command(plan_file: &str, force: bool, parallel: bool) -> Result<()> {
     // A YAML config selects the wave-ordered multi-export path (plan→apply
     // cycle): run every export wave-by-wave in ascending `wave:` order. A JSON
     // plan artifact falls through to the sealed single-export replay below.
     if plan_file.ends_with(".yaml") || plan_file.ends_with(".yml") {
-        return super::run::run_waves(plan_file, force);
+        return super::run::run_waves(plan_file, force, parallel);
+    }
+    if parallel {
+        log::warn!(
+            "--parallel applies only to wave-ordered config execution; ignored for a sealed plan artifact"
+        );
     }
 
     // 1. Load artifact
@@ -343,7 +348,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let path = write_artifact(&dir, &artifact);
 
-        let err = run_apply_command(&path, false).unwrap_err();
+        let err = run_apply_command(&path, false, false).unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             msg.contains("hours old") || msg.contains("24 h"),
@@ -361,7 +366,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let path = write_artifact(&dir, &artifact);
 
-        let err = run_apply_command(&path, false).unwrap_err();
+        let err = run_apply_command(&path, false, false).unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             msg.contains("drifted") || msg.contains("cursor"),
@@ -373,7 +378,8 @@ mod tests {
 
     #[test]
     fn missing_plan_file_returns_error() {
-        let err = run_apply_command("/tmp/rivet_nonexistent_xyzxyz.json", false).unwrap_err();
+        let err =
+            run_apply_command("/tmp/rivet_nonexistent_xyzxyz.json", false, false).unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             msg.contains("cannot read") || msg.contains("No such file"),
@@ -386,7 +392,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("plan.json");
         std::fs::write(&path, b"not valid json at all").unwrap();
-        let err = run_apply_command(path.to_str().unwrap(), false).unwrap_err();
+        let err = run_apply_command(path.to_str().unwrap(), false, false).unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             msg.contains("invalid plan") || msg.contains("JSON") || msg.contains("expected"),
@@ -417,7 +423,7 @@ mod tests {
         let tampered = json.replace("SELECT 1", "SELECT * FROM secrets");
         std::fs::write(&path, &tampered).unwrap();
 
-        let err = run_apply_command(&path, false).unwrap_err();
+        let err = run_apply_command(&path, false, false).unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             msg.contains("integrity check failed") && msg.contains("modified after planning"),
@@ -425,7 +431,7 @@ mod tests {
         );
 
         // And --force must NOT override it — a hand-edited contract is not opt-in.
-        let err_forced = run_apply_command(&path, true).unwrap_err();
+        let err_forced = run_apply_command(&path, true, false).unwrap_err();
         let msg_forced = format!("{err_forced:#}");
         assert!(
             msg_forced.contains("integrity check failed"),

--- a/src/pipeline/apply_cmd.rs
+++ b/src/pipeline/apply_cmd.rs
@@ -19,17 +19,17 @@ use crate::state::StateStore;
 use super::chunked::ChunkSource;
 use super::summary::ApplyContext;
 
-/// Entry point for `rivet apply <plan-file> [--parallel] [--force]`.
-pub fn run_apply_command(plan_file: &str, force: bool, parallel: bool) -> Result<()> {
+/// Entry point for `rivet apply <plan-file> [--parallel-export-processes] [--resume] [--force]`.
+pub fn run_apply_command(plan_file: &str, force: bool, parallel: bool, resume: bool) -> Result<()> {
     // A YAML config selects the wave-ordered multi-export path (plan→apply
     // cycle): run every export wave-by-wave in ascending `wave:` order. A JSON
     // plan artifact falls through to the sealed single-export replay below.
     if plan_file.ends_with(".yaml") || plan_file.ends_with(".yml") {
-        return super::run::run_waves(plan_file, force, parallel);
+        return super::run::run_waves(plan_file, force, parallel, resume);
     }
-    if parallel {
+    if parallel || resume {
         log::warn!(
-            "--parallel applies only to wave-ordered config execution; ignored for a sealed plan artifact"
+            "--parallel-export-processes / --resume apply only to wave-ordered config execution; ignored for a sealed plan artifact"
         );
     }
 
@@ -348,7 +348,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let path = write_artifact(&dir, &artifact);
 
-        let err = run_apply_command(&path, false, false).unwrap_err();
+        let err = run_apply_command(&path, false, false, false).unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             msg.contains("hours old") || msg.contains("24 h"),
@@ -366,7 +366,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let path = write_artifact(&dir, &artifact);
 
-        let err = run_apply_command(&path, false, false).unwrap_err();
+        let err = run_apply_command(&path, false, false, false).unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             msg.contains("drifted") || msg.contains("cursor"),
@@ -378,8 +378,8 @@ mod tests {
 
     #[test]
     fn missing_plan_file_returns_error() {
-        let err =
-            run_apply_command("/tmp/rivet_nonexistent_xyzxyz.json", false, false).unwrap_err();
+        let err = run_apply_command("/tmp/rivet_nonexistent_xyzxyz.json", false, false, false)
+            .unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             msg.contains("cannot read") || msg.contains("No such file"),
@@ -392,7 +392,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("plan.json");
         std::fs::write(&path, b"not valid json at all").unwrap();
-        let err = run_apply_command(path.to_str().unwrap(), false, false).unwrap_err();
+        let err = run_apply_command(path.to_str().unwrap(), false, false, false).unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             msg.contains("invalid plan") || msg.contains("JSON") || msg.contains("expected"),
@@ -423,7 +423,7 @@ mod tests {
         let tampered = json.replace("SELECT 1", "SELECT * FROM secrets");
         std::fs::write(&path, &tampered).unwrap();
 
-        let err = run_apply_command(&path, false, false).unwrap_err();
+        let err = run_apply_command(&path, false, false, false).unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             msg.contains("integrity check failed") && msg.contains("modified after planning"),
@@ -431,7 +431,7 @@ mod tests {
         );
 
         // And --force must NOT override it — a hand-edited contract is not opt-in.
-        let err_forced = run_apply_command(&path, true, false).unwrap_err();
+        let err_forced = run_apply_command(&path, true, false, false).unwrap_err();
         let msg_forced = format!("{err_forced:#}");
         assert!(
             msg_forced.contains("integrity check failed"),

--- a/src/pipeline/apply_cmd.rs
+++ b/src/pipeline/apply_cmd.rs
@@ -21,6 +21,13 @@ use super::summary::ApplyContext;
 
 /// Entry point for `rivet apply <plan-file> [--force]`.
 pub fn run_apply_command(plan_file: &str, force: bool) -> Result<()> {
+    // A YAML config selects the wave-ordered multi-export path (plan→apply
+    // cycle): run every export wave-by-wave in ascending `wave:` order. A JSON
+    // plan artifact falls through to the sealed single-export replay below.
+    if plan_file.ends_with(".yaml") || plan_file.ends_with(".yml") {
+        return super::run::run_waves(plan_file, force);
+    }
+
     // 1. Load artifact
     let artifact = PlanArtifact::from_file(plan_file)?;
 

--- a/src/pipeline/chunked/detect.rs
+++ b/src/pipeline/chunked/detect.rs
@@ -3,7 +3,7 @@
 //! Queries min/max (and optionally COUNT) from the source to compute chunk ranges,
 //! logs sparsity diagnostics, and returns the final `Vec<(i64, i64)>` chunk list.
 
-use super::math::{generate_chunks, strip_select_star_from};
+use super::math::{generate_chunks, strip_simple_projection_from};
 use crate::error::Result;
 use crate::scalar::{parse_date_flexible, parse_scalar_i64};
 use crate::source::Source;
@@ -15,7 +15,7 @@ use crate::source::Source;
 /// avoids the wrap entirely so `COUNT(*)` becomes a plain heap-scan / index-only
 /// scan with no spill.
 fn query_wrapped_row_count(src: &mut dyn Source, base_query: &str) -> Result<i64> {
-    let sql = match strip_select_star_from(base_query) {
+    let sql = match strip_simple_projection_from(base_query) {
         Some(table_ident) => format!("SELECT COUNT(*) FROM {table_ident}"),
         None => format!("SELECT COUNT(*) FROM ({base_query}) AS _rivet_rowcnt"),
     };
@@ -44,29 +44,21 @@ fn bail_if_null_keyed(
     export_name: &str,
     source_type: crate::config::SourceType,
 ) -> Result<()> {
-    let col = crate::sql::quote_ident(source_type, chunk_column);
-    // `COUNT(*) - COUNT(col)` = number of NULL-keyed rows, dialect-agnostic and
-    // reusing the same fast-path-vs-wrap shape as the row-count query.
-    let sql = match strip_select_star_from(base_query) {
-        Some(table_ident) => format!("SELECT COUNT(*) - COUNT({col}) FROM {table_ident}"),
-        None => format!("SELECT COUNT(*) - COUNT({col}) FROM ({base_query}) AS _rivet_nullcnt"),
-    };
-    let null_keyed = src
-        .query_scalar(&sql)?
-        .as_deref()
-        .map(parse_scalar_i64)
-        .transpose()?
-        .unwrap_or(0);
-    if null_keyed > 0 {
+    // Presence probe (not a count): is there ANY NULL-keyed row? For a NOT NULL
+    // column the planner returns nothing without a scan; for a nullable one it
+    // stops at the first NULL — so this never forces the cold full-index scan a
+    // `COUNT(*) - COUNT(col)` did. A nullable column with zero NULLs still passes
+    // (no row → no bail), preserving the "detect on live data" intent.
+    let sql = crate::sql::null_key_probe_sql(source_type, chunk_column, base_query);
+    if src.query_scalar(&sql)?.is_some() {
         anyhow::bail!(
-            "export '{}': {} row(s) have NULL in chunk_column '{}'. Range/date chunking filters \
+            "export '{}': found NULL in chunk_column '{}'. Range/date chunking filters \
              with `BETWEEN min AND max` (or `>= .. < ..`), which excludes NULL — those rows would \
              be silently dropped from the export. Fix one of: use a NOT NULL column for \
              chunk_column; add `WHERE {} IS NOT NULL` to the query to drop them explicitly; set \
              `chunk_dense: true` (ROW_NUMBER covers every row, NULL-keyed included); or use \
              `mode: full`.",
             export_name,
-            null_keyed,
             chunk_column,
             chunk_column
         );
@@ -283,7 +275,7 @@ pub(crate) fn detect_and_generate_chunks(
     // curated query has no catalog row — both log boundaries without density
     // rather than scan. The boundaries come from min/max above; the estimate
     // never feeds them.
-    let row_estimate = strip_select_star_from(base_query)
+    let row_estimate = strip_simple_projection_from(base_query)
         .and_then(|table_ident| crate::sql::row_estimate_sql(source_type, table_ident))
         .and_then(|sql| {
             src.query_scalar(&sql)
@@ -333,9 +325,10 @@ mod tests {
     struct ScriptedSource {
         replies: VecDeque<Result<Option<String>>>,
         seen_sql: Vec<String>,
-        /// Value returned for the NULL-key guard query (`COUNT(*) - COUNT(col)`).
-        /// Defaults to 0 so existing min/max/count scripts stay focused and the
-        /// guard is a transparent no-op; the bail tests set it explicitly.
+        /// Drives the NULL-key guard's presence probe (`… WHERE col IS NULL`):
+        /// `> 0` ⇒ a NULL exists (one row). Defaults to 0 so existing
+        /// min/max/count scripts stay focused and the guard is a transparent
+        /// no-op; the bail tests set it explicitly.
         null_keys: i64,
     }
 
@@ -364,11 +357,12 @@ mod tests {
     impl crate::source::Source for ScriptedSource {
         fn query_scalar(&mut self, sql: &str) -> Result<Option<String>> {
             self.seen_sql.push(sql.to_string());
-            // The NULL-key guard issues `COUNT(*) - COUNT(col)`; answer it from
-            // `null_keys` (default 0) so it doesn't consume the min/max/count
-            // script and existing tests stay unchanged.
-            if sql.contains("- COUNT(") {
-                return Ok(Some(self.null_keys.to_string()));
+            // The NULL-key guard now issues a presence probe `… WHERE col IS NULL
+            // LIMIT 1` (was COUNT(*) - COUNT(col)); answer it from `null_keys`
+            // (> 0 ⇒ a NULL exists → one row) so it doesn't consume the
+            // min/max/count script and existing tests stay focused.
+            if sql.contains("IS NULL") {
+                return Ok((self.null_keys > 0).then(|| "1".to_string()));
             }
             self.replies
                 .pop_front()
@@ -448,13 +442,12 @@ mod tests {
 
     #[test]
     fn null_keyed_rows_in_integer_range_bail_not_silently_dropped() {
-        // 3 rows have NULL chunk_column → range chunking would exclude them via
-        // BETWEEN. Refuse with a clear, counted error instead of dropping them.
+        // Rows have NULL chunk_column → range chunking would exclude them via
+        // BETWEEN. Refuse with a clear error instead of dropping them.
         let mut src = ScriptedSource::new([ok("1"), ok("1000"), ok("500")]).with_null_keys(3);
         let err = detect(&mut src, 100, false, None).unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("NULL in chunk_column"), "got: {msg}");
-        assert!(msg.contains("3 row(s)"), "should report the count: {msg}");
     }
 
     #[test]

--- a/src/pipeline/chunked/exec.rs
+++ b/src/pipeline/chunked/exec.rs
@@ -42,6 +42,8 @@ pub(crate) fn run_chunked_sequential(
     );
 
     let pb = ChunkProgress::new(&plan.export_name, chunks.len());
+    // Per-batch progress feed (single-threaded here, but the sink API is shared).
+    let streamed_rows = std::sync::Arc::new(std::sync::atomic::AtomicI64::new(0));
 
     for (i, (start, end)) in chunks.iter().enumerate() {
         if !resource::check_memory(plan.tuning.memory_threshold_mb) {
@@ -73,7 +75,8 @@ pub(crate) fn run_chunked_sequential(
             end_key: end.to_string(),
         });
 
-        let mut sink = ExportSink::new(plan)?;
+        let mut sink = ExportSink::new(plan)?
+            .with_row_progress(pb.handle(), std::sync::Arc::clone(&streamed_rows));
         src.export(
             // `chunk_query` wraps the base in a subquery → resolve NUMERIC
             // catalog hints from the unwrapped base (`wrapped`).
@@ -186,6 +189,9 @@ pub(crate) fn run_chunked_parallel(
     // that never arrives).
     let finished = AtomicUsize::new(0);
     let agg_rows = std::sync::atomic::AtomicI64::new(0);
+    // Rows streamed across ALL chunks (completed + in-flight) — drives the
+    // per-batch progress feed so the bar ticks during a chunk's read.
+    let streamed_rows = std::sync::Arc::new(std::sync::atomic::AtomicI64::new(0));
     let errors = std::sync::Mutex::new(Vec::<String>::new());
     // PartRecords pushed by workers, drained into record_part post-scope so the
     // I2/M1 → I7 → counters ordering lives once in commit::record_part. Tuple
@@ -336,6 +342,7 @@ pub(crate) fn run_chunked_parallel(
             let shared_fingerprint = &shared_fingerprint;
             let semaphore = &semaphore;
             let pb_thread = pb_handle.clone();
+            let streamed_rows = std::sync::Arc::clone(&streamed_rows);
             let start = *start;
             let end = *end;
             let shared_destination = std::sync::Arc::clone(&shared_destination);
@@ -353,7 +360,10 @@ pub(crate) fn run_chunked_parallel(
                     );
 
                     let mut thread_src = source::create_source(&plan_for_worker.source)?;
-                    let mut sink = ExportSink::new(&plan_for_worker)?;
+                    let mut sink = ExportSink::new(&plan_for_worker)?.with_row_progress(
+                        pb_thread.clone(),
+                        std::sync::Arc::clone(&streamed_rows),
+                    );
                     thread_src.export(
                         &source::ExportRequest::wrapped(
                             &chunk_query,
@@ -401,7 +411,10 @@ pub(crate) fn run_chunked_parallel(
                     }
 
                     let done = completed.fetch_add(1, Ordering::Relaxed) + 1;
-                    pb_thread.inc(agg_rows.load(Ordering::Relaxed));
+                    // Advance the chunk count; show the streamed-rows total (≥
+                    // agg_rows, monotonic) so the bar never jumps backward from
+                    // the in-flight per-batch updates.
+                    pb_thread.inc(streamed_rows.load(Ordering::Relaxed));
                     log::info!(
                         "export '{}': chunk {}/{} done ({} rows)",
                         export_name,

--- a/src/pipeline/chunked/math.rs
+++ b/src/pipeline/chunked/math.rs
@@ -8,7 +8,7 @@
 // `strip_select_star_from` lives in the `sql` leaf (shared with preflight and
 // plan::partition); re-exported here so `chunked`'s call sites and the
 // `chunked::strip_select_star_from` re-export are unchanged.
-pub(crate) use crate::sql::strip_select_star_from;
+pub(crate) use crate::sql::{strip_select_star_from, strip_simple_projection_from};
 
 pub fn generate_chunks(min: i64, max: i64, chunk_size: i64) -> Vec<(i64, i64)> {
     if max < min || chunk_size <= 0 {

--- a/src/pipeline/chunked/parallel_checkpoint.rs
+++ b/src/pipeline/chunked/parallel_checkpoint.rs
@@ -79,6 +79,9 @@ pub(crate) fn run_chunked_parallel_checkpoint(
     let state_ref = state.state_ref().clone();
     let run_id_arc = std::sync::Arc::new(run_id.clone());
     let agg_rows = std::sync::atomic::AtomicI64::new(0);
+    // Rows streamed across ALL tasks (completed + in-flight) — drives the
+    // per-batch progress feed so the bar ticks during a chunk's read.
+    let streamed_rows = std::sync::Arc::new(std::sync::atomic::AtomicI64::new(0));
     // Per-attempt retry counter bumped from inside each worker's retry
     // loop and folded into `summary.retries` after the scope joins, so the
     // console summary card / `rivet metrics` / `export_metrics.retries`
@@ -135,6 +138,7 @@ pub(crate) fn run_chunked_parallel_checkpoint(
             let fmt_label_w = fmt_label;
             let comp_label_w = comp_label;
             let pb_w = pb_cp_handle.clone();
+            let streamed_rows = std::sync::Arc::clone(&streamed_rows);
 
             s.spawn(move || {
                 let shared_destination = shared_destination;
@@ -229,7 +233,11 @@ pub(crate) fn run_chunked_parallel_checkpoint(
                                 }
                             };
 
-                            let mut sink = ExportSink::new(&plan_w)?;
+                            let mut sink = ExportSink::new(&plan_w)?
+                                .with_row_progress(
+                                    pb_w.clone(),
+                                    std::sync::Arc::clone(&streamed_rows),
+                                );
 
                             let export_attempt = (|| -> Result<(
                                 usize,
@@ -379,7 +387,7 @@ pub(crate) fn run_chunked_parallel_checkpoint(
                                 "after_chunk_complete",
                                 chunk_index,
                             );
-                            pb_w.inc(agg_rows.load(Ordering::Relaxed));
+                            pb_w.inc(streamed_rows.load(Ordering::Relaxed));
                         }
                         Err(e) => {
                             let msg = crate::redact::redact_error(&e);

--- a/src/pipeline/chunked/sequential_checkpoint.rs
+++ b/src/pipeline/chunked/sequential_checkpoint.rs
@@ -44,6 +44,10 @@ fn export_one_chunk_range(
     chunk_index: i64,
     plan: &ResolvedRunPlan,
     summary: &mut RunSummary,
+    row_progress: Option<(
+        &crate::pipeline::progress::ChunkProgressHandle,
+        &std::sync::Arc<std::sync::atomic::AtomicI64>,
+    )>,
 ) -> Result<(usize, Vec<super::super::commit::PartRecord>)> {
     let chunk_query = build_chunk_query_sql(
         base_query,
@@ -56,6 +60,9 @@ fn export_one_chunk_range(
     );
 
     let mut sink = ExportSink::new(plan)?;
+    if let Some((h, sr)) = row_progress {
+        sink = sink.with_row_progress(h.clone(), std::sync::Arc::clone(sr));
+    }
     src.export(
         &source::ExportRequest::wrapped(
             &chunk_query,
@@ -106,6 +113,10 @@ fn run_chunk_with_source_retries(
     chunk_index: i64,
     plan: &ResolvedRunPlan,
     summary: &mut RunSummary,
+    row_progress: Option<(
+        &crate::pipeline::progress::ChunkProgressHandle,
+        &std::sync::Arc<std::sync::atomic::AtomicI64>,
+    )>,
 ) -> Result<(usize, Vec<super::super::commit::PartRecord>)> {
     let mut last_err: Option<anyhow::Error> = None;
     for attempt in 0..=plan.tuning.max_retries {
@@ -152,6 +163,7 @@ fn run_chunk_with_source_retries(
             chunk_index,
             plan,
             summary,
+            row_progress,
         ) {
             Ok(v) => return Ok(v),
             Err(e) => {
@@ -196,6 +208,9 @@ pub(crate) fn run_chunked_sequential_checkpoint(
 
     let total_tasks = state.count_chunk_tasks_total(&run_id).unwrap_or(1);
     let pb = ChunkProgress::new(&plan.export_name, total_tasks);
+    let pb_handle = pb.handle();
+    // Per-batch progress feed: bar ticks during a chunk's read, not only at end.
+    let streamed_rows = std::sync::Arc::new(std::sync::atomic::AtomicI64::new(0));
 
     if !plan.resume && !resource::check_memory(plan.tuning.memory_threshold_mb) {
         log::warn!("memory threshold exceeded before chunk export; pausing 5s");
@@ -240,6 +255,7 @@ pub(crate) fn run_chunked_sequential_checkpoint(
             chunk_index,
             plan,
             summary,
+            Some((&pb_handle, &streamed_rows)),
         ) {
             Ok((rows, parts)) => {
                 summary.total_rows += rows as i64;

--- a/src/pipeline/finalize.rs
+++ b/src/pipeline/finalize.rs
@@ -61,7 +61,10 @@ pub(super) fn finalize_run_report(config_path: &str, summary: &RunSummary, kind:
 
     let stderr = std::io::stderr();
     let mut h = stderr.lock();
-    if written {
+    // Per-export `report:` lines double the output of a multi-export run (one
+    // per export); the run aggregate at the end already points at `.rivet/runs/`.
+    // Keep the line only for a single export, where it is the one place to look.
+    if written && !crate::pipeline::multi_export_mode() {
         let _ = writeln!(h, "report:    {}", dir.join("summary.md").display());
     }
     if summary.status == "failed" && summary.files_committed > 0 {

--- a/src/pipeline/finalize.rs
+++ b/src/pipeline/finalize.rs
@@ -434,6 +434,23 @@ pub(super) fn warn_if_prefix_has_completed_run(plan: &ResolvedRunPlan) {
     }
 }
 
+/// Whether this destination already holds a completed export (`_SUCCESS`).
+/// `rivet apply --resume` uses it to skip exports a prior run finished, so a
+/// re-run after a partial failure does not redo work already done. Reuses the
+/// same probe as [`warn_if_prefix_has_completed_run`]; a streaming destination
+/// (stdout) or a probe error counts as "not complete" (re-run it).
+pub(crate) fn destination_has_success(dest: &crate::config::DestinationConfig) -> bool {
+    use crate::destination::WriteCommitProtocol;
+    use crate::manifest::SUCCESS_FILENAME;
+    let Ok(d) = crate::destination::create_destination(dest) else {
+        return false;
+    };
+    if d.capabilities().commit_protocol == WriteCommitProtocol::Streaming {
+        return false;
+    }
+    matches!(d.head(SUCCESS_FILENAME), Ok(Some(_)))
+}
+
 /// The operator-facing body of the rerun-accumulation warning.
 ///
 /// Split out so a regression test can pin the exact wording — the live audit

--- a/src/pipeline/parallel_children.rs
+++ b/src/pipeline/parallel_children.rs
@@ -38,6 +38,9 @@ pub(super) fn run_exports_as_child_processes(
     resume: bool,
     force: bool,
     params: Option<&std::collections::HashMap<String, String>>,
+    // Wave-wide max export-name width so the card table aligns across the
+    // cost-gate's separate safe/lone batches, not just within one batch.
+    name_floor: usize,
 ) -> (Result<()>, HashMap<String, String>, String) {
     let exe = match std::env::current_exe() {
         Ok(p) => p,
@@ -76,14 +79,8 @@ pub(super) fn run_exports_as_child_processes(
 
     let (tx, rx) = mpsc::channel::<UiMessage>();
 
-    // Seed the card table's name column from the known export names so it is
-    // aligned from the first redraw (the renderer can't see a long name until
-    // its child emits `Started`).
-    let name_floor = exports
-        .iter()
-        .map(|e| e.name.chars().count())
-        .max()
-        .unwrap_or(0);
+    // `name_floor` (wave-wide max, from the caller) seeds the card table's name
+    // column so it aligns from the first redraw and across batches.
     let ui_handle = std::thread::Builder::new()
         .name("rivet-ipc-ui".into())
         .spawn(move || super::parent_ui::run_ui(rx, name_floor))

--- a/src/pipeline/parallel_children.rs
+++ b/src/pipeline/parallel_children.rs
@@ -76,9 +76,17 @@ pub(super) fn run_exports_as_child_processes(
 
     let (tx, rx) = mpsc::channel::<UiMessage>();
 
+    // Seed the card table's name column from the known export names so it is
+    // aligned from the first redraw (the renderer can't see a long name until
+    // its child emits `Started`).
+    let name_floor = exports
+        .iter()
+        .map(|e| e.name.chars().count())
+        .max()
+        .unwrap_or(0);
     let ui_handle = std::thread::Builder::new()
         .name("rivet-ipc-ui".into())
-        .spawn(move || super::parent_ui::run_ui(rx))
+        .spawn(move || super::parent_ui::run_ui(rx, name_floor))
         .ok();
 
     const CHILD_STDERR_LINE_CAP: usize = 5_000;

--- a/src/pipeline/parent_ui.rs
+++ b/src/pipeline/parent_ui.rs
@@ -155,18 +155,18 @@ const MIN_MODE_COL: usize = 7;
 ///   no-ops or, worse, line-wrap around long error messages and corrupt the
 ///   anchor — so we instead print each card exactly once when it
 ///   transitions to its terminal state.
-pub(crate) fn run_ui(rx: Receiver<UiMessage>) {
+pub(crate) fn run_ui(rx: Receiver<UiMessage>, name_floor: usize) {
     let width = pick_width();
     if console::Term::stderr().features().is_attended() {
-        run_ui_interactive(rx, width);
+        run_ui_interactive(rx, width, name_floor);
     } else {
-        run_ui_linear(rx, width);
+        run_ui_linear(rx, width, name_floor);
     }
 }
 
 /// In-place card-stack renderer for tty stderr.
-fn run_ui_interactive(rx: Receiver<UiMessage>, width: usize) {
-    let mut renderer = Renderer::new(width);
+fn run_ui_interactive(rx: Receiver<UiMessage>, width: usize, name_floor: usize) {
+    let mut renderer = Renderer::new(width, name_floor);
 
     loop {
         match rx.recv_timeout(IDLE_REDRAW_INTERVAL) {
@@ -197,8 +197,8 @@ fn run_ui_interactive(rx: Receiver<UiMessage>, width: usize) {
 /// Linear renderer for non-tty stderr.  Each card is printed once when it
 /// reaches its terminal state — there is no in-place redraw, so output is
 /// safe to `tee` / capture without phantom duplicates.
-fn run_ui_linear(rx: Receiver<UiMessage>, width: usize) {
-    let mut renderer = Renderer::new(width);
+fn run_ui_linear(rx: Receiver<UiMessage>, width: usize, name_floor: usize) {
+    let mut renderer = Renderer::new(width, name_floor);
     let mut printed: HashSet<String> = HashSet::new();
 
     while let Ok(msg) = rx.recv() {
@@ -227,7 +227,7 @@ fn run_ui_linear(rx: Receiver<UiMessage>, width: usize) {
 /// Append every card that has reached its terminal state but hasn't been
 /// printed yet to stderr, preserving the `Started`-event observation order.
 fn flush_finished_cards(renderer: &Renderer, printed: &mut HashSet<String>, width: usize) {
-    let (name_col, mode_col) = column_widths(&renderer.cards);
+    let (name_col, mode_col) = column_widths(&renderer.cards, renderer.name_floor);
     let mut out = String::new();
     for name in &renderer.order {
         if printed.contains(name) {
@@ -256,8 +256,8 @@ fn flush_finished_cards(renderer: &Renderer, printed: &mut HashSet<String>, widt
 /// Pick stable column widths for the name and mode columns by combining the
 /// observed maxima with `MIN_NAME_COL` / `MIN_MODE_COL` floors so the layout
 /// stays aligned even when only short names / modes have been observed yet.
-fn column_widths(cards: &HashMap<String, CardState>) -> (usize, usize) {
-    let mut name = 0usize;
+fn column_widths(cards: &HashMap<String, CardState>, name_floor: usize) -> (usize, usize) {
+    let mut name = name_floor;
     let mut mode = 0usize;
     for c in cards.values() {
         name = name.max(c.export_name.chars().count());
@@ -278,15 +278,19 @@ struct Renderer {
     /// repaint in place rather than appending a fresh card stack each time.
     last_drawn_lines: usize,
     width: usize,
+    /// Lower bound on the name column, seeded from the known export names so the
+    /// table is aligned from the first redraw (not widening as long names arrive).
+    name_floor: usize,
 }
 
 impl Renderer {
-    fn new(width: usize) -> Self {
+    fn new(width: usize, name_floor: usize) -> Self {
         Self {
             cards: HashMap::new(),
             order: Vec::new(),
             last_drawn_lines: 0,
             width,
+            name_floor,
         }
     }
 
@@ -399,7 +403,7 @@ impl Renderer {
             out.push('\r');
         }
 
-        let (name_col, mode_col) = column_widths(&self.cards);
+        let (name_col, mode_col) = column_widths(&self.cards, self.name_floor);
         let mut new_lines = 0usize;
         for name in &self.order {
             if let Some(card) = self.cards.get(name) {
@@ -596,12 +600,14 @@ fn render_final_line(
         return sanitize_terminal(cause);
     }
     let rss = if peak_rss_mb > 0 {
-        format!("  RSS {} MB", fmt_thousands(peak_rss_mb))
+        format!("  RSS {:>3} MB", fmt_thousands(peak_rss_mb))
     } else {
         String::new()
     };
+    // Fixed-width columns so values line up into a table regardless of magnitude:
+    // rows/files/bytes/duration are right-aligned (numbers read down a column).
     format!(
-        "{} rows  {} files  {}  {}{}",
+        "{:>11} rows  {:>3} files  {:>9}  {:>8}{}",
         fmt_thousands(total_rows),
         fmt_thousands(files_produced as i64),
         format_bytes(bytes_written),
@@ -695,7 +701,8 @@ mod tests {
         assert!(s.contains("123,456 rows"));
         assert!(s.contains("5 files"));
         assert!(s.contains("9.4s"));
-        assert!(s.contains("RSS 30 MB"));
+        // Columns are right-padded for table alignment, so check parts.
+        assert!(s.contains("RSS") && s.contains("30 MB"));
     }
 
     #[test]
@@ -802,7 +809,7 @@ mod tests {
         assert!(line.contains("100 rows"));
         assert!(line.contains("1 files"));
         assert!(line.contains("1.2s"));
-        assert!(line.contains("RSS 30 MB"));
+        assert!(line.contains("RSS") && line.contains("30 MB"));
     }
 
     #[test]

--- a/src/pipeline/plan_cmd.rs
+++ b/src/pipeline/plan_cmd.rs
@@ -16,8 +16,8 @@ use std::path::Path;
 use crate::config::Config;
 use crate::error::Result;
 use crate::plan::{
-    CampaignRecommendation, ComputedPlanData, ExportRecommendation, ExtractionStrategy,
-    PlanArtifact, PlanDiagnostics, PlanPrioritizationSnapshot, PrioritizationInputs, build_plan,
+    ComputedPlanData, ExportRecommendation, ExtractionStrategy, PlanArtifact, PlanDiagnostics,
+    PlanPrioritizationSnapshot, PrioritizationInputs, build_plan,
     campaign::recommend_campaign,
     inputs::{PrioritizationHints, build_prioritization_inputs},
     recommend::recommend_export,
@@ -408,11 +408,16 @@ fn emit_artifacts(
 ) -> Result<()> {
     match format {
         PlanOutputFormat::Pretty => {
-            for artifact in artifacts {
-                artifact.print_summary();
-            }
             if multi_export {
-                print_wave_execution_hint(artifacts, config_path);
+                // A schema scan can yield dozens of exports; the full per-export
+                // block would be hundreds of lines. Show a compact, one-line-per-
+                // export table sorted by wave, then the wave-execution hint. Use
+                // `--export <name>` for a single export's full detail.
+                print_compact_summary(artifacts, config_path);
+            } else {
+                for artifact in artifacts {
+                    artifact.print_summary();
+                }
             }
         }
         // Multi-export JSON to stdout: a single export prints its object
@@ -448,57 +453,57 @@ fn emit_artifacts(
     Ok(())
 }
 
-/// Print copy-pasteable `rivet run` commands grouped by advisory wave, so an
-/// operator can execute the plan in priority order. rivet itself runs config
-/// order (or all-at-once with `--parallel-exports`) and never consumes the
-/// waves, so this block is the bridge between the advice and the run. `rivet
-/// run` takes a single `--export`, so it is one command per export.
-fn print_wave_execution_hint(artifacts: &[PlanArtifact], config_path: &str) {
-    if let Some(campaign) = artifacts
-        .first()
-        .and_then(|a| a.prioritization.as_ref())
-        .and_then(|p| p.campaign.as_ref())
-        && let Some(hint) = build_wave_hint(campaign, config_path)
-    {
-        print!("{hint}");
-    }
-}
-
-/// Build the wave-ordered `rivet run` command list as a string (pure, so it is
-/// unit-tested). Returns `None` when there are no waves to suggest.
-fn build_wave_hint(campaign: &CampaignRecommendation, config_path: &str) -> Option<String> {
-    if campaign.waves.is_empty() {
-        return None;
-    }
-
-    let isolated: std::collections::HashSet<&str> = campaign
-        .ordered_exports
+/// Compact one-line-per-export table for a multi-export plan, sorted by wave
+/// (then by descending score, then name). The full per-export block
+/// (`print_summary`) would be hundreds of lines for a schema scan, so it is
+/// reserved for a single-export plan (`--export <name>`).
+fn print_compact_summary(artifacts: &[PlanArtifact], config_path: &str) {
+    let key = |a: &PlanArtifact| {
+        a.prioritization
+            .as_ref()
+            .map(|p| {
+                (
+                    p.export_recommendation.recommended_wave,
+                    p.export_recommendation.priority_score,
+                )
+            })
+            .unwrap_or((u32::MAX, 0))
+    };
+    let mut order: Vec<&PlanArtifact> = artifacts.iter().collect();
+    order.sort_by(|a, b| {
+        let (wa, sa) = key(a);
+        let (wb, sb) = key(b);
+        wa.cmp(&wb)
+            .then(sb.cmp(&sa))
+            .then(a.export_name.cmp(&b.export_name))
+    });
+    let name_w = order
         .iter()
-        .filter(|e| e.isolate_on_source)
-        .map(|e| e.export_name.as_str())
-        .collect();
+        .map(|a| a.export_name.chars().count())
+        .max()
+        .unwrap_or(6)
+        .clamp(6, 32);
 
-    let mut waves: Vec<_> = campaign.waves.iter().collect();
-    waves.sort_by_key(|w| w.wave);
-
-    let mut out = String::from(
-        "\n  Suggested execution (advisory — rivet runs config order, not waves):\n    \
-         run lowest wave first; `rivet run` takes one --export, so one command per export.\n",
+    println!();
+    println!(
+        "  Plan: {} exports — `rivet apply {}` runs them by wave (lowest first)",
+        artifacts.len(),
+        config_path
     );
-    for w in waves {
-        for export in &w.exports {
-            let note = if isolated.contains(export.as_str()) {
-                "   # isolate_on_source — run alone (no --parallel-exports)"
-            } else {
-                ""
-            };
-            out.push_str(&format!(
-                "    wave {}:  rivet run -c {} --export {}{}\n",
-                w.wave, config_path, export, note
-            ));
-        }
+    println!();
+    println!(
+        "  {:<5} {:<width$}  {:<11}  {:<12}  Verdict",
+        "Wave",
+        "Export",
+        "Strategy",
+        "Rows",
+        width = name_w
+    );
+    for a in &order {
+        println!("{}", a.summary_line(name_w));
     }
-    Some(out)
+    println!();
+    println!("  Full detail for one export:  rivet plan -c <config> --export <name>");
 }
 
 /// Write `wave: N` into each export of the YAML config **in place**, preserving
@@ -623,72 +628,6 @@ mod tests {
         let yaml = "exports:\n  - name: orders\n    mode: full\n";
         let out = apply_wave_annotations(yaml, &wave_map(&[("other", 1)]));
         assert_eq!(out, yaml);
-    }
-
-    use super::build_wave_hint;
-    use crate::plan::{
-        CampaignRecommendation, CostClass, ExportRecommendation, PriorityClass, RecommendedWave,
-        RiskClass,
-    };
-
-    fn rec(name: &str, isolate: bool) -> ExportRecommendation {
-        ExportRecommendation {
-            export_name: name.into(),
-            source_group: None,
-            priority_score: 0,
-            priority_class: PriorityClass::Low,
-            cost_class: CostClass::Low,
-            risk_class: RiskClass::Low,
-            recommended_wave: 0,
-            isolate_on_source: isolate,
-            reasons: vec![],
-        }
-    }
-
-    /// The hint renders waves lowest-first, one valid `rivet run --export` per
-    /// export, and tags only the `isolate_on_source` ones.
-    #[test]
-    fn wave_hint_groups_commands_by_wave_with_isolate_note() {
-        let campaign = CampaignRecommendation {
-            ordered_exports: vec![rec("heavy", true), rec("small", false)],
-            // deliberately out of wave order to prove the sort
-            waves: vec![
-                RecommendedWave {
-                    wave: 3,
-                    exports: vec!["heavy".into()],
-                },
-                RecommendedWave {
-                    wave: 1,
-                    exports: vec!["small".into(), "tiny".into()],
-                },
-            ],
-            source_group_warnings: vec![],
-        };
-
-        let hint = build_wave_hint(&campaign, "rivet.yaml").expect("waves present → Some");
-
-        let w1 = hint
-            .find("wave 1:  rivet run -c rivet.yaml --export small")
-            .unwrap();
-        let w1b = hint
-            .find("wave 1:  rivet run -c rivet.yaml --export tiny")
-            .unwrap();
-        let w3 = hint
-            .find("wave 3:  rivet run -c rivet.yaml --export heavy")
-            .unwrap();
-        assert!(w1 < w3 && w1b < w3, "waves must render lowest-first");
-        assert!(hint.contains("--export heavy   # isolate_on_source"));
-        assert!(!hint.contains("--export small   # isolate_on_source"));
-    }
-
-    #[test]
-    fn wave_hint_none_when_no_waves() {
-        let campaign = CampaignRecommendation {
-            ordered_exports: vec![],
-            waves: vec![],
-            source_group_warnings: vec![],
-        };
-        assert!(build_wave_hint(&campaign, "rivet.yaml").is_none());
     }
 
     /// Regression (audit #4): two distinct exports under one `--output FILE`

--- a/src/pipeline/plan_cmd.rs
+++ b/src/pipeline/plan_cmd.rs
@@ -129,7 +129,11 @@ pub fn run_plan_command(
     for a in &artifacts {
         if let Some(p) = a.prioritization.as_ref() {
             let rec = &p.export_recommendation;
-            let parallel_safe = rec.cost_class == crate::plan::CostClass::Low;
+            // ...and not flagged `isolate_on_source` by the campaign (a shared,
+            // contended source group) — the campaign owns the "run alone" call,
+            // so a cheap export there still runs on its own.
+            let parallel_safe =
+                rec.cost_class == crate::plan::CostClass::Low && !rec.isolate_on_source;
             fields.insert(
                 a.export_name.clone(),
                 vec![
@@ -498,14 +502,7 @@ fn print_compact_summary(artifacts: &[PlanArtifact], config_path: &str) {
         config_path
     );
     println!();
-    println!(
-        "  {:<5} {:<width$}  {:<11}  {:<12}  Verdict",
-        "Wave",
-        "Export",
-        "Strategy",
-        "Rows",
-        width = name_w
-    );
+    println!("{}", PlanArtifact::summary_header(name_w));
     for a in &order {
         println!("{}", a.summary_line(name_w));
     }
@@ -513,13 +510,6 @@ fn print_compact_summary(artifacts: &[PlanArtifact], config_path: &str) {
     println!("  Full detail for one export:  rivet plan -c <config> --export <name>");
 }
 
-/// Write `wave: N` into each export of the YAML config **in place**, preserving
-/// comments / structure / field order — a surgical text edit, not a serde
-/// round-trip (which would drop the operator's comments and `init` rationale).
-/// The fresh `wave:` is inserted right after each export's `- name:`; an
-/// existing `wave:` for that export is replaced. Only the standard block-style
-/// `- name: …` layout (what `rivet init` emits) is handled; an export whose
-/// name is not found in the file is left untouched.
 /// Per-export YAML fields that `plan` records in place (`wave`, `parallel_safe`),
 /// keyed by export name → ordered `(field, value)` pairs.
 type ExportFields = HashMap<String, Vec<(&'static str, String)>>;

--- a/src/pipeline/plan_cmd.rs
+++ b/src/pipeline/plan_cmd.rs
@@ -119,6 +119,28 @@ pub fn run_plan_command(
         artifacts.push(artifact);
     }
 
+    // Record the advisory wave on each export in the config (in place), so the
+    // operator sees / edits it and `rivet apply` can run exports wave-by-wave.
+    let waves: HashMap<String, u32> = artifacts
+        .iter()
+        .filter_map(|a| {
+            a.prioritization.as_ref().map(|p| {
+                (
+                    a.export_name.clone(),
+                    p.export_recommendation.recommended_wave,
+                )
+            })
+        })
+        .collect();
+    if !waves.is_empty() {
+        write_waves_to_config(config_path, &waves)?;
+        log::info!(
+            "plan: recorded wave assignments for {} export(s) in {}",
+            waves.len(),
+            config_path
+        );
+    }
+
     emit_artifacts(&artifacts, &format, multi_export, config_path)?;
 
     Ok(())
@@ -479,10 +501,129 @@ fn build_wave_hint(campaign: &CampaignRecommendation, config_path: &str) -> Opti
     Some(out)
 }
 
+/// Write `wave: N` into each export of the YAML config **in place**, preserving
+/// comments / structure / field order — a surgical text edit, not a serde
+/// round-trip (which would drop the operator's comments and `init` rationale).
+/// The fresh `wave:` is inserted right after each export's `- name:`; an
+/// existing `wave:` for that export is replaced. Only the standard block-style
+/// `- name: …` layout (what `rivet init` emits) is handled; an export whose
+/// name is not found in the file is left untouched.
+fn write_waves_to_config(config_path: &str, waves: &HashMap<String, u32>) -> Result<()> {
+    if waves.is_empty() {
+        return Ok(());
+    }
+    let original = std::fs::read_to_string(config_path).map_err(|e| {
+        anyhow::anyhow!(
+            "cannot read config '{}' to record waves: {}",
+            config_path,
+            e
+        )
+    })?;
+    let updated = apply_wave_annotations(&original, waves);
+    if updated != original {
+        std::fs::write(config_path, updated).map_err(|e| {
+            anyhow::anyhow!("cannot write waves to config '{}': {}", config_path, e)
+        })?;
+    }
+    Ok(())
+}
+
+/// Pure core of [`write_waves_to_config`] (text in → text out, unit-tested).
+fn apply_wave_annotations(yaml: &str, waves: &HashMap<String, u32>) -> String {
+    let mut out = String::with_capacity(yaml.len() + 32);
+    // (export name, indent of the `-`, indent of the export's fields) while
+    // inside an export block; `None` between / outside exports.
+    let mut current: Option<(String, usize, usize)> = None;
+
+    for line in yaml.split_inclusive('\n') {
+        let content = line.strip_suffix('\n').unwrap_or(line);
+
+        if let Some((dash_indent, name)) = parse_export_name(content) {
+            out.push_str(line);
+            let field_indent = dash_indent + 2;
+            if let Some(&wave) = waves.get(&name) {
+                out.push_str(&" ".repeat(field_indent));
+                out.push_str(&format!("wave: {wave}\n"));
+            }
+            current = Some((name, dash_indent, field_indent));
+            continue;
+        }
+
+        if let Some((name, dash_indent, field_indent)) = current.as_ref() {
+            let trimmed = content.trim_start();
+            let indent = content.len() - trimmed.len();
+            let blank_or_comment = trimmed.is_empty() || trimmed.starts_with('#');
+            if !blank_or_comment && indent <= *dash_indent {
+                current = None; // dedented out of the export block
+            } else if indent == *field_indent
+                && trimmed.starts_with("wave:")
+                && waves.contains_key(name)
+            {
+                continue; // drop the stale wave line — the fresh one is already in
+            }
+        }
+        out.push_str(line);
+    }
+    out
+}
+
+/// Parse a `<indent>- name: <name>` export list item → `(indent_of_dash, name)`.
+/// Handles quoted names; `None` for any other line.
+fn parse_export_name(line: &str) -> Option<(usize, String)> {
+    let trimmed = line.trim_start();
+    let dash_indent = line.len() - trimmed.len();
+    let rest = trimmed.strip_prefix("- ")?;
+    let value = rest.trim_start().strip_prefix("name:")?;
+    // Drop an inline ` # …` comment (a YAML comment is a space then a hash).
+    let value = value.split(" #").next().unwrap_or(value);
+    let name = value
+        .trim()
+        .trim_matches(|c: char| c == '"' || c == '\'')
+        .to_string();
+    (!name.is_empty()).then_some((dash_indent, name))
+}
+
 #[cfg(test)]
 mod tests {
     use super::per_export_output_path;
     use std::path::Path;
+
+    use super::apply_wave_annotations;
+    use std::collections::HashMap;
+
+    fn wave_map(pairs: &[(&str, u32)]) -> HashMap<String, u32> {
+        pairs.iter().map(|(n, w)| (n.to_string(), *w)).collect()
+    }
+
+    /// Inserts `wave:` right after each `- name:`, replaces a stale one, and
+    /// leaves comments / other fields / unlisted exports untouched.
+    #[test]
+    fn wave_annotations_insert_replace_and_preserve() {
+        let yaml = "exports:\n  - name: orders   # the orders table\n    mode: incremental\n    wave: 9\n    cursor_column: updated_at\n  - name: events\n    mode: full\ndestination:\n  type: local\n";
+        let out = apply_wave_annotations(yaml, &wave_map(&[("orders", 2), ("events", 1)]));
+        // orders: stale wave 9 replaced with 2, placed after name (comment kept)
+        assert!(
+            out.contains("- name: orders   # the orders table\n    wave: 2\n"),
+            "{out}"
+        );
+        assert!(
+            !out.contains("wave: 9"),
+            "stale wave must be dropped:\n{out}"
+        );
+        // events: fresh wave 1 inserted right after name
+        assert!(out.contains("- name: events\n    wave: 1\n"), "{out}");
+        // untouched: the cursor field and the trailing top-level key
+        assert!(out.contains("cursor_column: updated_at"));
+        assert!(out.contains("destination:\n  type: local"));
+    }
+
+    /// An export whose name isn't in the map is left byte-identical.
+    #[test]
+    fn wave_annotations_leave_unlisted_export_untouched() {
+        let yaml = "exports:\n  - name: orders\n    mode: full\n";
+        let out = apply_wave_annotations(yaml, &wave_map(&[("other", 1)]));
+        assert_eq!(out, yaml);
+    }
 
     use super::build_wave_hint;
     use crate::plan::{

--- a/src/pipeline/plan_cmd.rs
+++ b/src/pipeline/plan_cmd.rs
@@ -119,24 +119,31 @@ pub fn run_plan_command(
         artifacts.push(artifact);
     }
 
-    // Record the advisory wave on each export in the config (in place), so the
-    // operator sees / edits it and `rivet apply` can run exports wave-by-wave.
-    let waves: HashMap<String, u32> = artifacts
-        .iter()
-        .filter_map(|a| {
-            a.prioritization.as_ref().map(|p| {
-                (
-                    a.export_name.clone(),
-                    p.export_recommendation.recommended_wave,
-                )
-            })
-        })
-        .collect();
-    if !waves.is_empty() {
-        write_waves_to_config(config_path, &waves)?;
+    // Record the advisory wave + parallel-safety on each export in the config
+    // (in place), so the operator sees / edits them and `rivet apply` can run
+    // exports wave-by-wave, parallelizing only the cheap (low-cost) ones.
+    // `parallel_safe = cost_class Low` (< 100K rows): a heavy table already
+    // chunk-parallelizes internally, so two of them at once would overload the
+    // source — only the small / cheap exports share a concurrent wave batch.
+    let mut fields: ExportFields = HashMap::new();
+    for a in &artifacts {
+        if let Some(p) = a.prioritization.as_ref() {
+            let rec = &p.export_recommendation;
+            let parallel_safe = rec.cost_class == crate::plan::CostClass::Low;
+            fields.insert(
+                a.export_name.clone(),
+                vec![
+                    ("wave", rec.recommended_wave.to_string()),
+                    ("parallel_safe", parallel_safe.to_string()),
+                ],
+            );
+        }
+    }
+    if !fields.is_empty() {
+        write_plan_fields_to_config(config_path, &fields)?;
         log::info!(
-            "plan: recorded wave assignments for {} export(s) in {}",
-            waves.len(),
+            "plan: recorded wave + parallel-safety for {} export(s) in {}",
+            fields.len(),
             config_path
         );
     }
@@ -513,29 +520,39 @@ fn print_compact_summary(artifacts: &[PlanArtifact], config_path: &str) {
 /// existing `wave:` for that export is replaced. Only the standard block-style
 /// `- name: …` layout (what `rivet init` emits) is handled; an export whose
 /// name is not found in the file is left untouched.
-fn write_waves_to_config(config_path: &str, waves: &HashMap<String, u32>) -> Result<()> {
-    if waves.is_empty() {
+/// Per-export YAML fields that `plan` records in place (`wave`, `parallel_safe`),
+/// keyed by export name → ordered `(field, value)` pairs.
+type ExportFields = HashMap<String, Vec<(&'static str, String)>>;
+
+fn write_plan_fields_to_config(config_path: &str, fields: &ExportFields) -> Result<()> {
+    if fields.is_empty() {
         return Ok(());
     }
     let original = std::fs::read_to_string(config_path).map_err(|e| {
         anyhow::anyhow!(
-            "cannot read config '{}' to record waves: {}",
+            "cannot read config '{}' to record plan fields: {}",
             config_path,
             e
         )
     })?;
-    let updated = apply_wave_annotations(&original, waves);
+    let updated = apply_field_annotations(&original, fields);
     if updated != original {
         std::fs::write(config_path, updated).map_err(|e| {
-            anyhow::anyhow!("cannot write waves to config '{}': {}", config_path, e)
+            anyhow::anyhow!(
+                "cannot write plan fields to config '{}': {}",
+                config_path,
+                e
+            )
         })?;
     }
     Ok(())
 }
 
-/// Pure core of [`write_waves_to_config`] (text in → text out, unit-tested).
-fn apply_wave_annotations(yaml: &str, waves: &HashMap<String, u32>) -> String {
-    let mut out = String::with_capacity(yaml.len() + 32);
+/// Pure core of [`write_plan_fields_to_config`] (text in → text out, unit-tested).
+/// For each named export, inserts its `<field>: <value>` lines right after
+/// `- name:` and drops any stale line for those same fields.
+fn apply_field_annotations(yaml: &str, fields: &ExportFields) -> String {
+    let mut out = String::with_capacity(yaml.len() + 64);
     // (export name, indent of the `-`, indent of the export's fields) while
     // inside an export block; `None` between / outside exports.
     let mut current: Option<(String, usize, usize)> = None;
@@ -546,9 +563,11 @@ fn apply_wave_annotations(yaml: &str, waves: &HashMap<String, u32>) -> String {
         if let Some((dash_indent, name)) = parse_export_name(content) {
             out.push_str(line);
             let field_indent = dash_indent + 2;
-            if let Some(&wave) = waves.get(&name) {
-                out.push_str(&" ".repeat(field_indent));
-                out.push_str(&format!("wave: {wave}\n"));
+            if let Some(items) = fields.get(&name) {
+                for (key, value) in items {
+                    out.push_str(&" ".repeat(field_indent));
+                    out.push_str(&format!("{key}: {value}\n"));
+                }
             }
             current = Some((name, dash_indent, field_indent));
             continue;
@@ -561,10 +580,12 @@ fn apply_wave_annotations(yaml: &str, waves: &HashMap<String, u32>) -> String {
             if !blank_or_comment && indent <= *dash_indent {
                 current = None; // dedented out of the export block
             } else if indent == *field_indent
-                && trimmed.starts_with("wave:")
-                && waves.contains_key(name)
+                && let Some(items) = fields.get(name)
+                && items
+                    .iter()
+                    .any(|(key, _)| trimmed.starts_with(&format!("{key}:")))
             {
-                continue; // drop the stale wave line — the fresh one is already in
+                continue; // drop the stale field line — the fresh one is already in
             }
         }
         out.push_str(line);
@@ -593,11 +614,13 @@ mod tests {
     use super::per_export_output_path;
     use std::path::Path;
 
-    use super::apply_wave_annotations;
-    use std::collections::HashMap;
+    use super::{ExportFields, apply_field_annotations};
 
-    fn wave_map(pairs: &[(&str, u32)]) -> HashMap<String, u32> {
-        pairs.iter().map(|(n, w)| (n.to_string(), *w)).collect()
+    fn wave_fields(pairs: &[(&str, u32)]) -> ExportFields {
+        pairs
+            .iter()
+            .map(|(n, w)| (n.to_string(), vec![("wave", w.to_string())]))
+            .collect()
     }
 
     /// Inserts `wave:` right after each `- name:`, replaces a stale one, and
@@ -605,7 +628,7 @@ mod tests {
     #[test]
     fn wave_annotations_insert_replace_and_preserve() {
         let yaml = "exports:\n  - name: orders   # the orders table\n    mode: incremental\n    wave: 9\n    cursor_column: updated_at\n  - name: events\n    mode: full\ndestination:\n  type: local\n";
-        let out = apply_wave_annotations(yaml, &wave_map(&[("orders", 2), ("events", 1)]));
+        let out = apply_field_annotations(yaml, &wave_fields(&[("orders", 2), ("events", 1)]));
         // orders: stale wave 9 replaced with 2, placed after name (comment kept)
         assert!(
             out.contains("- name: orders   # the orders table\n    wave: 2\n"),
@@ -626,7 +649,7 @@ mod tests {
     #[test]
     fn wave_annotations_leave_unlisted_export_untouched() {
         let yaml = "exports:\n  - name: orders\n    mode: full\n";
-        let out = apply_wave_annotations(yaml, &wave_map(&[("other", 1)]));
+        let out = apply_field_annotations(yaml, &wave_fields(&[("other", 1)]));
         assert_eq!(out, yaml);
     }
 

--- a/src/pipeline/progress.rs
+++ b/src/pipeline/progress.rs
@@ -152,6 +152,18 @@ impl ChunkProgressHandle {
     /// hidden mode) and emits a `Progress` event when a unified UI is
     /// active (parallel-export-processes child or `--parallel-exports`).
     pub(crate) fn inc(&self, total_rows_so_far: i64) {
+        // Advance the chunk count, then refresh rows/rate at the new position.
+        self.bar.inc(1);
+        self.inner.chunks_done.fetch_add(1, Ordering::Relaxed);
+        self.set_rows(total_rows_so_far);
+    }
+
+    /// Update the running row count / rate WITHOUT advancing the chunk count.
+    /// Called per source batch so the bar ticks *during* a chunk's read — a wide
+    /// first chunk (e.g. 250k rows / 90 MB) would otherwise sit frozen at
+    /// "0 rows" for seconds, reading as idle. Emits a `Progress` event at the
+    /// current `chunks_done` so a unified UI updates too.
+    pub(crate) fn set_rows(&self, total_rows_so_far: i64) {
         let elapsed = self.inner.started_at.elapsed().as_secs_f64();
         let msg = if elapsed >= 0.5 && total_rows_so_far > 0 {
             let rps = total_rows_so_far as f64 / elapsed;
@@ -160,12 +172,10 @@ impl ChunkProgressHandle {
             fmt_rows(total_rows_so_far)
         };
         self.bar.set_message(msg);
-        self.bar.inc(1);
-        let chunks_done = self.inner.chunks_done.fetch_add(1, Ordering::Relaxed) + 1;
         if self.inner.capturing {
             ipc::emit_event(&ChildEvent::Progress {
                 export_name: self.inner.export_name.clone(),
-                chunks_done,
+                chunks_done: self.inner.chunks_done.load(Ordering::Relaxed),
                 rows: total_rows_so_far,
             });
         }
@@ -211,6 +221,20 @@ mod tests {
         h.inc(100);
         h.inc(250);
         assert_eq!(pb.inner.chunks_done.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn set_rows_updates_rows_without_advancing_the_chunk_counter() {
+        // Per-batch row updates must NOT bump the chunk count — only `inc`
+        // (per-chunk completion) does. Otherwise a wide chunk's many batches
+        // would each look like a finished chunk.
+        let pb = ChunkProgress::new("orders", 10);
+        let h = pb.handle();
+        h.set_rows(500);
+        h.set_rows(1_200);
+        assert_eq!(pb.inner.chunks_done.load(Ordering::Relaxed), 0);
+        h.inc(1_500); // a real chunk completion still advances it
+        assert_eq!(pb.inner.chunks_done.load(Ordering::Relaxed), 1);
     }
 
     #[test]

--- a/src/pipeline/run.rs
+++ b/src/pipeline/run.rs
@@ -92,7 +92,9 @@ fn emit_child_stderr(dump: &str, dir: &Path) {
     );
     let path = dir.join(name);
     match std::fs::write(&path, dump) {
-        Ok(()) => println!(
+        // stderr, not stdout — stdout may carry the machine-readable `--json`
+        // run summary, which this pointer would otherwise corrupt.
+        Ok(()) => eprintln!(
             "\n  child stderr (full per-export logs) → {}",
             path.display()
         ),

--- a/src/pipeline/run.rs
+++ b/src/pipeline/run.rs
@@ -532,27 +532,43 @@ pub(crate) fn run_waves(config_path: &str, force: bool) -> Result<()> {
         // the wave (the sequential loop, or the blocking child-process join)
         // before the next iteration starts the next wave.
         if parallel {
+            // Keyset safety-gate: within the wave, exports that paginate by a
+            // keyset chunk column run together in ONE concurrent batch; every
+            // other export (full scan / incremental / time-window / CDC) runs
+            // ALONE in its own single-child batch so it never stacks source
+            // pressure against a wave-mate. The per-child governor still bounds
+            // each one; this gate also bounds the concurrent connection count.
+            let (keyset, lone): (Vec<&ExportConfig>, Vec<&ExportConfig>) =
+                exports.iter().copied().partition(|e| is_parallel_safe(e));
             log::info!(
-                "apply: wave {} — {} export(s), parallel (subprocess)",
+                "apply: wave {} — {} keyset export(s) in parallel, {} run alone",
                 label,
-                exports.len()
+                keyset.len(),
+                lone.len()
             );
-            let slice: Vec<&ExportConfig> = exports.to_vec();
-            let (result, cf, stderr_dump) = parallel_children::run_exports_as_child_processes(
-                config_path,
-                &slice,
-                false,
-                false,
-                false,
-                force,
-                None,
-            );
-            child_failures.extend(cf);
-            combined_stderr.push_str(&stderr_dump);
-            all_exports.extend(slice);
-            if let Err(e) = result {
-                failures.push(e);
+            // One single-child batch per lone export (run sequentially), then
+            // one concurrent batch for all keyset exports.
+            let mut batches: Vec<Vec<&ExportConfig>> = lone.iter().map(|e| vec![*e]).collect();
+            if !keyset.is_empty() {
+                batches.push(keyset);
             }
+            for batch in &batches {
+                let (result, cf, stderr_dump) = parallel_children::run_exports_as_child_processes(
+                    config_path,
+                    batch,
+                    false,
+                    false,
+                    false,
+                    force,
+                    None,
+                );
+                child_failures.extend(cf);
+                combined_stderr.push_str(&stderr_dump);
+                if let Err(e) = result {
+                    failures.push(e);
+                }
+            }
+            all_exports.extend_from_slice(exports);
         } else {
             log::info!(
                 "apply: wave {} — {} export(s), sequential",
@@ -637,9 +653,18 @@ fn group_exports_by_wave(exports: &[ExportConfig]) -> Vec<(u32, Vec<&ExportConfi
     by_wave.into_iter().collect()
 }
 
+/// Config-derivable predicate: an export is safe to run concurrently with its
+/// wave-mates when it paginates the source by a keyset chunk column (bounded,
+/// index-backed scans). Full / incremental / time-window / CDC exports scan or
+/// stream the table, so they run ALONE within the wave to avoid stacking source
+/// pressure. Conservative on purpose — widen only with evidence.
+fn is_parallel_safe(export: &ExportConfig) -> bool {
+    export.mode == crate::config::ExportMode::Chunked && export.chunk_column.is_some()
+}
+
 #[cfg(test)]
 mod wave_grouping_tests {
-    use super::group_exports_by_wave;
+    use super::{group_exports_by_wave, is_parallel_safe};
 
     #[test]
     fn groups_ascending_with_unscheduled_last() {
@@ -663,6 +688,30 @@ mod wave_grouping_tests {
         assert_eq!(
             grouped[2].1[0].name, "b",
             "the no-wave export lands in the last group"
+        );
+    }
+
+    #[test]
+    fn parallel_safe_only_for_keyset_chunked() {
+        // default sample_export is mode=Full, chunk_column=None
+        let full = crate::config::sample_export("full");
+        assert!(!is_parallel_safe(&full), "full scan is not parallel-safe");
+
+        let mut chunked = crate::config::sample_export("chunked");
+        chunked.mode = crate::config::ExportMode::Chunked;
+        chunked.chunk_column = Some("id".into());
+        assert!(
+            is_parallel_safe(&chunked),
+            "keyset chunked is parallel-safe"
+        );
+
+        // chunked but no chunk_column → not keyset → not safe
+        let mut chunked_no_col = crate::config::sample_export("nocol");
+        chunked_no_col.mode = crate::config::ExportMode::Chunked;
+        chunked_no_col.chunk_column = None;
+        assert!(
+            !is_parallel_safe(&chunked_no_col),
+            "chunked without a chunk column is not keyset"
         );
     }
 }

--- a/src/pipeline/run.rs
+++ b/src/pipeline/run.rs
@@ -178,6 +178,13 @@ pub fn run(
         params,
     };
 
+    // Seeds the card-table name column so it aligns from the first redraw
+    // (the renderer can't see a long name until its export emits `Started`).
+    let name_floor = exports
+        .iter()
+        .map(|e| e.name.chars().count())
+        .max()
+        .unwrap_or(0);
     let process_mode_requested = parallel_export_processes_cli || config.parallel_export_processes;
     // Process-mode children re-exec `rivet run --export <name>` and re-load the
     // config from disk, so they cannot see the synthesised partition child
@@ -305,7 +312,7 @@ pub fn run(
         ipc::install_in_process_tx(tx);
         let ui_thread = std::thread::Builder::new()
             .name("rivet-ui".to_string())
-            .spawn(move || parent_ui::run_ui(rx))
+            .spawn(move || parent_ui::run_ui(rx, name_floor))
             .ok();
 
         let collected: std::sync::Mutex<Vec<(Result<()>, RunSummary)>> =
@@ -364,7 +371,7 @@ pub fn run(
         ipc::install_in_process_tx(tx);
         let ui_thread = std::thread::Builder::new()
             .name("rivet-ui".to_string())
-            .spawn(move || parent_ui::run_ui(rx))
+            .spawn(move || parent_ui::run_ui(rx, name_floor))
             .ok();
 
         for export in &exports {

--- a/src/pipeline/run.rs
+++ b/src/pipeline/run.rs
@@ -78,6 +78,37 @@ fn print_json_summary(agg: &crate::state::RunAggregate) {
     }
 }
 
+/// Emit captured child stderr from a parallel run. It's verbose — every child's
+/// full run card — so write it to a timestamped log beside the config and print
+/// a one-line pointer, instead of flooding the console with all N exports'
+/// stderr. Falls back to the inline console dump if the file can't be written.
+fn emit_child_stderr(dump: &str, dir: &Path) {
+    if dump.is_empty() {
+        return;
+    }
+    let name = format!(
+        "rivet-child-stderr-{}.log",
+        chrono::Utc::now().format("%Y%m%dT%H%M%S")
+    );
+    let path = dir.join(name);
+    match std::fs::write(&path, dump) {
+        Ok(()) => println!(
+            "\n  child stderr (full per-export logs) → {}",
+            path.display()
+        ),
+        Err(e) => {
+            log::warn!(
+                "could not write child stderr to {} ({e}); printing inline",
+                path.display()
+            );
+            use std::io::Write;
+            let mut h = std::io::stderr().lock();
+            let _ = h.write_all(dump.as_bytes());
+            let _ = h.flush();
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)] // CLI fan-in; surface stays stable per ADR-0013
 pub fn run(
     config_path: &str,
@@ -214,15 +245,10 @@ pub fn run(
                 e
             ),
         }
-        // Captured child stderr is printed AFTER the aggregate so the run
-        // summary stays immediately under the card stack — verbose log
-        // output sits below for triage when needed.
-        if !stderr_dump.is_empty() {
-            use std::io::Write;
-            let mut h = std::io::stderr().lock();
-            let _ = h.write_all(stderr_dump.as_bytes());
-            let _ = h.flush();
-        }
+        // Captured child stderr (verbose per-export cards) goes to a file
+        // artifact beside the config, with a one-line console pointer — the run
+        // summary stays clean instead of flooding with every child's stderr.
+        emit_child_stderr(&stderr_dump, &config_dir);
         return result;
     }
 
@@ -640,14 +666,9 @@ pub(crate) fn run_waves(
         aggregate::print(&agg);
         aggregate::persist(&state, &agg, None);
     }
-    // Captured child stderr prints AFTER the aggregate (parallel path only) so
-    // the run summary stays under the card stack, logs below — matching `run`.
-    if !combined_stderr.is_empty() {
-        use std::io::Write;
-        let mut h = std::io::stderr().lock();
-        let _ = h.write_all(combined_stderr.as_bytes());
-        let _ = h.flush();
-    }
+    // Captured child stderr (verbose per-export cards, parallel path only) goes
+    // to a file artifact beside the config, with a one-line console pointer.
+    emit_child_stderr(&combined_stderr, &config_dir);
 
     if !failures.is_empty() {
         let primary_idx = representative_failure_idx(&failures).unwrap();

--- a/src/pipeline/run.rs
+++ b/src/pipeline/run.rs
@@ -492,8 +492,17 @@ pub(crate) fn run_waves(config_path: &str, force: bool) -> Result<()> {
         return Ok(());
     }
 
-    // Compact per-export rendering when more than one export runs.
-    let prev_multi = MULTI_EXPORT_MODE.swap(total > 1, AtomicOrdering::Relaxed);
+    // `parallel_export_processes: true` opts into within-wave parallelism: each
+    // wave's exports run as concurrent child processes (per-child governor keeps
+    // each one source-safe), the call blocks until all exit = the wave barrier.
+    // Default stays sequential.
+    let parallel = config.parallel_export_processes;
+
+    // Compact per-export rendering for the SEQUENTIAL path only. The parallel
+    // (subprocess) path renders the parent card stack itself and each child sees
+    // `exports.len() == 1`, so the flag must stay clear there — matching `run`'s
+    // parallel-processes branch.
+    let prev_multi = MULTI_EXPORT_MODE.swap(total > 1 && !parallel, AtomicOrdering::Relaxed);
     struct ResetMulti(bool);
     impl Drop for ResetMulti {
         fn drop(&mut self) {
@@ -506,6 +515,12 @@ pub(crate) fn run_waves(config_path: &str, force: bool) -> Result<()> {
     let started_at = chrono::Utc::now();
     let mut summaries: Vec<RunSummary> = Vec::with_capacity(total);
     let mut failures: Vec<anyhow::Error> = Vec::new();
+    // Parallel-path accumulators: per-child metrics live in the state DB, so the
+    // parent reconstructs one aggregate from them after every wave has joined.
+    let mut all_exports: Vec<&ExportConfig> = Vec::with_capacity(total);
+    let mut child_failures: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+    let mut combined_stderr = String::new();
 
     for (wave, exports) in &by_wave {
         let label = if *wave == u32::MAX {
@@ -513,41 +528,79 @@ pub(crate) fn run_waves(config_path: &str, force: bool) -> Result<()> {
         } else {
             wave.to_string()
         };
-        log::info!(
-            "apply: wave {} — {} export(s), sequential",
-            label,
-            exports.len()
-        );
-        // The wave barrier is implicit while sequential: this loop body fully
-        // drains the wave before the next iteration. It becomes load-bearing
-        // once within-wave parallelism lands.
-        for export in exports {
-            let (res, summary) =
-                job::run_export_job(config_path, &config, export, &state, &config_dir, &opts);
-            if let Err(e) = res {
+        // The wave barrier is the loop itself: each strategy below fully drains
+        // the wave (the sequential loop, or the blocking child-process join)
+        // before the next iteration starts the next wave.
+        if parallel {
+            log::info!(
+                "apply: wave {} — {} export(s), parallel (subprocess)",
+                label,
+                exports.len()
+            );
+            let slice: Vec<&ExportConfig> = exports.to_vec();
+            let (result, cf, stderr_dump) = parallel_children::run_exports_as_child_processes(
+                config_path,
+                &slice,
+                false,
+                false,
+                false,
+                force,
+                None,
+            );
+            child_failures.extend(cf);
+            combined_stderr.push_str(&stderr_dump);
+            all_exports.extend(slice);
+            if let Err(e) = result {
                 failures.push(e);
             }
-            summaries.push(summary);
+        } else {
+            log::info!(
+                "apply: wave {} — {} export(s), sequential",
+                label,
+                exports.len()
+            );
+            for export in exports {
+                let (res, summary) =
+                    job::run_export_job(config_path, &config, export, &state, &config_dir, &opts);
+                if let Err(e) = res {
+                    failures.push(e);
+                }
+                summaries.push(summary);
+            }
         }
     }
 
     let finished_at = chrono::Utc::now();
     if total > 1 {
-        let entries: Vec<_> = summaries
-            .iter()
-            .map(aggregate::entry_from_summary)
-            .collect();
+        let entries = if parallel {
+            aggregate::collect_child_entries(&state, &all_exports, started_at, &child_failures)
+        } else {
+            summaries
+                .iter()
+                .map(aggregate::entry_from_summary)
+                .collect()
+        };
         let agg = aggregate::build(
             entries,
             started_at,
             finished_at,
             Some(config_path),
-            "wave-sequential",
+            if parallel {
+                "wave-parallel-processes"
+            } else {
+                "wave-sequential"
+            },
         );
         aggregate::print(&agg);
-        if let Ok(state) = StateStore::open(config_path) {
-            aggregate::persist(&state, &agg, None);
-        }
+        aggregate::persist(&state, &agg, None);
+    }
+    // Captured child stderr prints AFTER the aggregate (parallel path only) so
+    // the run summary stays under the card stack, logs below — matching `run`.
+    if !combined_stderr.is_empty() {
+        use std::io::Write;
+        let mut h = std::io::stderr().lock();
+        let _ = h.write_all(combined_stderr.as_bytes());
+        let _ = h.flush();
     }
 
     if !failures.is_empty() {

--- a/src/pipeline/run.rs
+++ b/src/pipeline/run.rs
@@ -462,6 +462,158 @@ pub fn run(
     Ok(())
 }
 
+/// `rivet apply -c config.yaml` (plan→apply cycle): run every export of the
+/// config **wave by wave** in ascending `wave:` order — exports with no `wave:`
+/// run last — reusing the same per-export job + run aggregate as [`run`]. This
+/// first cut runs each wave's exports SEQUENTIALLY (deterministic); safety-aware
+/// within-wave parallelism is a follow-up, and `partition_by` exports are not
+/// expanded here yet (use `rivet run` for those).
+pub(crate) fn run_waves(config_path: &str, force: bool) -> Result<()> {
+    let config = Config::load_with_params(config_path, None)?;
+    let config_dir = Path::new(config_path)
+        .parent()
+        .unwrap_or(Path::new("."))
+        .to_path_buf();
+    let opts = RunOptions {
+        validate: false,
+        reconcile: false,
+        resume: false,
+        force,
+        params: None,
+    };
+
+    // Group exports by wave (ascending; an export with no `wave:` runs last).
+    // The ordering is the contract apply depends on, so it lives in a pure
+    // tested helper rather than hiding inline here.
+    let by_wave = group_exports_by_wave(&config.exports);
+    let total: usize = by_wave.iter().map(|(_, v)| v.len()).sum();
+    if total == 0 {
+        log::warn!("apply: config '{config_path}' defines no exports");
+        return Ok(());
+    }
+
+    // Compact per-export rendering when more than one export runs.
+    let prev_multi = MULTI_EXPORT_MODE.swap(total > 1, AtomicOrdering::Relaxed);
+    struct ResetMulti(bool);
+    impl Drop for ResetMulti {
+        fn drop(&mut self) {
+            MULTI_EXPORT_MODE.store(self.0, AtomicOrdering::Relaxed);
+        }
+    }
+    let _reset = ResetMulti(prev_multi);
+
+    let state = StateStore::open(config_path)?;
+    let started_at = chrono::Utc::now();
+    let mut summaries: Vec<RunSummary> = Vec::with_capacity(total);
+    let mut failures: Vec<anyhow::Error> = Vec::new();
+
+    for (wave, exports) in &by_wave {
+        let label = if *wave == u32::MAX {
+            "unscheduled".to_string()
+        } else {
+            wave.to_string()
+        };
+        log::info!(
+            "apply: wave {} — {} export(s), sequential",
+            label,
+            exports.len()
+        );
+        // The wave barrier is implicit while sequential: this loop body fully
+        // drains the wave before the next iteration. It becomes load-bearing
+        // once within-wave parallelism lands.
+        for export in exports {
+            let (res, summary) =
+                job::run_export_job(config_path, &config, export, &state, &config_dir, &opts);
+            if let Err(e) = res {
+                failures.push(e);
+            }
+            summaries.push(summary);
+        }
+    }
+
+    let finished_at = chrono::Utc::now();
+    if total > 1 {
+        let entries: Vec<_> = summaries
+            .iter()
+            .map(aggregate::entry_from_summary)
+            .collect();
+        let agg = aggregate::build(
+            entries,
+            started_at,
+            finished_at,
+            Some(config_path),
+            "wave-sequential",
+        );
+        aggregate::print(&agg);
+        if let Ok(state) = StateStore::open(config_path) {
+            aggregate::persist(&state, &agg, None);
+        }
+    }
+
+    if !failures.is_empty() {
+        let primary_idx = representative_failure_idx(&failures).unwrap();
+        let primary = failures.remove(primary_idx);
+        if failures.is_empty() {
+            return Err(primary);
+        }
+        let others = failures
+            .iter()
+            .map(|e| format!("{e:#}"))
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(primary.context(format!(
+            "{} export(s) failed across waves; representative error follows (also: {others})",
+            failures.len() + 1
+        )));
+    }
+    Ok(())
+}
+
+/// Group exports by `wave:` in ascending order; an export with no `wave:` runs
+/// last (sorted as `u32::MAX`). Pure + unit-tested — the ordering is the
+/// contract `apply` depends on, so it does not hide inside [`run_waves`].
+fn group_exports_by_wave(exports: &[ExportConfig]) -> Vec<(u32, Vec<&ExportConfig>)> {
+    let mut by_wave: std::collections::BTreeMap<u32, Vec<&ExportConfig>> =
+        std::collections::BTreeMap::new();
+    for e in exports {
+        by_wave
+            .entry(e.wave.unwrap_or(u32::MAX))
+            .or_default()
+            .push(e);
+    }
+    by_wave.into_iter().collect()
+}
+
+#[cfg(test)]
+mod wave_grouping_tests {
+    use super::group_exports_by_wave;
+
+    #[test]
+    fn groups_ascending_with_unscheduled_last() {
+        let mut a = crate::config::sample_export("a");
+        a.wave = Some(3);
+        let mut b = crate::config::sample_export("b");
+        b.wave = None; // unscheduled → must sort last
+        let mut c = crate::config::sample_export("c");
+        c.wave = Some(1);
+        let mut d = crate::config::sample_export("d");
+        d.wave = Some(1); // shares wave 1 with c, preserves input order
+
+        let exports = vec![a, b, c, d];
+        let grouped = group_exports_by_wave(&exports);
+
+        let waves: Vec<u32> = grouped.iter().map(|(w, _)| *w).collect();
+        assert_eq!(waves, vec![1, 3, u32::MAX], "ascending, unscheduled last");
+        let wave1: Vec<&str> = grouped[0].1.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(wave1, vec!["c", "d"], "same-wave keeps input order");
+        assert_eq!(grouped[2].1.len(), 1);
+        assert_eq!(
+            grouped[2].1[0].name, "b",
+            "the no-wave export lands in the last group"
+        );
+    }
+}
+
 /// Index of the most "stop-worthy" failure in a batch: data-integrity (exit 3)
 /// outranks schema-drift (4), which outranks retryable (2), which outranks
 /// generic (1). The chosen error's typed marker then rides up so `classify_exit`

--- a/src/pipeline/run.rs
+++ b/src/pipeline/run.rs
@@ -17,7 +17,7 @@ use crate::error::Result;
 use crate::state::StateStore;
 
 use super::summary::RunSummary;
-use super::{aggregate, ipc, job, parallel_children, parent_ui, partition_expand};
+use super::{aggregate, finalize, ipc, job, parallel_children, parent_ui, partition_expand};
 
 /// Per-run configuration flags passed from the CLI to the pipeline.
 ///
@@ -468,7 +468,12 @@ pub fn run(
 /// first cut runs each wave's exports SEQUENTIALLY (deterministic); safety-aware
 /// within-wave parallelism is a follow-up, and `partition_by` exports are not
 /// expanded here yet (use `rivet run` for those).
-pub(crate) fn run_waves(config_path: &str, force: bool, parallel_cli: bool) -> Result<()> {
+pub(crate) fn run_waves(
+    config_path: &str,
+    force: bool,
+    parallel_cli: bool,
+    resume: bool,
+) -> Result<()> {
     let config = Config::load_with_params(config_path, None)?;
     let config_dir = Path::new(config_path)
         .parent()
@@ -477,7 +482,7 @@ pub(crate) fn run_waves(config_path: &str, force: bool, parallel_cli: bool) -> R
     let opts = RunOptions {
         validate: false,
         reconcile: false,
-        resume: false,
+        resume,
         force,
         params: None,
     };
@@ -528,8 +533,30 @@ pub(crate) fn run_waves(config_path: &str, force: bool, parallel_cli: bool) -> R
         } else {
             wave.to_string()
         };
+        // Skip-completed under --resume: an export whose destination already has
+        // `_SUCCESS` is done — re-running must not redo it (and would hit the
+        // resume gate). The rest run with `resume`, so an incomplete chunked
+        // export continues from its checkpoint. Reuses `finalize`'s prior-run
+        // probe rather than re-implementing the marker check.
+        let pending: Vec<&ExportConfig> = exports
+            .iter()
+            .copied()
+            .filter(|e| {
+                let done = resume && finalize::destination_has_success(&e.destination);
+                if done {
+                    log::info!(
+                        "apply: skipping '{}' — destination already complete (_SUCCESS)",
+                        e.name
+                    );
+                }
+                !done
+            })
+            .collect();
+        if pending.is_empty() {
+            continue;
+        }
         if total > 1 {
-            println!("\n  ── wave {label} · {} export(s) ──", exports.len());
+            println!("\n  ── wave {label} · {} export(s) ──", pending.len());
         }
         // The wave barrier is the loop itself: each strategy below fully drains
         // the wave (the sequential loop, or the blocking child-process join)
@@ -542,7 +569,7 @@ pub(crate) fn run_waves(config_path: &str, force: bool, parallel_cli: bool) -> R
             // source. The per-child governor still bounds each one; this gate also
             // bounds the concurrent connection count.
             let (safe, lone): (Vec<&ExportConfig>, Vec<&ExportConfig>) =
-                exports.iter().copied().partition(|e| is_parallel_safe(e));
+                pending.iter().copied().partition(|e| is_parallel_safe(e));
             log::info!(
                 "apply: wave {} — {} parallel-safe export(s) in parallel, {} run alone",
                 label,
@@ -561,7 +588,7 @@ pub(crate) fn run_waves(config_path: &str, force: bool, parallel_cli: bool) -> R
                     batch,
                     false,
                     false,
-                    false,
+                    resume,
                     force,
                     None,
                 );
@@ -571,14 +598,14 @@ pub(crate) fn run_waves(config_path: &str, force: bool, parallel_cli: bool) -> R
                     failures.push(e);
                 }
             }
-            all_exports.extend_from_slice(exports);
+            all_exports.extend_from_slice(&pending);
         } else {
             log::info!(
                 "apply: wave {} — {} export(s), sequential",
                 label,
-                exports.len()
+                pending.len()
             );
-            for export in exports {
+            for export in &pending {
                 let (res, summary) =
                     job::run_export_job(config_path, &config, export, &state, &config_dir, &opts);
                 if let Err(e) = res {

--- a/src/pipeline/run.rs
+++ b/src/pipeline/run.rs
@@ -225,6 +225,7 @@ pub fn run(
                 resume,
                 force,
                 params,
+                name_floor,
             );
         let finished_at = chrono::Utc::now();
         // Best-effort aggregate: open the state DB read-only-ish and reconstruct
@@ -615,6 +616,15 @@ pub(crate) fn run_waves(
             if !safe.is_empty() {
                 batches.push(safe);
             }
+            // Wave-wide name floor so cards align across the safe/lone batches
+            // (the cost gate splits a wave into one safe batch + N lone batches,
+            // each its own renderer — without a shared floor they'd each pad to
+            // their own widest name and the table would step).
+            let wave_name_floor = pending
+                .iter()
+                .map(|e| e.name.chars().count())
+                .max()
+                .unwrap_or(0);
             for batch in &batches {
                 let (result, cf, stderr_dump) = parallel_children::run_exports_as_child_processes(
                     config_path,
@@ -624,6 +634,7 @@ pub(crate) fn run_waves(
                     resume,
                     force,
                     None,
+                    wave_name_floor,
                 );
                 child_failures.extend(cf);
                 combined_stderr.push_str(&stderr_dump);

--- a/src/pipeline/run.rs
+++ b/src/pipeline/run.rs
@@ -535,25 +535,25 @@ pub(crate) fn run_waves(config_path: &str, force: bool, parallel_cli: bool) -> R
         // the wave (the sequential loop, or the blocking child-process join)
         // before the next iteration starts the next wave.
         if parallel {
-            // Keyset safety-gate: within the wave, exports that paginate by a
-            // keyset chunk column run together in ONE concurrent batch; every
-            // other export (full scan / incremental / time-window / CDC) runs
-            // ALONE in its own single-child batch so it never stacks source
-            // pressure against a wave-mate. The per-child governor still bounds
-            // each one; this gate also bounds the concurrent connection count.
-            let (keyset, lone): (Vec<&ExportConfig>, Vec<&ExportConfig>) =
+            // Cost safety-gate: within the wave, the cheap (`parallel_safe`)
+            // exports run together in ONE concurrent batch; every heavier export
+            // runs ALONE in its own single-child batch, since a big table already
+            // chunk-parallelizes internally and two at once would overload the
+            // source. The per-child governor still bounds each one; this gate also
+            // bounds the concurrent connection count.
+            let (safe, lone): (Vec<&ExportConfig>, Vec<&ExportConfig>) =
                 exports.iter().copied().partition(|e| is_parallel_safe(e));
             log::info!(
-                "apply: wave {} — {} keyset export(s) in parallel, {} run alone",
+                "apply: wave {} — {} parallel-safe export(s) in parallel, {} run alone",
                 label,
-                keyset.len(),
+                safe.len(),
                 lone.len()
             );
             // One single-child batch per lone export (run sequentially), then
-            // one concurrent batch for all keyset exports.
+            // one concurrent batch for all parallel-safe exports.
             let mut batches: Vec<Vec<&ExportConfig>> = lone.iter().map(|e| vec![*e]).collect();
-            if !keyset.is_empty() {
-                batches.push(keyset);
+            if !safe.is_empty() {
+                batches.push(safe);
             }
             for batch in &batches {
                 let (result, cf, stderr_dump) = parallel_children::run_exports_as_child_processes(
@@ -656,13 +656,14 @@ fn group_exports_by_wave(exports: &[ExportConfig]) -> Vec<(u32, Vec<&ExportConfi
     by_wave.into_iter().collect()
 }
 
-/// Config-derivable predicate: an export is safe to run concurrently with its
-/// wave-mates when it paginates the source by a keyset chunk column (bounded,
-/// index-backed scans). Full / incremental / time-window / CDC exports scan or
-/// stream the table, so they run ALONE within the wave to avoid stacking source
-/// pressure. Conservative on purpose — widen only with evidence.
+/// Whether an export may run concurrently with its wave-mates: the
+/// `parallel_safe` flag that `rivet plan` records from the source-aware cost
+/// class (true only for cheap, `Low`-cost tables — see
+/// [`ExportConfig::parallel_safe`]). A heavy table already chunk-parallelizes
+/// internally, so it runs ALONE within its wave; only the cheap exports share a
+/// concurrent batch. `None` (un-planned / hand-written) is treated as not-safe.
 fn is_parallel_safe(export: &ExportConfig) -> bool {
-    export.mode == crate::config::ExportMode::Chunked && export.chunk_column.is_some()
+    export.parallel_safe.unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -695,27 +696,18 @@ mod wave_grouping_tests {
     }
 
     #[test]
-    fn parallel_safe_only_for_keyset_chunked() {
-        // default sample_export is mode=Full, chunk_column=None
-        let full = crate::config::sample_export("full");
-        assert!(!is_parallel_safe(&full), "full scan is not parallel-safe");
+    fn parallel_safe_reads_the_plan_flag() {
+        // default sample_export leaves `parallel_safe` None → not safe
+        let unset = crate::config::sample_export("unset");
+        assert!(!is_parallel_safe(&unset), "None is treated as not-safe");
 
-        let mut chunked = crate::config::sample_export("chunked");
-        chunked.mode = crate::config::ExportMode::Chunked;
-        chunked.chunk_column = Some("id".into());
-        assert!(
-            is_parallel_safe(&chunked),
-            "keyset chunked is parallel-safe"
-        );
+        let mut safe = crate::config::sample_export("safe");
+        safe.parallel_safe = Some(true);
+        assert!(is_parallel_safe(&safe), "parallel_safe: true → concurrent");
 
-        // chunked but no chunk_column → not keyset → not safe
-        let mut chunked_no_col = crate::config::sample_export("nocol");
-        chunked_no_col.mode = crate::config::ExportMode::Chunked;
-        chunked_no_col.chunk_column = None;
-        assert!(
-            !is_parallel_safe(&chunked_no_col),
-            "chunked without a chunk column is not keyset"
-        );
+        let mut not_safe = crate::config::sample_export("heavy");
+        not_safe.parallel_safe = Some(false);
+        assert!(!is_parallel_safe(&not_safe), "parallel_safe: false → alone");
     }
 }
 

--- a/src/pipeline/run.rs
+++ b/src/pipeline/run.rs
@@ -468,7 +468,7 @@ pub fn run(
 /// first cut runs each wave's exports SEQUENTIALLY (deterministic); safety-aware
 /// within-wave parallelism is a follow-up, and `partition_by` exports are not
 /// expanded here yet (use `rivet run` for those).
-pub(crate) fn run_waves(config_path: &str, force: bool) -> Result<()> {
+pub(crate) fn run_waves(config_path: &str, force: bool, parallel_cli: bool) -> Result<()> {
     let config = Config::load_with_params(config_path, None)?;
     let config_dir = Path::new(config_path)
         .parent()
@@ -492,11 +492,11 @@ pub(crate) fn run_waves(config_path: &str, force: bool) -> Result<()> {
         return Ok(());
     }
 
-    // `parallel_export_processes: true` opts into within-wave parallelism: each
-    // wave's exports run as concurrent child processes (per-child governor keeps
-    // each one source-safe), the call blocks until all exit = the wave barrier.
-    // Default stays sequential.
-    let parallel = config.parallel_export_processes;
+    // `--parallel` (or `parallel_export_processes: true` in the config) opts into
+    // within-wave parallelism: each wave's exports run as concurrent child
+    // processes (per-child governor keeps each one source-safe), the call blocks
+    // until all exit = the wave barrier. Default stays sequential.
+    let parallel = parallel_cli || config.parallel_export_processes;
 
     // Compact per-export rendering for the SEQUENTIAL path only. The parallel
     // (subprocess) path renders the parent card stack itself and each child sees
@@ -528,6 +528,9 @@ pub(crate) fn run_waves(config_path: &str, force: bool) -> Result<()> {
         } else {
             wave.to_string()
         };
+        if total > 1 {
+            println!("\n  ── wave {label} · {} export(s) ──", exports.len());
+        }
         // The wave barrier is the loop itself: each strategy below fully drains
         // the wave (the sequential loop, or the blocking child-process join)
         // before the next iteration starts the next wave.

--- a/src/pipeline/sink/mod.rs
+++ b/src/pipeline/sink/mod.rs
@@ -98,6 +98,20 @@ pub(crate) struct ExportSink {
     /// checksum), resolved in `on_schema`. `None` = un-keyed (full export, or a
     /// stripped/synthetic cursor not present in the dest batch).
     pub(in crate::pipeline) checksum_key_col: Option<usize>,
+    /// Per-batch row-progress feed (chunked exports). `None` for paths that
+    /// don't drive a progress bar.
+    pub(in crate::pipeline) row_progress: Option<RowProgress>,
+}
+
+/// Per-batch progress feed for chunked exports: ticks the export's shared
+/// progress bar with the running row count *during* a chunk's read, so a wide
+/// first chunk (e.g. 250k rows / 90 MB) doesn't sit at "0 rows" for seconds and
+/// read as idle. `streamed` is shared across the export's chunk workers (each
+/// batch adds to it); `last_tick` throttles the bar/IPC refresh to ~8/s.
+pub(in crate::pipeline) struct RowProgress {
+    pub(in crate::pipeline) handle: crate::pipeline::progress::ChunkProgressHandle,
+    pub(in crate::pipeline) streamed: Arc<std::sync::atomic::AtomicI64>,
+    pub(in crate::pipeline) last_tick: std::time::Instant,
 }
 
 impl ExportSink {
@@ -146,7 +160,23 @@ impl ExportSink {
             parquet_row_group_rows: None,
             column_checksums: std::collections::BTreeMap::new(),
             checksum_key_col: None,
+            row_progress: None,
         })
+    }
+
+    /// Attach a per-batch row-progress feed (see [`RowProgress`]). Returns self
+    /// so a chunk worker can `ExportSink::new(plan)?.with_row_progress(...)`.
+    pub(in crate::pipeline) fn with_row_progress(
+        mut self,
+        handle: crate::pipeline::progress::ChunkProgressHandle,
+        streamed: Arc<std::sync::atomic::AtomicI64>,
+    ) -> Self {
+        self.row_progress = Some(RowProgress {
+            handle,
+            streamed,
+            last_tick: std::time::Instant::now(),
+        });
+        self
     }
 
     fn schema_without_internal(schema: &Schema, name: &str) -> Result<SchemaRef> {
@@ -450,6 +480,19 @@ impl ExportSink {
     /// Core batch processing: track quality/shape, enrich, write. Called after memory check.
     fn on_batch_inner(&mut self, dest_batch: &RecordBatch) -> Result<()> {
         self.total_rows += dest_batch.num_rows();
+        // Feed the running row count to the progress bar *during* the read, not
+        // only when the chunk completes (throttled to ~8/s).
+        if let Some(rp) = self.row_progress.as_mut() {
+            let n = dest_batch.num_rows() as i64;
+            let total = rp
+                .streamed
+                .fetch_add(n, std::sync::atomic::Ordering::Relaxed)
+                + n;
+            if rp.last_tick.elapsed() >= std::time::Duration::from_millis(120) {
+                rp.handle.set_rows(total);
+                rp.last_tick = std::time::Instant::now();
+            }
+        }
         self.part_rows += dest_batch.num_rows();
         self.track_quality(dest_batch);
         self.track_shape(dest_batch);

--- a/src/pipeline/sink/tests.rs
+++ b/src/pipeline/sink/tests.rs
@@ -410,6 +410,7 @@ fn minimal_sink() -> ExportSink {
         parquet_row_group_rows: None,
         column_checksums: std::collections::BTreeMap::new(),
         checksum_key_col: None,
+        row_progress: None,
     }
 }
 

--- a/src/plan/artifact.rs
+++ b/src/plan/artifact.rs
@@ -312,6 +312,38 @@ impl PlanArtifact {
         }
     }
 
+    /// One compact row for the multi-export plan table — `wave  export  strategy
+    /// rows  verdict`, the export name padded to `name_width` (ellipsised if
+    /// longer). Used instead of [`print_summary`] when planning many exports,
+    /// where the full per-export block would run to hundreds of lines.
+    pub fn summary_line(&self, name_width: usize) -> String {
+        let wave = self
+            .prioritization
+            .as_ref()
+            .map(|p| p.export_recommendation.recommended_wave.to_string())
+            .unwrap_or_else(|| "—".to_string());
+        let rows = self
+            .computed
+            .row_estimate
+            .map(|e| format!("~{}", format_rows(e)))
+            .unwrap_or_else(|| "—".to_string());
+        let name = if self.export_name.chars().count() > name_width {
+            let head: String = self.export_name.chars().take(name_width - 1).collect();
+            format!("{head}…")
+        } else {
+            self.export_name.clone()
+        };
+        format!(
+            "  {:<5} {:<width$}  {:<11}  {:<12}  {}",
+            wave,
+            name,
+            self.strategy.to_string(),
+            rows,
+            self.diagnostics.verdict,
+            width = name_width
+        )
+    }
+
     /// Pretty-print a human-readable plan summary to stdout.
     pub fn print_summary(&self) {
         println!();

--- a/src/plan/artifact.rs
+++ b/src/plan/artifact.rs
@@ -333,15 +333,34 @@ impl PlanArtifact {
         } else {
             self.export_name.clone()
         };
-        format!(
-            "  {:<5} {:<width$}  {:<11}  {:<12}  {}",
-            wave,
-            name,
-            self.strategy.to_string(),
-            rows,
-            self.diagnostics.verdict,
-            width = name_width
+        Self::compact_row(
+            &wave,
+            &name,
+            &self.strategy.to_string(),
+            &rows,
+            &self.diagnostics.verdict,
+            name_width,
         )
+    }
+
+    /// Header row for the compact multi-export plan table, matching
+    /// [`PlanArtifact::summary_line`]'s columns — both go through
+    /// [`PlanArtifact::compact_row`], so the geometry lives in one place and
+    /// widening a column can't silently misalign the table.
+    pub fn summary_header(name_width: usize) -> String {
+        Self::compact_row("Wave", "Export", "Strategy", "Rows", "Verdict", name_width)
+    }
+
+    /// The shared column geometry of the compact plan table (header + rows).
+    fn compact_row(
+        wave: &str,
+        export: &str,
+        strategy: &str,
+        rows: &str,
+        verdict: &str,
+        name_width: usize,
+    ) -> String {
+        format!("  {wave:<5} {export:<name_width$}  {strategy:<11}  {rows:<12}  {verdict}")
     }
 
     /// Pretty-print a human-readable plan summary to stdout.

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -52,7 +52,83 @@ pub(crate) fn strip_select_star_from(base_query: &str) -> Option<&str> {
         .and_then(|s| s.strip_prefix('*'))
         .map(str::trim_start)
         .and_then(|s| strip_prefix_ascii_ci(s, "from"))?;
-    let rest = after.trim_start();
+    parse_bare_table_ident(after.trim_start())
+}
+
+/// Like [`strip_select_star_from`] but accepts an explicit **plain column-list**
+/// projection (`SELECT id, title, … FROM <ident>`) — the shape `rivet init`
+/// scaffolds — not just `*`.
+///
+/// For a chunk-boundary probe (`min`/`max`/null-count/row-count of the chunk
+/// column) the projection is irrelevant: with **no `WHERE`** the row set is the
+/// whole table, so the column's extremes — and the row count — are identical
+/// whether read through the wide projection or straight off the table. Reading
+/// off the table lets the planner use the index instead of materialising every
+/// wide row into a temp-file spill (the wrap measured ~3.2 GB of temp_files on
+/// an 8.6 GB table).
+///
+/// Acceptance stays strict so a filtered / derived / joined / de-duplicated
+/// query is never rewritten to the bare table: the projection must be bare
+/// column references only — any `(` (function / subquery), quote, `DISTINCT`,
+/// or other token → `None`; any trailing clause after the table → `None`. On
+/// `None` the caller wraps exactly as before.
+pub(crate) fn strip_simple_projection_from(base_query: &str) -> Option<&str> {
+    let trimmed = base_query.trim();
+    let after_select = strip_prefix_ascii_ci(trimmed, "select").map(str::trim_start)?;
+    // Split on the first whitespace-bounded `from`. The projection is validated
+    // below to hold no `(`/quote, so that first `from` is necessarily the
+    // table's FROM (a subquery's `from` would sit behind a `(`; a column named
+    // `from` would need quoting) — never one inside a literal or derived table.
+    let from_at = find_from_keyword(after_select)?;
+    let projection = after_select[..from_at].trim();
+    if !is_plain_column_list(projection) {
+        return None;
+    }
+    parse_bare_table_ident(after_select[from_at + "from".len()..].trim_start())
+}
+
+/// Byte offset of the first whitespace/boundary-delimited `from` keyword
+/// (ASCII case-insensitive), or `None`. Only meaningful once the preceding text
+/// is known paren/quote-free (see [`strip_simple_projection_from`]).
+fn find_from_keyword(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i + 4 <= bytes.len() {
+        if s[i..i + 4].eq_ignore_ascii_case("from")
+            && (i == 0 || bytes[i - 1].is_ascii_whitespace())
+            && (i + 4 == bytes.len() || bytes[i + 4].is_ascii_whitespace())
+        {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
+/// A non-empty list of bare column references: only ASCII alphanumerics, `_`,
+/// `.`, `,`, `*`, and whitespace — and not a leading `DISTINCT` (which would
+/// change the row count / set, breaking the dense-chunk count and the
+/// whole-table equivalence the fast path relies on). Functions (`(`), quoted
+/// idents / string literals, and any other punctuation → `false`.
+fn is_plain_column_list(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    if let Some(rest) = strip_prefix_ascii_ci(s, "distinct")
+        && rest.starts_with(|c: char| c.is_whitespace())
+    {
+        return false;
+    }
+    s.chars().all(|c| {
+        c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | ',' | '*' | ' ' | '\t' | '\n' | '\r')
+    })
+}
+
+/// Validate `after_from` is a bare `[schema.]table` identifier with no trailing
+/// clause (WHERE/JOIN/comma/alias/semicolon), returning it. Shared by the `*`
+/// and column-list table-form recognisers so the strictness lives in one place.
+fn parse_bare_table_ident(after_from: &str) -> Option<&str> {
+    let rest = after_from.trim_start();
     let end = rest
         .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == '.'))
         .unwrap_or(rest.len());
@@ -101,9 +177,33 @@ pub(crate) fn aggregate_sql(
     base_query: &str,
 ) -> String {
     let q = quote_ident(source_type, col);
-    match strip_select_star_from(base_query) {
+    match strip_simple_projection_from(base_query) {
         Some(table_ident) => format!("SELECT {agg}({q}) FROM {table_ident}"),
         None => format!("SELECT {agg}({q}) FROM ({base_query}) AS _rivet"),
+    }
+}
+
+/// Presence probe for NULL chunk keys: one row iff `<col>` has any NULL. Replaces
+/// the old `COUNT(*) - COUNT(col)` full count in `bail_if_null_keyed` — the DB
+/// stops at the first NULL, and for a NOT NULL column the planner returns nothing
+/// without scanning, so the cold full-index scan that count forced (the seconds
+/// of upfront idle on a large chunked export) is gone. A nullable column with
+/// zero NULLs still yields no row, preserving the "detect on live data" intent.
+///
+/// Same bare-table-vs-wrap shape as [`aggregate_sql`]; `col` is dialect-quoted
+/// here. MSSQL uses `TOP 1` — the keyset `OFFSET/FETCH` limit form needs an
+/// `ORDER BY` this presence probe has no use for.
+pub(crate) fn null_key_probe_sql(source_type: SourceType, col: &str, base_query: &str) -> String {
+    let from = match strip_simple_projection_from(base_query) {
+        Some(table_ident) => table_ident.to_string(),
+        None => format!("({base_query}) AS _rivet_nullprobe"),
+    };
+    let q = quote_ident(source_type, col);
+    match source_type {
+        SourceType::Mssql => format!("SELECT TOP 1 1 FROM {from} WHERE {q} IS NULL"),
+        SourceType::Postgres | SourceType::Mysql => {
+            format!("SELECT 1 FROM {from} WHERE {q} IS NULL LIMIT 1")
+        }
     }
 }
 
@@ -199,6 +299,54 @@ mod tests {
     }
 
     #[test]
+    fn strip_simple_projection_accepts_plain_column_lists() {
+        // The shape `rivet init` scaffolds: an explicit column list off a bare
+        // table — the chunk-column probes can read straight off the table.
+        assert_eq!(
+            strip_simple_projection_from("SELECT id, title, body FROM content_items"),
+            Some("content_items")
+        );
+        // Star still works (a superset of strip_select_star_from).
+        assert_eq!(
+            strip_simple_projection_from("SELECT * FROM events"),
+            Some("events")
+        );
+        // Schema-qualified table, dotted columns, mixed case / extra whitespace.
+        assert_eq!(
+            strip_simple_projection_from("select a.x, a.y  from  public.users"),
+            Some("public.users")
+        );
+        // Folded multi-line (YAML `>` block) collapses to one line of columns.
+        assert_eq!(
+            strip_simple_projection_from("SELECT id, a, b, c, d FROM content_items\n"),
+            Some("content_items")
+        );
+    }
+
+    #[test]
+    fn strip_simple_projection_rejects_anything_that_changes_the_row_set() {
+        // WHERE / JOIN / GROUP / trailing clause / `;` — the bare table no
+        // longer matches the query's rows, so the caller must wrap (None).
+        assert!(strip_simple_projection_from("SELECT id FROM t WHERE id > 1").is_none());
+        assert!(
+            strip_simple_projection_from("SELECT a.id FROM t a JOIN u ON a.id = u.id").is_none()
+        );
+        assert!(strip_simple_projection_from("SELECT id FROM t GROUP BY id").is_none());
+        assert!(strip_simple_projection_from("SELECT id FROM t;").is_none());
+        // DISTINCT changes the row count/set (would break the dense-chunk COUNT).
+        assert!(strip_simple_projection_from("SELECT DISTINCT id FROM t").is_none());
+        // A function / expression in the projection — can't reason syntactically.
+        assert!(strip_simple_projection_from("SELECT count(*) FROM t").is_none());
+        assert!(strip_simple_projection_from("SELECT lower(name) FROM t").is_none());
+        // A subquery / derived table: the first `from` is the inner one.
+        assert!(strip_simple_projection_from("SELECT id FROM (SELECT id FROM y) z").is_none());
+        // A string literal in the projection could hide a `from`.
+        assert!(strip_simple_projection_from("SELECT 'from x' FROM t").is_none());
+        // Three-part identifier is not `[schema.]table`.
+        assert!(strip_simple_projection_from("SELECT id FROM a.b.c").is_none());
+    }
+
+    #[test]
     fn aggregate_sql_fast_path_on_table_shortcut() {
         assert_eq!(
             aggregate_sql(
@@ -227,6 +375,32 @@ mod tests {
             aggregate_sql(SourceType::Mysql, "min", "d", "SELECT d FROM t WHERE 1")
                 .contains("min(`d`)")
         );
+    }
+
+    #[test]
+    fn null_key_probe_sql_is_a_presence_probe_not_a_count() {
+        // Bare table / simple projection → probe the table directly (PG `LIMIT 1`).
+        assert_eq!(
+            null_key_probe_sql(SourceType::Postgres, "id", "SELECT id, title FROM orders"),
+            "SELECT 1 FROM orders WHERE \"id\" IS NULL LIMIT 1"
+        );
+        // MSSQL has no LIMIT in this position → TOP 1.
+        assert_eq!(
+            null_key_probe_sql(SourceType::Mssql, "id", "SELECT * FROM orders"),
+            "SELECT TOP 1 1 FROM orders WHERE [id] IS NULL"
+        );
+        // A filtered query can't be reasoned about → wrap, exactly as before.
+        assert_eq!(
+            null_key_probe_sql(
+                SourceType::Postgres,
+                "id",
+                "SELECT id FROM orders WHERE x > 1"
+            ),
+            "SELECT 1 FROM (SELECT id FROM orders WHERE x > 1) AS _rivet_nullprobe \
+             WHERE \"id\" IS NULL LIMIT 1"
+        );
+        // Never a COUNT — that full scan was the whole problem.
+        assert!(!null_key_probe_sql(SourceType::Mysql, "k", "SELECT * FROM t").contains("COUNT"));
     }
 
     #[test]

--- a/tests/live/live_wave_apply.rs
+++ b/tests/live/live_wave_apply.rs
@@ -83,3 +83,83 @@ exports:
          (continue/isolate — independent tables).",
     );
 }
+
+/// `apply --resume` skips an export whose destination already completed
+/// (`_SUCCESS`), so a re-run after a partial failure does not redo finished
+/// tables. A plain re-run (no `--resume`) DOES re-export — the contrast proves
+/// the skip is real, not apply silently never writing.
+#[test]
+#[ignore = "live: postgres"]
+fn resume_skips_completed_exports() {
+    require_alive(LiveService::Postgres);
+
+    let out = tempfile::tempdir().unwrap();
+    let cfg_dir = tempfile::tempdir().unwrap();
+    let exp = unique_name("orders_done");
+
+    let yaml = format!(
+        r#"
+source:
+  type: postgres
+  url_env: DATABASE_URL
+
+exports:
+  - name: {exp}
+    query: "SELECT id FROM orders"
+    mode: full
+    format: parquet
+    wave: 1
+    destination: {{ type: local, path: {root} }}
+"#,
+        root = out.path().display(),
+    );
+    let cfg = write_config(&cfg_dir, &yaml);
+
+    let run = |args: &[&str]| {
+        std::process::Command::new(RIVET_BIN)
+            .arg("apply")
+            .arg(cfg.to_str().unwrap())
+            .args(args)
+            .env("DATABASE_URL", POSTGRES_URL)
+            .output()
+            .expect("spawn rivet apply")
+    };
+    let parquet_count = || files_with_extension(out.path(), "parquet").len();
+
+    // Phase 1 — fresh run writes one Parquet + a `_SUCCESS` marker.
+    let first = run(&[]);
+    assert!(
+        first.status.success(),
+        "fresh apply must succeed; stderr:\n{}",
+        String::from_utf8_lossy(&first.stderr),
+    );
+    let after_first = parquet_count();
+    assert_eq!(after_first, 1, "fresh apply must write exactly one Parquet");
+
+    // Phase 2 — `--resume` sees `_SUCCESS` and SKIPS: no new Parquet, exit 0.
+    let resumed = run(&["--resume"]);
+    assert!(
+        resumed.status.success(),
+        "apply --resume must succeed (everything already complete); stderr:\n{}",
+        String::from_utf8_lossy(&resumed.stderr),
+    );
+    assert_eq!(
+        parquet_count(),
+        after_first,
+        "apply --resume must skip the completed export — no new Parquet written",
+    );
+
+    // Phase 3 (contrast) — a plain re-run re-exports, appending a second Parquet.
+    // Proves the Phase-2 skip is real, not apply simply never writing.
+    let rerun = run(&[]);
+    assert!(
+        rerun.status.success(),
+        "plain re-run must succeed; stderr:\n{}",
+        String::from_utf8_lossy(&rerun.stderr),
+    );
+    assert!(
+        parquet_count() > after_first,
+        "a plain re-run (no --resume) must re-export, adding a Parquet — \
+         confirming --resume's skip was the actual difference",
+    );
+}

--- a/tests/live/live_wave_apply.rs
+++ b/tests/live/live_wave_apply.rs
@@ -1,0 +1,85 @@
+//! LIVE: the wave-ordered `rivet apply <config>` executor (Postgres).
+//!
+//! Tables are independent, so a failing export in an early wave must NOT block
+//! later waves: `apply` collects the failure, runs every other export, and exits
+//! non-zero — the continue/isolate policy. This proves that end to end.
+//!
+//! Harness mirrors the other live suites: `use crate::common::*;`,
+//! `#[ignore = "live: postgres"]`, drive the real binary, assert on exit + files.
+
+use crate::common::*;
+
+/// A failing export in wave 1 must not stop waves 2 and 3: apply exits non-zero,
+/// but both downstream exports still produce their Parquet (continue/isolate).
+#[test]
+#[ignore = "live: postgres"]
+fn wave_failure_isolates_later_waves() {
+    require_alive(LiveService::Postgres);
+
+    let out = tempfile::tempdir().unwrap();
+    let cfg_dir = tempfile::tempdir().unwrap();
+    let bad = unique_name("bad");
+    let good_a = unique_name("orders_w2");
+    let good_b = unique_name("users_w3");
+
+    // wave 1 fails (query against a nonexistent table); waves 2/3 are valid
+    // tables. Waves are hand-set so apply runs them in order regardless of cost.
+    let yaml = format!(
+        r#"
+source:
+  type: postgres
+  url_env: DATABASE_URL
+
+exports:
+  - name: {bad}
+    query: "SELECT id FROM no_such_table_{bad}"
+    mode: full
+    format: parquet
+    wave: 1
+    destination: {{ type: local, path: {root}/{bad} }}
+  - name: {good_a}
+    query: "SELECT id FROM orders"
+    mode: full
+    format: parquet
+    wave: 2
+    destination: {{ type: local, path: {root}/{good_a} }}
+  - name: {good_b}
+    query: "SELECT id FROM users"
+    mode: full
+    format: parquet
+    wave: 3
+    destination: {{ type: local, path: {root}/{good_b} }}
+"#,
+        root = out.path().display(),
+    );
+    let cfg = write_config(&cfg_dir, &yaml);
+
+    let apply = std::process::Command::new(RIVET_BIN)
+        .args(["apply", cfg.to_str().unwrap()])
+        .env("DATABASE_URL", POSTGRES_URL)
+        .output()
+        .expect("spawn rivet apply");
+
+    // wave 1 failed → apply exits non-zero...
+    assert!(
+        !apply.status.success(),
+        "apply must exit non-zero when an export fails; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&apply.stdout),
+        String::from_utf8_lossy(&apply.stderr),
+    );
+
+    // ...but the later waves still ran: both downstream exports produced Parquet.
+    let a_files = files_with_extension(&out.path().join(&good_a), "parquet");
+    let b_files = files_with_extension(&out.path().join(&good_b), "parquet");
+    assert!(
+        !a_files.is_empty(),
+        "wave 2 export '{good_a}' must produce Parquet despite the wave-1 failure \
+         (continue/isolate — independent tables). stderr:\n{}",
+        String::from_utf8_lossy(&apply.stderr),
+    );
+    assert!(
+        !b_files.is_empty(),
+        "wave 3 export '{good_b}' must produce Parquet despite the wave-1 failure \
+         (continue/isolate — independent tables).",
+    );
+}

--- a/tests/live/live_wave_apply.rs
+++ b/tests/live/live_wave_apply.rs
@@ -150,7 +150,12 @@ exports:
     );
 
     // Phase 3 (contrast) — a plain re-run re-exports, appending a second Parquet.
-    // Proves the Phase-2 skip is real, not apply simply never writing.
+    // Proves the Phase-2 skip is real, not apply simply never writing. The part
+    // filename is second-granularity (`<export>_<YYYYMMDD_HHMMSS>.parquet`), so
+    // wait past the current second to guarantee a distinct name rather than an
+    // overwrite of Phase 1's file (the failure when all three phases land in one
+    // second).
+    std::thread::sleep(std::time::Duration::from_millis(1100));
     let rerun = run(&[]);
     assert!(
         rerun.status.success(),

--- a/tests/live_suite.rs
+++ b/tests/live_suite.rs
@@ -153,6 +153,8 @@ mod live_retry_and_faults;
 mod live_schema_drift;
 #[path = "live/live_temp_spill.rs"]
 mod live_temp_spill;
+#[path = "live/live_wave_apply.rs"]
+mod live_wave_apply;
 #[path = "live/preflight_missing_table.rs"]
 mod preflight_missing_table;
 #[path = "live/preflight_target_fail_note.rs"]


### PR DESCRIPTION
## Release 0.16.0 — the plan→apply cycle + operator UX (#53)

`rivet plan` becomes executable. It already scored and waved your exports; now `rivet apply <config>` runs them — wave by wave, lowest priority first, barrier between waves, cost-gated within-wave parallelism. Closes the OSS engine's loop: `init` → `plan` (annotates the config in place) → [review/edit] → `apply`.

**Important:** this release bundles PR #53 (operator UX / verify-depth + test-infra consolidation), which was merged but never released — v0.15.0 cherry-picked only the always-on value checksum from it.

### plan → apply cycle
- `rivet apply <config>.yaml` runs exports wave-by-wave; a failed export does **not** block its wave-mates (continue/isolate, exits non-zero). A `.json` path still means the sealed single-artifact replay.
- Cost-gated within-wave parallelism (`--parallel-export-processes`): cheap `parallel_safe` exports run concurrently as separate processes; a heavier export runs alone (it already chunk-parallelizes internally).
- `rivet apply <config> --resume`: skips `_SUCCESS` exports, resumes incomplete chunked exports from their checkpoints.
- `rivet plan` writes `wave:`/`parallel_safe:` into the config (in place) + a compact per-export table.

### operator UX & verify (#53)
- Graded `rivet validate --depth light|sample|full` + stable `RIVET_VERIFY_*` error codes.
- Memory-aware `rivet check` verdict (DEGRADED vs UNSAFE) + `check --json`.
- `rivet plan` explains the strategy (mode, chunk geometry, parallelism, RSS-budget fit, resumability).
- Signed releases (keyless cosign).

### multi-export console UX (dogfood)
- Strict aligned card table — every column fixed-width, name seeded wave-wide (aligned across cost-gate batches).
- Chunk progress ticks per source batch — a wide first chunk no longer reads as idle while it streams.
- Captured child stderr → file artifact (one-line console pointer) instead of flooding the run summary.
- Chunked boundary probes no longer force a full scan (presence probe, not `COUNT(*) - COUNT(col)`; bare-table projection).

### Tests
1766 lib + full offline suite green. Live (Postgres): a failed wave isolates its successors; `--resume` skips completed exports; keyset chunking verified count==distinct on PG/MySQL/MSSQL.

Full notes in [CHANGELOG.md](CHANGELOG.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QswtrPAD4MwGcUJdVy7Ehx
