### PR TITLE
Release 0.17.0: CDC __seq total-order + config load: block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+
+- **Config accepts an optional top-level `load:` block** for a downstream loader
+  (the `rivet-pro` warehouse load): the load target lives in the same config so
+  ONE file drives both export and load. Rivet does not interpret it — accepted
+  and ignored. Regenerated `schemas/rivet.schema.json`.
+
 ### Internal
 
 - **First-party extension seam (ADR-0026).** Named a minimal, stability-tracked subset of the library —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,19 @@
 # Changelog
 
-## Unreleased
+## 0.17.0 — 2026-07-07
 
 ### Added
 
+- **CDC emits a `__seq` column** — the change's ordinal within its source
+  transaction. `__pos` is the commit position, so every change of one
+  transaction shares it; `(__pos, __seq)` is the total change order. A
+  current-state dedup can no longer pick an arbitrary row when a primary key is
+  updated more than once in a single transaction (verified live on all three
+  engines: 8000 updates of one PK in one transaction produced a single `__pos`,
+  and an ordered-by-`__pos`-only dedup returned the wrong committed value).
+  Per-engine live conformance tests plus a `SUM(v)` source-vs-target
+  reconciliation over an intra-transaction workload. Both `rivet cdc` outputs
+  (NDJSON + Parquet) carry `__seq`.
 - **Config accepts an optional top-level `load:` block** for a downstream loader
   (the `rivet-pro` warehouse load): the load target lives in the same config so
   ONE file drives both export and load. Rivet does not interpret it — accepted

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,9 +888,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.16.9"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rivet-cli"
-version = "0.16.9"
+version = "0.17.0"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/docs/cdc-seq-ordering.md
+++ b/docs/cdc-seq-ordering.md
@@ -1,0 +1,86 @@
+# CDC change ordering: `__pos` is not a total order — add `__seq`
+
+## Problem (verified live on all three engines)
+
+The CDC output columns are `__op`, `__pos`, and the after-image. `__pos` is the
+**commit position** of the change's transaction:
+
+| engine  | `__pos`                                   | source                     |
+| ------- | ----------------------------------------- | -------------------------- |
+| MySQL   | `{"file":"binlog.000047","pos":11721549}` | transaction commit pos     |
+| Postgres| `{"lsn":"3D/485795A0"}`                    | `peek_changes` commit LSN  |
+| SQLServer | `{"lsn":"0000002d000000d80194"}`        | `__$start_lsn` (txn LSN)   |
+
+Commit position is exactly right for **resume/checkpoint** (all engines resume
+at a commit boundary). But it is **not a total order over changes**: every
+change in one transaction shares it. Proven — 8000 `UPDATE`s of one PK in a
+single transaction produced `COUNT(DISTINCT __pos) = 1` on **all three engines**.
+
+Downstream, the current-state dedup view
+
+```sql
+ROW_NUMBER() OVER (PARTITION BY <pk> ORDER BY <parsed __pos> DESC) = 1
+```
+
+has 8000 tied rows, so `ROW_NUMBER` picks an arbitrary one. Live result: the
+view returned `counter = 1` for a row whose committed value was `8000` —
+**silently wrong current state**. This bites any transaction that touches the
+same PK more than once (triggers, ORMs, read-modify-write loops, batch
+upserts). The row order inside the Parquet part *is* the change order, but that
+order is lost the moment the log is loaded into an (unordered) warehouse table.
+
+## Design: emit a per-change `__seq` (intra-transaction ordinal)
+
+Add a **`__seq`** column to the CDC output: the change's ordinal **within its
+commit group**. Keep `__pos` unchanged (still the commit position, still what
+resume uses). The pair `(__pos, __seq)` is then a **total order** that:
+
+- matches log order (commit order across transactions, emission order within),
+- is **deterministic and log-derived**, so a re-emitted change (at-least-once,
+  crash-before-ack) carries the **same** `(__pos, __seq)` — the dedup tiebreak
+  is a true tie between identical rows, so either wins and the value is right,
+- survives the load (it is a column, not row order).
+
+Dedup view becomes:
+
+```sql
+ROW_NUMBER() OVER (PARTITION BY <pk> ORDER BY <parsed __pos> DESC, __seq DESC) = 1
+```
+
+### Per-engine population
+
+`__seq` is a 0-based counter over the changes of one commit, in log order:
+
+- **SQL Server** — use the native **`__$seqval`** from the change table (it
+  already orders operations within `__$start_lsn`). `__seq = dense_rank of
+  __$seqval within __$start_lsn` (or `__$seqval` rendered as a comparable
+  fixed-width value). No invention — the engine hands us the order.
+- **PostgreSQL** — logical decoding yields the transaction's changes in order;
+  assign `0,1,2,…`, resetting when `__pos` (commit LSN) advances.
+- **MySQL** — binlog row events arrive in order within the transaction; assign
+  `0,1,2,…`, resetting at each commit `__pos`.
+
+Because the reset key is `__pos` (the commit position), the ordinal is
+reproducible from the log alone on every run — the at-least-once property above
+holds without any persisted counter.
+
+### Why not alternatives
+
+- **A single global run counter** (0,1,2,… over the whole run) breaks across
+  runs: run 2 resets to 0, so a newer change gets a smaller counter than an
+  older one from run 1. `(__pos, __seq)` avoids this by resetting per commit,
+  keeping the ordinal log-derived.
+- **Folding `__seq` into `__pos`** (making `__pos` distinct per change) would
+  break resume, which must stop on a commit boundary, not mid-transaction.
+- **Relying on Parquet row order** — lost on load into a warehouse table.
+
+## Blast radius
+
+- CDC sink schema gains one column (`__seq INT64`), all engines.
+- Three capture paths populate it (SQL Server from `__$seqval`; MySQL/Postgres
+  from a per-commit ordinal).
+- `validate.rs` can additionally assert `(__pos, __seq)` is strictly increasing
+  in part→row order (today it only checks `__pos` non-decreasing).
+- The `rivet-pro` dedup view template orders by `(__pos, __seq)`.
+- Regression test per engine: N changes to one PK in **one** transaction →
+  the dedup view returns the **last** change's value, not an arbitrary one.

--- a/schemas/latest/rivet.schema.json
+++ b/schemas/latest/rivet.schema.json
@@ -32,7 +32,7 @@
       "default": false
     },
     "load": {
-      "description": "Reserved for a downstream loader (e.g. the `rivet-pro` warehouse load):\nthe load target lives here so ONE config can drive both the export and a\ndownstream load. Rivet stops at \"file in a bucket\" and **does not\ninterpret** this block — it is accepted and ignored, present only so\n`rivet check` / `run` / `apply` don't reject a config that carries it.",
+      "description": "Reserved for a downstream, first-party warehouse loader: the load target\nlives here so ONE config can drive both the export and a\ndownstream load. Rivet stops at \"file in a bucket\" and **does not\ninterpret** this block — it is accepted and ignored, present only so\n`rivet check` / `run` / `apply` don't reject a config that carries it.",
       "default": null
     }
   },

