### PR TITLE
fix(cdc): bound Postgres/SQL Server drain memory to O(rollover) [Release 0.16.7]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.16.7 — 2026-07-05
+
+### Fixed
+
+- **CDC drain memory is now bounded — O(part rollover), not O(backlog) — on PostgreSQL and SQL Server.**
+  Both poll-model adapters read their entire pending backlog into memory in one query
+  (`pg_logical_slot_peek_changes(slot, NULL, NULL)` / `fn_cdc_get_all_changes(@from, max_lsn)`), so a large
+  replication lag spiked drain RSS. Measured draining a 1M-change backlog (5000-row transactions):
+  PostgreSQL 900 MB, SQL Server 1150 MB — against MySQL's streamed binlog at 76 MB. Both now read in
+  **bounded batches**: PostgreSQL peeks `upto_nchanges` = the part `rollover` and dedupes transactions by a
+  COMMIT-LSN frontier (refilling once the sink's ack advances the slot); SQL Server bounds the window to the
+  batch-th change's start LSN (a transaction boundary, so whole transactions only) and advances an internal
+  cursor. Drain RSS drops to **95 MB** (PostgreSQL) / **105 MB** (SQL Server), in line with MySQL. All CDC
+  invariants are unchanged — at-least-once, no split transactions, commit-boundary ack, the
+  retention-exhausted error, and NDJSON's single non-advancing peek — verified live (pg_cdc 15/15,
+  mssql_cdc 11/11). MySQL (already streamed) is untouched.
+
 ## 0.16.6 — 2026-07-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.16.6"
+version = "0.16.7"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rivet-cli"
-version = "0.16.6"
+version = "0.16.7"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/dev/cdc_interval/baseline_mem.sh
+++ b/dev/cdc_interval/baseline_mem.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# CDC drain MEMORY baseline — all three engines, one big backlog, one drain.
+#
+# Purpose: capture the "before-fix" peak drain RSS vs event count for MySQL,
+# PostgreSQL and SQL Server, so a later run (after the bounded-peek fix) is a
+# like-for-like comparison. Pumps N row changes in MODERATE transactions
+# (batch each ≤ BATCH rows) so a single giant transaction never confounds the
+# result — the question is memory-vs-BACKLOG, not memory-vs-transaction.
+#
+# Hypothesis under test: MySQL streams the binlog (O(largest transaction) →
+# flat RSS); PostgreSQL peeks the whole slot (O(total backlog)); SQL Server
+# polls the change-table window (likely O(backlog) too).
+#
+# Usage:
+#   RIVET_BIN=/tmp/rivet-cdc-bin/rivet N=1000000 dev/cdc_interval/baseline_mem.sh [pg|mysql|mssql|all]
+#
+# Writes per-engine drain out/err under $WORK; prints one summary line per engine.
+set -uo pipefail
+
+RIVET_BIN="${RIVET_BIN:-target/release/rivet}"
+[ -x "$RIVET_BIN" ] || RIVET_BIN=target/debug/rivet
+N="${N:-1000000}"
+BATCH="${BATCH:-5000}"
+WORK="${WORK:-/tmp/rivet-cdc-baseline}"
+ONLY="${1:-all}"
+PAD="p_$(printf '%*s' 38 '' | tr ' ' x)"   # ~40-char payload so events aren't trivially tiny
+R="$RIVET_BIN"
+mkdir -p "$WORK"
+say() { echo "[$(date +%H:%M:%S)] $*"; }
+
+PGC=rivet-postgres-cdc-1; MYC=rivet-mysql-cdc-1; MSC=rivet-mssql-cdc-1
+PG()  { docker exec "$PGC" psql -U rivet -d rivet -tAc "$1" 2>/dev/null; }
+MY()  { docker exec "$MYC" mysql -urivet -privet rivet -N -e "$1" 2>/dev/null; }
+MS()  { docker exec "$MSC" /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P 'Rivet_Passw0rd!' -d rivet -h -1 -Q "$1" 2>/dev/null; }
+# Numeric MSSQL query: SET NOCOUNT ON kills the "(N rows affected)" trailer, and
+# we take the FIRST integer token — so a count never fuses with the rowcount line.
+MSN() { docker exec "$MSC" /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P 'Rivet_Passw0rd!' -d rivet -h -1 -Q "SET NOCOUNT ON; $1" 2>/dev/null | grep -Eo '[0-9]+' | head -1; }
+
+# ── measured drain: "rows elapsedS rssMB" via /usr/bin/time -l (macOS, bytes) ──
+drain() { local cfg=$1 t0 t1 rows rss; t0=$(date +%s)
+  /usr/bin/time -l "$R" run -c "$cfg" > "$WORK/d.out" 2> "$WORK/d.err"
+  t1=$(date +%s)
+  rows=$(grep -E "^[[:space:]]+rows:" "$WORK/d.out" "$WORK/d.err" 2>/dev/null | head -1 | tr -dc '0-9')
+  rss=$(grep -E "maximum resident set size" "$WORK/d.err" | awk '{print $1}')
+  echo "${rows:-?} $((t1 - t0)) $(( ${rss:-0} / 1048576 ))"
+}
+
+baseline_pg() {
+  say "PG: setup"
+  PG "SELECT pg_drop_replication_slot('bl_pg') FROM pg_replication_slots WHERE slot_name='bl_pg'" >/dev/null
+  PG "DROP TABLE IF EXISTS bl; CREATE TABLE bl (id bigint primary key, v bigint not null, pad varchar(64) not null)" >/dev/null
+  rm -f "$WORK/pg.ckpt"; rm -rf "$WORK/pg_out"; mkdir -p "$WORK/pg_out"
+  cat > "$WORK/pg.yaml" <<EOF
+source: { type: postgres, url: "postgresql://rivet:rivet@127.0.0.1:5434/rivet" }
+exports:
+  - { name: bl, table: bl, mode: cdc, format: parquet, cdc: { checkpoint: "$WORK/pg.ckpt", slot: bl_pg, until_current: true, rollover: 50000 }, destination: { type: local, path: "$WORK/pg_out" } }
+EOF
+  "$R" run -c "$WORK/pg.yaml" >/dev/null 2>&1   # pin slot, drain 0
+  say "PG: pump $N in ${BATCH}-row txns"
+  PG "CREATE OR REPLACE PROCEDURE bl_pump() LANGUAGE plpgsql AS \$\$
+      DECLARE i bigint := 0;
+      BEGIN WHILE i < $N LOOP
+        INSERT INTO bl SELECT g, g, '$PAD' FROM generate_series(i+1, LEAST(i+$BATCH,$N)) g;
+        COMMIT; i := i + $BATCH; END LOOP; END \$\$;" >/dev/null
+  PG "CALL bl_pump()" >/dev/null
+  local wal; wal=$(PG "SELECT COALESCE(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn),0)::bigint/1048576 FROM pg_replication_slots WHERE slot_name='bl_pg'")
+  say "PG: drain (retained WAL=${wal}MB)"
+  local d; d=$(drain "$WORK/pg.yaml")
+  echo "RESULT postgres events=$(echo $d|awk '{print $1}') wall=$(echo $d|awk '{print $2}')s rss=$(echo $d|awk '{print $3}')MB retained_wal=${wal}MB"
+  PG "SELECT pg_drop_replication_slot('bl_pg') FROM pg_replication_slots WHERE slot_name='bl_pg'" >/dev/null
+  PG "DROP TABLE IF EXISTS bl" >/dev/null
+}
+
+baseline_mysql() {
+  say "MySQL: setup"
+  MY "DROP TABLE IF EXISTS bl; CREATE TABLE bl (id bigint primary key, v bigint not null, pad varchar(64) not null)"
+  MY "DROP TABLE IF EXISTS nums; CREATE TABLE nums (n int primary key)"
+  MY "SET SESSION cte_max_recursion_depth=1000000; INSERT INTO nums (n) WITH RECURSIVE s(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM s WHERE n < $BATCH) SELECT n FROM s"
+  rm -f "$WORK/my.ckpt"; rm -rf "$WORK/my_out"; mkdir -p "$WORK/my_out"
+  cat > "$WORK/my.yaml" <<EOF
+source: { type: mysql, url: "mysql://rivet:rivet@127.0.0.1:3307/rivet" }
+exports:
+  - { name: bl, table: bl, mode: cdc, format: parquet, cdc: { checkpoint: "$WORK/my.ckpt", server_id: 49222, until_current: true, rollover: 50000 }, destination: { type: local, path: "$WORK/my_out" } }
+EOF
+  "$R" run -c "$WORK/my.yaml" >/dev/null 2>&1   # pin binlog checkpoint at current, drain 0
+  say "MySQL: pump $N in ${BATCH}-row txns"
+  local i=0
+  while [ "$i" -lt "$N" ]; do   # each INSERT is its own autocommit txn ⇒ largest txn = BATCH
+    MY "INSERT INTO bl (id,v,pad) SELECT $i+n, $i+n, '$PAD' FROM nums WHERE $i+n <= $N"
+    i=$((i + BATCH))
+  done
+  say "MySQL: drain"
+  local d; d=$(drain "$WORK/my.yaml")
+  echo "RESULT mysql events=$(echo $d|awk '{print $1}') wall=$(echo $d|awk '{print $2}')s rss=$(echo $d|awk '{print $3}')MB retained_wal=n/a"
+  MY "DROP TABLE IF EXISTS bl, nums"
+}
+
+baseline_mssql() {
+  say "MSSQL: setup + enable CDC"
+  MS "IF OBJECT_ID('dbo.bl') IS NOT NULL DROP TABLE dbo.bl; CREATE TABLE dbo.bl (id bigint primary key, v bigint not null, pad varchar(64) not null);" >/dev/null
+  MS "IF EXISTS (SELECT 1 FROM cdc.change_tables ct JOIN sys.tables t ON ct.source_object_id=t.object_id WHERE t.name='bl')
+        EXEC sys.sp_cdc_disable_table @source_schema='dbo', @source_name='bl', @capture_instance='dbo_bl';" >/dev/null
+  MS "EXEC sys.sp_cdc_enable_table @source_schema='dbo', @source_name='bl', @role_name=NULL, @capture_instance='dbo_bl', @supports_net_changes=0;" >/dev/null
+  # Wait for the capture instance to come online (Agent).
+  for _ in $(seq 1 20); do
+    [ "$(MSN "SELECT COUNT(*) FROM cdc.change_tables ct JOIN sys.tables t ON ct.source_object_id=t.object_id WHERE t.name='bl'")" -ge 1 ] 2>/dev/null && break
+    sleep 2
+  done
+  rm -f "$WORK/ms.ckpt"; rm -rf "$WORK/ms_out"; mkdir -p "$WORK/ms_out"
+  cat > "$WORK/ms.yaml" <<EOF
+source:
+  type: mssql
+  url: "sqlserver://sa:Rivet_Passw0rd!@127.0.0.1:1434/rivet"
+  tls: { accept_invalid_certs: true }
+exports:
+  - { name: bl, table: bl, mode: cdc, format: parquet, cdc: { checkpoint: "$WORK/ms.ckpt", capture_instance: dbo_bl, until_current: true, rollover: 50000 }, destination: { type: local, path: "$WORK/ms_out" } }
+EOF
+  "$R" run -c "$WORK/ms.yaml" >/dev/null 2>&1   # pin checkpoint at current max LSN, drain 0
+  # Baseline the change-table count BEFORE pumping — stale rows below the pinned
+  # checkpoint LSN are never drained, but the Agent-extract wait must key on the
+  # DELTA (before→after), not an absolute count, or it can fire early.
+  local ct0; ct0=$(MSN "SELECT COUNT_BIG(*) FROM cdc.dbo_bl_CT"); ct0=${ct0:-0}
+  say "MSSQL: pump $N (cross-join, ${BATCH}-row batches; CT baseline=$ct0)"
+  local i=0
+  while [ "$i" -lt "$N" ]; do
+    MS "INSERT INTO dbo.bl (id,v,pad)
+        SELECT TOP ($BATCH) $i + ROW_NUMBER() OVER (ORDER BY (SELECT NULL)),
+               $i + ROW_NUMBER() OVER (ORDER BY (SELECT NULL)), '$PAD'
+        FROM sys.all_columns a CROSS JOIN sys.all_columns b;" >/dev/null
+    i=$((i + BATCH))
+  done
+  local target=$((ct0 + N))
+  say "MSSQL: wait for Agent to extract to CT>=$target"
+  for _ in $(seq 1 120); do
+    local ct; ct=$(MSN "SELECT COUNT_BIG(*) FROM cdc.dbo_bl_CT")
+    [ "${ct:-0}" -ge "$target" ] && { say "MSSQL: CT has ${ct} rows (delta $((ct - ct0)))"; break; }
+    sleep 5
+  done
+  say "MSSQL: drain"
+  local d; d=$(drain "$WORK/ms.yaml")
+  echo "RESULT mssql events=$(echo $d|awk '{print $1}') wall=$(echo $d|awk '{print $2}')s rss=$(echo $d|awk '{print $3}')MB retained_wal=n/a"
+  MS "EXEC sys.sp_cdc_disable_table @source_schema='dbo', @source_name='bl', @capture_instance='dbo_bl'; DROP TABLE IF EXISTS dbo.bl;" >/dev/null
+}
+
+say "=== CDC memory baseline: N=$N, batch=$BATCH, bin=$R, only=$ONLY ==="
+case "$ONLY" in
+  pg)     baseline_pg ;;
+  mysql)  baseline_mysql ;;
+  mssql)  baseline_mssql ;;
+  all)    baseline_mysql; baseline_pg; baseline_mssql ;;
+  *) echo "unknown target: $ONLY"; exit 1 ;;
+esac
+say "=== baseline complete ==="

