### PR TITLE
Release 0.16.8: CDC rollover default 100k + peek/rollover coupling encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.16.8 — 2026-07-06
+
+### Changed
+
+- **CDC part `rollover` default is now 100000 rows (was 10000)** — ~10× fewer output files per drain,
+  at the cost of more drain memory. The PostgreSQL peek reads a part's worth per batch, so drain RSS is
+  O(rollover) (≈ `28 MB + 1.3 KB × rollover` ≈ 166 MB at 100k). It stays a knob: raise `cdc.rollover` /
+  `--rollover` to cut file count further on a big host, or lower it to cap memory on a small extractor.
+  (A byte-size `max_file_size` target for CDC was prototyped and rejected: on PostgreSQL, paging the slot
+  IS the ack IS the durability point, so accumulating a large multi-batch part either loses the ability
+  to page — data loss — or requires holding the whole part's worth in memory, the very cost the 0.16.7
+  bounded-peek fix removed.)
+
+### Internal
+
+- **The CDC peek bound is derived from the part `rollover` by type, not by convention.** `peek_batch`
+  (a free `usize` three call sites kept equal to `rollover` by hand) becomes
+  `PeekBound { Sized(rollover) | Unbounded }`, so a PostgreSQL peek smaller than the part rollover —
+  which silently starves and drops the backlog — is now unrepresentable. Also removed a dead `exhausted`
+  guard in the SQL Server adapter, and recorded ADR-0025 on why the poll adapters' byte-identical refill
+  loop stays inlined per adapter (extracting it fights the borrow checker for < 10 lines).
+
 ## 0.16.7 — 2026-07-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.16.7"
+version = "0.16.8"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rivet-cli"
-version = "0.16.7"
+version = "0.16.8"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/docs/adr/0025-cdc-paged-refill-loop-inlined-per-adapter.md
+++ b/docs/adr/0025-cdc-paged-refill-loop-inlined-per-adapter.md
@@ -1,0 +1,57 @@
+# ADR-0025: The CDC paged refill loop stays inlined per adapter
+
+**Status**: Accepted
+**Date**: 2026-07-06
+
+---
+
+## Context
+
+After the 0.16.7 bounded-peek fix, the two poll-model CDC adapters —
+`source::postgres::cdc::PgChangeStream` and `source::mssql::cdc::MssqlChangeStream`
+— carry a **byte-for-byte identical** `next_change()`:
+
+```rust
+while self.pending.is_empty() && !self.exhausted {
+    if let Err(e) = self.fill() { return Some(Err(e)); }
+}
+self.pending.pop_front().map(Ok)
+```
+
+plus the same supporting state: `pending: VecDeque<ChangeEvent>`, `exhausted: bool`,
+and a `batch_limit` clamped from the peek bound. Only `fill()` is genuinely
+per-engine (PostgreSQL frames transactions + frontier-dedups a non-consuming
+`peek`; SQL Server windows the change table by LSN and advances an internal
+cursor). MySQL is the odd one out — it *blocks* on the binlog rather than paging,
+so it shares none of this skeleton.
+
+An architecture pass flags this as an un-extracted "polled paged stream" seam and
+proposes a shared driver — e.g. a `PolledPagedStream { fill(&mut self) }` the two
+adapters delegate to, or a `ChangeStream` default method.
+
+## Decision
+
+**Keep the loop inlined in each adapter. Do not extract a shared paged-stream
+driver.**
+
+## Consequences
+
+- A `ChangeStream` default method is wrong: MySQL implements `ChangeStream` but
+  blocks instead of paging, so a shared default `next_change` would be incorrect
+  for one of the three adapters (2-of-3, not 3-of-3).
+- A free-function / wrapper extraction fights the borrow checker. The loop must
+  hold `&mut self.pending` **and** call `self.fill()` (also `&mut self`) — a
+  borrow conflict. The only way through is an accessor trait
+  (`fn pending(&mut self) -> &mut VecDeque; fn exhausted(&self) -> bool; fn fill(&mut self)`)
+  with a blanket `next_change` — which is **more boilerplate than the five lines
+  and three fields it removes**, and pushes three trivial accessors into the
+  interface of both adapters.
+- Deletion test: extracting the loop concentrates one identical five-liner. The
+  win is small (locality, not leverage) and the abstraction's cost exceeds it.
+- The one thing worth encoding — that the PostgreSQL peek must be **≥ the part
+  rollover** or it starves — is captured instead by `PeekBound` (the sink builds
+  `PeekBound::Sized(rollover)`, NDJSON is `PeekBound::Unbounded`), so a peek that
+  undershoots the rollover is unrepresentable. That is the real correctness seam;
+  the refill loop's duplication is not.
+
+If a fourth poll adapter appears, or the two `fill()` bodies converge, reopen this.