--- a/schemas/latest/rivet.schema.json
+++ b/schemas/latest/rivet.schema.json
@@ -30,6 +30,10 @@
     "parallel_export_processes": {
       "type": "boolean",
       "default": false
+    },
+    "load": {
+      "description": "Reserved for a downstream loader (e.g. the `rivet-pro` warehouse load):\nthe load target lives here so ONE config can drive both the export and a\ndownstream load. Rivet stops at \"file in a bucket\" and **does not\ninterpret** this block — it is accepted and ignored, present only so\n`rivet check` / `run` / `apply` don't reject a config that carries it.",
+      "default": null
     }
   },
   "additionalProperties": false,

--- a/schemas/latest/rivet.schema.json
+++ b/schemas/latest/rivet.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Rivet config (rivet-cli 0.16.9)",
+  "title": "Rivet config (rivet-cli 0.17.0)",
   "description": "Top-level Rivet configuration root.\n\nOperators write this struct as YAML (typically `rivet.yaml`).  The\n`JsonSchema` derive is the source of truth for the `schemas/rivet.schema.json`\nartifact and the `rivet schema config` command's output (v0.7.3 P0).",
   "type": "object",
   "properties": {

--- a/schemas/rivet.schema.json
+++ b/schemas/rivet.schema.json
@@ -32,7 +32,7 @@
       "default": false
     },
     "load": {
-      "description": "Reserved for a downstream loader (e.g. the `rivet-pro` warehouse load):\nthe load target lives here so ONE config can drive both the export and a\ndownstream load. Rivet stops at \"file in a bucket\" and **does not\ninterpret** this block — it is accepted and ignored, present only so\n`rivet check` / `run` / `apply` don't reject a config that carries it.",
+      "description": "Reserved for a downstream, first-party warehouse loader: the load target\nlives here so ONE config can drive both the export and a\ndownstream load. Rivet stops at \"file in a bucket\" and **does not\ninterpret** this block — it is accepted and ignored, present only so\n`rivet check` / `run` / `apply` don't reject a config that carries it.",
       "default": null
     }
   },

--- a/schemas/rivet.schema.json
+++ b/schemas/rivet.schema.json
@@ -30,6 +30,10 @@
     "parallel_export_processes": {
       "type": "boolean",
       "default": false
+    },
+    "load": {
+      "description": "Reserved for a downstream loader (e.g. the `rivet-pro` warehouse load):\nthe load target lives here so ONE config can drive both the export and a\ndownstream load. Rivet stops at \"file in a bucket\" and **does not\ninterpret** this block — it is accepted and ignored, present only so\n`rivet check` / `run` / `apply` don't reject a config that carries it.",
+      "default": null
     }
   },
   "additionalProperties": false,