--- a/dev/cdc_interval/run_pg.sh
+++ b/dev/cdc_interval/run_pg.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# CDC drain-interval experiment — PostgreSQL edition.
+#
+# The PostgreSQL sibling of run.sh (which is MySQL). Same 10-table heat spectrum
+# (2 hot / 3 warm / 3 cold / 2 frozen), ONE multi-table CDC export (one logical
+# slot, one checkpoint, initial snapshots), a continuous loader, and per-table
+# convergence verdicts at growing drain intervals.
+#
+# WHAT IS DIFFERENT FROM MYSQL — and the reason this experiment exists:
+# MySQL's binlog is retained for replication/PITR regardless of rivet, so the
+# drain interval is "free" (bounded only by binlog retention). PostgreSQL's
+# logical slot PINS WAL: the WAL since the last advance is held ONLY because
+# rivet's slot has not consumed it. So a longer drain interval is NOT free here
+# — it shows up as retained WAL growing on the SOURCE (disk pressure), released
+# only when rivet drains and advances the slot. This harness measures exactly
+# that: `retained WAL` = pg_current_wal_lsn() - restart_lsn, sampled at the peak
+# (end of interval, before the drain) and after the drain (released).
+#
+# Ordering oracle: PostgreSQL __pos is {lsn:"X/Y"} (the COMMIT LSN). The lexical
+# "X/Y" string is NOT sortable across widths; the winner-per-id order is the
+# fixed-width hex key upper(lpad(hi,8,'0'))||upper(lpad(lo,8,'0')), tie-broken by
+# (filename, file_row_number) for events that share a COMMIT LSN.
+#
+# Portable to macOS's bash 3.2 (no assoc arrays — per-table state via files).
+#
+# Usage:
+#   RIVET_BIN=target/release/rivet dev/cdc_interval/run_pg.sh            # full run
+#   PHASES="2 2;4 1;6 1" dev/cdc_interval/run_pg.sh                      # custom schedule
+#   SKIP_SETUP=1 dev/cdc_interval/run_pg.sh                             # resume (keep tables/slot)
+#
+# Requires: docker compose --profile cdc up -d postgres-cdc, and `duckdb` on PATH
+# (the destination-side merge oracle). Writes everything under $WORK.
+set -uo pipefail
+
+RIVET_BIN="${RIVET_BIN:-target/release/rivet}"
+PG_CDC_URL="${PG_CDC_URL:-postgresql://rivet:rivet@127.0.0.1:5434/rivet}"
+PG_CONTAINER="${PG_CONTAINER:-rivet-postgres-cdc-1}"
+SLOT="${SLOT:-cdc_interval_pg}"
+WORK="${WORK:-/tmp/rivet-cdc-interval-pg}"
+# "<minutes> <reps>" per phase, ';'-separated. Default: three growing intervals.
+PHASES="${PHASES:-2 2;4 1;6 1}"
+
+R="$RIVET_BIN"
+CFG="$WORK/cdc.yaml"; OUT="$WORK/out"; LOG="$WORK/progress.log"
+PAUSE="$WORK/loader.pause"; STOP="$WORK/loader.stop"
+HOT="ci_h1 ci_h2"; WARM="ci_w1 ci_w2 ci_w3"; COLD="ci_c1 ci_c2 ci_c3"; FROZEN="ci_f1 ci_f2"
+ALL="$HOT $WARM $COLD $FROZEN"
+PG() { docker exec "$PG_CONTAINER" psql -U rivet -d rivet -tAc "$1" 2>/dev/null; }
+say() { echo "[$(date +%H:%M:%S)] $*" | tee -a "$LOG"; }
+
+# retained WAL (bytes) the slot is pinning = current WAL end - slot restart_lsn.
+wal_retained_mb() {
+  local b; b=$(PG "SELECT COALESCE(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn),0)::bigint \
+                   FROM pg_replication_slots WHERE slot_name='$SLOT'")
+  echo $(( ${b:-0} / 1048576 ))
+}
+slot_line() {
+  PG "SELECT active::text||' '||wal_status||' restart='||restart_lsn||' confirmed='||confirmed_flush_lsn \
+      FROM pg_replication_slots WHERE slot_name='$SLOT'"
+}
+
+mkdir -p "$OUT"; rm -f "$PAUSE" "$STOP"
+cat > "$CFG" <<EOF
+source: { type: postgres, url: "$PG_CDC_URL" }
+exports:
+  - name: cdc_interval
+    tables: [$(echo $ALL | tr ' ' ',' | sed 's/,/, /g')]
+    mode: cdc
+    format: parquet
+    cdc: { initial: snapshot, checkpoint: "$WORK/cdc.ckpt", slot: $SLOT, until_current: true, rollover: 50000 }
+    destination: { type: local, path: "$OUT" }
+EOF
+
+if [ "${SKIP_SETUP:-0}" != "1" ]; then
+  # Start clean: drop the slot (frees pinned WAL) and the tables + checkpoint.
+  PG "SELECT pg_drop_replication_slot('$SLOT') FROM pg_replication_slots WHERE slot_name='$SLOT'" >/dev/null
+  rm -f "$WORK/cdc.ckpt"; rm -rf "$OUT"; mkdir -p "$OUT"
+  for t in $ALL; do
+    PG "DROP TABLE IF EXISTS $t;
+        CREATE TABLE $t (id BIGINT PRIMARY KEY, v BIGINT NOT NULL, pad VARCHAR(64) NOT NULL,
+          row_hash TEXT GENERATED ALWAYS AS (md5(id::text||'#'||v::text||'#'||pad)) STORED);" >/dev/null
+    echo 1 > "$WORK/next.$t"
+  done
+  for t in $ALL; do   # pre-seed so initial snapshots are non-trivial
+    vals=$(awk 'BEGIN{for(i=1;i<=2000;i++){printf "%s(%d,%d,'"'"'seed%d'"'"')",(i>1?",":""),i,i*3,i%97}}')
+    PG "INSERT INTO $t (id,v,pad) VALUES $vals" >/dev/null; echo 2001 > "$WORK/next.$t"
+  done
+  say "pre-seeded 10 tables x 2000 rows"
+fi
+
+insert_batch() { # table n
+  local t=$1 n=$2 a b vals
+  a=$(cat "$WORK/next.$t"); b=$((a + n - 1))
+  vals=$(awk -v a="$a" -v b="$b" 'BEGIN{for(i=a;i<=b;i++){printf "%s(%d,%d,'"'"'p%d'"'"')",(i>a?",":""),i,i*7,i%1000}}')
+  PG "INSERT INTO $t (id,v,pad) VALUES $vals" >/dev/null || say "loader: $t insert @$a failed"
+  echo $((b + 1)) > "$WORK/next.$t"
+}
+
+loader() {  # ~230 rows/s across the spectrum; hot tables also purge (delete-load)
+  local tick=0
+  while [ ! -f "$STOP" ]; do
+    [ -f "$PAUSE" ] && { sleep 1; continue; }
+    tick=$((tick + 1))
+    for t in $HOT;  do insert_batch "$t" 250
+      PG "UPDATE $t SET v=v+1 WHERE id % 17 = $((tick % 17)) AND id > $(( $(cat "$WORK/next.$t") - 5000 ))" >/dev/null; done
+    for t in $WARM; do insert_batch "$t" 50; done
+    [ $((tick % 6))  -eq 0 ] && for t in $COLD;   do insert_batch "$t" 3; done
+    [ $((tick % 60)) -eq 0 ] && for t in $FROZEN; do insert_batch "$t" 1; done
+    if [ $((tick % 12)) -eq 0 ]; then
+      for t in $HOT; do local cut=$(( $(cat "$WORK/next.$t") - 60000 ))
+        # PostgreSQL DELETE has no LIMIT — bound it by ctid subselect.
+        [ $cut -gt 2000 ] && PG "DELETE FROM $t WHERE ctid IN \
+          (SELECT ctid FROM $t WHERE id < $cut AND id > 2000 LIMIT 80000)" >/dev/null; done
+    fi
+    sleep 5
+  done
+  say "loader stopped"
+}
+
+wal_sampler() {  # continuous WAL time-series — the disk-pressure curve + a disk-safety watch
+  local csv="$WORK/wal_trace.csv" b w free
+  echo "epoch,retained_mb,waldir_mb,vol_avail_mb" > "$csv"
+  while [ ! -f "$STOP" ]; do
+    b=$(PG "SELECT COALESCE(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn),0)::bigint FROM pg_replication_slots WHERE slot_name='$SLOT'")
+    w=$(PG "SELECT COALESCE(sum(size),0)::bigint FROM pg_ls_waldir()")
+    free=$(docker exec "$PG_CONTAINER" df -Pm /var/lib/postgresql/data 2>/dev/null | awk 'NR==2{print $4}')
+    echo "$(date +%s),$(( ${b:-0}/1048576 )),$(( ${w:-0}/1048576 )),${free:-?}" >> "$csv"
+    sleep 120
+  done
+}
+
+drain() { # -> "rows elapsedS rssMB"
+  local t0 t1 rows rss; t0=$(date +%s)
+  /usr/bin/time -l "$R" run -c "$CFG" > "$WORK/d.out" 2> "$WORK/d.err"
+  t1=$(date +%s)
+  rows=$(cat "$WORK/d.out" "$WORK/d.err" | grep -E "^[[:space:]]+rows:" | head -1 | tr -dc '0-9')
+  rss=$(grep -E "maximum resident set size" "$WORK/d.err" | awk '{print $1}')
+  echo "${rows:-?} $((t1 - t0))s $(( ${rss:-0} / 1048576 ))MB"
+}
+
+merge_metric() { # table -> "count xor" of the reconstructed current state
+  local t=$1 snap_arm=""
+  ls "$OUT/$t"/snapshot/*.parquet >/dev/null 2>&1 && snap_arm="
+    SELECT id,row_hash,'' AS lsn_key,'insert' AS op,'' AS fn,-1::BIGINT AS frn
+    FROM read_parquet('$OUT/$t/snapshot/*.parquet') UNION ALL"
+  if ls "$OUT/$t"/cdc-*.parquet >/dev/null 2>&1; then
+    duckdb -noheader -csv -c "
+      WITH uni AS ($snap_arm
+        SELECT id,row_hash,
+          upper(lpad(split_part(json_extract_string(__pos,'\$.lsn'),'/',1),8,'0')) ||
+          upper(lpad(split_part(json_extract_string(__pos,'\$.lsn'),'/',2),8,'0')) AS lsn_key,
+          __op AS op, filename AS fn, file_row_number AS frn
+        FROM read_parquet('$OUT/$t/cdc-*.parquet', filename=true, file_row_number=true)),
+      r AS (SELECT *, ROW_NUMBER() OVER (PARTITION BY id ORDER BY lsn_key DESC, fn DESC, frn DESC) rn FROM uni)
+      SELECT COUNT(*)||' '||COALESCE(bit_xor(CAST(concat('0x',substring(row_hash,1,15)) AS UBIGINT)),0)
+      FROM r WHERE rn=1 AND op<>'delete'" 2>>"$LOG"
+  else
+    duckdb -noheader -csv -c "
+      SELECT COUNT(*)||' '||COALESCE(bit_xor(CAST(concat('0x',substring(row_hash,1,15)) AS UBIGINT)),0)
+      FROM read_parquet('$OUT/$t/snapshot/*.parquet')" 2>>"$LOG"
+  fi
+}
+
+verify() {
+  local wal_peak; wal_peak=$(wal_retained_mb)     # end-of-interval peak: slot pinned this much WAL
+  say "  slot before drain: $(slot_line) | retained WAL=${wal_peak}MB"
+  touch "$PAUSE"; sleep 7          # let the in-flight batch land, then quiesce
+  local d1; d1=$(drain)            # the big backlog drain — advances the slot
+  local t
+  for t in $ALL; do
+    PG "SELECT COUNT(*) FROM $t" > "$WORK/sc.$t"
+    PG "SELECT COALESCE(bit_xor(('x'||substring(row_hash,1,15))::bit(60)::bigint),0) FROM $t" > "$WORK/sx.$t"
+    echo $(( $(cat "$WORK/next.$t") - 1 )) > "$WORK/mx.$t"
+  done
+  local d2; d2=$(drain)            # must be 0: nothing ran between the two drains
+  local wal_after; wal_after=$(wal_retained_mb)   # released after the advance
+  rm -f "$PAUSE"
+  local verdict="OK" line
+  for t in $ALL; do
+    local mm dc dx; mm=$(merge_metric "$t"); dc=${mm% *}; dx=${mm#* }
+    local seen; seen=$(duckdb -noheader -csv -c "
+      SELECT COUNT(DISTINCT id) FROM (
+        $(ls "$OUT/$t"/cdc-*.parquet >/dev/null 2>&1 && echo "SELECT id FROM read_parquet('$OUT/$t/cdc-*.parquet') WHERE __op='insert' UNION")
+        SELECT id FROM read_parquet('$OUT/$t/snapshot/*.parquet'))" 2>>"$LOG")
+    local sc sx mx v="ok"; sc=$(cat "$WORK/sc.$t"); sx=$(cat "$WORK/sx.$t"); mx=$(cat "$WORK/mx.$t")
+    [ "$sc" = "$dc" ] || v="COUNT($sc!=$dc)"
+    [ "$sx" = "$dx" ] || v="$v XOR"
+    [ "$seen" = "$mx" ] || v="$v CONS($seen!=$mx)"
+    [ "$v" = "ok" ] || verdict="FAIL"
+    line="$line $t=$v"
+  done
+  [ "${d2%% *}" = "0" ] || verdict="$verdict WARN(d2=${d2%% *})"
+  say "VERIFY d1=[$d1] d2=[$d2] WAL:${wal_peak}MB->${wal_after}MB =>$line"
+  say "TOTAL: $verdict | parts=$(find "$OUT" -name 'cdc-*.parquet' | wc -l | tr -d ' ')"
+}
+
+[ "${SKIP_SETUP:-0}" = "1" ] || { say "=== pin slot + initial snapshots ==="
+  "$R" run -c "$CFG" > "$WORK/d.out" 2>&1 && say "pin+snapshots ok | $(slot_line)" \
+    || { say "PIN FAILED: $(tail -3 "$WORK/d.out")"; exit 1; }; }
+loader & LP=$!; say "loader pid=$LP"
+wal_sampler & WS=$!; say "wal_sampler pid=$WS (trace -> $WORK/wal_trace.csv)"
+
+IFS=';'; for phase in $PHASES; do IFS=' '
+  set -- $phase; mins=$1; reps=$2
+  for rep in $(seq 1 "$reps"); do
+    say "--- phase ${mins}min rep $rep/$reps (slot pinning WAL for ${mins}min) ---"; sleep $((mins * 60)); verify
+  done
+done
+touch "$STOP"; wait "$LP" 2>/dev/null; wait "$WS" 2>/dev/null
+say "=== final verify after loader stop ==="; verify
+for t in $ALL; do PG "DROP TABLE IF EXISTS $t" >/dev/null; done
+PG "SELECT pg_drop_replication_slot('$SLOT') FROM pg_replication_slots WHERE slot_name='$SLOT'" >/dev/null
+say "=== complete (slot dropped, WAL released) ==="

--- a/dev/cdc_interval/soak_all.sh
+++ b/dev/cdc_interval/soak_all.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# CDC drain-interval MEMORY soak — one engine, growing intervals, bounded drain.
+#
+# Post-fix validation: under continuous churn, drain at growing intervals
+# (default 10/20/30/60/120 min) and assert (a) peak drain RSS stays FLAT as the
+# per-interval backlog grows 12× (the bounded-peek fix — a leak or an O(backlog)
+# regression shows as RSS tracking the interval), and (b) every inserted row is
+# captured (source COUNT(*) == distinct ids in the drained parts).
+#
+# Run one engine per invocation (parallelise across engines from the caller):
+#   RIVET_BIN=/tmp/rivet-cdc-bin/rivet PHASES="10 20 30 60 120" \
+#     dev/cdc_interval/soak_all.sh pg     > pg.soak.log 2>&1 &
+#
+# Requires: docker compose --profile cdc up, and `duckdb` on PATH.
+set -uo pipefail
+
+RIVET_BIN="${RIVET_BIN:-target/release/rivet}"
+[ -x "$RIVET_BIN" ] || RIVET_BIN=target/debug/rivet
+ENGINE="${1:?usage: soak_all.sh <pg|mysql|mssql>}"
+PHASES="${PHASES:-10 20 30 60 120}"   # minutes, space-separated
+BATCH="${BATCH:-2000}"                # rows per churn tick
+TICK="${TICK:-5}"                     # seconds between churn ticks (~24k rows/min)
+WORK="${WORK:-/tmp/rivet-cdc-soak/$ENGINE}"
+R="$RIVET_BIN"
+PAD="s_$(printf '%*s' 38 '' | tr ' ' x)"
+mkdir -p "$WORK"
+STOP="$WORK/churn.stop"; PAUSE="$WORK/churn.pause"; rm -f "$STOP" "$PAUSE"
+LOG="$WORK/soak.log"
+say() { echo "[$(date +%H:%M:%S)] [$ENGINE] $*" | tee -a "$LOG"; }
+
+PGC=rivet-postgres-cdc-1; MYC=rivet-mysql-cdc-1; MSC=rivet-mssql-cdc-1
+PG()  { docker exec "$PGC" psql -U rivet -d rivet -tAc "$1" 2>/dev/null; }
+MY()  { docker exec "$MYC" mysql -urivet -privet rivet -N -e "$1" 2>/dev/null; }
+MS()  { docker exec "$MSC" /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P 'Rivet_Passw0rd!' -d rivet -h -1 -Q "$1" 2>/dev/null; }
+MSN() { MS "SET NOCOUNT ON; $1" | grep -Eo '[0-9]+' | head -1; }
+
+CFG="$WORK/cdc.yaml"; OUT="$WORK/out"; NEXT="$WORK/next"
+
+setup() {
+  rm -rf "$OUT"; mkdir -p "$OUT"; rm -f "$WORK/cdc.ckpt"; echo 1 > "$NEXT"
+  case "$ENGINE" in
+    pg)
+      PG "SELECT pg_drop_replication_slot('soak_pg') FROM pg_replication_slots WHERE slot_name='soak_pg'" >/dev/null
+      PG "DROP TABLE IF EXISTS sk; CREATE TABLE sk (id bigint primary key, v bigint not null, pad varchar(64) not null)" >/dev/null
+      cat > "$CFG" <<EOF
+source: { type: postgres, url: "postgresql://rivet:rivet@127.0.0.1:5434/rivet" }
+exports:
+  - { name: sk, table: sk, mode: cdc, format: parquet, cdc: { checkpoint: "$WORK/cdc.ckpt", slot: soak_pg, until_current: true, rollover: 50000 }, destination: { type: local, path: "$OUT" } }
+EOF
+      ;;
+    mysql)
+      MY "DROP TABLE IF EXISTS sk; CREATE TABLE sk (id bigint primary key, v bigint not null, pad varchar(64) not null)"
+      cat > "$CFG" <<EOF
+source: { type: mysql, url: "mysql://rivet:rivet@127.0.0.1:3307/rivet" }
+exports:
+  - { name: sk, table: sk, mode: cdc, format: parquet, cdc: { checkpoint: "$WORK/cdc.ckpt", server_id: 49333, until_current: true, rollover: 50000 }, destination: { type: local, path: "$OUT" } }
+EOF
+      ;;
+    mssql)
+      MS "IF OBJECT_ID('dbo.sk') IS NOT NULL DROP TABLE dbo.sk; CREATE TABLE dbo.sk (id bigint primary key, v bigint not null, pad varchar(64) not null);" >/dev/null
+      MS "IF EXISTS (SELECT 1 FROM cdc.change_tables WHERE capture_instance='dbo_sk') EXEC sys.sp_cdc_disable_table @source_schema='dbo',@source_name='sk',@capture_instance='dbo_sk';" >/dev/null
+      MS "EXEC sys.sp_cdc_enable_table @source_schema='dbo',@source_name='sk',@role_name=NULL,@capture_instance='dbo_sk',@supports_net_changes=0;" >/dev/null
+      for _ in $(seq 1 20); do [ "$(MSN "SELECT COUNT(*) FROM cdc.change_tables WHERE capture_instance='dbo_sk'")" -ge 1 ] 2>/dev/null && break; sleep 2; done
+      cat > "$CFG" <<EOF
+source:
+  type: mssql
+  url: "sqlserver://sa:Rivet_Passw0rd!@127.0.0.1:1434/rivet"
+  tls: { accept_invalid_certs: true }
+exports:
+  - { name: sk, table: sk, mode: cdc, format: parquet, cdc: { checkpoint: "$WORK/cdc.ckpt", capture_instance: dbo_sk, until_current: true, rollover: 50000 }, destination: { type: local, path: "$OUT" } }
+EOF
+      ;;
+  esac
+  "$R" run -c "$CFG" >/dev/null 2>&1   # pin the anchor, drain 0
+}
+
+insert_rows() { # a .. b
+  local a=$1 b=$2
+  case "$ENGINE" in
+    pg)    PG "INSERT INTO sk SELECT g,g,'$PAD' FROM generate_series($a,$b) g" >/dev/null ;;
+    mysql) MY "SET SESSION cte_max_recursion_depth=1000000; INSERT INTO sk (id,v,pad) SELECT n,n,'$PAD' FROM (WITH RECURSIVE s(n) AS (SELECT $a UNION ALL SELECT n+1 FROM s WHERE n < $b) SELECT n FROM s) q" ;;
+    mssql) MS "SET NOCOUNT ON; INSERT INTO dbo.sk (id,v,pad) SELECT TOP ($((b-a+1))) $((a-1))+ROW_NUMBER() OVER (ORDER BY (SELECT NULL)), $((a-1))+ROW_NUMBER() OVER (ORDER BY (SELECT NULL)), '$PAD' FROM sys.all_columns x CROSS JOIN sys.all_columns y;" >/dev/null ;;
+  esac
+}
+
+churner() {
+  while [ ! -f "$STOP" ]; do
+    [ -f "$PAUSE" ] && { sleep 1; continue; }
+    local a b; a=$(cat "$NEXT"); b=$((a + BATCH - 1))
+    insert_rows "$a" "$b"; echo $((b + 1)) > "$NEXT"
+    sleep "$TICK"
+  done
+}
+
+src_count() {
+  case "$ENGINE" in
+    pg)    PG "SELECT COUNT(*) FROM sk" ;;
+    mysql) MY "SELECT COUNT(*) FROM sk" ;;
+    mssql) MS "SET NOCOUNT ON; SELECT COUNT_BIG(*) FROM dbo.sk" | grep -Eo '[0-9]+' | head -1 ;;
+  esac
+}
+
+# MSSQL only: wait until the Agent has extracted every inserted row into the CT.
+mssql_agent_catchup() {
+  local want; want=$(src_count)
+  for _ in $(seq 1 60); do
+    [ "$(MSN "SELECT COUNT_BIG(*) FROM cdc.dbo_sk_CT")" -ge "$want" ] 2>/dev/null && return
+    sleep 3
+  done
+}
+
+drain_measure() { # -> "events rssMB"
+  /usr/bin/time -l "$R" run -c "$CFG" > "$WORK/d.out" 2> "$WORK/d.err"
+  local rows rss
+  rows=$(grep -E "^[[:space:]]+rows:" "$WORK/d.out" "$WORK/d.err" 2>/dev/null | head -1 | tr -dc '0-9')
+  rss=$(grep -E "maximum resident set size" "$WORK/d.err" | awk '{print $1}')
+  echo "${rows:-?} $(( ${rss:-0} / 1048576 ))"
+}
+
+dest_distinct() {
+  # A single-table export writes parts to the destination path directly.
+  ls "$OUT"/cdc-*.parquet >/dev/null 2>&1 || { echo 0; return; }
+  duckdb -noheader -csv -c "SELECT COUNT(DISTINCT id) FROM read_parquet('$OUT/cdc-*.parquet') WHERE __op='insert'" 2>/dev/null
+}
+
+say "=== soak start: phases='$PHASES' min, churn ${BATCH}/${TICK}s, bin=$R ==="
+setup
+churner & CH=$!
+say "churner pid=$CH"
+FIRST_RSS=""; LAST_RSS=""; VERDICT=OK
+for mins in $PHASES; do
+  say "--- interval ${mins}min (accumulating backlog) ---"
+  sleep $((mins * 60))
+  touch "$PAUSE"; sleep 3                 # quiesce so source count == what will drain
+  [ "$ENGINE" = mssql ] && mssql_agent_catchup
+  read -r EV RSS <<<"$(drain_measure)"
+  SC=$(src_count); DD=$(dest_distinct)
+  local_ok=OK; [ "$SC" = "$DD" ] || local_ok="COUNT($SC!=$DD)"
+  [ "$local_ok" = OK ] || VERDICT=FAIL
+  rm -f "$PAUSE"
+  [ -z "$FIRST_RSS" ] && FIRST_RSS=$RSS; LAST_RSS=$RSS
+  say "RESULT interval=${mins}min events=${EV} rss=${RSS}MB src=${SC} dest_distinct=${DD} => ${local_ok}"
+done
+touch "$STOP"; wait "$CH" 2>/dev/null
+
+# RSS-trend leak gate: the last (largest-backlog) drain must not exceed 1.5× the
+# first — a leak or an O(backlog) regression blows well past this.
+TREND=OK
+[ -n "$FIRST_RSS" ] && [ "$LAST_RSS" -gt $(( FIRST_RSS * 3 / 2 )) ] && { TREND="RSS-TREND-FAIL"; VERDICT=FAIL; }
+say "=== soak done: verdict=$VERDICT | RSS first=${FIRST_RSS}MB last=${LAST_RSS}MB ($TREND) ==="
+
+# Cleanup
+case "$ENGINE" in
+  pg)    PG "SELECT pg_drop_replication_slot('soak_pg') FROM pg_replication_slots WHERE slot_name='soak_pg'" >/dev/null; PG "DROP TABLE IF EXISTS sk" >/dev/null ;;
+  mysql) MY "DROP TABLE IF EXISTS sk" ;;
+  mssql) MS "EXEC sys.sp_cdc_disable_table @source_schema='dbo',@source_name='sk',@capture_instance='dbo_sk'; DROP TABLE IF EXISTS dbo.sk;" >/dev/null ;;
+esac

--- a/schemas/latest/rivet.schema.json
+++ b/schemas/latest/rivet.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Rivet config (rivet-cli 0.16.6)",
+  "title": "Rivet config (rivet-cli 0.16.7)",
   "description": "Top-level Rivet configuration root.\n\nOperators write this struct as YAML (typically `rivet.yaml`).  The\n`JsonSchema` derive is the source of truth for the `schemas/rivet.schema.json`\nartifact and the `rivet schema config` command's output (v0.7.3 P0).",
   "type": "object",
   "properties": {

--- a/schemas/rivet.schema.json
+++ b/schemas/rivet.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Rivet config (rivet-cli 0.16.6)",
+  "title": "Rivet config (rivet-cli 0.16.7)",
   "description": "Top-level Rivet configuration root.\n\nOperators write this struct as YAML (typically `rivet.yaml`).  The\n`JsonSchema` derive is the source of truth for the `schemas/rivet.schema.json`\nartifact and the `rivet schema config` command's output (v0.7.3 P0).",
   "type": "object",
   "properties": {

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -246,7 +246,7 @@ struct CdcArgs {
 fn dispatch_cdc(a: CdcArgs) -> Result<()> {
     let (url, _prov) = resolve_init_source(a.source, a.source_env, a.source_file)?;
     let ckpt = a.checkpoint.map(std::path::PathBuf::from);
-    let cdc_cfg = crate::source::cdc::CdcConfig {
+    let mut cdc_cfg = crate::source::cdc::CdcConfig {
         url: url.clone(),
         server_id: a.server_id,
         slot: a.slot,
@@ -256,6 +256,10 @@ fn dispatch_cdc(a: CdcArgs) -> Result<()> {
         // The CLI carries no TlsConfig; `None` ⇒ the require_tls_or_loopback gate
         // refuses a remote host (config-driven `rivet run` supplies source.tls).
         tls: None,
+        // NDJSON never advances the slot, so it cannot page: one huge peek drains
+        // the whole backlog and the LSN-frontier check ends the stream. The
+        // `--output` sink overrides this with its part `rollover` below.
+        peek_batch: usize::MAX,
     };
     let Some(dir) = a.output else {
         // NDJSON to stdout: no durable sink, so the slot is deliberately not
@@ -285,6 +289,8 @@ fn dispatch_cdc(a: CdcArgs) -> Result<()> {
         path: Some(dir.clone()),
         ..Default::default()
     })?;
+    // The file sink acks per part, so it CAN page: bound the peek to the part size.
+    cdc_cfg.peek_batch = a.rollover;
     let now = chrono::Utc::now().to_rfc3339();
     crate::source::cdc::run_capture(crate::source::cdc::CdcCapture {
         cdc_cfg,

--- a/src/pipeline/cdc_job.rs
+++ b/src/pipeline/cdc_job.rs
@@ -297,6 +297,9 @@ fn run_cdc_inner(
             checkpoint: cdc.checkpoint.as_ref().map(PathBuf::from),
             until_current: cdc.until_current,
             tls: config.source.tls.clone(),
+            // Bound the PostgreSQL peek to the part size: each peeked batch is
+            // flushed + acked before the next, so drain memory is O(rollover).
+            peek_batch: cdc.rollover.unwrap_or(10_000),
         },
         outputs,
         format: export.format,

--- a/src/source/cdc/mod.rs
+++ b/src/source/cdc/mod.rs
@@ -217,6 +217,13 @@ pub(crate) struct CdcConfig {
     /// `require_tls_or_loopback` gate the batch path uses (refuse remote
     /// plaintext / unauthenticated TLS). `None` ⇒ loopback-only (the CLI default).
     pub tls: Option<crate::config::TlsConfig>,
+    /// Max changes the PostgreSQL adapter pulls per `peek` — the memory bound of
+    /// the drain (O(batch), not O(total backlog)). A durable (acking) sink sets
+    /// this to its part `rollover` so each peeked batch is flushed + acked before
+    /// the next; the NDJSON path (which never advances the slot) sets it huge so
+    /// one peek drains everything and the LSN-frontier check ends the stream.
+    /// Ignored by the MySQL (streaming) and SQL Server adapters.
+    pub peek_batch: usize,
 }
 
 /// The CDC engine, resolved ONCE from the source URL's scheme. Every
@@ -274,11 +281,14 @@ impl CdcEngine {
             Self::Postgres => {
                 // Slot creation IS the anchor; open() creates it only on a
                 // genuine FIRST run (resume_expected=false).
+                // Anchor-only open: it creates the slot and is dropped without
+                // reading, so the peek batch is irrelevant (any valid value).
                 drop(crate::source::postgres::cdc::PgChangeStream::open(
                     url,
                     slot,
                     resume_expected,
                     tls,
+                    1,
                 )?);
                 Ok(())
             }
@@ -358,6 +368,7 @@ pub(crate) fn create_change_stream(cfg: &CdcConfig) -> Result<Box<dyn ChangeStre
                     &cfg.slot,
                     resume_expected,
                     tls,
+                    cfg.peek_batch,
                 )
                 .context(PG_CDC_HINT)?,
             ))
@@ -380,8 +391,14 @@ pub(crate) fn create_change_stream(cfg: &CdcConfig) -> Result<Box<dyn ChangeStre
                         .map(str::to_string)
                 });
             Ok(Box::new(
-                crate::source::mssql::cdc::MssqlChangeStream::from_url(url, ci, from_lsn, tls)
-                    .context(MSSQL_CDC_HINT)?,
+                crate::source::mssql::cdc::MssqlChangeStream::from_url(
+                    url,
+                    ci,
+                    from_lsn,
+                    tls,
+                    cfg.peek_batch,
+                )
+                .context(MSSQL_CDC_HINT)?,
             ))
         }
     }

--- a/src/source/mssql/cdc.rs
+++ b/src/source/mssql/cdc.rs
@@ -4,7 +4,8 @@
 //! LSN window — plain T-SQL over `tiberius` (no CDC-specific crate exists or is
 //! needed).
 //!
-//! `next_change` polls the change function once into a buffer and drains it; a
+//! `next_change` polls the change function in bounded LSN batches into a buffer
+//! and drains it (memory is O(batch), not O(total window)); a
 //! continuous daemon wraps [`crate::source::cdc::run`] in an outer poll loop. The
 //! runtime + connection are held by the stream (paid once, not per poll).
 //!
@@ -60,15 +61,28 @@ pub(crate) struct MssqlChangeStream {
     capture_instance: String,
     schema: String,
     table: String,
+    /// Internal read cursor — advanced per bounded batch so the next poll reads
+    /// the following window. NOT the durable resume position: that is the sink's
+    /// checkpoint (advanced only after a durable part), so a crash re-reads from
+    /// there (at-least-once) regardless of how far this cursor has moved.
     from_lsn: Option<String>,
     pending: VecDeque<ChangeEvent>,
-    drained: bool,
+    /// Max changes to pull per poll — bounds drain memory to O(batch) instead of
+    /// O(total change-table window). See [`crate::source::cdc::CdcConfig::peek_batch`].
+    batch_limit: i64,
+    /// A poll that returns no rows has drained the window up to the current max
+    /// LSN — the stream ends (the next scheduler run resumes from the checkpoint).
+    exhausted: bool,
 }
 
 impl MssqlChangeStream {
     /// Connect and bind to a capture instance. Holds the runtime + connection for
     /// the life of the stream (folds the per-poll runtime/connect smell away).
-    pub(crate) fn open(cfg: &MssqlCdcConfig, tls: Option<&TlsConfig>) -> Result<Self> {
+    pub(crate) fn open(
+        cfg: &MssqlCdcConfig,
+        tls: Option<&TlsConfig>,
+        peek_batch: usize,
+    ) -> Result<Self> {
         if !cfg
             .capture_instance
             .bytes()
@@ -129,7 +143,8 @@ impl MssqlChangeStream {
             table,
             from_lsn: cfg.from_lsn.clone(),
             pending: VecDeque::new(),
-            drained: false,
+            batch_limit: peek_batch.clamp(1, i32::MAX as usize) as i64,
+            exhausted: false,
         })
     }
 
@@ -140,6 +155,7 @@ impl MssqlChangeStream {
         capture_instance: &str,
         from_lsn: Option<String>,
         tls: Option<&TlsConfig>,
+        peek_batch: usize,
     ) -> Result<Self> {
         // Refuse remote plaintext / unauthenticated TLS before any dial (the gate
         // the batch MssqlSource uses).
@@ -156,56 +172,61 @@ impl MssqlChangeStream {
                 from_lsn,
             },
             tls,
+            peek_batch,
         )
     }
 
-    /// Poll the change table once over `[min_lsn, max_lsn]` into `pending`.
+    /// Poll ONE **bounded batch** of the change table into `pending`. `@to` is the
+    /// `__$start_lsn` of the `batch_limit`-th change, so the window `[@from, @to]`
+    /// returns only **whole transactions** (`fn_cdc_get_all_changes` never splits a
+    /// `__$start_lsn` group) — memory is O(batch), never O(total window). The
+    /// internal cursor then advances to `@to`; the next poll continues past it. A
+    /// poll that returns no rows has drained the window up to the current max LSN.
     fn fill(&mut self) -> Result<()> {
-        let Self {
-            rt,
-            client,
-            capture_instance,
-            schema,
-            table,
-            from_lsn,
-            pending,
-            ..
-        } = self;
-        // Resume window: read changes *after* the last durably-written LSN
-        // (`fn_cdc_increment_lsn`); on the first run (no checkpoint) start at the
-        // change table's min LSN. The guard skips the query when there is nothing
-        // new (`@from > @to`) or nothing captured yet (NULL LSNs) — calling
-        // `fn_cdc_get_all_changes` with those raises an error rather than 0 rows.
-        //
-        // If the resume LSN has fallen BELOW the min LSN, the cleanup job removed
-        // the changes between them — resuming from min would silently skip them. So
-        // we THROW instead, forcing a re-snapshot, rather than hide a gap. (First run
-        // sets `@from = @min`, so `@from < @min` is false there — only a stale resume
-        // checkpoint trips it.)
-        let from_expr = match from_lsn {
+        if self.exhausted {
+            return Ok(());
+        }
+        let ci = self.capture_instance.clone();
+        // Resume window: read changes *after* the last cursor LSN
+        // (`fn_cdc_increment_lsn`); on the first poll (no cursor) start at the
+        // change table's min LSN. If the cursor has fallen BELOW the min LSN the
+        // cleanup job removed the changes — THROW (forcing a re-snapshot) rather
+        // than silently skip. `@to` bounds the batch at a real transaction
+        // boundary (the batch_limit-th change's start LSN); NULL LSNs / nothing
+        // new leave `@to` NULL and the final SELECT returns zero rows.
+        let from_expr = match &self.from_lsn {
             Some(hex) => format!("sys.fn_cdc_increment_lsn(0x{hex})"),
-            None => format!("sys.fn_cdc_get_min_lsn('{ci}')", ci = capture_instance),
+            None => format!("sys.fn_cdc_get_min_lsn('{ci}')"),
         };
         let sql = format!(
             "DECLARE @from binary(10) = {from_expr}; \
              DECLARE @min binary(10) = sys.fn_cdc_get_min_lsn('{ci}'); \
-             DECLARE @to binary(10) = sys.fn_cdc_get_max_lsn(); \
+             DECLARE @max binary(10) = sys.fn_cdc_get_max_lsn(); \
              IF @from IS NOT NULL AND @min IS NOT NULL AND @from < @min \
                 THROW 51000, 'rivet cdc: the resume position is older than the SQL Server \
 CDC change-table retention (the cleanup job removed it). Resuming would silently skip changes \
 — re-snapshot the table (mode: full) and restart CDC from a fresh checkpoint.', 1; \
-             IF @from IS NOT NULL AND @to IS NOT NULL AND @from <= @to \
+             DECLARE @to binary(10) = NULL; \
+             IF @from IS NOT NULL AND @max IS NOT NULL AND @from <= @max \
+                SELECT @to = MAX(s) FROM (SELECT TOP ({batch}) __$start_lsn AS s \
+                    FROM cdc.fn_cdc_get_all_changes_{ci}(@from, @max, N'all') \
+                    ORDER BY __$start_lsn) q; \
+             IF @to IS NOT NULL \
                 SELECT * FROM cdc.fn_cdc_get_all_changes_{ci}(@from, @to, N'all') \
                 ORDER BY __$start_lsn, __$seqval;",
-            ci = capture_instance,
-            from_expr = from_expr,
+            batch = self.batch_limit,
         );
         // The most common SQL Server gotcha — "Invalid object name
         // cdc.fn_cdc_get_all_changes_…" — surfaces here, at the first poll, not at
         // connect. Append the setup hint so the missing CDC enable is obvious.
-        let rows = rt
-            .block_on(async { client.simple_query(sql).await?.into_first_result().await })
-            .map_err(|e| anyhow::Error::new(e).context(crate::source::cdc::MSSQL_CDC_HINT))?;
+        let rows = {
+            let Self { rt, client, .. } = self;
+            rt.block_on(async { client.simple_query(sql).await?.into_first_result().await })
+                .map_err(|e| anyhow::Error::new(e).context(crate::source::cdc::MSSQL_CDC_HINT))?
+        };
+        // Rows are ordered ascending by start LSN, so the last one's `__$start_lsn`
+        // is `@to` — the cursor advances there regardless of each row's op.
+        let mut max_lsn: Option<String> = None;
         for r in &rows {
             let mut op_code = 0i32;
             let mut lsn = String::new();
@@ -233,16 +254,19 @@ CDC change-table retention (the cleanup job removed it). Resuming would silently
                     }
                 }
             }
+            if !lsn.is_empty() {
+                max_lsn = Some(lsn.clone());
+            }
             let Some(op) = map_op(op_code) else { continue };
             // after-image for insert/update; the key (before-image) for delete
             let (before, after) = match op {
                 ChangeOp::Delete => (Some(values), None),
                 _ => (None, Some(values)),
             };
-            pending.push_back(ChangeEvent {
+            self.pending.push_back(ChangeEvent {
                 op,
-                schema: schema.clone(),
-                table: table.clone(),
+                schema: self.schema.clone(),
+                table: self.table.clone(),
                 before,
                 after,
                 position: Position(json!({ "lsn": lsn })),
@@ -251,14 +275,21 @@ CDC change-table retention (the cleanup job removed it). Resuming would silently
                 image_names: Some(std::sync::Arc::from(names)),
             });
         }
+        match max_lsn {
+            // Advance the internal cursor to @to; the next poll reads past it.
+            Some(l) => self.from_lsn = Some(l),
+            // No rows ⇒ the window is drained up to the current max LSN.
+            None => self.exhausted = true,
+        }
         Ok(())
     }
 }
 
 impl ChangeStream for MssqlChangeStream {
     fn next_change(&mut self) -> Option<Result<ChangeEvent>> {
-        if self.pending.is_empty() && !self.drained {
-            self.drained = true;
+        // Refill a bounded batch whenever the buffer drains, advancing the cursor
+        // each time, until a poll returns nothing (window drained to the max LSN).
+        while self.pending.is_empty() && !self.exhausted {
             if let Err(e) = self.fill() {
                 return Some(Err(e));
             }
@@ -482,7 +513,7 @@ mod tests {
         // let the capture Agent job scan the log (~5 s cycle)
         std::thread::sleep(std::time::Duration::from_secs(8));
 
-        let mut s = MssqlChangeStream::open(&cfg("dbo_cdc_unit"), None).unwrap();
+        let mut s = MssqlChangeStream::open(&cfg("dbo_cdc_unit"), None, 10_000).unwrap();
         let mut ops = Vec::new();
         while let Some(ev) = s.next_change() {
             ops.push(ev.unwrap().op);

--- a/src/source/postgres/cdc.rs
+++ b/src/source/postgres/cdc.rs
@@ -36,7 +36,17 @@ pub(crate) struct PgChangeStream {
     client: Client,
     slot: String,
     pending: VecDeque<ChangeEvent>,
-    drained: bool,
+    /// Max changes to pull per `peek` — the memory bound of the drain
+    /// (O(batch), not O(total backlog)). See [`crate::source::cdc::CdcConfig::peek_batch`].
+    batch_limit: i32,
+    /// Largest COMMIT LSN already yielded THIS run. A refill re-peeks from the
+    /// slot's (un-acked) `restart_lsn`, so any transaction at/below this was
+    /// already delivered — it is dropped, making the refill idempotent.
+    frontier: u64,
+    /// A peek that yields no NEW transaction, or returns fewer than a full
+    /// batch, has drained everything past the ack frontier — the stream ends
+    /// (a non-acking consumer, e.g. NDJSON, ends here after its one big peek).
+    exhausted: bool,
 }
 
 impl PgChangeStream {
@@ -52,6 +62,7 @@ impl PgChangeStream {
         slot: &str,
         resume_expected: bool,
         tls: Option<&TlsConfig>,
+        peek_batch: usize,
     ) -> Result<Self> {
         // Same gate the batch path uses: refuse remote plaintext (CWE-319), and
         // use a verifying TLS connector when a TlsConfig is enforced.
@@ -90,33 +101,55 @@ impl PgChangeStream {
             client,
             slot: slot.to_string(),
             pending: VecDeque::new(),
-            drained: false,
+            // A logical slot never has 2^31 pending changes in one peek; clamp to
+            // the `pg_logical_slot_peek_changes` int4 arg and keep it >= 1.
+            batch_limit: peek_batch.clamp(1, i32::MAX as usize) as i32,
+            frontier: 0,
+            exhausted: false,
         })
     }
 
-    /// Poll the slot once into `pending` **without consuming it**
-    /// (`pg_logical_slot_peek_changes`). The slot is only advanced later, in
-    /// [`ChangeStream::ack`], once the changes are durably written — so a crash
-    /// before durability re-reads them (at-least-once) instead of losing them.
+    /// Peek **one bounded batch** into `pending` **without consuming it**
+    /// (`pg_logical_slot_peek_changes(slot, NULL, batch_limit)`). `upto_nchanges`
+    /// caps the batch at a **commit boundary** (PostgreSQL only stops after a
+    /// whole transaction), so memory is O(batch), never O(total backlog). The
+    /// slot is advanced later, in [`ChangeStream::ack`], once the changes are
+    /// durably written — a crash before durability re-reads them (at-least-once).
+    ///
+    /// Refill safety: a peek always starts at the slot's `restart_lsn`, which the
+    /// consumer's ack advances between batches. Until that ack lands the same
+    /// changes are visible again, so this drops any transaction whose COMMIT LSN
+    /// is at or below [`Self::frontier`] (already yielded). A peek that adds no
+    /// new transaction — or returns less than a full batch — has drained
+    /// everything past the ack frontier and marks the stream [`Self::exhausted`].
     fn fill(&mut self) -> Result<()> {
         let rows = self.client.query(
-            "SELECT lsn::text, data FROM pg_logical_slot_peek_changes($1, NULL, NULL)",
-            &[&self.slot],
+            "SELECT lsn::text, data FROM pg_logical_slot_peek_changes($1, NULL, $2)",
+            &[&self.slot, &self.batch_limit],
         )?;
+        let n_rows = rows.len();
         // Frame transactions (BEGIN … changes … COMMIT) and stamp every change with
-        // its transaction's COMMIT LSN — that is the only valid slot-advance
-        // boundary (advancing to a change's own mid-transaction LSN re-reads the
-        // whole transaction) and the commit-boundary resume position. Logical
-        // decoding only ever emits complete, committed transactions.
+        // its transaction's COMMIT LSN — the only valid slot-advance boundary and
+        // the commit-boundary resume position. Logical decoding only ever emits
+        // complete, committed transactions.
         let mut tx: Vec<ChangeEvent> = Vec::new();
+        let mut yielded_any = false;
         for r in rows {
             let lsn: String = r.get(0);
             let data: String = r.get(1);
             if data.starts_with("COMMIT") {
-                let commit = Position(json!({ "lsn": lsn }));
-                for mut ev in tx.drain(..) {
-                    ev.position = commit.clone();
-                    self.pending.push_back(ev);
+                let commit_lsn = parse_lsn(&lsn).unwrap_or(0);
+                // Already yielded on a prior (un-acked) peek ⇒ drop, idempotent.
+                if commit_lsn > self.frontier {
+                    let commit = Position(json!({ "lsn": lsn }));
+                    for mut ev in tx.drain(..) {
+                        ev.position = commit.clone();
+                        self.pending.push_back(ev);
+                    }
+                    self.frontier = commit_lsn;
+                    yielded_any = true;
+                } else {
+                    tx.clear();
                 }
             } else if data.starts_with("BEGIN") {
                 tx.clear();
@@ -124,14 +157,31 @@ impl PgChangeStream {
                 tx.push(ev);
             }
         }
+        // No new transaction (a non-acking consumer's second peek re-reads the
+        // same rows) or a short batch (backlog fit in one peek) ⇒ drained.
+        if !yielded_any || n_rows < self.batch_limit as usize {
+            self.exhausted = true;
+        }
         Ok(())
     }
 }
 
+/// Parse a `pg_lsn` rendering `X/Y` (two hex halves of a 64-bit position) into a
+/// comparable `u64`. `None` on a malformed value — the frontier check then treats
+/// it as `0` (never drops a real transaction on a parse miss).
+fn parse_lsn(lsn: &str) -> Option<u64> {
+    let (hi, lo) = lsn.split_once('/')?;
+    let hi = u32::from_str_radix(hi.trim(), 16).ok()?;
+    let lo = u32::from_str_radix(lo.trim(), 16).ok()?;
+    Some((u64::from(hi) << 32) | u64::from(lo))
+}
+
 impl ChangeStream for PgChangeStream {
     fn next_change(&mut self) -> Option<Result<ChangeEvent>> {
-        if self.pending.is_empty() && !self.drained {
-            self.drained = true;
+        // Refill a bounded batch whenever the buffer drains — the ack (from the
+        // sink, after a durable part) has advanced the slot, so the next peek
+        // reads fresh changes. `fill` marks `exhausted` once nothing new remains.
+        while self.pending.is_empty() && !self.exhausted {
             if let Err(e) = self.fill() {
                 return Some(Err(e));
             }
@@ -801,7 +851,7 @@ mod tests {
             .unwrap();
 
         // Slot must exist BEFORE the changes for them to be captured.
-        let mut s = PgChangeStream::open(CONN, SLOT, false, None).unwrap();
+        let mut s = PgChangeStream::open(CONN, SLOT, false, None, 10_000).unwrap();
         admin
             .batch_execute(
                 "DROP TABLE IF EXISTS cdc_unit; CREATE TABLE cdc_unit (id INT PRIMARY KEY, v INT)",


### PR DESCRIPTION
## Problem

Both poll-model CDC adapters read their **entire pending backlog into memory in one query** — PostgreSQL via `pg_logical_slot_peek_changes(slot, NULL, NULL)`, SQL Server via `fn_cdc_get_all_changes(@from, max_lsn)` — so drain RSS grew linearly with replication lag. MySQL (streamed binlog) was already bounded.

Measured draining a **1M-change backlog** (5000-row transactions):

| Engine | Before | After | |
|---|---:|---:|---|
| MySQL (reference, streamed) | 76 MB | 76 MB | untouched |
| **PostgreSQL** | **900 MB** | **95 MB** | ~9.5× |
| **SQL Server** | **1150 MB** | **105 MB** | ~11× |

## Fix — read in bounded batches

- **PostgreSQL:** peek `upto_nchanges` = the part `rollover`, dedupe transactions by a COMMIT-LSN frontier (a refill re-peeks from the un-acked `restart_lsn`, so already-yielded transactions are dropped), and refill once the sink's ack advances the slot. NDJSON never advances the slot → one big peek, ended by the frontier check.
- **SQL Server:** bound the window to `@to` = the batch-th change's start LSN (a real transaction boundary, so `fn_cdc_get_all_changes` returns **whole transactions only**), advance an internal cursor, refill until drained. The durable resume position stays the sink checkpoint.

`peek_batch` is threaded through `CdcConfig`: the file sink sets it to its part `rollover` (it acks per part, so it can page); NDJSON sets it huge. Memory is now **O(rollover)**.

## Validation

- **Memory:** 900→95 MB (PG), 1150→105 MB (MSSQL) on 1M changes — in line with MySQL.
- **Live regression (all pass):** `pg_cdc` **15/15**, `mssql_cdc` **11/11** — resume, idle-first-run, crash-before-ack/checkpoint, multi-table resume, vanished-slot loud-fail, retention THROW, type matrix, PK edge cases.
- Drain-interval convergence **10/10** with a zero control drain (no re-read after ack); full offline suite green (315 passed); `cargo publish --dry-run --locked` OK.
- A 4-engine-hour drain-interval memory soak (10/20/30/60/120 min) is running for extra leak/trend confirmation.

Invariants preserved: at-least-once, no split transactions, commit-boundary ack, retention-exhausted error, NDJSON's single non-advancing peek.

**Files:** `src/source/postgres/cdc.rs`, `src/source/mssql/cdc.rs`, `src/source/cdc/mod.rs`, `src/pipeline/cdc_job.rs`, `src/cli/dispatch.rs` + `dev/cdc_interval/` harnesses. Release bump to **0.16.7** (Cargo + lock, CHANGELOG, schema mirror).

🤖 Generated with [Claude Code](https://claude.com/claude-code)