--- a/docs/reference/cdc.md
+++ b/docs/reference/cdc.md
@@ -20,7 +20,7 @@ rivet cdc --source 'mysql://rivet_cdc:***@db:3306/app' --table orders
 # write typed Parquet files (one row per change, after-image / upsert shape)
 rivet cdc --source 'mysql://rivet_cdc:***@db:3306/app' \
           --table orders --output ./cdc-out --format parquet \
-          --checkpoint ./orders.ckpt --rollover 10000
+          --checkpoint ./orders.ckpt --rollover 100000
 ```
 
 Prefer `--source-env VAR` or `--source-file path` over an inline URL outside local
@@ -33,6 +33,7 @@ dev — the URL is otherwise visible in `ps` / shell history.
 | `--table NAME` | only emit this table (repeatable for NDJSON; **exactly one** required for `--output`, whose schema is resolved from the source). |
 | `--output DIR` | write typed Parquet/CSV files instead of NDJSON. |
 | `--max-events N` | stop after N changes (otherwise stream until interrupted; the per-event checkpoint makes an interrupted run resumable). |
+| `--rollover N` | rows per output part file (default `100000`); also rolls at a transaction boundary, never splitting one. **This is the file-size ⇄ memory dial**: larger ⇒ fewer, bigger files but more drain memory (the PostgreSQL peek reads a part's worth per batch, so drain RSS is O(rollover) — ≈`28 MB + 1.3 KB × rollover`). Raise it to cut file count on a big host; lower it to cap memory on a small extractor. (Config: `cdc.rollover`.) |
 | `--slot NAME` | PostgreSQL logical slot (default `rivet_slot`; created if absent). |
 | `--capture-instance NAME` | SQL Server CDC capture instance (e.g. `dbo_orders`) — required for `sqlserver://`. |
 | `--until-current` | Catch up to the source's current log end, then **exit** instead of streaming. For MySQL this sets `BINLOG_DUMP_NON_BLOCK`; PostgreSQL / SQL Server already drain-and-exit. With `--max-events N`, the run stops at the smaller of "N events" or "end of log" — so it never blocks waiting for the N-th event. Ideal for a scheduler. |

