### PR TITLE
Release 0.16.4: CDC hardening campaign — 42 findings, MySQL idle-anchor fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.16.4 — 2026-07-03
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rivet-cli"
-version = "0.16.3"
+version = "0.16.4"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/schemas/latest/rivet.schema.json
+++ b/schemas/latest/rivet.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Rivet config (rivet-cli 0.16.3)",
+  "title": "Rivet config (rivet-cli 0.16.4)",
   "description": "Top-level Rivet configuration root.\n\nOperators write this struct as YAML (typically `rivet.yaml`).  The\n`JsonSchema` derive is the source of truth for the `schemas/rivet.schema.json`\nartifact and the `rivet schema config` command's output (v0.7.3 P0).",
   "type": "object",
   "properties": {

--- a/schemas/rivet.schema.json
+++ b/schemas/rivet.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Rivet config (rivet-cli 0.16.3)",
+  "title": "Rivet config (rivet-cli 0.16.4)",
   "description": "Top-level Rivet configuration root.\n\nOperators write this struct as YAML (typically `rivet.yaml`).  The\n`JsonSchema` derive is the source of truth for the `schemas/rivet.schema.json`\nartifact and the `rivet schema config` command's output (v0.7.3 P0).",
   "type": "object",
   "properties": {


### PR DESCRIPTION
Version bump to 0.16.4 (Cargo.toml + lock + regenerated schema + CHANGELOG). The substance merged in #62; headline for operators: **v0.16.3 MySQL CDC silently loses every change that lands between bounded runs** — the checkpoint was never written on part-less runs, so every run re-anchored at current. 0.16.4 pins the checkpoint at open.

Release-path guards run locally: `cargo metadata --locked`, `cargo publish --dry-run`, cargo-chef manifest gate, 4,056 offline tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014R5mjtY9mmAsKKp9FdVh4P