### PR TITLE
Release 0.16.6: cross-shape manifest guard (#44) + cursor-range contract (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
-## Unreleased
+## 0.16.6 — 2026-07-05
+
+### Added
+
+- **The manifest ships the cursor RANGE as a reconciliation contract.** An incremental export's
+  `source.extraction` now records the strategy, cursor column, and the `cursor_low..cursor_high` range
+  the run covered. Continuity is verifiable from manifests alone — run N+1's `cursor_low` must equal
+  run N's `cursor_high`; a non-contiguous low is a silently-skipped range — without querying rivet's
+  private state. The field is opt-in (older manifests parse with no extraction section). Ported from
+  the pip_db_replicator meta-catalog idea; `cursor_type` / `source_row_count` are follow-ups.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.16.5"
+version = "0.16.6"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rivet-cli"
-version = "0.16.5"
+version = "0.16.6"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/schemas/latest/rivet.schema.json
+++ b/schemas/latest/rivet.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Rivet config (rivet-cli 0.16.5)",
+  "title": "Rivet config (rivet-cli 0.16.6)",
   "description": "Top-level Rivet configuration root.\n\nOperators write this struct as YAML (typically `rivet.yaml`).  The\n`JsonSchema` derive is the source of truth for the `schemas/rivet.schema.json`\nartifact and the `rivet schema config` command's output (v0.7.3 P0).",
   "type": "object",
   "properties": {

--- a/schemas/rivet.schema.json
+++ b/schemas/rivet.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Rivet config (rivet-cli 0.16.5)",
+  "title": "Rivet config (rivet-cli 0.16.6)",
   "description": "Top-level Rivet configuration root.\n\nOperators write this struct as YAML (typically `rivet.yaml`).  The\n`JsonSchema` derive is the source of truth for the `schemas/rivet.schema.json`\nartifact and the `rivet schema config` command's output (v0.7.3 P0).",
   "type": "object",
   "properties": {


### PR DESCRIPTION
Two operator-facing changes since 0.16.5: the cross-shape manifest clobbering guard (#44) and the cursor-range reconciliation contract in the manifest (#72). Version bump + lock + regenerated schema (0.16.6) + CHANGELOG. Release-path guards green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014R5mjtY9mmAsKKp9FdVh4P