### PR TITLE
Release 0.16.3: arrow / parquet 58 → 59 (supersedes #58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.16.3 (2026-06-30) — dependency bump: arrow / parquet 58 → 59
+
+A pure dependency bump (no config-grammar change — the schema bump is the version title only).
+
+### Changed
+
+- Bumped `arrow`, `arrow-schema`, and `parquet` 58 → 59. parquet 59 reshaped `LogicalType`'s parametrized
+  variants (struct-variants with inline fields → tuple-variants wrapping nested structs); the only code
+  affected was one type-round-trip test asserting Parquet logical types, migrated to parquet 59's public
+  `LogicalType::{integer,decimal,time,timestamp}` constructors. **No behavioral change** — the live
+  `parquet_schema_pins_{postgres,mysql}_matrix_logical_types` tests confirm arrow 59 emits byte-identical
+  Parquet logical types. The bump also drops three transitive deps (`integer-encoding`, `ordered-float`,
+  `thrift`), 497 → 494 crates.
+
 ## 0.16.2 (2026-06-30) — operator diagnostics: stable codes, `--json` everywhere, warning severity, `doctor --json`
 
 Backward-compatible operator-UX additions (roadmap §9.6 item 7). The config grammar is unchanged — the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -128,7 +128,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -139,9 +139,9 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arrow"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
+checksum = "ffaaa3e009861fd829d0a24dd6f115aa8e4634324bb092147d43baafe69ca4a7"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
+checksum = "3ac95125e1d71c4a252b5a9c729aef111e80418f08aaa6dbabd1ba66918247fc"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
+checksum = "0c60c79628e9a97cb90d7a0dc3e944f216a902f837d4ecabc14d524bddbbc137"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
+checksum = "6026f638c400e9878c1b1cc05c3cfd46fbf381285916ab408678701c1df46c1a"
 dependencies = [
  "bytes",
  "half",
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
+checksum = "c82c236c3caf8df5664284f3f1fbe89938852163998c3fdbf37e84ac220445e9"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94e8cf7e517657a52b91ea1263acf38c4ca62a84655d72458a3359b12ab97de"
+checksum = "12714e5fb7954159af1e26d4e0d37108bcf1a2ad5ee5c5bf02a944d564d588b7"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -240,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
+checksum = "7bd568aa70c4ec5947027b0d5caee94877433b661a0bb9e8ddceeeb5f0c9b1ab"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -253,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f"
+checksum = "e57ee4d470eab1a021bc4b63fa2b2c15d572892bf227b0a982d3b755a6c662b5"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -267,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "205ca2119e6d679d5c133c6f30e68f027738d95ed948cf77677ea69c7800036b"
+checksum = "38f47e0e7a284e1f3707a780dc8cd5451b1614e9e398ea2d9ca03c7a2fe9a9ed"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
+checksum = "a79cf73ad2eba8686ec2aa9bbf8671208e509025f166afc040cedbd94ffe4983"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
+checksum = "cea0f7d8ed6182f14952761e2c0f989852d5aa334fcbc49f73a9f2247c25b879"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
+checksum = "80b3e786a0dd9103acd583a6fb486dbf2f3268466cc0bd571dcf34cef231c1f1"
 dependencies = [
  "serde_core",
  "serde_json",
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
+checksum = "067a67e0361f6c31f4a7248759f36ca4ca71b187a941ed4d49da1c7d3d4db624"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -342,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
+checksum = "99bc95847f3ff62a2b03d6f8ce2e3e78f01362060549a2a311898dd442f6256d"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -1123,7 +1123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1731,12 +1731,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
 name = "io-enum"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,15 +2335,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2394,9 +2379,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
+checksum = "970dff83e97d953c827ae8176f6bf4e9f77bf62daacc01ec5df348ec5eacd913"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -2420,7 +2405,6 @@ dependencies = [
  "seq-macro",
  "simdutf8",
  "snap",
- "thrift",
  "twox-hash",
  "zstd",
 ]
@@ -3198,7 +3182,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3629,7 +3613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3736,7 +3720,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3777,17 +3761,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "thrift"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
-dependencies = [
- "byteorder",
- "integer-encoding",
- "ordered-float",
 ]
 
 [[package]]
@@ -4486,7 +4459,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,11 @@ md-5 = "0.11"
 # `canonical_extension_types` enables Arrow's canonical extension wrappers
 # (`arrow_schema::extension::{Uuid, Json}`) — see Cargo dep on `parquet`
 # below for the writer-side pairing.
-arrow = { version = "58", features = ["canonical_extension_types"] }
+arrow = { version = "59", features = ["canonical_extension_types"] }
 # Direct dep on `arrow-schema` so we can use the `extension` module — the
 # `arrow` facade re-exports `DataType` / `Field` but not the `extension`
 # submodule. Version is pinned to match `arrow`'s transitive choice.
-arrow-schema = { version = "58", features = ["canonical_extension_types"] }
+arrow-schema = { version = "59", features = ["canonical_extension_types"] }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive", "env"] }
 csv = "1"
@@ -67,7 +67,7 @@ opendal = { version = "0.55", features = ["blocking", "services-fs", "services-s
 # this flag, those columns would fall back to `String` and our downstream
 # autoload story (DuckDB → native UUID, ClickHouse → Nullable(UUID), …)
 # stays one cast away. See `src/types/mapping.rs` for the emission site.
-parquet = { version = "58", features = ["arrow", "zstd", "lz4", "flate2", "arrow_canonical_extension_types"] }
+parquet = { version = "59", features = ["arrow", "zstd", "lz4", "flate2", "arrow_canonical_extension_types"] }
 clap_complete = "4"
 postgres = { version = "0.19", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-0_8"] }
 postgres-native-tls = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rivet-cli"
-version = "0.16.2"
+version = "0.16.3"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/schemas/latest/rivet.schema.json
+++ b/schemas/latest/rivet.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Rivet config (rivet-cli 0.16.2)",
+  "title": "Rivet config (rivet-cli 0.16.3)",
   "description": "Top-level Rivet configuration root.\n\nOperators write this struct as YAML (typically `rivet.yaml`).  The\n`JsonSchema` derive is the source of truth for the `schemas/rivet.schema.json`\nartifact and the `rivet schema config` command's output (v0.7.3 P0).",
   "type": "object",
   "properties": {

--- a/schemas/rivet.schema.json
+++ b/schemas/rivet.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Rivet config (rivet-cli 0.16.2)",
+  "title": "Rivet config (rivet-cli 0.16.3)",
   "description": "Top-level Rivet configuration root.\n\nOperators write this struct as YAML (typically `rivet.yaml`).  The\n`JsonSchema` derive is the source of truth for the `schemas/rivet.schema.json`\nartifact and the `rivet schema config` command's output (v0.7.3 P0).",
   "type": "object",
   "properties": {

--- a/tests/type_roundtrip/parquet_schema.rs
+++ b/tests/type_roundtrip/parquet_schema.rs
@@ -106,42 +106,20 @@ fn parquet_schema_pins_postgres_matrix_logical_types() {
         &cols,
         "c_smallint",
         INT32,
-        Some(Integer {
-            bit_width: 16,
-            is_signed: true,
-        }),
+        Some(LogicalType::integer(16, true)),
     );
     assert_col(&cols, "c_integer", INT32, None);
     assert_col(&cols, "c_bigint", INT64, None);
 
     // Decimals: small precision fits INT64; precision > 18 escalates to FLBA.
-    assert_col(
-        &cols,
-        "amount",
-        INT64,
-        Some(Decimal {
-            scale: 2,
-            precision: 18,
-        }),
-    );
+    assert_col(&cols, "amount", INT64, Some(LogicalType::decimal(2, 18)));
     assert_col(
         &cols,
         "fee",
         FIXED_LEN_BYTE_ARRAY,
-        Some(Decimal {
-            scale: 6,
-            precision: 20,
-        }),
+        Some(LogicalType::decimal(6, 20)),
     );
-    assert_col(
-        &cols,
-        "price",
-        INT64,
-        Some(Decimal {
-            scale: 2,
-            precision: 10,
-        }),
-    );
+    assert_col(&cols, "price", INT64, Some(LogicalType::decimal(2, 10)));
 
     // Floats
     assert_col(&cols, "c_real", FLOAT, None);
@@ -153,28 +131,25 @@ fn parquet_schema_pins_postgres_matrix_logical_types() {
         &cols,
         "c_time",
         INT64,
-        Some(Time {
-            is_adjusted_to_u_t_c: false,
-            unit: parquet::basic::TimeUnit::MICROS,
-        }),
+        Some(LogicalType::time(false, parquet::basic::TimeUnit::MICROS)),
     );
     assert_col(
         &cols,
         "created_at",
         INT64,
-        Some(Timestamp {
-            is_adjusted_to_u_t_c: false,
-            unit: parquet::basic::TimeUnit::MICROS,
-        }),
+        Some(LogicalType::timestamp(
+            false,
+            parquet::basic::TimeUnit::MICROS,
+        )),
     );
     assert_col(
         &cols,
         "created_at_tz",
         INT64,
-        Some(Timestamp {
-            is_adjusted_to_u_t_c: true,
-            unit: parquet::basic::TimeUnit::MICROS,
-        }),
+        Some(LogicalType::timestamp(
+            true,
+            parquet::basic::TimeUnit::MICROS,
+        )),
     );
 
     // Strings / text
@@ -235,10 +210,7 @@ fn parquet_schema_pins_mysql_matrix_logical_types() {
         &cols,
         "c_tinyint",
         INT32,
-        Some(Integer {
-            bit_width: 16,
-            is_signed: true,
-        }),
+        Some(LogicalType::integer(16, true)),
     );
     assert_col(&cols, "c_bigint", INT64, None);
 
@@ -248,10 +220,7 @@ fn parquet_schema_pins_mysql_matrix_logical_types() {
         &cols,
         "c_tinyint_u",
         INT32,
-        Some(Integer {
-            bit_width: 16,
-            is_signed: true,
-        }),
+        Some(LogicalType::integer(16, true)),
     );
     assert_col(&cols, "c_smallint_u", INT32, None);
     assert_col(&cols, "c_int_u", INT64, None);
@@ -259,59 +228,37 @@ fn parquet_schema_pins_mysql_matrix_logical_types() {
         &cols,
         "c_bigint_u",
         INT64,
-        Some(Integer {
-            bit_width: 64,
-            is_signed: false,
-        }),
+        Some(LogicalType::integer(64, false)),
     );
 
     // Decimals identical to PG matrix.
-    assert_col(
-        &cols,
-        "amount",
-        INT64,
-        Some(Decimal {
-            scale: 2,
-            precision: 18,
-        }),
-    );
+    assert_col(&cols, "amount", INT64, Some(LogicalType::decimal(2, 18)));
     assert_col(
         &cols,
         "fee",
         FIXED_LEN_BYTE_ARRAY,
-        Some(Decimal {
-            scale: 6,
-            precision: 20,
-        }),
+        Some(LogicalType::decimal(6, 20)),
     );
-    assert_col(
-        &cols,
-        "price",
-        INT64,
-        Some(Decimal {
-            scale: 2,
-            precision: 10,
-        }),
-    );
+    assert_col(&cols, "price", INT64, Some(LogicalType::decimal(2, 10)));
 
     // Temporal — both naive (DATETIME) and tz (TIMESTAMP) map.
     assert_col(
         &cols,
         "created_at_dt",
         INT64,
-        Some(Timestamp {
-            is_adjusted_to_u_t_c: false,
-            unit: parquet::basic::TimeUnit::MICROS,
-        }),
+        Some(LogicalType::timestamp(
+            false,
+            parquet::basic::TimeUnit::MICROS,
+        )),
     );
     assert_col(
         &cols,
         "created_at_ts",
         INT64,
-        Some(Timestamp {
-            is_adjusted_to_u_t_c: true,
-            unit: parquet::basic::TimeUnit::MICROS,
-        }),
+        Some(LogicalType::timestamp(
+            true,
+            parquet::basic::TimeUnit::MICROS,
+        )),
     );
 
     // Binary family — all three MySQL binary widths land as BYTE_ARRAY.
@@ -328,10 +275,7 @@ fn parquet_schema_pins_mysql_matrix_logical_types() {
         &cols,
         "year_col",
         INT32,
-        Some(Integer {
-            bit_width: 16,
-            is_signed: true,
-        }),
+        Some(LogicalType::integer(16, true)),
     );
 
     // `extras` is MySQL `JSON` — now emits native `LogicalType::Json`.


### PR DESCRIPTION
## Release 0.16.3 — arrow / parquet 58 → 59

Supersedes #58 (Dependabot's cargo-major bump, which left CI red). This branch is that bump **plus** the migration to make it green, packaged as the 0.16.3 patch release.

### The breaking change
parquet 59 reshaped `LogicalType`'s parametrized variants — struct-variants with inline fields became tuple-variants wrapping nested structs (`Decimal { scale, precision }` → `Decimal(DecimalType { … })`; same for `Integer` / `Time` / `Timestamp`).

**Scope was tiny:** `src/` compiled clean — all 33 errors were in a single test file (`tests/type_roundtrip/parquet_schema.rs`, 16 construction sites). Migrated to parquet 59's public constructors (`LogicalType::{integer,decimal,time,timestamp}`) — cleaner than the nested-struct form, no extra import.

### No behavioral change
- `clippy --all-targets` clean, full offline suite green (1768 lib + 1859 integration, 0 failed).
- Live `parquet_schema_pins_{postgres,mysql}_matrix_logical_types` **pass** → arrow 59 emits byte-identical Parquet logical types.
- Bonus: drops three transitive deps (`integer-encoding`, `ordered-float`, `thrift`), 497 → 494 crates.

### Release 0.16.3
0.16.2 → 0.16.3; `Cargo.lock` synced; both schema files regenerated (title-version only). Guards green: `cargo metadata --locked`, `schema_drift`, `cargo_manifest_chef`, `cargo audit` (clean), lib 1768, pre-push 304.

After merge: tag `v0.16.3` on `main` → crates.io + GitHub release + Docker + Homebrew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
