### PR TITLE
fix: cross-shape manifest clobbering at a shared prefix (finding #44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **A batch and a CDC export sharing one prefix no longer destroy each other's manifest** (finding
+  #44, caught during a live GCS walkthrough: the CDC run's `manifest.json` silently replaced the batch
+  export's, orphaning its parts from `rivet validate`). Two layers: the CDC scaffold now gets its own
+  sub-prefix (`exports/<table>/cdc/`, local `./output/<table>/cdc/`), and every write path refuses an
+  EXPLICIT cross-shape manifest overwrite BEFORE the first part lands — a clean config error naming
+  both shapes and the fix. Manifests now carry a `mode` field (`batch`/`cdc`); manifests written by
+  older versions have no `mode` and are always allowed, so existing CDC deployments keep resuming
+  after the upgrade.
+
 ## 0.16.5 — 2026-07-04
 
 ### Fixed

--- a/src/init/yaml_scaffold.rs
+++ b/src/init/yaml_scaffold.rs
@@ -213,9 +213,19 @@ fn export_segment(info: &TableInfo, source_type: &str) -> String {
     }
 }
 
-/// `exports/<table>/` in the bucket, or `exports/<schema>__<table>/` for non-`public` PostgreSQL.
-fn table_export_prefix(info: &TableInfo, source_type: &str) -> String {
-    format!("exports/{}/", export_segment(info, source_type))
+/// `exports/<table>/` in the bucket, or `exports/<schema>__<table>/` for
+/// non-`public` PostgreSQL. CDC scaffolds get `exports/<table>/cdc/` — a batch
+/// and a CDC export of the SAME table would otherwise share a prefix and
+/// clobber each other's `manifest.json`/`_SUCCESS` (finding #44: the batch
+/// manifest silently vanished under the CDC run's, orphaning its parts from
+/// `rivet validate`).
+fn table_export_prefix(info: &TableInfo, source_type: &str, mode: &str) -> String {
+    let seg = export_segment(info, source_type);
+    if mode == "cdc" {
+        format!("exports/{seg}/cdc/")
+    } else {
+        format!("exports/{seg}/")
+    }
 }
 
 /// Emit a YAML scalar that is unambiguous for any plain-text value the user
@@ -497,7 +507,7 @@ fn export_block_lines(
     lines.push(
         "      row_hash: true  # _rivet_row_hash: per-row hash for change detection".to_string(),
     );
-    lines.extend(destination_scaffold(info, source_type, dest));
+    lines.extend(destination_scaffold(info, source_type, dest, mode));
 
     lines.extend(decimal_override_lines(info));
 
@@ -543,7 +553,7 @@ fn cdc_export_lines(
         )),
         _ => {}
     }
-    lines.extend(destination_scaffold(info, source_type, dest));
+    lines.extend(destination_scaffold(info, source_type, dest, "cdc"));
     lines.extend(decimal_override_lines(info));
     lines
 }