--- a/schemas/rivet.schema.json
+++ b/schemas/rivet.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Rivet config (rivet-cli 0.16.9)",
+  "title": "Rivet config (rivet-cli 0.17.0)",
   "description": "Top-level Rivet configuration root.\n\nOperators write this struct as YAML (typically `rivet.yaml`).  The\n`JsonSchema` derive is the source of truth for the `schemas/rivet.schema.json`\nartifact and the `rivet schema config` command's output (v0.7.3 P0).",
   "type": "object",
   "properties": {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -38,8 +38,8 @@ pub struct Config {
     pub parallel_exports: bool,
     #[serde(default)]
     pub parallel_export_processes: bool,
-    /// Reserved for a downstream loader (e.g. the `rivet-pro` warehouse load):
-    /// the load target lives here so ONE config can drive both the export and a
+    /// Reserved for a downstream, first-party warehouse loader: the load target
+    /// lives here so ONE config can drive both the export and a
     /// downstream load. Rivet stops at "file in a bucket" and **does not
     /// interpret** this block — it is accepted and ignored, present only so
     /// `rivet check` / `run` / `apply` don't reject a config that carries it.
@@ -1338,7 +1338,7 @@ mod audit_csv_compression {
 
 #[cfg(test)]
 mod reserved_load_extension {
-    //! A downstream loader (rivet-pro) carries its warehouse target in a
+    //! A downstream first-party loader carries its warehouse target in a
     //! top-level `load:` block so ONE config drives export + load. OSS must
     //! accept and ignore it — otherwise `check`/`run`/`apply` would reject the
     //! single-file config. Reverting the reserved field turns this red.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -38,6 +38,16 @@ pub struct Config {
     pub parallel_exports: bool,
     #[serde(default)]
     pub parallel_export_processes: bool,
+    /// Reserved for a downstream loader (e.g. the `rivet-pro` warehouse load):
+    /// the load target lives here so ONE config can drive both the export and a
+    /// downstream load. Rivet stops at "file in a bucket" and **does not
+    /// interpret** this block — it is accepted and ignored, present only so
+    /// `rivet check` / `run` / `apply` don't reject a config that carries it.
+    // Deliberately never read by OSS — it is a reserved passthrough for a
+    // downstream loader; only serde (accept) and schemars (document) touch it.
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub load: Option<serde_json::Value>,
 }
 
 impl Config {
@@ -1323,6 +1333,24 @@ mod audit_csv_compression {
                 ct.label()
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod reserved_load_extension {
+    //! A downstream loader (rivet-pro) carries its warehouse target in a
+    //! top-level `load:` block so ONE config drives export + load. OSS must
+    //! accept and ignore it — otherwise `check`/`run`/`apply` would reject the
+    //! single-file config. Reverting the reserved field turns this red.
+    use super::*;
+
+    #[test]
+    fn reserved_top_level_load_block_is_accepted_and_ignored() {
+        let yaml = "source:\n  type: postgres\n  url: \"postgresql://localhost/test\"\n\
+             exports:\n  - name: t\n    query: \"SELECT 1\"\n    format: parquet\n    destination:\n      type: gcs\n      bucket: b\n      prefix: \"t/\"\n\
+             load:\n  project: p\n  dataset: d\n  cleanup_source: true\n";
+        let cfg = Config::from_yaml(yaml).expect("config with a reserved `load:` block must parse");
+        assert!(cfg.load.is_some(), "the load block is captured opaquely");
     }
 }
 

--- a/src/plan/build.rs
+++ b/src/plan/build.rs
@@ -543,6 +543,7 @@ mod tests {
             notifications: None,
             parallel_exports: false,
             parallel_export_processes: false,
+            load: None,
         }
     }
 

--- a/src/source/cdc/mod.rs
+++ b/src/source/cdc/mod.rs
@@ -108,6 +108,45 @@ pub(crate) struct ChangeEvent {
     /// deletes) is unrepresentable. `None` ⇒ positional full row (MySQL
     /// binlog carries no names; its arity guard stays load-bearing).
     pub(crate) image_names: Option<std::sync::Arc<[String]>>,
+    /// Ordinal of this change **within its source transaction** (0-based),
+    /// stamped by [`TxnSeq`] as the stream is consumed. `position` alone is the
+    /// commit position — every change in one transaction shares it — so ordering
+    /// a current-state dedup by `position` picks an arbitrary row when a PK is
+    /// touched more than once per transaction. `(position, seq)` is the total
+    /// order; being log-derived it is identical on an at-least-once re-emit.
+    pub(crate) seq: u64,
+}
+
+/// Stamps each change with its intra-transaction ordinal ([`ChangeEvent::seq`]).
+/// The ordinal resets whenever the change's `position` (the commit position)
+/// changes — every change in one transaction shares that position, so this is
+/// the reliable transaction boundary on ALL engines. (`committed` cannot serve:
+/// the poll-based PostgreSQL / SQL Server adapters read already-committed data
+/// and mark EVERY change `committed`, which would reset the ordinal every row.)
+/// Being derived from `position` + log order, the ordinal is reproduced exactly
+/// on an at-least-once replay.
+#[derive(Default)]
+pub(crate) struct TxnSeq {
+    counter: u64,
+    prev: Option<Position>,
+}
+
+impl TxnSeq {
+    /// Ordinal for a change at commit `position`: 0 when `position` differs from
+    /// the previous change (a new transaction), else one more than the last.
+    pub(crate) fn next(&mut self, position: &Position) -> u64 {
+        if self.prev.as_ref() == Some(position) {
+            self.counter += 1;
+        } else {
+            self.counter = 0;
+            self.prev = Some(position.clone());
+        }
+        self.counter
+    }
+
+    pub(crate) fn stamp(&mut self, ev: &mut ChangeEvent) {
+        ev.seq = self.next(&ev.position);
+    }
 }
 
 impl ChangeEvent {
@@ -158,8 +197,10 @@ pub(crate) fn run(
     max_events: Option<usize>,
 ) -> Result<()> {
     let mut emitted = 0usize;
+    let mut txn_seq = TxnSeq::default();
     while let Some(ev) = stream.next_change() {
-        let ev = ev?;
+        let mut ev = ev?;
+        txn_seq.stamp(&mut ev);
         // Checkpoint at every commit boundary BEFORE the table filter — the
         // resume position is a stream property; a transaction whose last
         // event lands on an unlisted table must still advance it (mirrors
@@ -187,6 +228,7 @@ pub(crate) fn run(
             "before": to_json(&ev.before),
             "after": to_json(&ev.after),
             "pos": ev.position.0,
+            "seq": ev.seq,
         });
         println!("{line}");
         emitted += 1;
@@ -670,5 +712,27 @@ mod tests {
                 "{bad:?} → {err}"
             );
         }
+    }
+
+    #[test]
+    fn txn_seq_ordinals_reset_when_commit_position_changes() {
+        // `position` (commit-scoped) alone ties every change in a transaction;
+        // `__seq` restores intra-transaction order and RESETS when the commit
+        // position changes — the reliable txn boundary on every engine (PG/MSSQL
+        // mark every change `committed`, so `committed` can't be it).
+        let mut ts = TxnSeq::default();
+        let pa = Position(serde_json::json!({ "lsn": "A" })); // transaction A
+        let pb = Position(serde_json::json!({ "lsn": "B" })); // transaction B
+        // A = 3 changes, B = 2 changes.
+        let seqs: Vec<u64> = [&pa, &pa, &pa, &pb, &pb]
+            .iter()
+            .map(|p| ts.next(p))
+            .collect();
+        assert_eq!(seqs, vec![0, 1, 2, 0, 1]);
+
+        // Same position again after B still counts up within B.
+        assert_eq!(ts.next(&pb), 2);
+        // A new position resets.
+        assert_eq!(ts.next(&Position(serde_json::json!({ "lsn": "C" }))), 0);
     }
 }

--- a/src/source/cdc/sink.rs
+++ b/src/source/cdc/sink.rs
@@ -20,7 +20,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use arrow::array::{ArrayRef, StringArray};
+use arrow::array::{ArrayRef, Int64Array, StringArray};
 use arrow::datatypes::DataType;
 use arrow::datatypes::{Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
@@ -36,7 +36,7 @@ use crate::manifest::{
 use crate::pipeline::commit::{PartRecord, write_part_file};
 use crate::pipeline::manifest_writer::write_manifest;
 use crate::source::cdc::value::{self, RivetValue};
-use crate::source::cdc::{ChangeEvent, ChangeOp, ChangeStream, Position};
+use crate::source::cdc::{ChangeEvent, ChangeOp, ChangeStream, Position, TxnSeq};
 use crate::types::{TypeMapping, build_arrow_field};
 
 /// One table's wiring in a (possibly multi-table) CDC run: where its parts go
@@ -234,9 +234,14 @@ pub(crate) fn run_to_files(
     // since the last ack — the only position it is ever valid to advance to.
     let mut last_commit: Option<Position> = None;
     let mut unacked_commit = false;
+    // Stamp each change with its intra-transaction ordinal (`__seq`) over the
+    // WHOLE stream, before routing — a `(position, seq)` total order the load
+    // dedup can trust even when a PK is touched twice in one transaction.
+    let mut txn_seq = TxnSeq::default();
 
     while let Some(ev) = stream.next_change() {
-        let ev = ev?;
+        let mut ev = ev?;
+        txn_seq.stamp(&mut ev);
         // The commit boundary is a property of the STREAM, not of any routed
         // table — record it BEFORE the routing filter. MySQL marks only the
         // LAST event of a transaction committed; if that event lands on an
@@ -324,6 +329,9 @@ fn ensure_schema(
         let mut fields = vec![
             Field::new("__op", DataType::Utf8, false),
             Field::new("__pos", DataType::Utf8, false),
+            // Intra-transaction ordinal — `(__pos, __seq)` is the total change
+            // order the load dedup sorts by (see `TxnSeq`).
+            Field::new("__seq", DataType::Int64, false),
         ];
         for m in columns.iter() {
             // Reuse the batch path's field builder so json/uuid/enum carry their
@@ -417,6 +425,7 @@ fn flush(
             .map(|e| Some(e.position.0.to_string()))
             .collect::<StringArray>(),
     );
+    let seqs: ArrayRef = Arc::new(events.iter().map(|e| e.seq as i64).collect::<Int64Array>());
     // Finding #37: a mid-window DDL desynchronizes the event images from the
     // resolved schema — positional mapping then puts a dropped column's value
     // into its NEIGHBOR (observed live: after DROP COLUMN a, row1's 'AAA'
@@ -466,7 +475,7 @@ fn flush(
         }
     }
 
-    let mut arrays: Vec<ArrayRef> = vec![ops, poss];
+    let mut arrays: Vec<ArrayRef> = vec![ops, poss, seqs];
     let mut col_sums: Vec<(String, u64)> = Vec::with_capacity(columns.len());
     for (i, m) in columns.iter().enumerate() {
         // Engine/native-type cell normalisation (e.g. MySQL binlog quirks: BIT
@@ -769,6 +778,7 @@ mod tests {
             position: Position(serde_json::json!({ "lsn": format!("{id:08X}") })),
             committed: true,
             image_names: None,
+            seq: 0,
         }
     }
 
@@ -904,6 +914,7 @@ mod tests {
             position: Position(serde_json::json!({})),
             committed: true,
             image_names: None,
+            seq: 0,
         };
         let mut cols = vec![
             decimal_col("placeholder", 38, 0), // SQL Server: scale unknown at resolve

--- a/src/source/mssql/cdc.rs
+++ b/src/source/mssql/cdc.rs
@@ -272,6 +272,7 @@ CDC change-table retention (the cleanup job removed it). Resuming would silently
                 // The change table only ever holds already-committed changes.
                 committed: true,
                 image_names: Some(std::sync::Arc::from(names)),
+                seq: 0, // stamped by TxnSeq as the stream is consumed
             });
         }
         match max_lsn {

--- a/src/source/mysql/cdc.rs
+++ b/src/source/mysql/cdc.rs
@@ -233,6 +233,7 @@ impl MysqlChangeStream {
                         position: position.clone(),
                         committed: false,
                         image_names: image_names.clone(),
+                        seq: 0, // stamped by TxnSeq as the stream is consumed
                     });
                 }
                 if self.tx.len() > MAX_TX_ROWS {

--- a/src/source/postgres/cdc.rs
+++ b/src/source/postgres/cdc.rs
@@ -276,6 +276,7 @@ fn parse_test_decoding(lsn: &str, data: &str) -> Option<ChangeEvent> {
         position: Position(json!({ "lsn": lsn })),
         // The slot only ever yields already-committed changes.
         committed: true,
+        seq: 0, // stamped by TxnSeq as the stream is consumed
     })
 }
 

--- a/tests/cdc_conformance_gate.rs
+++ b/tests/cdc_conformance_gate.rs
@@ -29,6 +29,12 @@ use Expect::{NA, Test};
 /// (mysql + pg) and tests/live/live_cdc_mssql.rs.
 const CASES: &[(&str, Expect, Expect, Expect)] = &[
     (
+        "intra_transaction_seq",
+        Test("fn cdc_intra_transaction_updates_get_distinct_seq"),
+        Test("fn pg_cdc_intra_transaction_updates_get_distinct_seq"),
+        Test("fn mssql_cdc_intra_transaction_updates_get_distinct_seq"),
+    ),
+    (
         "resume_two_run",
         Test("fn cdc_resume_captures_only_new_changes"),
         Test("fn pg_cdc_resume_captures_only_new_changes"),

--- a/tests/cdc_conformance_gate.rs
+++ b/tests/cdc_conformance_gate.rs
@@ -35,6 +35,12 @@ const CASES: &[(&str, Expect, Expect, Expect)] = &[
         Test("fn mssql_cdc_intra_transaction_updates_get_distinct_seq"),
     ),
     (
+        "sum_reconciles_intra_txn",
+        Test("fn cdc_sum_reconciles_across_intra_txn_updates"),
+        Test("fn pg_cdc_sum_reconciles_across_intra_txn_updates"),
+        Test("fn mssql_cdc_sum_reconciles_across_intra_txn_updates"),
+    ),
+    (
         "resume_two_run",
         Test("fn cdc_resume_captures_only_new_changes"),
         Test("fn pg_cdc_resume_captures_only_new_changes"),

--- a/tests/common/parquet.rs
+++ b/tests/common/parquet.rs
@@ -10,7 +10,7 @@
 
 #![allow(dead_code)]
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::path::Path;
 
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
@@ -181,4 +181,185 @@ pub fn assert_intra_transaction_seq(out: &Path, n: i64) {
         .map(|(i, _)| counters[i])
         .unwrap();
     assert_eq!(latest, n, "the max-__seq change must carry counter = n");
+}
+
+// ── CDC current-state SUM reconciliation (source == deduped target) ──────────
+//
+// The strong end-to-end oracle: apply a workload of many transactions (some
+// updating one PK several times in ONE transaction) and assert the source's
+// final `SUM(v)` equals the target's, where the target is deduped STRICTLY by
+// `(__pos, __seq)` — with row order discarded, exactly as an unordered warehouse
+// table forces. Fails without `__seq` (the intra-transaction `__pos` tie makes
+// the dedup pick an arbitrary version, skewing the sum); passes with it.
+
+/// A captured change: the columns the reconciliation needs (`id BIGINT, v
+/// BIGINT` + the CDC meta). `v` on a delete is the (irrelevant) before-image.
+pub struct CdcChange {
+    pub id: i64,
+    pub v: i64,
+    pub op: String,
+    pub pos: String,
+    pub seq: i64,
+}
+
+/// Source engine — selects how `__pos` parses into a monotonic position.
+#[derive(Clone, Copy)]
+pub enum CdcEngine {
+    MySql,
+    Postgres,
+    SqlServer,
+}
+
+/// Read every CDC change (`id, v, __op, __pos, __seq`) from the `.parquet`
+/// parts under `dir`.
+pub fn read_cdc_changes(dir: &Path) -> Vec<CdcChange> {
+    use arrow::array::{Array, AsArray};
+    let mut out = Vec::new();
+    for path in files_with_extension(dir, "parquet") {
+        for batch in reader(&path) {
+            let b = batch.unwrap();
+            let col_i64 = |name: &str| {
+                b.column_by_name(name)
+                    .unwrap_or_else(|| panic!("{name} column present"))
+                    .as_primitive::<arrow::datatypes::Int64Type>()
+                    .clone()
+            };
+            let col_str = |name: &str| {
+                b.column_by_name(name)
+                    .unwrap_or_else(|| panic!("{name} column present"))
+                    .as_string::<i32>()
+                    .clone()
+            };
+            let (id, v, seq) = (col_i64("id"), col_i64("v"), col_i64("__seq"));
+            let (op, pos) = (col_str("__op"), col_str("__pos"));
+            for r in 0..b.num_rows() {
+                out.push(CdcChange {
+                    id: id.value(r),
+                    v: v.value(r),
+                    op: op.value(r).to_string(),
+                    pos: pos.value(r).to_string(),
+                    seq: seq.value(r),
+                });
+            }
+        }
+    }
+    out
+}
+
+/// `__pos` → a single monotonic `u128`, per engine (`__seq` is the lower-order
+/// tiebreak, applied separately). MySQL `{file,pos}`; PostgreSQL `{lsn:"hi/lo"}`
+/// (hex halves); SQL Server `{lsn:"<fixed-width hex>"}`.
+fn pos_u128(engine: CdcEngine, pos: &str) -> u128 {
+    let j: serde_json::Value =
+        serde_json::from_str(pos).unwrap_or_else(|_| panic!("__pos is not JSON: {pos}"));
+    match engine {
+        CdcEngine::MySql => {
+            let file = j["file"].as_str().expect("__pos.file");
+            let file_num: u128 = file
+                .rsplit('.')
+                .next()
+                .and_then(|s| s.parse().ok())
+                .expect("binlog file number");
+            let p = j["pos"].as_u64().expect("__pos.pos") as u128;
+            (file_num << 64) | p
+        }
+        CdcEngine::Postgres => {
+            let lsn = j["lsn"].as_str().expect("__pos.lsn");
+            let (hi, lo) = lsn.split_once('/').expect("lsn hi/lo");
+            let hi = u128::from_str_radix(hi, 16).expect("lsn hi hex");
+            let lo = u128::from_str_radix(lo, 16).expect("lsn lo hex");
+            (hi << 32) | lo
+        }
+        CdcEngine::SqlServer => {
+            let lsn = j["lsn"].as_str().expect("__pos.lsn");
+            u128::from_str_radix(lsn, 16).expect("lsn hex")
+        }
+    }
+}
+
+/// Dedup the change log to current state by `(__pos, __seq)` — row order
+/// DISCARDED (the log is scrambled first, as an unordered warehouse table
+/// leaves it) — and `SUM(v)` over the surviving (non-deleted) rows.
+pub fn deduped_current_sum(mut changes: Vec<CdcChange>, engine: CdcEngine) -> i64 {
+    // Deterministic scramble: only (__pos, __seq) may decide the latest row.
+    use std::hash::{Hash, Hasher};
+    changes.sort_by_key(|c| {
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        (c.id, c.seq, &c.pos).hash(&mut h);
+        h.finish()
+    });
+    let mut best: HashMap<i64, ((u128, i64), i64, bool)> = HashMap::new();
+    for c in changes {
+        let key = (pos_u128(engine, &c.pos), c.seq);
+        let is_delete = c.op == "delete";
+        match best.get(&c.id) {
+            Some((k, _, _)) if *k >= key => {}
+            _ => {
+                best.insert(c.id, (key, c.v, is_delete));
+            }
+        }
+    }
+    best.values()
+        .filter(|(_, _, del)| !del)
+        .map(|(_, v, _)| *v)
+        .sum()
+}
+
+/// Count of `(transaction, PK)` pairs touched more than once — i.e. a PK updated
+/// several times in one transaction. A reconciliation workload MUST produce some,
+/// else the intra-transaction case is untested and the sum passes vacuously.
+pub fn intra_txn_multi_change_count(changes: &[CdcChange]) -> usize {
+    let mut per: HashMap<(&str, i64), usize> = HashMap::new();
+    for c in changes {
+        *per.entry((c.pos.as_str(), c.id)).or_default() += 1;
+    }
+    per.values().filter(|&&n| n > 1).count()
+}
+
+/// A deterministic reconciliation workload as transactions of engine-agnostic
+/// SQL statements (`id BIGINT, v BIGINT`). EVERY transaction updates one PK 2–4
+/// times (`v = v + delta`), so the committed `v` differs from every intermediate
+/// version — a dedup that ordered by `__pos` alone would skew `SUM(v)`. Mixed
+/// with fresh inserts and deletes. The caller wraps each inner `Vec` in its
+/// engine's `BEGIN`/`COMMIT`.
+pub fn cdc_sum_workload(tbl: &str) -> Vec<Vec<String>> {
+    const K: i64 = 25; // shared key range 1..=K
+    const M: i64 = 200; // transactions
+    let mut txns: Vec<Vec<String>> = Vec::new();
+    // Seed the shared keys with v = 0.
+    txns.push(
+        (1..=K)
+            .map(|k| format!("INSERT INTO {tbl} (id, v) VALUES ({k}, 0)"))
+            .collect(),
+    );
+    let mut rng: u64 = 0x1234_5678_9abc_def0;
+    let mut next = move || {
+        rng ^= rng << 13;
+        rng ^= rng >> 7;
+        rng ^= rng << 17;
+        rng
+    };
+    let mut extra_key = K;
+    for t in 0..M {
+        let mut stmts = Vec::new();
+        let key = (next() % K as u64) as i64 + 1;
+        let r = 2 + next() % 3; // 2..=4 updates to the SAME key in this txn
+        for _ in 0..r {
+            let delta = (next() % 100) as i64 + 1;
+            stmts.push(format!("UPDATE {tbl} SET v = v + {delta} WHERE id = {key}"));
+        }
+        if t % 4 == 0 {
+            extra_key += 1;
+            let val = (next() % 500) as i64;
+            stmts.push(format!(
+                "INSERT INTO {tbl} (id, v) VALUES ({extra_key}, {val})"
+            ));
+        }
+        if t % 5 == 0 {
+            let dk = (next() % K as u64) as i64 + 1;
+            stmts.push(format!("DELETE FROM {tbl} WHERE id = {dk}"));
+        }
+        txns.push(stmts);
+    }
+    txns
 }

--- a/tests/common/parquet.rs
+++ b/tests/common/parquet.rs
@@ -82,3 +82,103 @@ pub fn dir_parquet_ids(dir: &Path) -> Vec<i64> {
 pub fn dir_parquet_id_set(dir: &Path) -> BTreeSet<i64> {
     dir_parquet_ids(dir).into_iter().collect()
 }
+
+// ── CDC `__seq` conformance helpers (used by every engine's live CDC test) ───
+
+fn reader(path: &Path) -> parquet::arrow::arrow_reader::ParquetRecordBatchReader {
+    let bytes = std::fs::read(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    ParquetRecordBatchReaderBuilder::try_new(bytes::Bytes::from(bytes))
+        .unwrap_or_else(|e| panic!("open {}: {e}", path.display()))
+        .build()
+        .unwrap()
+}
+
+/// The `i64` values of column `col` across every `.parquet` under `dir`, in row
+/// order (e.g. `__seq`, or a `BIGINT` data column).
+pub fn dir_parquet_i64(dir: &Path, col: &str) -> Vec<i64> {
+    use arrow::array::{Array, AsArray};
+    let mut out = Vec::new();
+    for path in files_with_extension(dir, "parquet") {
+        for batch in reader(&path) {
+            let batch = batch.unwrap();
+            let c = batch
+                .column_by_name(col)
+                .unwrap_or_else(|| panic!("column {col} present"));
+            let a = c
+                .as_primitive_opt::<arrow::datatypes::Int64Type>()
+                .unwrap_or_else(|| panic!("{col} decodes as Int64"));
+            (0..a.len()).for_each(|i| out.push(a.value(i)));
+        }
+    }
+    out
+}
+
+/// Distinct string values of `col` across every `.parquet` under `dir`.
+pub fn dir_parquet_distinct_strings(dir: &Path, col: &str) -> BTreeSet<String> {
+    use arrow::array::{Array, AsArray};
+    let mut out = BTreeSet::new();
+    for path in files_with_extension(dir, "parquet") {
+        for batch in reader(&path) {
+            let batch = batch.unwrap();
+            let c = batch
+                .column_by_name(col)
+                .unwrap_or_else(|| panic!("column {col} present"));
+            let a = c
+                .as_string_opt::<i32>()
+                .unwrap_or_else(|| panic!("{col} is Utf8"));
+            (0..a.len()).for_each(|i| {
+                out.insert(a.value(i).to_string());
+            });
+        }
+    }
+    out
+}
+
+/// True if any `.parquet` under `dir` carries a column named `col`.
+pub fn dir_parquet_has_column(dir: &Path, col: &str) -> bool {
+    files_with_extension(dir, "parquet").iter().any(|p| {
+        let bytes = std::fs::read(p).unwrap();
+        ParquetRecordBatchReaderBuilder::try_new(bytes::Bytes::from(bytes))
+            .unwrap()
+            .schema()
+            .fields()
+            .iter()
+            .any(|f| f.name() == col)
+    })
+}
+
+/// Assert the intra-transaction `__seq` conformance case: `out` holds exactly
+/// `n` updates of ONE PK done in a SINGLE transaction, so they share one
+/// `__pos`, `__seq` is the distinct order `0..n-1`, and the greatest-`__seq`
+/// change carries the committed value (`counter = n`). An `ORDER BY (__pos,
+/// __seq)` dedup therefore returns the last write, not an arbitrary row. Shared
+/// so every engine's CDC test asserts the fix identically.
+pub fn assert_intra_transaction_seq(out: &Path, n: i64) {
+    assert!(
+        dir_parquet_has_column(out, "__seq"),
+        "CDC output must carry the __seq column"
+    );
+    let seqs = dir_parquet_i64(out, "__seq");
+    let counters = dir_parquet_i64(out, "counter");
+    assert_eq!(seqs.len() as i64, n, "all {n} updates must be captured");
+    assert_eq!(
+        dir_parquet_distinct_strings(out, "__pos").len(),
+        1,
+        "all changes of one transaction share a single __pos — the tie __seq breaks"
+    );
+    let mut sorted = seqs.clone();
+    sorted.sort_unstable();
+    sorted.dedup();
+    assert_eq!(sorted.len() as i64, n, "__seq must be distinct per change");
+    assert_eq!(
+        (*sorted.first().unwrap(), *sorted.last().unwrap()),
+        (0, n - 1)
+    );
+    let latest = seqs
+        .iter()
+        .enumerate()
+        .max_by_key(|(_, s)| **s)
+        .map(|(i, _)| counters[i])
+        .unwrap();
+    assert_eq!(latest, n, "the max-__seq change must carry counter = n");
+}

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -328,6 +328,53 @@ fn cdc_intra_transaction_updates_get_distinct_seq() {
     assert_intra_transaction_seq(&out, N);
 }
 
+#[test]
+#[ignore = "live: requires docker compose --profile cdc mysql-cdc"]
+fn cdc_sum_reconciles_across_intra_txn_updates() {
+    // The strong end-to-end oracle: SUM(v) on the source must equal SUM(v) on
+    // the target deduped STRICTLY by (__pos, __seq), row order discarded (as an
+    // unordered warehouse table forces). Every transaction updates one PK 2–4
+    // times, so a __pos-only dedup would pick an intermediate `v` and skew the
+    // sum — this reconciles only because __seq totally-orders the log.
+    let d = tempfile::tempdir().unwrap();
+    let tbl = unique_name("rivet_cdc_sum");
+    let _drop = Table(tbl.clone());
+    let mut c = conn();
+    c.query_drop(format!(
+        "CREATE TABLE {tbl} (id BIGINT PRIMARY KEY, v BIGINT NOT NULL)"
+    ))
+    .unwrap();
+    let ckpt = d.path().join("cdc.ckpt");
+    write_checkpoint(&mut c, &ckpt);
+
+    for txn in cdc_sum_workload(&tbl) {
+        c.query_drop("START TRANSACTION").unwrap();
+        for stmt in txn {
+            c.query_drop(stmt).unwrap();
+        }
+        c.query_drop("COMMIT").unwrap();
+    }
+    let source_sum: i64 = c
+        .query_first(format!("SELECT COALESCE(SUM(v), 0) FROM {tbl}"))
+        .unwrap()
+        .unwrap();
+
+    let out = d.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    run_rivet_ok(&cdc_config(&d, &tbl, &ckpt, &out));
+
+    let changes = read_cdc_changes(&out);
+    assert!(
+        intra_txn_multi_change_count(&changes) > 0,
+        "workload must exercise intra-transaction multi-updates or the sum passes vacuously"
+    );
+    let target_sum = deduped_current_sum(changes, CdcEngine::MySql);
+    assert_eq!(
+        source_sum, target_sum,
+        "deduped-by-(__pos,__seq) SUM(v) must equal the source's SUM(v)"
+    );
+}
+
 // Idle-first-run anchor model (per-engine, see CLAUDE.md): MySQL's ONLY resume
 // anchor is the client checkpoint file, and the sink writes it at part commits —
 // so the first checkpointed open must persist its coordinates immediately, or an
@@ -520,6 +567,56 @@ fn pg_cdc_intra_transaction_updates_get_distinct_seq() {
     run_rivet_ok(&pg_cdc_config(&d, &tbl, &slot, &out));
 
     assert_intra_transaction_seq(&out, N);
+}
+
+#[test]
+#[ignore = "live: requires docker compose postgres (wal_level=logical)"]
+fn pg_cdc_sum_reconciles_across_intra_txn_updates() {
+    // Peer of cdc_sum_reconciles_across_intra_txn_updates for PostgreSQL.
+    use postgres::NoTls;
+    let d = tempfile::tempdir().unwrap();
+    let tbl = unique_name("rivet_cdc_pg_sum");
+    let slot = unique_name("rivet_sum_slot");
+    let mut c = postgres::Client::connect(POSTGRES_CDC_URL, NoTls).expect("connect postgres");
+    c.batch_execute(&format!(
+        "DROP TABLE IF EXISTS {tbl}; CREATE TABLE {tbl} (id BIGINT PRIMARY KEY, v BIGINT NOT NULL); \
+         ALTER TABLE {tbl} REPLICA IDENTITY FULL"
+    ))
+    .unwrap();
+    let _tbl = PgTable::adopt(tbl.clone());
+    c.execute(
+        "SELECT pg_create_logical_replication_slot($1, 'test_decoding')",
+        &[&slot],
+    )
+    .unwrap();
+    let _slot = Slot(slot.clone());
+
+    for txn in cdc_sum_workload(&tbl) {
+        c.batch_execute(&format!("BEGIN; {}; COMMIT", txn.join("; ")))
+            .unwrap();
+    }
+    let source_sum: i64 = c
+        .query_one(
+            &format!("SELECT COALESCE(SUM(v), 0)::bigint FROM {tbl}"),
+            &[],
+        )
+        .unwrap()
+        .get::<_, i64>(0);
+
+    let out = d.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    run_rivet_ok(&pg_cdc_config(&d, &tbl, &slot, &out));
+
+    let changes = read_cdc_changes(&out);
+    assert!(
+        intra_txn_multi_change_count(&changes) > 0,
+        "workload must exercise intra-transaction multi-updates or the sum passes vacuously"
+    );
+    let target_sum = deduped_current_sum(changes, CdcEngine::Postgres);
+    assert_eq!(
+        source_sum, target_sum,
+        "deduped-by-(__pos,__seq) SUM(v) must equal the source's SUM(v)"
+    );
 }
 
 /// Assert every source column of the batch export is byte-for-byte identical

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -291,6 +291,43 @@ fn cdc_throughput_drains_a_large_backlog() {
     );
 }
 
+#[test]
+#[ignore = "live: requires docker compose --profile cdc mysql-cdc"]
+fn cdc_intra_transaction_updates_get_distinct_seq() {
+    // A PK updated many times in ONE transaction: every change shares the commit
+    // __pos, so ordering a current-state dedup by __pos alone picks an ARBITRARY
+    // row (observed live: `counter = 1` for a row whose committed value was N).
+    // `__seq` — the intra-transaction ordinal — restores the total order.
+    // Regression for the silently-wrong current-state class.
+    const N: i64 = 200;
+    let d = tempfile::tempdir().unwrap();
+    let tbl = unique_name("rivet_cdc_seq");
+    let _drop = Table(tbl.clone());
+    let mut c = conn();
+    c.query_drop(format!(
+        "CREATE TABLE {tbl} (id INT PRIMARY KEY, counter BIGINT)"
+    ))
+    .unwrap();
+    c.query_drop(format!("INSERT INTO {tbl} VALUES (1, 0)"))
+        .unwrap();
+    let ckpt = d.path().join("cdc.ckpt");
+    write_checkpoint(&mut c, &ckpt);
+
+    // N updates of the SAME row in a SINGLE transaction.
+    c.query_drop("START TRANSACTION").unwrap();
+    for i in 1..=N {
+        c.query_drop(format!("UPDATE {tbl} SET counter = {i} WHERE id = 1"))
+            .unwrap();
+    }
+    c.query_drop("COMMIT").unwrap();
+
+    let out = d.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    run_rivet_ok(&cdc_config(&d, &tbl, &ckpt, &out));
+
+    assert_intra_transaction_seq(&out, N);
+}
+
 // Idle-first-run anchor model (per-engine, see CLAUDE.md): MySQL's ONLY resume
 // anchor is the client checkpoint file, and the sink writes it at part commits —
 // so the first checkpointed open must persist its coordinates immediately, or an
@@ -445,6 +482,44 @@ fn pg_cdc_resume_captures_only_new_changes() {
         2,
         "resume drains only the 2 new changes (slot advanced, no re-read)"
     );
+}
+
+#[test]
+#[ignore = "live: requires docker compose postgres (wal_level=logical)"]
+fn pg_cdc_intra_transaction_updates_get_distinct_seq() {
+    // Peer of cdc_intra_transaction_updates_get_distinct_seq. PostgreSQL emits
+    // every change of a transaction at the COMMIT lsn (and marks each
+    // `committed`), so __pos ties them — __seq restores the order.
+    use postgres::NoTls;
+    const N: i64 = 200;
+    let d = tempfile::tempdir().unwrap();
+    let tbl = unique_name("rivet_cdc_pg_seq");
+    let slot = unique_name("rivet_seq_slot");
+    let mut c = postgres::Client::connect(POSTGRES_CDC_URL, NoTls).expect("connect postgres");
+    c.batch_execute(&format!(
+        "DROP TABLE IF EXISTS {tbl}; CREATE TABLE {tbl} (id INT PRIMARY KEY, counter BIGINT); \
+         ALTER TABLE {tbl} REPLICA IDENTITY FULL; INSERT INTO {tbl} VALUES (1, 0)"
+    ))
+    .unwrap();
+    let _tbl = PgTable::adopt(tbl.clone());
+    c.execute(
+        "SELECT pg_create_logical_replication_slot($1, 'test_decoding')",
+        &[&slot],
+    )
+    .unwrap();
+    let _slot = Slot(slot.clone());
+
+    // N updates of the SAME row in ONE transaction (a DO block is one txn).
+    c.batch_execute(&format!(
+        "DO $$ BEGIN FOR i IN 1..{N} LOOP UPDATE {tbl} SET counter = i WHERE id = 1; END LOOP; END $$"
+    ))
+    .unwrap();
+
+    let out = d.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    run_rivet_ok(&pg_cdc_config(&d, &tbl, &slot, &out));
+
+    assert_intra_transaction_seq(&out, N);
 }
 
 /// Assert every source column of the batch export is byte-for-byte identical

--- a/tests/live/live_cdc_mssql.rs
+++ b/tests/live/live_cdc_mssql.rs
@@ -131,6 +131,70 @@ fn mssql_cdc_intra_transaction_updates_get_distinct_seq() {
     assert_intra_transaction_seq(&out, N);
 }
 
+#[test]
+#[ignore = "live: requires docker compose mssql with SQL Server Agent + CDC"]
+fn mssql_cdc_sum_reconciles_across_intra_txn_updates() {
+    // Peer of cdc_sum_reconciles_across_intra_txn_updates for SQL Server.
+    let _serial = CDC_SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    let d = tempfile::tempdir().unwrap();
+    let table = unique_name("rivet_cdc_ms_sum");
+    let ci = format!("dbo_{table}");
+    mssql_cdc_drop_table(&format!("dbo.{table}"));
+    mssql_cdc_exec(&format!(
+        "CREATE TABLE dbo.{table}(id BIGINT PRIMARY KEY, v BIGINT NOT NULL)"
+    ));
+    enable_cdc(&table, &ci);
+    let _guard = MssqlCdcTable {
+        table: table.clone(),
+        ci: ci.clone(),
+    };
+
+    for txn in cdc_sum_workload(&table) {
+        mssql_cdc_exec(&format!("BEGIN TRAN; {}; COMMIT;", txn.join("; ")));
+    }
+    // A sentinel (v=0, does not move the sum) as the final change: once the
+    // capture job has it, every prior change is captured too (LSN order) — a
+    // robust drain signal when the exact CT row count is hard to predict
+    // (0-row UPDATEs/DELETEs produce no CT rows).
+    const SENTINEL: i64 = 9_000_000;
+    mssql_cdc_exec(&format!("INSERT INTO dbo.{table} VALUES ({SENTINEL}, 0)"));
+    let mut drained = false;
+    for _ in 0..120 {
+        if mssql_cdc_query_i64(&format!(
+            "SELECT COUNT(*) FROM cdc.{ci}_CT WHERE id = {SENTINEL}"
+        )) >= 1
+        {
+            drained = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    }
+    assert!(drained, "capture job did not reach the sentinel in 60s");
+
+    // The query helper reads an INT column; the deterministic workload's sum is
+    // a few tens of thousands, so CAST to INT is exact (and guards against a
+    // silent widening bug better than a BIGINT the helper would misread).
+    let source_sum = mssql_cdc_query_i64(&format!(
+        "SELECT CAST(COALESCE(SUM(v), 0) AS INT) FROM dbo.{table}"
+    ));
+
+    let ckpt = d.path().join("cdc.ckpt");
+    let out = d.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    run_rivet_ok(&mssql_cdc_config(&d, &table, &ci, &ckpt, &out));
+
+    let changes = read_cdc_changes(&out);
+    assert!(
+        intra_txn_multi_change_count(&changes) > 0,
+        "workload must exercise intra-transaction multi-updates or the sum passes vacuously"
+    );
+    let target_sum = deduped_current_sum(changes, CdcEngine::SqlServer);
+    assert_eq!(
+        source_sum, target_sum,
+        "deduped-by-(__pos,__seq) SUM(v) must equal the source's SUM(v)"
+    );
+}
+
 // Idle-first-run anchor model (per-engine, see CLAUDE.md): SQL Server has no
 // client-side anchor to pin — a run without a checkpoint floors at
 // `fn_cdc_get_min_lsn` (over-reads, never skips). This test pins that property:

--- a/tests/live/live_cdc_mssql.rs
+++ b/tests/live/live_cdc_mssql.rs
@@ -92,6 +92,45 @@ fn mssql_cdc_resume_captures_only_new_changes() {
     );
 }
 
+#[test]
+#[ignore = "live: requires docker compose mssql with SQL Server Agent + CDC"]
+fn mssql_cdc_intra_transaction_updates_get_distinct_seq() {
+    // Peer of cdc_intra_transaction_updates_get_distinct_seq. SQL Server stamps
+    // every change of a transaction with the same __$start_lsn (what rivet emits
+    // as __pos), so __pos ties them — __seq restores the intra-transaction order.
+    let _serial = CDC_SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    const N: i64 = 200;
+    let d = tempfile::tempdir().unwrap();
+    let table = unique_name("rivet_cdc_ms_seq");
+    let ci = format!("dbo_{table}");
+    mssql_cdc_drop_table(&format!("dbo.{table}"));
+    mssql_cdc_exec(&format!(
+        "CREATE TABLE dbo.{table}(id INT PRIMARY KEY, counter BIGINT)"
+    ));
+    // The seed INSERT precedes CDC enable, so only the N updates are captured.
+    mssql_cdc_exec(&format!("INSERT INTO dbo.{table} VALUES (1, 0)"));
+    enable_cdc(&table, &ci);
+    let _guard = MssqlCdcTable {
+        table: table.clone(),
+        ci: ci.clone(),
+    };
+
+    let ckpt = d.path().join("cdc.ckpt");
+    // N updates of the SAME row in a SINGLE transaction.
+    mssql_cdc_exec(&format!(
+        "BEGIN TRAN; DECLARE @i INT = 1; WHILE @i <= {N} BEGIN \
+         UPDATE dbo.{table} SET counter = @i WHERE id = 1; SET @i = @i + 1; END; COMMIT;"
+    ));
+    // SQL Server records each UPDATE as two CT rows (before + after image).
+    wait_for_capture(&ci, 2 * N);
+
+    let out = d.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    run_rivet_ok(&mssql_cdc_config(&d, &table, &ci, &ckpt, &out));
+
+    assert_intra_transaction_seq(&out, N);
+}
+
 // Idle-first-run anchor model (per-engine, see CLAUDE.md): SQL Server has no
 // client-side anchor to pin — a run without a checkpoint floors at
 // `fn_cdc_get_min_lsn` (over-reads, never skips). This test pins that property:


### PR DESCRIPTION
## Release 0.17.0 — CDC `__seq` total-order + config `load:` block

Two changes, both additive / backward-compatible.

### CDC `__seq` — correct current-state dedup
`__pos` is the **commit** position, so every change in one transaction shares
it. A current-state dedup ordered by `__pos` alone therefore picked an
**arbitrary** row when a PK was updated more than once in a single transaction
(triggers, ORMs, read-modify-write). Verified live: 8000 updates of one PK in
one transaction → a single distinct `__pos`, and a `__pos`-only dedup returned
`counter=1` for a row whose committed value was `8000`.

Fix: emit a `__seq` column — the intra-transaction ordinal, stamped as the
stream is consumed and reset when `__pos` changes (the reliable transaction
boundary on **all** engines; PostgreSQL/SQL Server mark every change
`committed`, so that flag can't serve). `(__pos, __seq)` is the total order,
log-derived so it survives an at-least-once replay unchanged.

Tests: `TxnSeq` unit; per-engine live `*_intra_transaction_updates_get_distinct_seq`
and `*_sum_reconciles_across_intra_txn_updates` (a `SUM(v)` source-vs-target
reconciliation with row order discarded), all registered in the CDC conformance
gate. Design: `docs/cdc-seq-ordering.md`.

### Config top-level `load:` block
`Config` accepts an optional, reserved `load:` block (opaque `serde_json::Value`,
ignored by OSS) so ONE config can drive both the export and a downstream
`rivet-pro` warehouse load without a second file. `deny_unknown_fields` otherwise
made `check`/`run`/`apply` reject it.

### Housekeeping
- crossbeam-epoch 0.9.18 → 0.9.20 (RUSTSEC-2026-0204, transitive), clears cargo-audit.
- Regenerated `schemas/rivet.schema.json` (+ `latest`), CHANGELOG, version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsabsUrfFxxY4xmHUPgg2U