--- a/schemas/latest/rivet.schema.json
+++ b/schemas/latest/rivet.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Rivet config (rivet-cli 0.16.7)",
+  "title": "Rivet config (rivet-cli 0.16.8)",
   "description": "Top-level Rivet configuration root.\n\nOperators write this struct as YAML (typically `rivet.yaml`).  The\n`JsonSchema` derive is the source of truth for the `schemas/rivet.schema.json`\nartifact and the `rivet schema config` command's output (v0.7.3 P0).",
   "type": "object",
   "properties": {
@@ -757,7 +757,7 @@
           "minimum": 0
         },
         "rollover": {
-          "description": "Rows per output part file (default 10000). A part also rolls at a\ntransaction boundary, so it never splits a transaction.",
+          "description": "Rows per output part file (default 100000). A part also rolls at a\ntransaction boundary, so it never splits a transaction. Larger ⇒ fewer,\nbigger files but more drain memory — the PostgreSQL peek reads a part's\nworth per batch, so drain RSS is O(rollover). Tune per workload: raise it\nto cut file count, lower it to cap memory on a small extractor.",
           "type": [
             "integer",
             "null"

--- a/schemas/rivet.schema.json
+++ b/schemas/rivet.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Rivet config (rivet-cli 0.16.7)",
+  "title": "Rivet config (rivet-cli 0.16.8)",
   "description": "Top-level Rivet configuration root.\n\nOperators write this struct as YAML (typically `rivet.yaml`).  The\n`JsonSchema` derive is the source of truth for the `schemas/rivet.schema.json`\nartifact and the `rivet schema config` command's output (v0.7.3 P0).",
   "type": "object",
   "properties": {
@@ -757,7 +757,7 @@
           "minimum": 0
         },
         "rollover": {
-          "description": "Rows per output part file (default 10000). A part also rolls at a\ntransaction boundary, so it never splits a transaction.",
+          "description": "Rows per output part file (default 100000). A part also rolls at a\ntransaction boundary, so it never splits a transaction. Larger ⇒ fewer,\nbigger files but more drain memory — the PostgreSQL peek reads a part's\nworth per batch, so drain RSS is O(rollover). Tune per workload: raise it\nto cut file count, lower it to cap memory on a small extractor.",
           "type": [
             "integer",
             "null"

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -183,8 +183,10 @@ pub enum Commands {
         /// Output file format when `--output` is set: `parquet` (default) or `csv`.
         #[arg(long, value_name = "FORMAT", default_value = "parquet")]
         format: String,
-        /// Rows per output file (rollover) when `--output` is set.
-        #[arg(long, value_name = "N", default_value_t = 10_000)]
+        /// Rows per output file (rollover) when `--output` is set. Larger ⇒ fewer,
+        /// bigger files but more drain memory (the PostgreSQL peek reads a part's
+        /// worth per batch: memory is O(rollover)). Turn it up/down per workload.
+        #[arg(long, value_name = "N", default_value_t = 100_000)]
         rollover: usize,
         /// PostgreSQL logical slot name (CDC; created if absent).
         #[arg(long, value_name = "NAME", default_value = "rivet_slot")]

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -246,7 +246,7 @@ struct CdcArgs {
 fn dispatch_cdc(a: CdcArgs) -> Result<()> {
     let (url, _prov) = resolve_init_source(a.source, a.source_env, a.source_file)?;
     let ckpt = a.checkpoint.map(std::path::PathBuf::from);
-    let mut cdc_cfg = crate::source::cdc::CdcConfig {
+    let cdc_cfg = crate::source::cdc::CdcConfig {
         url: url.clone(),
         server_id: a.server_id,
         slot: a.slot,
@@ -256,16 +256,17 @@ fn dispatch_cdc(a: CdcArgs) -> Result<()> {
         // The CLI carries no TlsConfig; `None` ⇒ the require_tls_or_loopback gate
         // refuses a remote host (config-driven `rivet run` supplies source.tls).
         tls: None,
-        // NDJSON never advances the slot, so it cannot page: one huge peek drains
-        // the whole backlog and the LSN-frontier check ends the stream. The
-        // `--output` sink overrides this with its part `rollover` below.
-        peek_batch: usize::MAX,
     };
     let Some(dir) = a.output else {
         // NDJSON to stdout: no durable sink, so the slot is deliberately not
         // advanced (correct at-least-once — the consumer owns durability). Resume
         // for MySQL is the checkpoint file; PostgreSQL re-reads from the slot.
-        let mut stream = crate::source::cdc::create_change_stream(&cdc_cfg)?;
+        // No ack ⇒ it cannot page, so `Unbounded`: one peek drains the whole
+        // backlog and the LSN-frontier check ends the stream.
+        let mut stream = crate::source::cdc::create_change_stream(
+            &cdc_cfg,
+            crate::source::cdc::PeekBound::Unbounded,
+        )?;
         return crate::source::cdc::run(stream.as_mut(), ckpt, a.table, a.max_events);
     };
 
@@ -289,8 +290,8 @@ fn dispatch_cdc(a: CdcArgs) -> Result<()> {
         path: Some(dir.clone()),
         ..Default::default()
     })?;
-    // The file sink acks per part, so it CAN page: bound the peek to the part size.
-    cdc_cfg.peek_batch = a.rollover;
+    // `run_capture` derives the peek bound from this export's `rollover` (below),
+    // so the sink and the stream share one source of truth for the part size.
     let now = chrono::Utc::now().to_rfc3339();
     crate::source::cdc::run_capture(crate::source::cdc::CdcCapture {
         cdc_cfg,

--- a/src/config/export.rs
+++ b/src/config/export.rs
@@ -519,8 +519,11 @@ pub struct CdcExportConfig {
     pub until_current: bool,
     /// Stop after N change events (default: until end of stream / interrupted).
     pub max_events: Option<usize>,
-    /// Rows per output part file (default 10000). A part also rolls at a
-    /// transaction boundary, so it never splits a transaction.
+    /// Rows per output part file (default 100000). A part also rolls at a
+    /// transaction boundary, so it never splits a transaction. Larger ⇒ fewer,
+    /// bigger files but more drain memory — the PostgreSQL peek reads a part's
+    /// worth per batch, so drain RSS is O(rollover). Tune per workload: raise it
+    /// to cut file count, lower it to cap memory on a small extractor.
     pub rollover: Option<usize>,
     /// Roll a part once its buffered changes reach this many MB, whichever comes
     /// first with `rollover`. Caps the in-memory buffer and the part file size by

--- a/src/pipeline/cdc_job.rs
+++ b/src/pipeline/cdc_job.rs
@@ -299,12 +299,12 @@ fn run_cdc_inner(
             tls: config.source.tls.clone(),
             // Bound the PostgreSQL peek to the part size: each peeked batch is
             // flushed + acked before the next, so drain memory is O(rollover).
-            peek_batch: cdc.rollover.unwrap_or(10_000),
+            peek_batch: cdc.rollover.unwrap_or(100_000),
         },
         outputs,
         format: export.format,
         max_events: cdc.max_events,
-        rollover: cdc.rollover.unwrap_or(10_000),
+        rollover: cdc.rollover.unwrap_or(100_000),
         rollover_memory_bytes: cdc.rollover_memory_mb.map(|mb| mb * 1024 * 1024),
         run_id: run_id.to_string(),
         started_at: now,

--- a/src/pipeline/cdc_job.rs
+++ b/src/pipeline/cdc_job.rs
@@ -297,9 +297,6 @@ fn run_cdc_inner(
             checkpoint: cdc.checkpoint.as_ref().map(PathBuf::from),
             until_current: cdc.until_current,
             tls: config.source.tls.clone(),
-            // Bound the PostgreSQL peek to the part size: each peeked batch is
-            // flushed + acked before the next, so drain memory is O(rollover).
-            peek_batch: cdc.rollover.unwrap_or(100_000),
         },
         outputs,
         format: export.format,

--- a/src/source/cdc/mod.rs
+++ b/src/source/cdc/mod.rs
@@ -217,13 +217,36 @@ pub(crate) struct CdcConfig {
     /// `require_tls_or_loopback` gate the batch path uses (refuse remote
     /// plaintext / unauthenticated TLS). `None` ⇒ loopback-only (the CLI default).
     pub tls: Option<crate::config::TlsConfig>,
-    /// Max changes the PostgreSQL adapter pulls per `peek` — the memory bound of
-    /// the drain (O(batch), not O(total backlog)). A durable (acking) sink sets
-    /// this to its part `rollover` so each peeked batch is flushed + acked before
-    /// the next; the NDJSON path (which never advances the slot) sets it huge so
-    /// one peek drains everything and the LSN-frontier check ends the stream.
-    /// Ignored by the MySQL (streaming) and SQL Server adapters.
-    pub peek_batch: usize,
+}
+
+/// How many changes a poll adapter pulls per `peek` — the drain's memory bound.
+/// It is NOT a free number: on PostgreSQL the peek is non-consuming and pages
+/// forward only when the sink acks (advances the slot) at a `rollover` boundary,
+/// so a peek SMALLER than the part rollover starves — the second peek re-reads
+/// the same changes, trips `exhausted`, and drops the rest of the backlog. This
+/// enum makes that unrepresentable: the acking sink builds [`PeekBound::Sized`]
+/// **from its own rollover** (so peek == rollover, always ≥), and the NDJSON
+/// driver — which never acks — is [`PeekBound::Unbounded`] (one peek drains
+/// everything; the LSN-frontier check ends the stream). There is no way to hand
+/// the stream a bare "peek 500" that undershoots the rollover.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum PeekBound {
+    /// Peek at most this many changes per batch — the sink passes its part
+    /// `rollover`, so it is ≥ rollover by construction.
+    Sized(usize),
+    /// One peek pulls the whole backlog (the non-acking NDJSON path).
+    Unbounded,
+}
+
+impl PeekBound {
+    /// Resolve to a positive `upto_nchanges`-style row cap the adapters clamp to
+    /// their SQL arg width. `Unbounded` ⇒ the i32 ceiling (effectively "all").
+    pub(crate) fn rows_capped(self) -> usize {
+        match self {
+            PeekBound::Sized(n) => n.clamp(1, i32::MAX as usize),
+            PeekBound::Unbounded => i32::MAX as usize,
+        }
+    }
 }
 
 /// The CDC engine, resolved ONCE from the source URL's scheme. Every
@@ -282,13 +305,13 @@ impl CdcEngine {
                 // Slot creation IS the anchor; open() creates it only on a
                 // genuine FIRST run (resume_expected=false).
                 // Anchor-only open: it creates the slot and is dropped without
-                // reading, so the peek batch is irrelevant (any valid value).
+                // reading, so the peek bound is irrelevant.
                 drop(crate::source::postgres::cdc::PgChangeStream::open(
                     url,
                     slot,
                     resume_expected,
                     tls,
-                    1,
+                    PeekBound::Unbounded,
                 )?);
                 Ok(())
             }
@@ -338,7 +361,10 @@ pub(crate) const MSSQL_CDC_HINT: &str = "if this is a permissions/setup error: S
 /// Construct the right [`ChangeStream`] adapter for the source URL's scheme —
 /// dispatching by engine exactly as [`crate::source::create_source`] does for the
 /// batch path.
-pub(crate) fn create_change_stream(cfg: &CdcConfig) -> Result<Box<dyn ChangeStream>> {
+pub(crate) fn create_change_stream(
+    cfg: &CdcConfig,
+    peek: PeekBound,
+) -> Result<Box<dyn ChangeStream>> {
     use anyhow::Context;
     let url = cfg.url.as_str();
     let tls = cfg.tls.as_ref();
@@ -368,7 +394,7 @@ pub(crate) fn create_change_stream(cfg: &CdcConfig) -> Result<Box<dyn ChangeStre
                     &cfg.slot,
                     resume_expected,
                     tls,
-                    cfg.peek_batch,
+                    peek,
                 )
                 .context(PG_CDC_HINT)?,
             ))
@@ -392,11 +418,7 @@ pub(crate) fn create_change_stream(cfg: &CdcConfig) -> Result<Box<dyn ChangeStre
                 });
             Ok(Box::new(
                 crate::source::mssql::cdc::MssqlChangeStream::from_url(
-                    url,
-                    ci,
-                    from_lsn,
-                    tls,
-                    cfg.peek_batch,
+                    url, ci, from_lsn, tls, peek,
                 )
                 .context(MSSQL_CDC_HINT)?,
             ))
@@ -540,7 +562,10 @@ pub(crate) fn run_capture(cap: CdcCapture<'_>) -> Result<Vec<crate::manifest::Ru
     let url = cap.cdc_cfg.url.clone();
     let tls = cap.cdc_cfg.tls.clone();
     let checkpoint = cap.cdc_cfg.checkpoint.clone();
-    let mut stream = create_change_stream(&cap.cdc_cfg)?;
+    // Derive the peek bound from the ONE rollover the sink also uses — so the
+    // PG peek is always ≥ the part rollover (never starves). The single source
+    // of truth for both is `cap.rollover`.
+    let mut stream = create_change_stream(&cap.cdc_cfg, PeekBound::Sized(cap.rollover))?;
     // Fault point: stream (and any server-side anchor) opened, nothing read.
     crate::test_hook::maybe_panic_at("cdc_after_open");
     let engine = CdcEngine::from_url(&url)?;

--- a/src/source/mssql/cdc.rs
+++ b/src/source/mssql/cdc.rs
@@ -68,7 +68,7 @@ pub(crate) struct MssqlChangeStream {
     from_lsn: Option<String>,
     pending: VecDeque<ChangeEvent>,
     /// Max changes to pull per poll — bounds drain memory to O(batch) instead of
-    /// O(total change-table window). See [`crate::source::cdc::CdcConfig::peek_batch`].
+    /// O(total change-table window). See [`crate::source::cdc::PeekBound`].
     batch_limit: i64,
     /// A poll that returns no rows has drained the window up to the current max
     /// LSN — the stream ends (the next scheduler run resumes from the checkpoint).
@@ -81,7 +81,7 @@ impl MssqlChangeStream {
     pub(crate) fn open(
         cfg: &MssqlCdcConfig,
         tls: Option<&TlsConfig>,
-        peek_batch: usize,
+        peek: crate::source::cdc::PeekBound,
     ) -> Result<Self> {
         if !cfg
             .capture_instance
@@ -143,7 +143,7 @@ impl MssqlChangeStream {
             table,
             from_lsn: cfg.from_lsn.clone(),
             pending: VecDeque::new(),
-            batch_limit: peek_batch.clamp(1, i32::MAX as usize) as i64,
+            batch_limit: peek.rows_capped() as i64,
             exhausted: false,
         })
     }
@@ -155,7 +155,7 @@ impl MssqlChangeStream {
         capture_instance: &str,
         from_lsn: Option<String>,
         tls: Option<&TlsConfig>,
-        peek_batch: usize,
+        peek: crate::source::cdc::PeekBound,
     ) -> Result<Self> {
         // Refuse remote plaintext / unauthenticated TLS before any dial (the gate
         // the batch MssqlSource uses).
@@ -172,7 +172,7 @@ impl MssqlChangeStream {
                 from_lsn,
             },
             tls,
-            peek_batch,
+            peek,
         )
     }
 
@@ -183,9 +183,8 @@ impl MssqlChangeStream {
     /// internal cursor then advances to `@to`; the next poll continues past it. A
     /// poll that returns no rows has drained the window up to the current max LSN.
     fn fill(&mut self) -> Result<()> {
-        if self.exhausted {
-            return Ok(());
-        }
+        // Only ever called from `next_change` under `!self.exhausted`, so no
+        // early-return guard here (matches the PostgreSQL adapter).
         let ci = self.capture_instance.clone();
         // Resume window: read changes *after* the last cursor LSN
         // (`fn_cdc_increment_lsn`); on the first poll (no cursor) start at the
@@ -513,7 +512,12 @@ mod tests {
         // let the capture Agent job scan the log (~5 s cycle)
         std::thread::sleep(std::time::Duration::from_secs(8));
 
-        let mut s = MssqlChangeStream::open(&cfg("dbo_cdc_unit"), None, 10_000).unwrap();
+        let mut s = MssqlChangeStream::open(
+            &cfg("dbo_cdc_unit"),
+            None,
+            crate::source::cdc::PeekBound::Sized(10_000),
+        )
+        .unwrap();
         let mut ops = Vec::new();
         while let Some(ev) = s.next_change() {
             ops.push(ev.unwrap().op);

--- a/src/source/postgres/cdc.rs
+++ b/src/source/postgres/cdc.rs
@@ -37,7 +37,7 @@ pub(crate) struct PgChangeStream {
     slot: String,
     pending: VecDeque<ChangeEvent>,
     /// Max changes to pull per `peek` — the memory bound of the drain
-    /// (O(batch), not O(total backlog)). See [`crate::source::cdc::CdcConfig::peek_batch`].
+    /// (O(batch), not O(total backlog)). See [`crate::source::cdc::PeekBound`].
     batch_limit: i32,
     /// Largest COMMIT LSN already yielded THIS run. A refill re-peeks from the
     /// slot's (un-acked) `restart_lsn`, so any transaction at/below this was
@@ -62,7 +62,7 @@ impl PgChangeStream {
         slot: &str,
         resume_expected: bool,
         tls: Option<&TlsConfig>,
-        peek_batch: usize,
+        peek: crate::source::cdc::PeekBound,
     ) -> Result<Self> {
         // Same gate the batch path uses: refuse remote plaintext (CWE-319), and
         // use a verifying TLS connector when a TlsConfig is enforced.
@@ -101,9 +101,10 @@ impl PgChangeStream {
             client,
             slot: slot.to_string(),
             pending: VecDeque::new(),
-            // A logical slot never has 2^31 pending changes in one peek; clamp to
-            // the `pg_logical_slot_peek_changes` int4 arg and keep it >= 1.
-            batch_limit: peek_batch.clamp(1, i32::MAX as usize) as i32,
+            // `PeekBound::Sized` carries the sink's part rollover (so peek ≥
+            // rollover, never starves); `Unbounded` is the i32 ceiling. Either
+            // way it fits the `pg_logical_slot_peek_changes` int4 arg.
+            batch_limit: peek.rows_capped() as i32,
             frontier: 0,
             exhausted: false,
         })
@@ -851,7 +852,14 @@ mod tests {
             .unwrap();
 
         // Slot must exist BEFORE the changes for them to be captured.
-        let mut s = PgChangeStream::open(CONN, SLOT, false, None, 10_000).unwrap();
+        let mut s = PgChangeStream::open(
+            CONN,
+            SLOT,
+            false,
+            None,
+            crate::source::cdc::PeekBound::Sized(10_000),
+        )
+        .unwrap();
         admin
             .batch_execute(
                 "DROP TABLE IF EXISTS cdc_unit; CREATE TABLE cdc_unit (id INT PRIMARY KEY, v INT)",


### PR DESCRIPTION
Everything ships under **0.16.8**.

## Changed (user-facing)

- **CDC part `rollover` default 10000 → 100000 rows** — ~10× fewer output files per drain. Drain memory is O(rollover) (the PostgreSQL peek reads a part's worth per batch; ≈ `28 MB + 1.3 KB × rollover` ≈ 166 MB at 100k), and it stays a knob (`cdc.rollover` / `--rollover`): raise for fewer files, lower to cap memory. Measured on a heat-spectrum soak (2/3-min intervals, ~1000 rows/s): 100k → ~162 MB, 50k → ~93 MB, both flat vs backlog, convergence 10/10.
- A byte-size `max_file_size` target for CDC was **prototyped and rejected** — on PostgreSQL, paging the slot *is* the ack *is* the durability point, so a large multi-batch part either loses the ability to page (an A/B dropped 3.99M/4M rows) or holds the whole part in memory (the cost 0.16.7 removed).

## Internal (architecture review follow-up)

- **`peek ≥ rollover` is now encoded, not conventional.** `peek_batch` (a free `usize` three call sites kept equal to `rollover` by hand) becomes `PeekBound { Sized(rollover) | Unbounded }`; the acking sink derives `Sized(cap.rollover)` from the one rollover it also feeds the sink, NDJSON is `Unbounded`. A PG peek that undershoots the rollover — which silently starves — is unrepresentable. The `usize::MAX` sentinel is gone.
- Deleted a dead `exhausted` guard in the SQL Server `fill()` (unreachable; PG never had it).
- **ADR-0025** — why the poll adapters' byte-identical refill loop stays inlined per adapter (a shared driver breaks MySQL, which blocks not pages; extracting it fights the borrow checker for < 10 lines).

## Verification

- Offline cdc/pg/mssql 45/45, sink 18/18, schema_drift 3/3, full offline suite green, `cargo publish --dry-run --locked` path + `cargo metadata --locked` clean.
- **Live: pg_cdc 15/15, mssql_cdc 11/11** (resume, idle-first-run, crash-before-ack/checkpoint, multi-table resume, vanished-slot, retention THROW, type matrix) after the PeekBound change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)