### PR TITLE
feat: first-party extension seam contract (ADR-0026, Phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,29 @@ jobs:
           done
           [ "$FAIL" = "0" ]
 
+  boundary:
+    name: OSS must not depend on rivet-pro (one-way seam, ADR-0026)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: No rivet-pro references in OSS sources
+        # The paid tier (rivet-pro, private/BSL) depends on this engine — never
+        # the reverse. A `use rivet_pro` or a Cargo.toml dependency would make
+        # the MIT binary unbuildable without the private crate and leak paid
+        # code into an MIT distribution. docs/ may name it (ADR-0026); code and
+        # manifest may not.
+        # `-w` (whole word) is used deliberately: a plain substring match
+        # false-positives on identifiers like `_rivet_probe` (an SQL alias in
+        # src/preflight/mssql.rs). `git grep -E` does NOT support `\b` portably,
+        # so `-w` is the portable word-boundary. It still matches both real
+        # forms — `rivet_pro` (Rust) and `rivet-pro` (Cargo/repo).
+        run: |
+          if git grep -nwE 'rivet[_-]pro' -- src/ Cargo.toml; then
+            echo "::error::OSS tree references the private rivet-pro crate — the extension seam is one-way (ADR-0026). Remove it."
+            exit 1
+          fi
+          echo "ok: no rivet-pro references in src/ or Cargo.toml"
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Internal
+
+- **First-party extension seam (ADR-0026).** Named a minimal, stability-tracked subset of the library —
+  the `types` / `types::target` resolution items (`TypeMapping`, `ExportTarget::resolve_table` /
+  `resolve_column`, `TargetColumnSpec`, `TargetInput`) — as the contract the private `rivet-pro` crate
+  (paid tier, BSL 1.1) builds on. These stay `pub`; a shape change is now deliberate (update `rivet-pro`
+  + a `Breaking (extension seam)` note). Amends ADR-0002: the full `rivet-engine` extraction is deferred
+  until a non-first-party consumer appears. Enforced by a compile-canary (`tests/offline/extension_seam.rs`)
+  and a CI `boundary` job that forbids any `rivet-pro` reference in `src/` — the dependency is one-way.
+  No user-facing or runtime change.
+
 ## 0.16.9 — 2026-07-06
 
 ### Changed

--- a/docs/adr/0002-cli-product-vs-library.md
+++ b/docs/adr/0002-cli-product-vs-library.md
@@ -71,6 +71,7 @@ harness needs it", not "public API".
 - **Docs reflect intent**: `cargo doc` will not generate docs for `pub(crate)` modules, reducing confusion about the intended API surface.
 - **Binary compilation path**: `src/main.rs` declares all modules privately via `mod` — it never uses the library crate. The two targets are independent compilation units that happen to share source files.
 - **Future library path**: If Rivet ever offers a stable embedding API, a separate `rivet-engine` crate should be extracted with its own semver-tracked surface, rather than promoting internal types to `pub`.
+  - *Amended by [ADR-0026](0026-first-party-extension-seam.md)*: a minimal **first-party** extension seam (the `types`/`types::target` resolution items) is now stability-tracked in-crate for the private `rivet-pro` companion. The full `rivet-engine` extraction is deferred until a *non-first-party* external consumer appears.
 
 ---
 

--- a/docs/adr/0026-first-party-extension-seam.md
+++ b/docs/adr/0026-first-party-extension-seam.md
@@ -1,0 +1,53 @@
+# ADR-0026: First-party extension seam (amends ADR-0002)
+
+**Status**: Accepted
+**Date**: 2026-07
+**Amends**: [ADR-0002 — CLI Product vs Library](0002-cli-product-vs-library.md)
+**Context**: A private, source-available companion crate — **`rivet-pro`** (BSL 1.1, separate repo) — now builds the paid tier (warehouse load, whole-database discovery, continuous CDC) on top of the OSS engine. It links the `rivet` library and depends on a small set of already-`pub` items. ADR-0002 declares the library "not a stable public API" and (Consequence #4 / *Future library path*) prescribes extracting a separate `rivet-engine` crate *if* a stable embedding surface is ever needed. This ADR decides what to do now that there is exactly **one, first-party** embedding consumer.
+
+---
+
+## Decision
+
+**Name a minimal, stability-tracked *first-party extension seam*. Defer the full `rivet-engine` extraction until a non-first-party (external) consumer appears.**
+
+The seam is the exact set of library items `rivet-pro` depends on. It stays `pub`, and a change to the **shape** of any item below is a deliberate act: update `rivet-pro` in lockstep and record it in `CHANGELOG.md` under a `Breaking (extension seam)` line.
+
+### The seam (v0.16.x)
+
+| Item | Path |
+|---|---|
+| `TypeMapping`, `RivetType`, `TimeUnit`, `TypeFidelity`, `SourceColumn` | `rivet::types` |
+| `ExportTarget` (+ variants `DuckDb`/`BigQuery`/`Snowflake`/`ClickHouse`) | `rivet::types::target` |
+| `ExportTarget::resolve_table(&[TypeMapping]) -> Vec<TargetColumnSpec>` | `rivet::types::target` |
+| `ExportTarget::resolve_column(TargetInput) -> TargetColumnSpec` | `rivet::types::target` |
+| `TargetColumnSpec`, `TargetInput`, `TargetStatus` | `rivet::types::target` |
+
+Everything else in the library keeps the ADR-0002 posture: `pub` only for the test harness, no stability guarantee.
+
+### The CLI superset uses the process boundary, not a Rust API
+
+`rivet-pro` ships a superset `rivet` binary (OSS subcommands + `load`/`discover`/`daemon`). It composes them at the **argv/process boundary**: unknown subcommands are delegated to the OSS `rivet` binary (already a stable product contract — config YAML + exit-code taxonomy + manifest). The `cli` module is deliberately **binary-only** (declared in `main.rs`, absent from `lib.rs`; its dispatch reaches `crate::init`, also binary-only). Pulling `cli` into the library to expose `Commands`/`dispatch` would violate ADR-0002's minimal-library principle and freeze the entire command surface. We do not do that.
+
+---
+
+## Rationale
+
+- **One consumer ≠ a public API.** A full `rivet-engine` extraction (separate crate, two manifests, re-export churn) is the right move for *external* consumers with independent release cadence. With a single first-party consumer we own both sides, so a *named + tested* subset delivers the stability guarantee at a fraction of the cost.
+- **Smallest seam.** Every `pub` item on the seam is a compatibility commitment. The list is exactly what `rivet-pro` uses today — resolution only. `Destination` promotion (a likely next seam) is **deferred** until a Pro feature needs it, then added here with the same discipline.
+- **One-way dependency.** `rivet-pro` depends on `rivet`; the OSS tree must never depend on `rivet-pro` — otherwise the MIT binary can't build without the private crate and paid code leaks into an MIT distribution.
+
+---
+
+## Enforcement
+
+1. **Seam-stability canary** — `tests/offline/extension_seam.rs` compile-locks every signature above. If it fails to build, an item on the seam changed: update `rivet-pro` and add the `Breaking (extension seam)` CHANGELOG line — do not just edit the test to compile.
+2. **Dependency-direction guard** — the CI `boundary` job fails if `src/` or `Cargo.toml` references `rivet-pro` / `rivet_pro`.
+
+---
+
+## Consequences
+
+- The seam table is the contract. Widen it only by adding a row here + a canary line, never silently.
+- `rivet-pro`'s own CI (dual-checkout, builds against OSS `main`) is a second, cross-repo canary.
+- **Trigger to revisit**: the day a *second, external* consumer wants to embed the engine, extract `rivet-engine` per ADR-0002's *Future library path* and move this seam into its semver'd surface.

--- a/tests/offline/extension_seam.rs
+++ b/tests/offline/extension_seam.rs
@@ -1,0 +1,42 @@
+//! ADR-0026 — first-party extension seam stability canary.
+//!
+//! `rivet-pro` (private, BSL 1.1, separate repo) depends on the exact library
+//! items referenced below. This module COMPILE-LOCKS their shape: if it fails
+//! to build, an item on the seam changed. That is a deliberate decision —
+//! update `rivet-pro` in lockstep AND record it in `CHANGELOG.md` under a
+//! `Breaking (extension seam)` line. Do NOT just edit this file to compile.
+//!
+//! See docs/adr/0026-first-party-extension-seam.md for the full seam table.
+
+use rivet::types::TypeMapping;
+use rivet::types::target::{ExportTarget, TargetColumnSpec, TargetInput};
+
+// ExportTarget::resolve_table(self, &[TypeMapping]) -> Vec<TargetColumnSpec>
+fn seam_resolve_table(t: ExportTarget, mappings: &[TypeMapping]) -> Vec<TargetColumnSpec> {
+    t.resolve_table(mappings)
+}
+
+// ExportTarget::resolve_column(self, TargetInput<'_>) -> TargetColumnSpec
+fn seam_resolve_column(t: ExportTarget, input: TargetInput<'_>) -> TargetColumnSpec {
+    t.resolve_column(input)
+}
+
+// The four warehouse variants rivet-pro matches on.
+fn seam_variants() -> [ExportTarget; 4] {
+    [
+        ExportTarget::DuckDb,
+        ExportTarget::BigQuery,
+        ExportTarget::Snowflake,
+        ExportTarget::ClickHouse,
+    ]
+}
+
+#[test]
+fn first_party_extension_seam_is_stable() {
+    // Binding each item to an explicitly-typed function pointer double-locks
+    // the signature and — since CI runs `clippy --all-targets -D warnings`,
+    // tests included — keeps the dead_code lint from firing on the helpers.
+    let _rt: fn(ExportTarget, &[TypeMapping]) -> Vec<TargetColumnSpec> = seam_resolve_table;
+    let _rc: fn(ExportTarget, TargetInput<'_>) -> TargetColumnSpec = seam_resolve_column;
+    assert_eq!(seam_variants().len(), 4);
+}

--- a/tests/offline_suite.rs
+++ b/tests/offline_suite.rs
@@ -26,6 +26,8 @@ mod config_parse_errors;
 mod config_secrets;
 #[path = "offline/examples_parse.rs"]
 mod examples_parse;
+#[path = "offline/extension_seam.rs"]
+mod extension_seam;
 #[path = "offline/format_fuzz.rs"]
 mod format_fuzz;
 #[path = "offline/planner_fuzz.rs"]


### PR DESCRIPTION
## Phase 1 — first-party extension seam contract

Makes the boundary between this OSS engine and the private **`rivet-pro`** crate (paid tier, BSL 1.1) *contractual and enforced* — **without exposing any new API or changing runtime behavior**.

### Why this shape (and not the plan's "promote `Destination`/expose `Commands`")

Exploration corrected the original plan:

- The items `rivet-pro` needs (`types` / `types::target` resolution) are **already `pub`**. Nothing to promote.
- **ADR-0002** explicitly forbids promoting internals to `pub` for a stable embedding API and prescribes extracting a separate `rivet-engine` crate instead. With a single *first-party* consumer, that extraction is premature.
- The `cli` module is **binary-only by design** (declared in `main.rs`, absent from `lib.rs`; its dispatch reaches `crate::init`, also bin-only). Exposing `Commands`/`dispatch` would pull `cli`+`init` into the library and freeze the whole command surface — against ADR-0002. The superset `rivet` binary composes at the **argv/process boundary** instead.

So the real gap was never "open the seam" (it's open) — it was making it a **tracked contract** with **enforced one-way dependency**.

### What's in this PR

- **`docs/adr/0026-first-party-extension-seam.md`** — amends ADR-0002. Names the minimal seam (the `types`/`types::target` resolution items), defers the `rivet-engine` extraction until a *non-first-party* consumer appears, and records the argv-boundary decision for the CLI superset.
- **`tests/offline/extension_seam.rs`** — a compile-canary locking every seam signature. If it fails to build, the seam changed: a deliberate act, paired with a `Breaking (extension seam)` CHANGELOG line.
- **`ci.yml` `boundary` job** — a whole-word `git grep` guard forbidding any `rivet-pro` reference in `src/` or `Cargo.toml`. (`-w`, not `\b` — `git grep -E` doesn't support `\b` portably; verified it still excludes `_rivet_probe`.)
- CHANGELOG `Unreleased` entry + an ADR-0002 cross-reference.

### Verification

- `pre-commit`: `fmt` + `clippy --all-targets -D warnings` + `audit` — all green.
- `pre-push`: full offline suite — **316 passed, 468 skipped**, including the new `first_party_extension_seam_is_stable`.
- Boundary guard dry-run: clean on the current tree; catches `use rivet_pro::` and `rivet-pro =`; skips `_rivet_probe`.

No `src/` behavior change; no new public surface. Ships whenever the next release cuts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsabsUrfFxxY4xmHUPgg2U
