### PR TITLE
Fix the 0.16.1 release: synced Cargo.lock + --locked CI guard

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -36,4 +36,20 @@ else
   cargo test --tests --quiet
 fi
 
+# The test run above ran a non-`--locked` cargo build, which silently reconciles
+# the working-tree Cargo.lock against Cargo.toml. If that left the lock DIRTY,
+# the COMMITTED lock was stale — and the pushed commit would fail the release's
+# `cargo publish --locked` (exit 101, *after* the tag is cut). 0.16.1 stalled
+# exactly this way: a version bump regenerated the lock but never committed it.
+# Checking *after* the build is the trick — it forces the reconcile that exposes
+# a committed-stale lock as a dirty working tree (a pre-build `--locked` check
+# sees the already-reconciled tree and is fooled).
+if ! git diff --quiet -- Cargo.lock; then
+  echo "pre-push: ERROR — Cargo.lock is out of sync with Cargo.toml." >&2
+  echo "  The test run just reconciled it, so the committed lock is stale and the" >&2
+  echo "  release's 'cargo publish --locked' would abort. Commit the synced lock:" >&2
+  echo "    git add Cargo.lock && git commit --amend --no-edit   (or a fresh commit)" >&2
+  exit 1
+fi
+
 echo "pre-push: ok"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,14 @@ jobs:
         with:
           toolchain: "1.94"
       - uses: Swatinem/rust-cache@v2
+      # The release publishes with `cargo publish --locked`; mirror that here on
+      # the clean checkout — BEFORE any `cargo test`/`build` silently reconciles
+      # the working-tree lock — so a Cargo.toml version bump that forgot to commit
+      # the regenerated Cargo.lock fails the PR, not the tag. (0.16.1's crates.io
+      # publish stalled exactly this way: lock still pinned 0.16.0.) `cargo
+      # metadata` resolves without compiling, so this is a couple of seconds.
+      - name: Cargo.lock is in sync with Cargo.toml (release uses --locked)
+        run: cargo metadata --locked --format-version 1 > /dev/null
       # `cargo test --all-targets` links every integration-test binary in the
       # DEBUG profile — each statically links the full dep tree (arrow / parquet
       # / openssl / ring / tiberius) with full debug info, hundreds of MB apiece.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,3 +153,23 @@ stricter MSRV image, a `--locked` resolve) can reject what `cargo build` accepts
 add a **local regression guard** that mimics its check (here: the
 `cargo_manifest_chef` offline test asserts no multi-line inline tables) so the
 mismatch fails loud and local instead of half-way through publishing.
+
+The very next release (0.16.1) proved how easy it is to get the *guard itself*
+wrong. The release runs `cargo publish --locked`; a version bump that did not
+commit the regenerated `Cargo.lock` (lock still pinned 0.16.0 against a 0.16.1
+manifest) made `--locked` abort with exit 101 — again *after* the tag was cut.
+The obvious guard, an offline test that reads `Cargo.lock` at runtime and
+compares its `rivet-cli` version to `Cargo.toml`, **does not work**: `cargo test`
+silently reconciles the working-tree lock *before* the test body runs, so the
+test always reads the fixed version and passes even on a stale committed lock.
+(Proven by running the RED case — the desynced lock still passed.) The staleness
+lives only in git, and `cargo` erases it on the way to running your check.
+
+Process rule: **a guard for a `--locked` mismatch must itself run `--locked` on a
+clean tree, not read files at runtime.** The working guard is a CI step —
+`cargo metadata --locked` on the freshly-checked-out commit, *before* any
+`cargo build`/`test` reconciles the lock — which fails fast on a stale committed
+lock without compiling. More generally: when a check's subject is mutated by the
+act of checking it (cargo reconciling the lock, a formatter rewriting the file),
+the runtime read is a no-op; assert against the committed state or the
+strict-mode tool, never the post-reconcile working tree.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "arrow",


### PR DESCRIPTION
## Fix the 0.16.1 release: synced Cargo.lock + `--locked` CI guard

0.16.1's **crates.io publish failed** — `cargo publish --locked` aborted (exit 101): the committed `Cargo.lock` still pinned `rivet-cli = 0.16.0` against the 0.16.1 manifest. The version bump regenerated the lock locally, but it was never `git add`ed. The release path's `--locked` is stricter than `cargo build` (same trap as the Docker/cargo-chef one, different tool).

Binaries + GitHub release published for v0.16.1; only crates.io stalled. Recovery: this PR + force-retag v0.16.1 onto the fixed commit.

### Fix
- Commit the synced `Cargo.lock` (rivet-cli 0.16.1).

### Guard (the subtle part)
- A CI step runs `cargo metadata --locked` on the **clean checkout, before** any `cargo build`/`test` reconciles the working-tree lock — so a stale committed lock fails the PR, not the tag. `cargo metadata` resolves without compiling (~seconds).
- A naive offline test that reads `Cargo.lock` at runtime and compares versions **does not work**: `cargo test` silently reconciles the working-tree lock before the test body runs, so it reads the fixed version and passes even on a stale committed lock. Verified by running the RED case — it passed. The staleness lives only in git; cargo erases it on the way to your check.

### Docs
- `CLAUDE.md`: extend the "verify the real release build path" rule with this case + the general "don't assert against the post-reconcile working tree" lesson.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QswtrPAD4MwGcUJdVy7Ehx
