### PR TITLE
Release 0.16.1: fix the release Docker image build (multi-line inline tables)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.16.1 (2026-06-29) — release Docker images build again
+
+0.16.0 published to crates.io, shipped its binaries, and cut a GitHub release — but both Docker images
+(`linux/amd64`, `linux/arm64`) failed to build. `cargo chef prepare` (the dependency-caching step) uses a
+spec-strict TOML parser that rejects **multi-line inline tables**, which `cargo build` tolerates. Two
+`dep = {` … `}` entries (`postgres`, `postgres-types`) tripped it with `invalid inline table`, so the
+publish landed half-complete and could not be re-run from the tag.
+
+### Fixed
+
+- Collapsed the `postgres` and `postgres-types` dependency tables onto one line each (no version/feature
+  change — `Cargo.lock` untouched). The release Docker build passes again.
+
+### Internal
+
+- Regression guard: an offline test (`cargo_manifest_chef`) asserts `Cargo.toml` carries no multi-line
+  inline tables, so the parser mismatch fails loud and local instead of at release time.
+
 ## 0.16.0 (2026-06-28) — the plan→apply cycle: wave-ordered, cost-gated, resumable execution
 
 `rivet plan` becomes executable. It already scored and waved your exports; now `rivet apply <config>`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,3 +128,28 @@ trace name the slow step; `EXPLAIN (ANALYZE, BUFFERS)` the exact SQL rivet emits
 rather than guessing the plan. A fix shipped against an unmeasured hypothesis is
 a guess wearing a diff — each of the three wrong guesses above cost a build +
 install + dogfood round-trip that a 20-second cold trace would have skipped.
