### PR TITLE
fix(cdc): first run died on the scaffolded checkpoint's missing parent dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **First CDC run no longer fails when the scaffolded checkpoint directory doesn't exist.** `rivet init
+  --mode cdc` scaffolds `checkpoint: ./cdc/<table>.ckpt`, but nothing created `./cdc/` — the very first
+  `rivet run` (the README CDC quickstart, step 3) died with an ENOENT dressed in the grants hint. Found
+  by a fresh-client dress rehearsal of the released 0.16.4 binary; the checkpoint save now creates
+  parent directories and carries an honest per-step error context (`creating checkpoint directory …`)
+  instead of the misleading permissions framing.
+
 ## 0.16.4 — 2026-07-03
 
 ### Added

--- a/src/source/cdc/mod.rs
+++ b/src/source/cdc/mod.rs
@@ -60,11 +60,24 @@ impl Position {
     }
 
     /// Persist atomically (temp file + rename) so a crash never leaves a torn
-    /// checkpoint that would resume from a corrupt position.
+    /// checkpoint that would resume from a corrupt position. Creates the
+    /// parent directory: `rivet init --mode cdc` scaffolds
+    /// `checkpoint: ./cdc/<table>.ckpt`, and the first client-flow rehearsal
+    /// (finding #43) died on the missing `./cdc/` with an ENOENT dressed in
+    /// the grants hint — a quickstart-blocking wall for every fresh user.
     pub(crate) fn save(&self, path: &Path) -> Result<()> {
+        use anyhow::Context as _;
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating checkpoint directory '{}'", parent.display()))?;
+        }
         let tmp = path.with_extension("tmp");
-        std::fs::write(&tmp, serde_json::to_vec(&self.0)?)?;
-        std::fs::rename(&tmp, path)?;
+        std::fs::write(&tmp, serde_json::to_vec(&self.0)?)
+            .with_context(|| format!("writing checkpoint '{}'", path.display()))?;
+        std::fs::rename(&tmp, path)
+            .with_context(|| format!("committing checkpoint '{}'", path.display()))?;
         Ok(())
     }
 }
@@ -544,6 +557,30 @@ pub(crate) fn run_capture(cap: CdcCapture<'_>) -> Result<Vec<crate::manifest::Ru
 
 #[cfg(test)]
 mod tests {
+    /// Finding #43: `rivet init --mode cdc` scaffolds
+    /// `checkpoint: ./cdc/<table>.ckpt`; the first save must create the
+    /// parent, or every fresh quickstart dies on ENOENT dressed in the
+    /// grants hint.
+    #[test]
+    fn checkpoint_save_creates_missing_parent_directories() {
+        let d = tempfile::tempdir().unwrap();
+        let path = d.path().join("cdc").join("nested").join("orders.ckpt");
+        let pos = Position(serde_json::json!({"file": "binlog.000001", "pos": 4}));
+        pos.save(&path).expect("save must create parents");
+        let loaded = Position::load(&path).unwrap().expect("roundtrip");
+        assert_eq!(loaded.0["pos"], 4);
+        // And the error context names the path, not the grants, when the
+        // parent CANNOT be created (a file where the dir should be).
+        let blocker = d.path().join("blocked");
+        std::fs::write(&blocker, b"file").unwrap();
+        let bad = blocker.join("x.ckpt");
+        let err = pos.save(&bad).unwrap_err().to_string();
+        assert!(
+            err.contains("checkpoint directory"),
+            "the failure must name the real cause: {err}"
+        );
+    }
+
     use super::*;
 
     // Ultrareview bug_001: the loud-fail-on-missing-anchor promise held only


### PR DESCRIPTION
Found by the pilot dress rehearsal: following the README CDC quickstart with the released v0.16.4 binary fails at step 3 — `init --mode cdc` scaffolds `checkpoint: ./cdc/<table>.ckpt`, nothing creates `./cdc/`, first run dies with ENOENT wrapped in the grants hint. Quickstart-blocking for every fresh user; warrants 0.16.5.

Fix: `Position::save` creates parents + honest per-step IO contexts. Unit-pinned (creation + error naming). Full client flow re-run green incl. kill -9 mid-drain with zero loss (5,001/5,001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014R5mjtY9mmAsKKp9FdVh4P