@@ -592,8 +602,9 @@ fn destination_scaffold(
     info: &TableInfo,
     source_type: &str,
     dest: &InitYamlDestination,
+    mode: &str,
 ) -> Vec<String> {
-    let prefix = yaml_quote_if_needed(&table_export_prefix(info, source_type));
+    let prefix = yaml_quote_if_needed(&table_export_prefix(info, source_type, mode));
     if let Some(bucket) = &dest.gcs_bucket {
         let bucket = yaml_quote_if_needed(bucket);
         let mut v = vec![
@@ -626,8 +637,12 @@ fn destination_scaffold(
         // a schema-wide init's exports don't all share ./output — that collides
         // their manifest.json / _SUCCESS and makes a second run read a sibling's
         // parts (the scary double-count WARN).
-        let path =
-            yaml_quote_if_needed(&format!("./output/{}/", export_segment(info, source_type)));
+        let seg = export_segment(info, source_type);
+        let path = if mode == "cdc" {
+            yaml_quote_if_needed(&format!("./output/{seg}/cdc/"))
+        } else {
+            yaml_quote_if_needed(&format!("./output/{seg}/"))
+        };
         vec![
             "    destination:".to_string(),
             "      type: local".to_string(),

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -128,6 +128,13 @@ pub struct RunManifest {
     pub manifest_version: u32,
     pub run_id: String,
     pub export_name: String,
+    /// Which pipeline shape wrote this manifest — `batch` or `cdc`. Guards a
+    /// prefix against silent cross-shape clobbering (finding #44: a CDC run
+    /// overwrote a batch export's manifest at a shared prefix, orphaning its
+    /// parts from `rivet validate`). Defaults to `batch` for manifests
+    /// written before this field existed.
+    #[serde(default = "default_manifest_mode")]
+    pub mode: String,
     pub started_at: String,
     pub finished_at: String,
     pub status: ManifestStatus,
@@ -334,6 +341,7 @@ mod tests {
             .filter(|p| p.status == PartStatus::Committed)
             .count() as u32;
         RunManifest {
+            mode: "batch".to_string(),
             manifest_version: MANIFEST_VERSION,
             run_id: "orders_20260521T120000.000".into(),
             export_name: "public.orders".into(),
@@ -556,5 +564,97 @@ mod tests {
         let parsed: RunManifest = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.run_id, "r1");
         assert_eq!(parsed.validate_self_consistency(), Ok(()));
+    }
+}
+
+fn default_manifest_mode() -> String {
+    "batch".to_string()
+}
+
+/// Finding #44 guard: refuse to overwrite a manifest written by the OTHER
+/// pipeline shape. Same-shape overwrites stay allowed (a batch full re-run
+/// replaces its own manifest by design; CDC extends its own). A missing or
+/// unreadable manifest is not this guard's business — corruption surfaces in
+/// `rivet validate`, and first runs must not require a read round-trip.
+pub fn guard_manifest_mode(
+    dest: &dyn crate::destination::Destination,
+    new_mode: &str,
+) -> anyhow::Result<()> {
+    let Ok(bytes) = dest.read("manifest.json") else {
+        return Ok(());
+    };
+    let Ok(existing) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return Ok(());
+    };
+    // A manifest WITHOUT the field predates 0.16.6 — every live CDC
+    // deployment's prefix looks like that after an upgrade, and refusing it
+    // would brick their own resume. Absent mode ⇒ unknown ⇒ allow; only an
+    // EXPLICIT cross-shape mismatch refuses.
+    let Some(existing_mode) = existing.get("mode").and_then(|m| m.as_str()) else {
+        return Ok(());
+    };
+    if existing_mode != new_mode {
+        anyhow::bail!(
+            "destination already holds a '{existing_mode}' manifest (run_id {run}); refusing to \
+             overwrite it with a '{new_mode}' manifest — a batch export and a CDC export sharing \
+             one prefix silently destroy each other's audit trail. Give this export its own \
+             prefix (the scaffold now uses exports/<table>/cdc/ for CDC).",
+            run = existing
+                .get("run_id")
+                .and_then(|r| r.as_str())
+                .unwrap_or("unknown"),
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod mode_guard_tests {
+    use super::*;
+
+    #[test]
+    fn pre_mode_manifests_default_to_batch() {
+        // The REAL committed v0.16 manifest (compat fixture) predates the
+        // `mode` field — it must parse and read as batch.
+        let old = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/compat/v0.16/cdc_manifest.json"),
+        )
+        .expect("compat fixture");
+        let m: RunManifest = serde_json::from_str(&old).expect("old manifests parse");
+        assert_eq!(m.mode, "batch");
+    }
+
+    #[test]
+    fn cross_shape_overwrite_is_refused_same_shape_allowed() {
+        let d = tempfile::tempdir().unwrap();
+        let dest = crate::destination::create_destination(&crate::config::DestinationConfig {
+            destination_type: crate::config::DestinationType::Local,
+            path: Some(d.path().to_str().unwrap().to_string()),
+            ..Default::default()
+        })
+        .unwrap();
+        // empty prefix: any mode fine
+        guard_manifest_mode(dest.as_ref(), "batch").unwrap();
+        std::fs::write(
+            d.path().join("manifest.json"),
+            r#"{"mode":"batch","run_id":"r1"}"#,
+        )
+        .unwrap();
+        guard_manifest_mode(dest.as_ref(), "batch").expect("same shape re-run allowed");
+        let err = guard_manifest_mode(dest.as_ref(), "cdc")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("refusing to"), "loud refusal: {err}");
+        assert!(
+            err.contains("exports/<table>/cdc/"),
+            "carries the recovery: {err}"
+        );
+        // A pre-0.16.6 manifest (no mode field) must be ALLOWED — every live
+        // CDC deployment's prefix looks like that right after an upgrade, and
+        // refusing would brick their own resume. Unknown ⇒ pass.
+        std::fs::write(d.path().join("manifest.json"), r#"{"run_id":"legacy"}"#).unwrap();
+        guard_manifest_mode(dest.as_ref(), "cdc").expect("legacy prefixes must keep resuming");
+        guard_manifest_mode(dest.as_ref(), "batch").expect("in either direction");
     }
 }

--- a/src/pipeline/cdc_job.rs
+++ b/src/pipeline/cdc_job.rs
@@ -252,6 +252,10 @@ fn run_cdc_inner(
             export.destination.clone()
         };
         let dest = crate::destination::create_destination(&dcfg)?;
+        // Finding #44, early check: refuse BEFORE the first part lands if the
+        // prefix belongs to the other pipeline shape (config error, fail the
+        // run cleanly — the write-seam guard stays as the backstop).
+        crate::manifest::guard_manifest_mode(dest.as_ref(), "cdc")?;
         let uri = dcfg
             .path
             .clone()

--- a/src/pipeline/chunked/exec.rs
+++ b/src/pipeline/chunked/exec.rs
@@ -112,6 +112,7 @@ pub(crate) fn run_chunked_sequential(
                 format::create_format(plan.format, plan.compression, plan.compression_level, None);
             let base = super::chunk_part_filename(&plan.export_name, i, fmt.file_extension());
             let dest = destination::create_destination(&plan.destination)?;
+            crate::manifest::guard_manifest_mode(dest.as_ref(), "batch")?;
             // Shared commit path (I1→I2→I7 + counters + journal + fault hooks).
             // write_sink_parts drains every part the sink produced — the
             // final temp file plus anything maybe_split rotated at
@@ -260,6 +261,8 @@ pub(crate) fn run_chunked_parallel(
     // (`dispatch task is gone: runtime dropped` from the HTTP client).
     let shared_destination =
         std::sync::Arc::new(destination::create_destination(&plan.destination)?);
+    // Finding #44 early check (see single.rs) — chunked writes share the fate.
+    crate::manifest::guard_manifest_mode(&**shared_destination, "batch")?;
     destination::log_capabilities(
         &plan.export_name,
         &**shared_destination,

--- a/src/pipeline/keyset.rs
+++ b/src/pipeline/keyset.rs
@@ -108,6 +108,10 @@ pub(crate) fn run_keyset(
             fmt.file_extension()
         );
         let dest = destination::create_destination(&plan.destination)?;
+        // Finding #44, early check: fail cleanly before the first part if this
+        // prefix already belongs to a CDC export (cross-shape manifests clobber
+        // each other; the write-seam guard is the backstop).
+        crate::manifest::guard_manifest_mode(dest.as_ref(), "batch")?;
         // Shared commit path (I1→I2→I7 + counters + journal + fault hooks).
         // write_sink_parts drains every part the sink produced — the final
         // temp file plus anything maybe_split rotated at max_file_size — so

--- a/src/pipeline/manifest_reconcile.rs
+++ b/src/pipeline/manifest_reconcile.rs
@@ -214,6 +214,7 @@ mod tests {
 
     fn manifest(parts: Vec<ManifestPart>) -> RunManifest {
         RunManifest {
+            mode: "batch".to_string(),
             manifest_version: MANIFEST_VERSION,
             run_id: "r".into(),
             export_name: "e".into(),

--- a/src/pipeline/manifest_writer.rs
+++ b/src/pipeline/manifest_writer.rs
@@ -160,6 +160,7 @@ impl ManifestBuilder {
         let finished_at = chrono::Utc::now();
         RunManifest {
             manifest_version: crate::manifest::MANIFEST_VERSION,
+            mode: "batch".to_string(),
             run_id: self.run_id,
             export_name: self.export_name,
             started_at: self.started_at.to_rfc3339(),
@@ -304,6 +305,12 @@ pub fn write_manifest(dest: &dyn Destination, manifest: &RunManifest) -> Result<
         );
         return Ok(WriteOutcome::SkippedStreaming);
     }
+
+    // Finding #44: a batch and a CDC export sharing one prefix silently
+    // destroyed each other's manifest (last writer wins, prior parts orphaned
+    // from validate). Refuse cross-shape overwrites at the ONE seam both
+    // pipelines write through.
+    crate::manifest::guard_manifest_mode(dest, &manifest.mode)?;
 
     let bytes = serde_json::to_vec_pretty(manifest)?;
 

--- a/src/pipeline/resume_decisions.rs
+++ b/src/pipeline/resume_decisions.rs
@@ -200,6 +200,7 @@ mod tests {
             .filter(|p| p.status == PartStatus::Committed)
             .count() as u32;
         RunManifest {
+            mode: "batch".to_string(),
             manifest_version: MANIFEST_VERSION,
             run_id: "r1".into(),
             export_name: "public.orders".into(),

--- a/src/pipeline/single.rs
+++ b/src/pipeline/single.rs
@@ -343,6 +343,10 @@ pub(super) fn run_single_export(
     let fmt = format::create_format(plan.format, plan.compression, plan.compression_level, None);
     let ext = fmt.file_extension();
     let dest = destination::create_destination(&plan.destination)?;
+    // Finding #44, early check: fail cleanly before the first part if this
+    // prefix already belongs to a CDC export (cross-shape manifests clobber
+    // each other; the write-seam guard is the backstop).
+    crate::manifest::guard_manifest_mode(dest.as_ref(), "batch")?;
 
     // ADR-0004: log backend capabilities; warn when non-retry-safe destination is configured with retries.
     destination::log_capabilities(

--- a/src/pipeline/validate_cmd.rs
+++ b/src/pipeline/validate_cmd.rs
@@ -652,6 +652,7 @@ mod tests {
         let row_count: i64 = parts.iter().map(|p| p.rows).sum();
         let part_count = parts.len() as u32;
         RunManifest {
+            mode: "batch".to_string(),
             manifest_version: MANIFEST_VERSION,
             run_id: "r-validate-cmd".into(),
             export_name: "orders".into(),

--- a/src/pipeline/validate_manifest.rs
+++ b/src/pipeline/validate_manifest.rs
@@ -810,6 +810,7 @@ mod tests {
             .filter(|p| p.status == PartStatus::Committed)
             .count() as u32;
         RunManifest {
+            mode: "batch".to_string(),
             manifest_version: MANIFEST_VERSION,
             run_id: "r".into(),
             export_name: "public.orders".into(),

--- a/src/source/cdc/sink.rs
+++ b/src/source/cdc/sink.rs
@@ -577,6 +577,7 @@ fn build_manifest(
 ) -> RunManifest {
     RunManifest {
         manifest_version: MANIFEST_VERSION,
+        mode: "cdc".to_string(),
         run_id: run_id.to_string(),
         export_name: out.table.clone(),
         started_at: started_at.to_string(),

--- a/tests/live/live_cdc_mbt.rs
+++ b/tests/live/live_cdc_mbt.rs
@@ -1189,3 +1189,52 @@ fn cdc_scenario_smoke_mssql() {
     }
     assert_eq!(rows, 2, "mssql scenario: pin → churn → drain (job-lagged)");
 }
+
+// Finding #44: a batch and a CDC export sharing one prefix silently
+// destroyed each other's manifest.json (last writer wins — the batch part
+// vanished from validate's view in the GCS walkthrough that surfaced this).
+// Two layers, both pinned here: the scaffolds now separate the prefixes, and
+// the manifest writer refuses an EXPLICIT cross-shape overwrite.
+#[test]
+#[ignore = "live: requires docker compose --profile cdc mysql-cdc"]
+fn cdc_scaffold_gets_its_own_prefix_and_cross_shape_overwrite_is_refused() {
+    let mut scn = CdcScenario::mysql("cdc_shape", "id INT PRIMARY KEY, v INT");
+
+    // Layer 1: the scaffolds separate prefixes out of the box.
+    let d = tempfile::tempdir().unwrap();
+    let out = std::process::Command::new(RIVET_BIN)
+        .args([
+            "init",
+            "--source-env",
+            "RIVET_SHAPE_URL",
+            "--table",
+            &scn.table,
+            "--mode",
+            "cdc",
+            "-o",
+            d.path().join("cdc.yaml").to_str().unwrap(),
+        ])
+        .env("RIVET_SHAPE_URL", MYSQL_CDC_URL)
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let yaml = std::fs::read_to_string(d.path().join("cdc.yaml")).unwrap();
+    assert!(
+        yaml.contains(&format!("./output/{}/cdc/", scn.table)),
+        "cdc scaffold must use its own sub-prefix: {yaml}"
+    );
+
+    // Layer 2: the writer refuses a cross-shape manifest overwrite. The
+    // scenario's rig wrote a CDC manifest into its out dir; a batch export
+    // pointed at the SAME prefix must fail loudly.
+    scn.sql(&format!("INSERT INTO {} VALUES (1, 10)", scn.table));
+    scn.rig.run_ok(); // cdc manifest now present at the prefix
+    let batch_rig = Rig::mysql_batch(&scn.table)
+        .source_url(MYSQL_CDC_URL)
+        .dest_path(scn.rig.out_dir());
+    let err = batch_rig.run_expect_fail();
+    assert!(
+        err.contains("refusing to") && err.contains("'cdc' manifest"),
+        "cross-shape overwrite must refuse loudly, naming the shapes: {err}"
+    );
+}

--- a/tests/offline/audit_validate_warning_label.rs
+++ b/tests/offline/audit_validate_warning_label.rs
@@ -27,6 +27,7 @@ const RIVET_BIN: &str = env!("CARGO_BIN_EXE_rivet");
 /// verdict passes (the surplus is then the only advisory entry).
 fn one_part_manifest() -> RunManifest {
     RunManifest {
+        mode: "batch".to_string(),
         manifest_version: MANIFEST_VERSION,
         run_id: "r-l14".into(),
         export_name: "orders".into(),

--- a/tests/offline/trust_artifacts_integration.rs
+++ b/tests/offline/trust_artifacts_integration.rs
@@ -142,6 +142,7 @@ fn build_manifest(run_id: &str, status: ManifestStatus, parts: Vec<ManifestPart>
         .filter(|p| p.status == PartStatus::Committed)
         .count() as u32;
     RunManifest {
+        mode: "batch".to_string(),
         manifest_version: MANIFEST_VERSION,
         run_id: run_id.into(),
         export_name: "public.orders".into(),

--- a/tests/offline/validate_historical.rs
+++ b/tests/offline/validate_historical.rs
@@ -33,6 +33,7 @@ use rivet::pipeline::{ValidateOutputFormat, ValidateTarget, run_validate_command
 /// historical-prefix flags affect.
 fn empty_success_manifest(run_id: &str, export_name: &str) -> RunManifest {
     RunManifest {
+        mode: "batch".to_string(),
         manifest_version: MANIFEST_VERSION,
         run_id: run_id.into(),
         export_name: export_name.into(),


### PR DESCRIPTION
A batch and a CDC export of the same table scaffold to the SAME prefix and their manifests overwrite each other (last writer wins — caught live in a GCS walkthrough when the batch manifest vanished under the CDC run's). Fix: separate scaffold prefixes (`exports/<table>/cdc/`) + a `mode` field in manifests + early cross-shape refusal on every write path before the first part lands. Legacy manifests (no `mode`) are always allowed — existing CDC deployments keep resuming after upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014R5mjtY9mmAsKKp9FdVh4P