### PR TITLE
fix(mongo): make the 4.4→8.0 live matrix green

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -570,14 +570,14 @@ services:
     ports:
       - "27018:27017"
     healthcheck:
-      # Healthy ONLY when this node is an elected PRIMARY, not merely when
-      # rs.status() responds — `rs.initiate()` returns ok immediately but the
-      # primary election lags (seconds, worst on 4.4). Gating `--wait` on
-      # `isMaster().ismaster` (cross-version 4.4→8.0; `hello` is 5.0+) is what
-      # stops `db.watch()` from racing the election and failing with error 13436
-      # NotPrimaryOrSecondary. Initiate on first poll (catch), then report
-      # unhealthy until primary so `--wait` keeps polling.
-      test: ["CMD-SHELL", "mongosh --quiet --eval 'try{rs.status()}catch(e){rs.initiate({_id:\"rs0\",members:[{_id:0,host:\"127.0.0.1:27017\"}]})}; db.isMaster().ismaster?quit(0):quit(1)' || mongo --quiet --eval 'try{rs.status()}catch(e){rs.initiate({_id:\"rs0\",members:[{_id:0,host:\"127.0.0.1:27017\"}]})}; db.isMaster().ismaster?quit(0):quit(1)'"]
+      # Healthy ONLY when this node is an elected PRIMARY, so `--wait` blocks until
+      # `db.watch()` can actually run (else error 13436 NotPrimaryOrSecondary).
+      # Initiate on `!rs.status().ok`, NOT on a thrown error: on 4.4's legacy `mongo`
+      # shell rs.status() RETURNS `{ok:0}` on an uninitiated RS without throwing, so a
+      # `catch`-based initiate never fires and the RS is never initiated (verified on
+      # a real mongo:4.4). `hello` is 5.0+, so gate on `isMaster().ismaster`
+      # (cross-version 4.4→8.0). `mongo` is the 4.4 fallback (no mongosh there).
+      test: ["CMD-SHELL", "mongosh --quiet --eval 'var st; try{st=rs.status()}catch(e){st={ok:0}}; if(!st.ok){try{rs.initiate({_id:\"rs0\",members:[{_id:0,host:\"127.0.0.1:27017\"}]})}catch(e){}}; db.isMaster().ismaster?quit(0):quit(1)' || mongo --quiet --eval 'var st; try{st=rs.status()}catch(e){st={ok:0}}; if(!st.ok){try{rs.initiate({_id:\"rs0\",members:[{_id:0,host:\"127.0.0.1:27017\"}]})}catch(e){}}; db.isMaster().ismaster?quit(0):quit(1)'"]
       interval: 5s
       timeout: 5s
       retries: 30

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -570,7 +570,14 @@ services:
     ports:
       - "27018:27017"
     healthcheck:
-      test: ["CMD-SHELL", "mongosh --quiet --eval 'try{rs.status().ok}catch(e){rs.initiate({_id:\"rs0\",members:[{_id:0,host:\"127.0.0.1:27017\"}]})}' || mongo --quiet --eval 'try{rs.status().ok}catch(e){rs.initiate({_id:\"rs0\",members:[{_id:0,host:\"127.0.0.1:27017\"}]})}'"]
+      # Healthy ONLY when this node is an elected PRIMARY, not merely when
+      # rs.status() responds — `rs.initiate()` returns ok immediately but the
+      # primary election lags (seconds, worst on 4.4). Gating `--wait` on
+      # `isMaster().ismaster` (cross-version 4.4→8.0; `hello` is 5.0+) is what
+      # stops `db.watch()` from racing the election and failing with error 13436
+      # NotPrimaryOrSecondary. Initiate on first poll (catch), then report
+      # unhealthy until primary so `--wait` keeps polling.
+      test: ["CMD-SHELL", "mongosh --quiet --eval 'try{rs.status()}catch(e){rs.initiate({_id:\"rs0\",members:[{_id:0,host:\"127.0.0.1:27017\"}]})}; db.isMaster().ismaster?quit(0):quit(1)' || mongo --quiet --eval 'try{rs.status()}catch(e){rs.initiate({_id:\"rs0\",members:[{_id:0,host:\"127.0.0.1:27017\"}]})}; db.isMaster().ismaster?quit(0):quit(1)'"]
       interval: 5s
       timeout: 5s
       retries: 30

--- a/tests/common/mongo.rs
+++ b/tests/common/mongo.rs
@@ -42,6 +42,22 @@ impl MongoTest {
         format!("mongodb://127.0.0.1:{port}/{db}?directConnection=true")
     }
 
+    /// Server major version via `buildInfo` (4, 5, 6, 7, 8); `0` if unavailable.
+    /// Used to skip version-gated tests — e.g. `read_concern: snapshot` needs 5.0+,
+    /// so on 4.4 the snapshot test self-skips rather than failing the matrix.
+    pub fn server_major(&self) -> u32 {
+        self.rt.block_on(async {
+            self.client
+                .database("admin")
+                .run_command(doc! { "buildInfo": 1 })
+                .await
+                .ok()
+                .and_then(|d| d.get_str("version").ok().map(str::to_string))
+                .and_then(|v| v.split('.').next().and_then(|s| s.parse().ok()))
+                .unwrap_or(0)
+        })
+    }
+
     fn coll(&self, name: &str) -> Collection<Document> {
         self.client.database(&self.db).collection(name)
     }

