### PR TITLE
ci(nightly): mutants job timeout 50 → 180 min (first real run hit the ceiling)

### DIFF
--- a/.github/workflows/nightly-live.yml
+++ b/.github/workflows/nightly-live.yml
@@ -196,7 +196,10 @@ jobs:
   # only — live tests are #[ignore]d, so mutants runs the cheap suite.
   mutants-cdc:
     name: cargo-mutants (CDC modules)
-    timeout-minutes: 50
+    # 50 min hit the ceiling on the first real run: decimal.rs ALONE takes
+    # ~49 min locally on a faster box (108 mutants x offline suite), and this
+    # job also covers cdc/value.rs on a 2-core runner. Nightly has the budget.
+    timeout-minutes: 180
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Nightly re-dispatch after the .live-tmp prolog: full live suite green (yesterday's failure site), scouts + soak green; mutants-cdc cancelled at exactly timeout-minutes: 50. Local calibration says decimal.rs alone is ~49 min; the job also runs value.rs on a 2-core runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014R5mjtY9mmAsKKp9FdVh4P