+
+## Verify the real release build path, not just `cargo build`
+
+A green `cargo build` does not mean the release will build. The release path runs
+**different, stricter tooling** than local dev, and the gap only surfaces at the
+tag — *after* crates.io, the binaries, and the GitHub release have already
+published, when the failure is no longer re-runnable from the immutable tag.
+
+0.16.0 shipped this way: `cargo build` plus the whole offline + live suite were
+green, all four binaries and the crate published — but **both Docker images
+failed**. The release Dockerfile's `cargo chef prepare` (dependency-cache layer)
+parses `Cargo.toml` with `cargo-manifest`, a **spec-strict** TOML parser that
+rejects multi-line inline tables (`postgres = {` … newline … `}`). `cargo`'s own
+parser tolerates them, so the two offending tables sailed through every local
+check for months and broke only the one build path no local command exercises.
+The fix was one line each; the cost was a whole 0.16.1 patch release.
+
+Process rule: **before tagging a release, run the release build path itself, not
+a proxy for it** — build the Docker image locally (or at least run `cargo chef
+prepare`), plus whatever `cargo publish --dry-run` / cross-compile / packaging
+step the workflow runs. When a release-only tool (cargo-chef, cargo-manifest, a
+stricter MSRV image, a `--locked` resolve) can reject what `cargo build` accepts,
+add a **local regression guard** that mimics its check (here: the
+`cargo_manifest_chef` offline test asserts no multi-line inline tables) so the
+mismatch fails loud and local instead of half-way through publishing.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rivet-cli"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"
@@ -69,10 +69,7 @@ opendal = { version = "0.55", features = ["blocking", "services-fs", "services-s
 # stays one cast away. See `src/types/mapping.rs` for the emission site.
 parquet = { version = "58", features = ["arrow", "zstd", "lz4", "flate2", "arrow_canonical_extension_types"] }
 clap_complete = "4"
-postgres = {
-    version = "0.19",
-    features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-0_8"],
-}
+postgres = { version = "0.19", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-0_8"] }
 postgres-native-tls = "0.5"
 # `vendored` statically links OpenSSL on Linux so `cargo install rivet-cli` works
 # on bare systems and our cross-compiled aarch64-unknown-linux-gnu release
@@ -81,10 +78,7 @@ postgres-native-tls = "0.5"
 # is ever compiled or linked there.
 native-tls = { version = "0.2", features = ["vendored"] }
 rand = "0.10"
-postgres-types = {
-    version = "0.2",
-    features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-0_8"],
-}
+postgres-types = { version = "0.2", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-0_8"] }
 bigdecimal = "0.4"
 byteorder = "1"
 uuid = "0.8"

--- a/schemas/latest/rivet.schema.json
+++ b/schemas/latest/rivet.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Rivet config (rivet-cli 0.16.0)",
+  "title": "Rivet config (rivet-cli 0.16.1)",
   "description": "Top-level Rivet configuration root.\n\nOperators write this struct as YAML (typically `rivet.yaml`).  The\n`JsonSchema` derive is the source of truth for the `schemas/rivet.schema.json`\nartifact and the `rivet schema config` command's output (v0.7.3 P0).",
   "type": "object",
   "properties": {

--- a/schemas/rivet.schema.json
+++ b/schemas/rivet.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Rivet config (rivet-cli 0.16.0)",
+  "title": "Rivet config (rivet-cli 0.16.1)",
   "description": "Top-level Rivet configuration root.\n\nOperators write this struct as YAML (typically `rivet.yaml`).  The\n`JsonSchema` derive is the source of truth for the `schemas/rivet.schema.json`\nartifact and the `rivet schema config` command's output (v0.7.3 P0).",
   "type": "object",
   "properties": {

--- a/tests/offline/cargo_manifest_chef.rs
+++ b/tests/offline/cargo_manifest_chef.rs
@@ -1,0 +1,49 @@
+//! Guard: the crate manifest must stay parseable by `cargo-chef`, whose TOML
+//! parser (`cargo-manifest`) is spec-strict and rejects **multi-line inline
+//! tables** that `cargo build` happily tolerates. A `dep = {` opened on one
+//! line and closed on the next breaks only the release Docker image build
+//! (`cargo chef prepare --recipe-path recipe.json`) — every other build stays
+//! green, so it sails through local checks and CI and only surfaces at release.
+//!
+//! This is exactly what bit 0.16.0: both `linux/amd64` and `linux/arm64` Docker
+//! builds failed with `invalid inline table` at the `postgres = {` line, *after*
+//! crates.io, the binaries, and the GitHub release had already published — an
+//! un-re-runnable, half-published release. The fix is trivial (one line each);
+//! the cost was a whole patch release. This test makes the regression loud and
+//! local instead.
+
+use std::path::PathBuf;
+
+/// Every TOML inline table (`key = { … }`) must open and close on the same
+/// line. A trailing `= {` with nothing after it begins a multi-line inline
+/// table, which the TOML spec forbids and `cargo-chef` rejects.
+#[test]
+fn cargo_toml_has_no_multiline_inline_tables() {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    let text = std::fs::read_to_string(&manifest).expect("read Cargo.toml");
+
+    let offenders: Vec<String> = text
+        .lines()
+        .enumerate()
+        .filter(|(_, line)| {
+            let t = line.trim_start();
+            if t.starts_with('#') {
+                return false; // a commented-out example is not a real table
+            }
+            // `<key> = {` followed only by whitespace to end-of-line: an inline
+            // table opened but not closed here. A closed single-line table
+            // (`= { version = "1" }`) leaves non-whitespace after the `= {`.
+            matches!(t.split_once("= {"), Some((_, rest)) if rest.trim().is_empty())
+        })
+        .map(|(i, line)| format!("  line {}: {}", i + 1, line.trim()))
+        .collect();
+
+    assert!(
+        offenders.is_empty(),
+        "Cargo.toml has multi-line inline table(s) — collapse each onto one line.\n\
+         `cargo build` tolerates them, but `cargo chef prepare` in the release Docker \
+         build rejects them as `invalid inline table` (this is what broke the 0.16.0 \
+         image build):\n{}",
+        offenders.join("\n")
+    );
+}

--- a/tests/offline_suite.rs
+++ b/tests/offline_suite.rs
@@ -14,6 +14,8 @@
 
 #[path = "offline/audit_validate_warning_label.rs"]
 mod audit_validate_warning_label;
+#[path = "offline/cargo_manifest_chef.rs"]
+mod cargo_manifest_chef;
 #[path = "offline/cli_contract.rs"]
 mod cli_contract;
 #[path = "offline/config_fuzz.rs"]


### PR DESCRIPTION
## 0.16.1 — release Docker images build again

0.16.0 published crates.io, binaries, and a GitHub release — but **both Docker images failed**. `cargo chef prepare` (the dependency-caching step in the release Dockerfile) uses a spec-strict TOML parser that rejects **multi-line inline tables**, which `cargo build` tolerates. The `postgres` and `postgres-types` dependency tables spanned multiple lines → `invalid inline table` → a half-published, un-re-runnable release (the tag's code carries the bug).

### Fix
- Collapsed `postgres` and `postgres-types` onto one line each. No version/feature change; `Cargo.lock` untouched.
- Reproduced the failure locally with `cargo-chef` (same `invalid inline table` at line 72); confirmed it passes after.

### Regression guard
- New offline test `cargo_manifest_chef` asserts `Cargo.toml` has no multi-line inline tables. Proven RED on the multi-line form (`line 72: postgres = {`), GREEN after the fix — so the parser mismatch fails loud and local instead of at release time.

Version bump 0.16.1 + CHANGELOG + regenerated config schema (title carries the version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QswtrPAD4MwGcUJdVy7Ehx