--- a/tests/common/rig.rs
+++ b/tests/common/rig.rs
@@ -295,6 +295,14 @@ impl Rig {
         )
     }
 
+    /// Run rivet; return the raw output without asserting either way — for tests
+    /// whose VALID outcomes include both success and a loud failure (e.g. a
+    /// mid-stream outage that rivet may either retry through or safely refuse).
+    pub fn run(&self) -> std::process::Output {
+        let cfg = self.config_path();
+        super::runner::run_rivet(&["run", "--config", cfg.to_str().unwrap()])
+    }
+
     /// Run and read every parquet part back — the canonical
     /// capture-and-verify shape the outcome gate keys on.
     pub fn run_and_read(&self) -> Vec<arrow::record_batch::RecordBatch> {

--- a/tests/live/live_mongo.rs
+++ b/tests/live/live_mongo.rs
@@ -254,6 +254,12 @@ fn mongo_batch_read_concern_snapshot_empty_first_run_then_populated() {
     const RS_PORT: u16 = 27018;
     let db = unique_name("mrc_snap");
     let m = MongoTest::connect(RS_PORT, &db);
+    // `read_concern: snapshot` for a find requires MongoDB 5.0+; on 4.4 it is
+    // unsupported, so self-skip rather than fail the version matrix.
+    if m.server_major() < 5 {
+        eprintln!("skipping: read_concern: snapshot needs MongoDB 5.0+ (server is 4.x)");
+        return;
+    }
     m.drop_collection("t");
 
     let rig = Rig::mongo_batch("t")

--- a/tests/live/live_mongo_retry_and_faults.rs
+++ b/tests/live/live_mongo_retry_and_faults.rs
@@ -80,13 +80,36 @@ fn mongo_export_recovers_after_mid_stream_proxy_disable_then_enable_with_retries
     });
 
     let rig = proxied(&db);
-    rig.run_ok(); // recovers via the chunk retry loop, or panics with the output
+    let out = rig.run(); // may retry through the outage, or safely refuse — both valid
     let _ = bg.join();
 
+    // rivet has TWO correct responses to a mid-stream outage, and WHICH one fires
+    // is timing-dependent (did the socket die before or after the first part
+    // committed?) — so the test must accept both. Asserting only the in-place-retry
+    // path was flaky across the version matrix (5.0/8.0 committed parts faster, so
+    // the retry was correctly refused and the run failed loud):
+    //   1. outage before any part committed → retry on a fresh connection → done;
+    //   2. outage after parts committed → REFUSE the retry (re-reading would
+    //      duplicate committed rows) and fail LOUDLY — never a silent partial —
+    //      then a clean re-run over the healthy link completes the export.
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("cannot safely retry"),
+            "a mid-stream outage must surface as the safe-retry refusal, not another \
+             failure:\n{stderr}"
+        );
+        reset_mongo_proxy(); // link healthy again
+        rig.run_ok(); // clean re-run completes the export
+    }
+
+    // Either path ends with every row present. The refuse-then-rerun path is
+    // at-least-once (committed parts + a full re-export can leave duplicate ROWS),
+    // so assert on the DISTINCT _id set — the completeness oracle, dup-immune.
     assert_eq!(
         dir_parquet_distinct_strings(&rig.out_dir(), "_id").len(),
         100_000,
-        "recovery must be complete — every row present after the outage"
+        "a mid-stream outage must never lose a row — recovered in place or safely re-run",
     );
 }
 


### PR DESCRIPTION
The dispatched `mongo-versions` matrix on #82 caught three cross-version issues the local (mongo:7) run missed — **none a data-correctness bug in the engine**:

1. **v4.4 — all CDC failed** (error 13436 `NotPrimaryOrSecondary`): the `mongo-rs` healthcheck reported healthy as soon as `rs.status()` responded, but `rs.initiate()` returns ok *before* the primary is elected (worst on 4.4), so `docker compose up -d --wait` unblocked and `db.watch()` raced the election. Gate the healthcheck on `isMaster().ismaster` (cross-version; `hello` is 5.0+) → `--wait` waits for a real PRIMARY.
2. **v4.4 — `read_concern: snapshot` test**: snapshot needs 5.0+; self-skip on server major < 5 (new `MongoTest::server_major()`).
3. **v5.0/v8.0 — mid-stream proxy-disable fault test was timing-flaky**: parts committed faster there, so rivet correctly REFUSED the unsafe retry and failed loud, but the test only accepted in-place retry. Assert the real contract: recover in place OR refuse loudly + clean re-run — both at-least-once, never silent partial (new non-panicking `Rig::run()`).

Full mongo live suite **31/31 green locally**; mongo-versions matrix re-dispatched on this branch to confirm 4.4→8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qLinoxhY46uqo5mNJAmno