### PR TITLE
fix(cdc): run-unique manifest sidecar + test de-compromising + mutation program

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -24,4 +24,10 @@ exclude_re = [
     # running the whole module against the deleted-field mutant) — the
     # initial value is unobservable.
     "delete field passed from struct ManifestVerification expression in verify_at_destination",
+    # scalar_to_string takes a `tiberius::Row`, which cannot be constructed
+    # outside the driver — its dispatch stubs are unkillable offline. The
+    # value logic was extracted into `numeric_to_display` (unit-tested,
+    # RED-proven); the dispatch itself is live-guarded (query_scalar feeds
+    # min/max bounds exercised by the live planner suites).
+    "replace scalar_to_string -> Option<String>",
 ]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,22 @@
+# cargo-mutants configuration (docs/mutation-plan.md).
+#
+# `exclude_re` entries are TRIAGED equivalent mutants — mutations that are
+# semantically identical to the original code, so no test can (or should)
+# distinguish them. Every entry carries its reason; adding one without a
+# reason comment is a review defect. Accepted-but-real behaviours (operator
+# UX, log lines) belong in docs/mutants-baseline.txt, not here.
+
+exclude_re = [
+    # 64*1024 is a streaming READ BUFFER size in compute_part_checksums —
+    # any chunking yields byte-identical digests; 64+1024 only changes I/O
+    # granularity. Verified by hand (matrix audit, 2026-07-13).
+    "replace \\* with \\+ in compute_part_checksums",
+    # `scale < 0` vs `scale <= 0` in the decimal str<->scaled converters:
+    # at scale == 0 the negative-scale branch (factor = 10^0 = 1) computes
+    # exactly what the scale_u == 0 fast path returns — branch parity makes
+    # the boundary invisible by construction. The REAL neighbour bug at
+    # `value < 0` (signed zero) is covered by scaled_zero_formats_unsigned.
+    "replace < with <= in scaled_i128_to_decimal_str",
+    "replace < with <= in decimal_str_to_scaled_i128",
+    "replace < with <= in decimal_str_to_scaled_i256",
+]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -19,4 +19,9 @@ exclude_re = [
     "replace < with <= in scaled_i128_to_decimal_str",
     "replace < with <= in decimal_str_to_scaled_i128",
     "replace < with <= in decimal_str_to_scaled_i256",
+    # The optimistic base's `passed: true` in verify_at_destination is
+    # overwritten by recompute_passed() on EVERY exit path (verified by
+    # running the whole module against the deleted-field mutant) — the
+    # initial value is unobservable.
+    "delete field passed from struct ManifestVerification expression in verify_at_destination",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,38 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets -- -D warnings
 
+  # Mutation PR gate (docs/mutation-plan.md): mutate ONLY the lines this PR
+  # changed and run the lib suite against each mutant. A missed mutant in your
+  # own diff = your new code has an assertion gap — fail here, in minutes,
+  # instead of surfacing in the nightly tier runs. Equivalent mutants are
+  # excluded via .cargo/mutants.toml (with reasons).
+  mutants-in-diff:
+    name: Mutants (changed lines)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.94"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: mutants
+      - name: Install cargo-mutants
+        run: cargo install cargo-mutants --locked
+      - name: Mutate the PR diff
+        env:
+          # Mutants never need debuginfo — halves build dirs, speeds links.
+          CARGO_PROFILE_DEV_DEBUG: "0"
+        run: |
+          git diff "origin/${{ github.base_ref }}"...HEAD > pr.diff
+          # Exit code 2 = missed mutants (the gate's failure); 0 = all caught
+          # or nothing to mutate in this diff.
+          cargo mutants --in-diff pr.diff -j 2 -- --lib
+
   test:
     name: Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,10 @@ jobs:
     name: Mutants (changed lines)
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
-    timeout-minutes: 45
+    # First live run: 52 mutants took 42m on the 2-core runner (cold baseline
+    # build 270s + ~80s/mutant) — 45m was one flaky rebuild away from a
+    # spurious timeout on a large PR.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/nightly-live.yml
+++ b/.github/workflows/nightly-live.yml
@@ -169,11 +169,17 @@ jobs:
         # stay skipped for TIME, not permissions (the .live-tmp prolog above
         # now provisions the shared mount here too): all three have a
         # dedicated home in ci.yml's `test-type-validators` job on every PR.
+        # `--skip mongo` (substring), NOT `--skip live_mongo --skip live_cdc_mongo`
+        # (module prefixes): the prefix form missed the engine-agnostic
+        # `chunking_stand::stand_*_mongo` tests, which were then SELECTED on this
+        # mongo-less stack and panicked at require_alive — the exact latent
+        # failure the matrix audit predicted. Every Mongo test (module-named or
+        # stand_*) is owned by the `mongo-versions` job, same as ci.yml's e2e.
         run: |
           cargo test --release -- --ignored \
             --skip full_content_export_max_pressure \
             --skip validates --skip edge_cases --skip via_duckdb \
-            --skip live_mongo --skip live_cdc_mongo
+            --skip mongo
 
       - name: Dump service logs on failure
         if: failure()

--- a/.github/workflows/nightly-live.yml
+++ b/.github/workflows/nightly-live.yml
@@ -220,17 +220,27 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Start Mongo stack
+        # minio + fake-gcs ride along for the engine-agnostic chunking_stand
+        # Mongo cells (dest_gcs/dest_s3) — no other job has BOTH a Mongo server
+        # and these tests selected (e2e `--skip mongo` excludes them; the matrix
+        # audit found all four cells never ran in any CI job).
         run: |
           mkdir -p tests/.live-tmp
-          docker compose up -d --wait mongo mongo-rs mongo-auth toxiproxy
+          docker compose up -d --wait mongo mongo-rs mongo-auth toxiproxy minio fake-gcs
           sudo chmod -R 0777 tests/.live-tmp
 
       - name: Run Mongo live tests
         # `live_mongo` matches every live_mongo* module (batch, crash-recovery,
         # harm-permission, retry-and-faults); `live_cdc_mongo` the CDC suite.
+        # The four `stand_*_mongo` names are the chunking_stand Mongo cells —
+        # positional filters are substrings, so they are named EXACTLY (a bare
+        # `stand_` would also select the mysql/mssql stand tests, whose engines
+        # this slim stack does not run).
         run: |
           cargo test --release --test live_suite -- --ignored \
-            live_mongo live_cdc_mongo
+            live_mongo live_cdc_mongo \
+            stand_dest_gcs_mongo stand_dest_s3_mongo \
+            stand_format_csv_mongo stand_compression_codecs_mongo
 
       - name: Dump Mongo logs on failure
         if: failure()

--- a/.github/workflows/nightly-live.yml
+++ b/.github/workflows/nightly-live.yml
@@ -281,18 +281,28 @@ jobs:
         env:
           CARGO_PROFILE_DEV_DEBUG: "0" # mutants never need debuginfo
         run: |
-          if [ $(( $(date +%j) % 2 )) -eq 0 ]; then
-            echo "group: ledger/pipeline (Tier 0)"
-            FILES="-f src/pipeline/manifest_writer.rs -f src/pipeline/manifest_reconcile.rs \
-                   -f src/manifest.rs -f src/pipeline/finalize.rs -f src/pipeline/single.rs \
-                   -f src/pipeline/keyset.rs -f src/pipeline/resume_decisions.rs \
-                   -f src/pipeline/chunked/resume_m8.rs -f src/pipeline/validate_manifest.rs"
-          else
-            echo "group: CDC/value/integrity (Tier 1-2)"
-            FILES="-f src/source/cdc/value.rs -f src/source/cdc/sink.rs \
-                   -f src/source/postgres/cdc.rs -f src/source/value_checksum.rs \
-                   -f src/types/decimal.rs"
-          fi
+          case $(( $(date +%j) % 3 )) in
+            0)
+              echo "group: ledger/pipeline (Tier 0)"
+              FILES="-f src/pipeline/manifest_writer.rs -f src/pipeline/manifest_reconcile.rs \
+                     -f src/manifest.rs -f src/pipeline/finalize.rs -f src/pipeline/single.rs \
+                     -f src/pipeline/keyset.rs -f src/pipeline/resume_decisions.rs \
+                     -f src/pipeline/chunked/resume_m8.rs -f src/pipeline/validate_manifest.rs"
+              ;;
+            1)
+              echo "group: CDC/value/integrity (Tier 1-2)"
+              FILES="-f src/source/cdc/value.rs -f src/source/cdc/sink.rs \
+                     -f src/source/postgres/cdc.rs -f src/source/value_checksum.rs \
+                     -f src/types/decimal.rs"
+              ;;
+            2)
+              echo "group: planning/formats/gates (waves 4-6)"
+              FILES="-f src/pipeline/chunked/math.rs -f src/pipeline/chunked/detect.rs \
+                     -f src/plan/build.rs -f src/format/csv.rs -f src/source/mongo/mod.rs \
+                     -f src/source/mssql/mod.rs -f src/source/postgres/mod.rs \
+                     -f src/pipeline/apply_cmd.rs"
+              ;;
+          esac
           # `|| true`: known misses are adjudicated by the baseline diff below,
           # not by the raw exit code.
           cargo mutants --no-shuffle -j 2 $FILES -- --lib || true

--- a/.github/workflows/nightly-live.yml
+++ b/.github/workflows/nightly-live.yml
@@ -263,11 +263,12 @@ jobs:
   # names a test blind spot. Scoped to the modules where the 2026-07 campaign
   # found 33 defects (whole-crate mutants would take hours). Offline tests
   # only — live tests are #[ignore]d, so mutants runs the cheap suite.
-  mutants-cdc:
-    name: cargo-mutants (CDC modules)
-    # 50 min hit the ceiling on the first real run: decimal.rs ALONE takes
-    # ~49 min locally on a faster box (108 mutants x offline suite), and this
-    # job also covers cdc/value.rs on a 2-core runner. Nightly has the budget.
+  mutants-nightly:
+    name: cargo-mutants (tier rotation + baseline ratchet)
+    # docs/mutation-plan.md: one tier group per night (even/odd day of year),
+    # lib cycle, diffed against the committed baseline. The job is GREEN as
+    # long as no NEW missed mutant appears — known misses live in
+    # docs/mutants-baseline.txt and only ever shrink (gap-ratchet discipline).
     timeout-minutes: 180
     runs-on: ubuntu-latest
     steps:
@@ -276,15 +277,36 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-mutants
         run: cargo install cargo-mutants --locked
-      - name: Mutants over CDC + checksum + decimal canon
+      - name: Mutants (rotating tier group)
+        env:
+          CARGO_PROFILE_DEV_DEBUG: "0" # mutants never need debuginfo
         run: |
-          cargo mutants --no-shuffle -vV \
-            -f src/source/cdc/value.rs \
-            -f src/source/cdc/sink.rs \
-            -f src/source/postgres/cdc.rs \
-            -f src/source/value_checksum.rs \
-            -f src/types/decimal.rs \
-            -- --tests
+          if [ $(( $(date +%j) % 2 )) -eq 0 ]; then
+            echo "group: ledger/pipeline (Tier 0)"
+            FILES="-f src/pipeline/manifest_writer.rs -f src/pipeline/manifest_reconcile.rs \
+                   -f src/manifest.rs -f src/pipeline/finalize.rs -f src/pipeline/single.rs \
+                   -f src/pipeline/keyset.rs -f src/pipeline/resume_decisions.rs \
+                   -f src/pipeline/chunked/resume_m8.rs -f src/pipeline/validate_manifest.rs"
+          else
+            echo "group: CDC/value/integrity (Tier 1-2)"
+            FILES="-f src/source/cdc/value.rs -f src/source/cdc/sink.rs \
+                   -f src/source/postgres/cdc.rs -f src/source/value_checksum.rs \
+                   -f src/types/decimal.rs"
+          fi
+          # `|| true`: known misses are adjudicated by the baseline diff below,
+          # not by the raw exit code.
+          cargo mutants --no-shuffle -j 2 $FILES -- --lib || true
+      - name: Ratchet against the baseline
+        run: |
+          sort -u mutants.out/missed.txt 2>/dev/null > got.txt || touch got.txt
+          sort -u docs/mutants-baseline.txt 2>/dev/null > base.txt || touch base.txt
+          comm -23 got.txt base.txt > new-missed.txt
+          if [ -s new-missed.txt ]; then
+            echo "::error::NEW missed mutants (not in docs/mutants-baseline.txt):"
+            cat new-missed.txt
+            exit 1
+          fi
+          echo "no new missed mutants ($(wc -l < got.txt) known, all in baseline)"
       - name: Upload mutants report
         if: always()
         uses: actions/upload-artifact@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,20 @@ filename-sanitized. **A test that passes only by sleeping ≥1s between runs is
 documenting the gap, not closing it** — the batch clobber hid behind exactly
 such a `sleep(1100ms)` for months.
 
+The rule extends past the parts to **every per-run SIDECAR**. The CDC sink
+named its parts run-uniquely but wrote the manifest to the fixed
+`manifest.json` — N `until_current` runs into one prefix clobbered it (parts
+accumulated, manifest didn't), and the first consumer that summed manifests
+across runs (the Pro loader's reconcile) under-counted 30 parts as 55 rows.
+No OSS test saw it because every "repeated run" test re-read the PARQUET —
+the artifact that survives — never the manifest. Fix: `write_manifest` leaves
+an immutable `manifest-<run_id>.json` copy beside the canonical last-writer-
+wins pointer (`run_unique_manifest_name` / `is_run_unique_manifest_name` in
+`src/manifest.rs`); guard/validate/resume keep reading the canonical name.
+Process rule: **a "repeated runs accumulate" claim must be asserted on the
+manifest copies (`dir_manifest_copy_total_rows`), not a data re-read** — the
+data surviving is exactly what makes a sidecar clobber invisible.
+
 ## Silent-loss classes from the live GCS run: cells, and names
 
 Two same-day bugs, one lesson each — both survived every count/sum check
@@ -389,3 +403,51 @@ count-only heuristic on engines with no trustworthy scan-free row estimate**
 rather than skipping — the engine with the weakest catalog stats (MySQL) is
 exactly where the pathology is least visible. A sparsity/cost check gated behind
 `row_estimate.is_some()` is a check that abandons the user who needs it most.
+
+## A green test that was never RED is unverified — mutate the product to prove it
+
+The 2026-07 audit found **63 green tests that could not fail against the exact
+bug they guarded**: sleeps masking a fixed granularity contract, CDC tests
+trusting `manifest_rows()` (rivet's own summary), cloud-dest "all rows" cells
+asserting file PRESENCE (`mc ls | wc -l`), reconcile tests trusting rivet's own
+verdict. A 3766-mutant corpus then measured the same defect from the other
+side: whole functions stubbed to `Ok(Default::default())` —
+`finalize_manifest`, `apply_m8_resume_decisions`, `source_checksums` — survived
+the full lib suite. 23 real gaps were closed the same day, every closure
+RED-proven. Three rules fell out, each bitten at least twice:
+
+1. **RED-prove every data-loss/integrity test before committing it.** Apply
+   the mutant (stub the function, flip the operator), watch the NEW test fail,
+   revert. One of the audit's own fixes was vacuous against its intended
+   mutant (`recompute_passed()` masked it — the mutant proved EQUIVALENT, a
+   different verdict entirely); another assert was fix-invariant (`file_log`
+   accumulates whether or not the manifest sidecar clobbers) and passed both
+   pre- and post-fix. Reading the test cannot tell you this; only the mutant
+   can. Enforcement: `cargo mutants --in-diff` gates PRs (ci.yml), the nightly
+   tier rotation ratchets against `docs/mutants-baseline.txt` (shrink-only),
+   equivalents live in `.cargo/mutants.toml` with reasons.
+
+2. **Fixtures must cross the mechanism's activation threshold.** A fold over
+   ONE element makes every fold operator identical (`0^s == 0|s` — the
+   single-part form-B fixture hid `^=`→`|=` in validate's cross-part fold);
+   a single run makes any part-name granularity collision-free (the
+   `sleep(1100ms)`s hid the second-granularity clobber); a single row hides
+   accumulation arithmetic. If the mechanism under test folds/accumulates/
+   collides, the fixture needs ≥2 of the thing — same family as the
+   "engineer fixtures past activation thresholds" self-oracle rule.
+
+3. **A sleep (or any workaround) in a test that compensates for PRODUCT
+   behaviour is a product bug report, not a test fix.** The `sleep(1100ms)`
+   authors knew rivet stamped filenames at second granularity — the comment
+   said so — and routed the test around a real data-loss bug instead of
+   filing it. 29 such sleeps also INVERTED over time: after the `%3f` fix
+   they made the tests permanently unable to catch a regression back.
+   When a test needs artificial separation (time, ordering, uniqueness) that
+   the product claims to provide, stop and check the product first.
+
+Scope honesty: mutation testing measures assertion SENSITIVITY on code that
+exists. It cannot see a missing behaviour (the manifest-clobber fix itself was
+invisible to it — an independent-oracle harness caught that), nor a test and
+code that agree on a wrong spec. Layers: matrices (coverage exists) → mutants
+(assertions bite) → live suites (integration) → independent-oracle harness
+(absent behaviour). One layer's green is not another layer's proof.

--- a/docs/behaviour-matrix.yaml
+++ b/docs/behaviour-matrix.yaml
@@ -21,7 +21,7 @@ scenarios:
     postgres: { test: full_mode_repeated_run_accumulates_manifest_entries }
     mysql:    { test: mysql_full_mode_repeated_run_accumulates_manifest_entries }
     mssql:    { test: mssql_full_mode_repeated_run_accumulates_manifest_entries }
-    mongo:    { test: mongo_batch_type_fidelity_document_is_verbatim_extjson }
+    mongo:    { test: mongo_batch_two_rapid_runs_into_same_prefix_do_not_clobber }
 
   - id: mode_incremental
     what: "mode: incremental — WHERE cursor > last_value; re-run picks up only new rows"

--- a/docs/chunking-matrix.yaml
+++ b/docs/chunking-matrix.yaml
@@ -107,7 +107,7 @@ scenarios:
     postgres: { test: full_mode_repeated_run_accumulates_manifest_entries }
     mysql:    { test: mysql_full_mode_repeated_run_accumulates_manifest_entries }
     mssql:    { test: mssql_full_mode_repeated_run_accumulates_manifest_entries }
-    mongo:    { test: mongo_batch_type_fidelity_document_is_verbatim_extjson }
+    mongo:    { test: mongo_batch_two_rapid_runs_into_same_prefix_do_not_clobber }
 
   - id: incremental_cursor
     what: "mode: incremental — WHERE cursor > last_value, re-run picks up only new rows"

--- a/docs/mutants-baseline.txt
+++ b/docs/mutants-baseline.txt
@@ -9,10 +9,185 @@
 # The nightly mutants job diffs its missed list against this file: a missed
 # mutant NOT listed here fails the job. This file only ever SHRINKS (delete
 # lines as tests close them); adding a line requires the same adjudication.
-# Corpus: 3766 mutants over 3 tiers, 2026-07-14 (docs/mutation-plan.md).
+# Corpus: 3766 mutants over 3 tiers, 2026-07-14 (docs/mutation-plan.md).#
+# v2 (2026-07-14): + waves 4-6 leftovers (chunk planning / source builders /
+# destinations / formats / plan / cmd layer) — orchestration & live-guarded
+# paths plus accepted cosmetics. NOTE: entries carry file:line, so refactors
+# shift them; the nightly triage re-anchors moved entries instead of treating
+# them as new misses.
+src/destination/cloud.rs:180:9: replace <impl super::Destination for CloudDestination<B>>::write -> Result<super::WriteOutcome> with Ok(Default::default())
+src/destination/cloud.rs:233:9: replace <impl super::Destination for CloudDestination<B>>::list_prefix -> Result<Vec<super::ObjectMeta>> with Ok(vec![])
+src/destination/cloud.rs:237:41: replace || with && in <impl super::Destination for CloudDestination<B>>::list_prefix
+src/destination/cloud.rs:241:21: delete field recursive from struct opendal::options::ListOptions expression in <impl super::Destination for CloudDestination<B>>::list_prefix
+src/destination/cloud.rs:249:21: delete field recursive from struct opendal::options::ListOptions expression in <impl super::Destination for CloudDestination<B>>::list_prefix
+src/destination/cloud.rs:256:40: replace != with == in <impl super::Destination for CloudDestination<B>>::list_prefix
+src/destination/cloud.rs:277:9: replace <impl super::Destination for CloudDestination<B>>::read -> Result<Vec<u8>> with Ok(vec![0])
+src/destination/cloud.rs:277:9: replace <impl super::Destination for CloudDestination<B>>::read -> Result<Vec<u8>> with Ok(vec![1])
+src/destination/cloud.rs:277:9: replace <impl super::Destination for CloudDestination<B>>::read -> Result<Vec<u8>> with Ok(vec![])
+src/destination/cloud.rs:283:9: replace <impl super::Destination for CloudDestination<B>>::head -> Result<Option<super::ObjectMeta>> with Ok(None)
+src/destination/cloud.rs:293:23: replace match guard e.kind() == opendal::ErrorKind::NotFound with false in <impl super::Destination for CloudDestination<B>>::head
+src/destination/cloud.rs:293:23: replace match guard e.kind() == opendal::ErrorKind::NotFound with true in <impl super::Destination for CloudDestination<B>>::head
+src/destination/cloud.rs:293:32: replace == with != in <impl super::Destination for CloudDestination<B>>::head
+src/destination/cloud.rs:305:9: replace <impl super::Destination for CloudDestination<B>>::r#move -> Result<()> with Ok(())
+src/destination/cloud.rs:48:38: replace * with +
+src/destination/cloud.rs:48:38: replace * with /
+src/destination/cloud.rs:48:45: replace * with +
+src/destination/cloud.rs:48:45: replace * with /
+src/destination/cloud.rs:56:9: replace <impl Drop for OneShotReservation>::drop with ()
+src/destination/cloud.rs:64:5: replace reserve_oneshot -> Option<OneShotReservation> with None
+src/destination/local.rs:199:23: replace match guard e.kind() == std::io::ErrorKind::NotFound with true in <impl super::Destination for LocalDestination>::head
+src/destination/local.rs:215:23: replace match guard e.raw_os_error() == Some(libc::EXDEV) with false in <impl super::Destination for LocalDestination>::r#move
+src/destination/local.rs:215:23: replace match guard e.raw_os_error() == Some(libc::EXDEV) with true in <impl super::Destination for LocalDestination>::r#move
+src/destination/local.rs:215:40: replace == with != in <impl super::Destination for LocalDestination>::r#move
+src/destination/local.rs:70:19: replace match guard e.kind() == ErrorKind::AlreadyExists with true in stage_copy
+src/destination/mod.rs:106:9: replace WriteOutcome::opaque -> Self with Default::default()
+src/destination/mod.rs:151:9: replace Destination::list_prefix -> Result<Vec<ObjectMeta>> with Ok(vec![])
+src/destination/mod.rs:159:9: replace Destination::read -> Result<Vec<u8>> with Ok(vec![0])
+src/destination/mod.rs:159:9: replace Destination::read -> Result<Vec<u8>> with Ok(vec![1])
+src/destination/mod.rs:159:9: replace Destination::read -> Result<Vec<u8>> with Ok(vec![])
+src/destination/mod.rs:168:9: replace Destination::head -> Result<Option<ObjectMeta>> with Ok(None)
+src/destination/mod.rs:187:9: replace Destination::r#move -> Result<()> with Ok(())
+src/destination/mod.rs:205:5: replace log_capabilities with ()
+src/destination/mod.rs:214:25: replace && with || in log_capabilities
+src/destination/mod.rs:214:40: replace > with < in log_capabilities
+src/destination/mod.rs:214:40: replace > with == in log_capabilities
+src/destination/mod.rs:214:40: replace > with >= in log_capabilities
+src/destination/mod.rs:214:8: delete ! in log_capabilities
+src/destination/s3.rs:69:17: delete field profile from struct reqsign::AwsConfig expression in <impl CloudBackend for S3Backend>::build_operator
+src/destination/stdout.rs:16:9: replace <impl super::Destination for StdoutDestination>::write -> Result<super::WriteOutcome> with Ok(Default::default())
+src/format/parquet.rs:85:9: replace <impl super::FormatWriter for ParquetFormatWriter>::write_batch -> Result<()> with Ok(())
+src/format/parquet.rs:95:9: replace <impl super::FormatWriter for ParquetFormatWriter>::bytes_written -> u64 with 0
+src/format/parquet.rs:95:9: replace <impl super::FormatWriter for ParquetFormatWriter>::bytes_written -> u64 with 1
 src/manifest.rs:362:9: replace <impl std::fmt::Display for ManifestInconsistency>::fmt -> std::fmt::Result with Ok(Default::default())
+src/pipeline/apply_cmd.rs:122:22: replace match guard dir.exists() with false in run_apply_command
+src/pipeline/apply_cmd.rs:122:22: replace match guard dir.exists() with true in run_apply_command
+src/pipeline/apply_cmd.rs:211:5: replace reject_unrecoverable_inline_url -> Result<()> with Ok(())
+src/pipeline/apply_cmd.rs:27:37: replace || with && in run_apply_command
+src/pipeline/apply_cmd.rs:30:17: replace || with && in run_apply_command
+src/pipeline/apply_cmd.rs:75:49: replace >= with < in run_apply_command
+src/pipeline/chunked/detect.rs:111:5: replace log_chunk_sparsity_at_run with ()
+src/pipeline/chunked/detect.rs:114:37: replace * with + in log_chunk_sparsity_at_run
+src/pipeline/chunked/detect.rs:114:37: replace * with / in log_chunk_sparsity_at_run
+src/pipeline/chunked/detect.rs:115:31: replace - with + in log_chunk_sparsity_at_run
+src/pipeline/chunked/detect.rs:115:31: replace - with / in log_chunk_sparsity_at_run
+src/pipeline/chunked/detect.rs:115:63: replace * with + in log_chunk_sparsity_at_run
+src/pipeline/chunked/detect.rs:115:63: replace * with / in log_chunk_sparsity_at_run
+src/pipeline/chunked/detect.rs:271:36: replace - with + in detect_and_generate_chunks
+src/pipeline/chunked/detect.rs:271:36: replace - with / in detect_and_generate_chunks
+src/pipeline/chunked/detect.rs:326:29: replace - with + in detect_and_generate_chunks
+src/pipeline/chunked/detect.rs:326:29: replace - with / in detect_and_generate_chunks
+src/pipeline/chunked/detect.rs:364:32: replace > with < in detect_and_generate_chunks
+src/pipeline/chunked/detect.rs:364:32: replace > with == in detect_and_generate_chunks
+src/pipeline/chunked/detect.rs:364:32: replace > with >= in detect_and_generate_chunks
+src/pipeline/chunked/detect.rs:399:29: replace <= with > in detect_and_generate_chunks
+src/pipeline/chunked/detect.rs:70:5: replace log_chunk_boundaries_list with ()
+src/pipeline/chunked/detect.rs:79:29: replace + with * in log_chunk_boundaries_list
+src/pipeline/chunked/detect.rs:92:72: replace - with + in log_chunk_boundaries_list
+src/pipeline/chunked/detect.rs:92:72: replace - with / in log_chunk_boundaries_list
+src/pipeline/chunked/exec.rs:101:28: replace += with *= in run_chunked_sequential
+src/pipeline/chunked/exec.rs:101:28: replace += with -= in run_chunked_sequential
+src/pipeline/chunked/exec.rs:110:28: replace > with < in run_chunked_sequential
+src/pipeline/chunked/exec.rs:110:28: replace > with == in run_chunked_sequential
+src/pipeline/chunked/exec.rs:110:28: replace > with >= in run_chunked_sequential
+src/pipeline/chunked/exec.rs:164:5: replace run_chunked_parallel -> Result<()> with Ok(())
+src/pipeline/chunked/exec.rs:229:44: replace && with || in run_chunked_parallel
+src/pipeline/chunked/exec.rs:229:56: replace > with < in run_chunked_parallel
+src/pipeline/chunked/exec.rs:229:56: replace > with == in run_chunked_parallel
+src/pipeline/chunked/exec.rs:229:56: replace > with >= in run_chunked_parallel
+src/pipeline/chunked/exec.rs:28:5: replace run_chunked_sequential -> Result<()> with Ok(())
+src/pipeline/chunked/exec.rs:302:57: replace >= with < in run_chunked_parallel
+src/pipeline/chunked/exec.rs:305:44: replace < with <= in run_chunked_parallel
+src/pipeline/chunked/exec.rs:305:44: replace < with == in run_chunked_parallel
+src/pipeline/chunked/exec.rs:305:44: replace < with > in run_chunked_parallel
+src/pipeline/chunked/exec.rs:329:16: delete ! in run_chunked_parallel
+src/pipeline/chunked/exec.rs:331:23: delete ! in run_chunked_parallel
+src/pipeline/chunked/exec.rs:392:40: replace > with < in run_chunked_parallel
+src/pipeline/chunked/exec.rs:392:40: replace > with == in run_chunked_parallel
+src/pipeline/chunked/exec.rs:392:40: replace > with >= in run_chunked_parallel
+src/pipeline/chunked/exec.rs:416:74: replace + with * in run_chunked_parallel
+src/pipeline/chunked/exec.rs:416:74: replace + with - in run_chunked_parallel
+src/pipeline/chunked/math.rs:134:17: replace match guard chunk_dense with false in chunk_plan_fingerprint
+src/pipeline/chunked/mod.rs:117:5: replace prepare_chunk_plan -> Result<Vec<(i64, i64)>> with Ok(vec![(-1, -1)])
+src/pipeline/chunked/mod.rs:117:5: replace prepare_chunk_plan -> Result<Vec<(i64, i64)>> with Ok(vec![(-1, 0)])
+src/pipeline/chunked/mod.rs:117:5: replace prepare_chunk_plan -> Result<Vec<(i64, i64)>> with Ok(vec![(-1, 1)])
+src/pipeline/chunked/mod.rs:117:5: replace prepare_chunk_plan -> Result<Vec<(i64, i64)>> with Ok(vec![(0, -1)])
+src/pipeline/chunked/mod.rs:117:5: replace prepare_chunk_plan -> Result<Vec<(i64, i64)>> with Ok(vec![(0, 0)])
+src/pipeline/chunked/mod.rs:117:5: replace prepare_chunk_plan -> Result<Vec<(i64, i64)>> with Ok(vec![(0, 1)])
+src/pipeline/chunked/mod.rs:117:5: replace prepare_chunk_plan -> Result<Vec<(i64, i64)>> with Ok(vec![(1, -1)])
+src/pipeline/chunked/mod.rs:117:5: replace prepare_chunk_plan -> Result<Vec<(i64, i64)>> with Ok(vec![(1, 0)])
+src/pipeline/chunked/mod.rs:117:5: replace prepare_chunk_plan -> Result<Vec<(i64, i64)>> with Ok(vec![(1, 1)])
+src/pipeline/chunked/mod.rs:117:5: replace prepare_chunk_plan -> Result<Vec<(i64, i64)>> with Ok(vec![])
+src/pipeline/chunked/mod.rs:146:5: replace prepare_chunk_plan_fresh -> Result<Vec<(i64, i64)>> with Ok(vec![(-1, -1)])
+src/pipeline/chunked/mod.rs:146:5: replace prepare_chunk_plan_fresh -> Result<Vec<(i64, i64)>> with Ok(vec![(-1, 0)])
+src/pipeline/chunked/mod.rs:146:5: replace prepare_chunk_plan_fresh -> Result<Vec<(i64, i64)>> with Ok(vec![(-1, 1)])
+src/pipeline/chunked/mod.rs:146:5: replace prepare_chunk_plan_fresh -> Result<Vec<(i64, i64)>> with Ok(vec![(0, -1)])
+src/pipeline/chunked/mod.rs:146:5: replace prepare_chunk_plan_fresh -> Result<Vec<(i64, i64)>> with Ok(vec![(0, 0)])
+src/pipeline/chunked/mod.rs:146:5: replace prepare_chunk_plan_fresh -> Result<Vec<(i64, i64)>> with Ok(vec![(0, 1)])
+src/pipeline/chunked/mod.rs:146:5: replace prepare_chunk_plan_fresh -> Result<Vec<(i64, i64)>> with Ok(vec![(1, -1)])
+src/pipeline/chunked/mod.rs:146:5: replace prepare_chunk_plan_fresh -> Result<Vec<(i64, i64)>> with Ok(vec![(1, 0)])
+src/pipeline/chunked/mod.rs:146:5: replace prepare_chunk_plan_fresh -> Result<Vec<(i64, i64)>> with Ok(vec![(1, 1)])
+src/pipeline/chunked/mod.rs:146:5: replace prepare_chunk_plan_fresh -> Result<Vec<(i64, i64)>> with Ok(vec![])
+src/pipeline/chunked/mod.rs:200:22: replace > with < in ensure_chunk_checkpoint_plan
+src/pipeline/chunked/mod.rs:200:22: replace > with == in ensure_chunk_checkpoint_plan
+src/pipeline/chunked/mod.rs:200:22: replace > with >= in ensure_chunk_checkpoint_plan
+src/pipeline/chunked/parallel_checkpoint.rs:161:24: delete ! in run_chunked_parallel_checkpoint
+src/pipeline/chunked/parallel_checkpoint.rs:204:40: replace > with < in run_chunked_parallel_checkpoint
+src/pipeline/chunked/parallel_checkpoint.rs:204:40: replace > with == in run_chunked_parallel_checkpoint
+src/pipeline/chunked/parallel_checkpoint.rs:204:40: replace > with >= in run_chunked_parallel_checkpoint
+src/pipeline/chunked/parallel_checkpoint.rs:218:37: replace * with + in run_chunked_parallel_checkpoint
+src/pipeline/chunked/parallel_checkpoint.rs:218:37: replace * with / in run_chunked_parallel_checkpoint
+src/pipeline/chunked/parallel_checkpoint.rs:218:56: replace - with + in run_chunked_parallel_checkpoint
+src/pipeline/chunked/parallel_checkpoint.rs:218:56: replace - with / in run_chunked_parallel_checkpoint
+src/pipeline/chunked/parallel_checkpoint.rs:219:37: replace + with * in run_chunked_parallel_checkpoint
+src/pipeline/chunked/parallel_checkpoint.rs:219:37: replace + with - in run_chunked_parallel_checkpoint
+src/pipeline/chunked/parallel_checkpoint.rs:226:48: replace < with <= in run_chunked_parallel_checkpoint
+src/pipeline/chunked/parallel_checkpoint.rs:226:48: replace < with == in run_chunked_parallel_checkpoint
+src/pipeline/chunked/parallel_checkpoint.rs:226:48: replace < with > in run_chunked_parallel_checkpoint
+src/pipeline/chunked/parallel_checkpoint.rs:227:41: replace && with || in run_chunked_parallel_checkpoint
+src/pipeline/chunked/parallel_checkpoint.rs:266:52: replace == with != in run_chunked_parallel_checkpoint
+src/pipeline/chunked/parallel_checkpoint.rs:299:48: replace < with <= in run_chunked_parallel_checkpoint
+src/pipeline/chunked/parallel_checkpoint.rs:299:48: replace < with == in run_chunked_parallel_checkpoint
+src/pipeline/chunked/parallel_checkpoint.rs:299:48: replace < with > in run_chunked_parallel_checkpoint
+src/pipeline/chunked/parallel_checkpoint.rs:300:41: replace && with || in run_chunked_parallel_checkpoint
+src/pipeline/chunked/parallel_checkpoint.rs:40:5: replace run_chunked_parallel_checkpoint -> Result<()> with Ok(())
+src/pipeline/chunked/parallel_checkpoint.rs:443:8: delete ! in run_chunked_parallel_checkpoint
+src/pipeline/chunked/parallel_checkpoint.rs:452:16: replace > with < in run_chunked_parallel_checkpoint
+src/pipeline/chunked/parallel_checkpoint.rs:452:16: replace > with == in run_chunked_parallel_checkpoint
+src/pipeline/chunked/parallel_checkpoint.rs:452:16: replace > with >= in run_chunked_parallel_checkpoint
 src/pipeline/chunked/resume_m8.rs:286:22: replace > with >= in apply_m8_resume_decisions
 src/pipeline/chunked/resume_m8.rs:296:22: replace > with >= in apply_m8_resume_decisions
+src/pipeline/chunked/sequential_checkpoint.rs:121:5: replace run_chunk_with_source_retries -> Result<(usize, Vec<super::super::commit::PartRecord>)> with Ok((0, vec![]))
+src/pipeline/chunked/sequential_checkpoint.rs:121:5: replace run_chunk_with_source_retries -> Result<(usize, Vec<super::super::commit::PartRecord>)> with Ok((1, vec![]))
+src/pipeline/chunked/sequential_checkpoint.rs:123:20: replace > with < in run_chunk_with_source_retries
+src/pipeline/chunked/sequential_checkpoint.rs:123:20: replace > with == in run_chunk_with_source_retries
+src/pipeline/chunked/sequential_checkpoint.rs:123:20: replace > with >= in run_chunk_with_source_retries
+src/pipeline/chunked/sequential_checkpoint.rs:134:46: replace * with + in run_chunk_with_source_retries
+src/pipeline/chunked/sequential_checkpoint.rs:134:46: replace * with / in run_chunk_with_source_retries
+src/pipeline/chunked/sequential_checkpoint.rs:134:65: replace - with + in run_chunk_with_source_retries
+src/pipeline/chunked/sequential_checkpoint.rs:134:65: replace - with / in run_chunk_with_source_retries
+src/pipeline/chunked/sequential_checkpoint.rs:134:70: replace + with * in run_chunk_with_source_retries
+src/pipeline/chunked/sequential_checkpoint.rs:134:70: replace + with - in run_chunk_with_source_retries
+src/pipeline/chunked/sequential_checkpoint.rs:149:28: replace < with <= in run_chunk_with_source_retries
+src/pipeline/chunked/sequential_checkpoint.rs:149:28: replace < with == in run_chunk_with_source_retries
+src/pipeline/chunked/sequential_checkpoint.rs:149:28: replace < with > in run_chunk_with_source_retries
+src/pipeline/chunked/sequential_checkpoint.rs:149:54: replace && with || in run_chunk_with_source_retries
+src/pipeline/chunked/sequential_checkpoint.rs:170:28: replace < with <= in run_chunk_with_source_retries
+src/pipeline/chunked/sequential_checkpoint.rs:170:28: replace < with == in run_chunk_with_source_retries
+src/pipeline/chunked/sequential_checkpoint.rs:170:28: replace < with > in run_chunk_with_source_retries
+src/pipeline/chunked/sequential_checkpoint.rs:170:54: replace && with || in run_chunk_with_source_retries
+src/pipeline/chunked/sequential_checkpoint.rs:189:5: replace run_chunked_sequential_checkpoint -> Result<()> with Ok(())
+src/pipeline/chunked/sequential_checkpoint.rs:215:21: replace && with || in run_chunked_sequential_checkpoint
+src/pipeline/chunked/sequential_checkpoint.rs:215:24: delete ! in run_chunked_sequential_checkpoint
+src/pipeline/chunked/sequential_checkpoint.rs:215:8: delete ! in run_chunked_sequential_checkpoint
+src/pipeline/chunked/sequential_checkpoint.rs:221:12: delete ! in run_chunked_sequential_checkpoint
+src/pipeline/chunked/sequential_checkpoint.rs:261:36: replace += with *= in run_chunked_sequential_checkpoint
+src/pipeline/chunked/sequential_checkpoint.rs:261:36: replace += with -= in run_chunked_sequential_checkpoint
+src/pipeline/chunked/sequential_checkpoint.rs:314:16: replace > with < in run_chunked_sequential_checkpoint
+src/pipeline/chunked/sequential_checkpoint.rs:314:16: replace > with == in run_chunked_sequential_checkpoint
+src/pipeline/chunked/sequential_checkpoint.rs:314:16: replace > with >= in run_chunked_sequential_checkpoint
+src/pipeline/chunked/sequential_checkpoint.rs:52:5: replace export_one_chunk_range -> Result<(usize, Vec<super::super::commit::PartRecord>)> with Ok((0, vec![]))
+src/pipeline/chunked/sequential_checkpoint.rs:52:5: replace export_one_chunk_range -> Result<(usize, Vec<super::super::commit::PartRecord>)> with Ok((1, vec![]))
+src/pipeline/chunked/sequential_checkpoint.rs:85:24: replace == with != in export_one_chunk_range
 src/pipeline/finalize.rs:124:9: delete match arm "success" in finalize_manifest
 src/pipeline/finalize.rs:125:9: delete match arm "failed" in finalize_manifest
 src/pipeline/finalize.rs:156:25: delete ! in finalize_manifest
@@ -55,6 +230,73 @@ src/pipeline/keyset.rs:213:22: replace < with > in run_keyset
 src/pipeline/keyset.rs:34:9: delete match arm ExtractionStrategy::Keyset(kp) in keyset_plan
 src/pipeline/keyset.rs:69:5: replace read_keyset_page -> Result<Option<KeysetPage>> with Ok(None)
 src/pipeline/keyset.rs:89:13: replace == with != in read_keyset_page
+src/pipeline/plan_cmd.rs:105:41: replace == with != in run_plan_command
+src/pipeline/plan_cmd.rs:136:32: replace == with != in run_plan_command
+src/pipeline/plan_cmd.rs:136:63: replace && with || in run_plan_command
+src/pipeline/plan_cmd.rs:136:66: delete ! in run_plan_command
+src/pipeline/plan_cmd.rs:146:8: delete ! in run_plan_command
+src/pipeline/plan_cmd.rs:174:54: replace || with && in per_export_output_path
+src/pipeline/plan_cmd.rs:197:22: replace match guard !dir.as_os_str().is_empty() with true in per_export_output_path
+src/pipeline/plan_cmd.rs:243:36: replace && with || in build_plan_artifact
+src/pipeline/plan_cmd.rs:243:39: delete ! in build_plan_artifact
+src/pipeline/plan_cmd.rs:267:66: replace && with || in build_plan_artifact
+src/pipeline/plan_cmd.rs:295:9: delete match arm ExtractionStrategy::Chunked(cp) in build_plan_artifact
+src/pipeline/plan_cmd.rs:385:46: replace - with + in compute_plan_data
+src/pipeline/plan_cmd.rs:385:46: replace - with / in compute_plan_data
+src/pipeline/plan_cmd.rs:385:56: replace + with * in compute_plan_data
+src/pipeline/plan_cmd.rs:385:56: replace + with - in compute_plan_data
+src/pipeline/plan_cmd.rs:423:5: replace emit_artifacts -> Result<()> with Ok(())
+src/pipeline/plan_cmd.rs:442:32: replace > with < in emit_artifacts
+src/pipeline/plan_cmd.rs:442:32: replace > with == in emit_artifacts
+src/pipeline/plan_cmd.rs:442:32: replace > with >= in emit_artifacts
+src/pipeline/plan_cmd.rs:475:5: replace print_compact_summary with ()
+src/pipeline/plan_cmd.rs:49:5: replace run_plan_command -> Result<()> with Ok(())
+src/pipeline/plan_cmd.rs:521:5: replace write_plan_fields_to_config -> Result<()> with Ok(())
+src/pipeline/plan_cmd.rs:532:16: replace != with == in write_plan_fields_to_config
+src/pipeline/plan_cmd.rs:558:44: replace + with * in apply_field_annotations
+src/pipeline/plan_cmd.rs:572:55: replace || with && in apply_field_annotations
+src/pipeline/plan_cmd.rs:573:16: delete ! in apply_field_annotations
+src/pipeline/plan_cmd.rs:58:30: replace == with != in run_plan_command
+src/pipeline/plan_cmd.rs:600:42: replace || with && in parse_export_name
+src/pipeline/plan_cmd.rs:81:39: replace > with < in run_plan_command
+src/pipeline/plan_cmd.rs:81:39: replace > with == in run_plan_command
+src/pipeline/plan_cmd.rs:81:39: replace > with >= in run_plan_command
+src/pipeline/plan_cmd.rs:97:36: replace > with < in run_plan_command
+src/pipeline/plan_cmd.rs:97:36: replace > with == in run_plan_command
+src/pipeline/plan_cmd.rs:97:36: replace > with >= in run_plan_command
+src/pipeline/reconcile_cmd.rs:169:34: replace == with != in reconcile_chunked_inner
+src/pipeline/reconcile_cmd.rs:169:39: replace && with || in reconcile_chunked_inner
+src/pipeline/reconcile_cmd.rs:169:65: replace == with != in reconcile_chunked_inner
+src/pipeline/reconcile_cmd.rs:172:34: replace == with != in reconcile_chunked_inner
+src/pipeline/reconcile_cmd.rs:250:5: replace emit_report -> Result<()> with Ok(())
+src/pipeline/reconcile_cmd.rs:268:5: replace print_report_pretty with ()
+src/pipeline/reconcile_cmd.rs:297:5: replace format_status_note -> String with "xyzzy".into()
+src/pipeline/reconcile_cmd.rs:297:5: replace format_status_note -> String with String::new()
+src/pipeline/reconcile_cmd.rs:40:5: replace run_reconcile_command -> Result<()> with Ok(())
+src/pipeline/reconcile_cmd.rs:48:26: replace == with != in run_reconcile_command
+src/pipeline/reconcile_cmd.rs:94:24: replace > with < in enforce_reconcile_exit
+src/pipeline/reconcile_cmd.rs:94:24: replace > with == in enforce_reconcile_exit
+src/pipeline/reconcile_cmd.rs:94:24: replace > with >= in enforce_reconcile_exit
+src/pipeline/repair_cmd.rs:105:8: delete ! in run_repair_command
+src/pipeline/repair_cmd.rs:134:30: replace != with == in load_or_build_reconcile
+src/pipeline/repair_cmd.rs:186:13: delete match arm (Ok(s), Ok(e)) in execute_repair
+src/pipeline/repair_cmd.rs:209:47: replace - with + in execute_repair
+src/pipeline/repair_cmd.rs:209:47: replace - with / in execute_repair
+src/pipeline/repair_cmd.rs:288:8: delete ! in execute_repair
+src/pipeline/repair_cmd.rs:318:5: replace record_repair_parts_in_manifest -> Result<()> with Ok(())
+src/pipeline/repair_cmd.rs:338:83: replace + with * in record_repair_parts_in_manifest
+src/pipeline/repair_cmd.rs:338:83: replace + with - in record_repair_parts_in_manifest
+src/pipeline/repair_cmd.rs:349:17: replace += with *= in record_repair_parts_in_manifest
+src/pipeline/repair_cmd.rs:349:17: replace += with -= in record_repair_parts_in_manifest
+src/pipeline/repair_cmd.rs:400:5: replace emit_plan -> Result<()> with Ok(())
+src/pipeline/repair_cmd.rs:413:5: replace emit_report -> Result<()> with Ok(())
+src/pipeline/repair_cmd.rs:426:5: replace print_plan_pretty with ()
+src/pipeline/repair_cmd.rs:436:8: delete ! in print_plan_pretty
+src/pipeline/repair_cmd.rs:442:24: replace && with || in print_plan_pretty
+src/pipeline/repair_cmd.rs:449:5: replace print_report_pretty with ()
+src/pipeline/repair_cmd.rs:80:5: replace run_repair_command -> Result<()> with Ok(())
+src/pipeline/repair_cmd.rs:88:26: replace == with != in run_repair_command
+src/pipeline/repair_cmd.rs:92:8: delete ! in run_repair_command
 src/pipeline/single.rs:171:5: replace run_export -> Result<()> with Ok(())
 src/pipeline/single.rs:175:36: replace == with != in run_export
 src/pipeline/single.rs:175:72: replace && with || in run_export
@@ -94,6 +336,14 @@ src/pipeline/single.rs:79:28: replace < with <= in run_with_reconnect
 src/pipeline/single.rs:79:28: replace < with == in run_with_reconnect
 src/pipeline/single.rs:79:28: replace < with > in run_with_reconnect
 src/pipeline/single.rs:79:54: replace && with || in run_with_reconnect
+src/pipeline/validate_cmd.rs:116:58: replace > with < in run_validate_command
+src/pipeline/validate_cmd.rs:395:54: replace && with || in verify_one_prefix
+src/pipeline/validate_cmd.rs:408:34: replace == with != in verify_one_prefix
+src/pipeline/validate_cmd.rs:411:31: replace match guard pc.is_ok() with false in verify_one_prefix
+src/pipeline/validate_cmd.rs:411:31: replace match guard pc.is_ok() with true in verify_one_prefix
+src/pipeline/validate_cmd.rs:463:5: replace render_pretty with ()
+src/pipeline/validate_cmd.rs:482:12: delete ! in render_pretty
+src/pipeline/validate_cmd.rs:552:8: delete ! in render_pretty
 src/pipeline/validate_manifest.rs:141:32: replace > with >= in read_capped
 src/pipeline/validate_manifest.rs:210:5: replace default_depth_level -> String with "xyzzy".into()
 src/pipeline/validate_manifest.rs:210:5: replace default_depth_level -> String with String::new()
@@ -112,6 +362,21 @@ src/pipeline/validate_manifest.rs:762:5: replace preview -> String with String::
 src/pipeline/validate_manifest.rs:763:26: replace > with < in preview
 src/pipeline/validate_manifest.rs:763:26: replace > with == in preview
 src/pipeline/validate_manifest.rs:763:26: replace > with >= in preview
+src/plan/build.rs:155:34: replace == with != in full_strategy
+src/plan/build.rs:509:5: replace parse_column_overrides_pub -> Result<crate::types::ColumnOverrides> with Ok(Default::default())
+src/plan/build.rs:520:5: replace parse_column_overrides -> Result<crate::types::ColumnOverrides> with Ok(Default::default())
+src/plan/contract.rs:111:9: replace IncrementalCursorPlan::column_for_storage_extract -> &str with ""
+src/plan/contract.rs:111:9: replace IncrementalCursorPlan::column_for_storage_extract -> &str with "xyzzy"
+src/plan/contract.rs:156:9: replace ExtractionStrategy::requires_parallel_execution -> bool with false
+src/plan/contract.rs:156:9: replace ExtractionStrategy::requires_parallel_execution -> bool with true
+src/plan/contract.rs:175:13: delete match arm ExtractionStrategy::Keyset(kp) in ExtractionStrategy::chunk_key
+src/plan/contract.rs:190:9: replace ExtractionStrategy::incremental_plan -> Option<&IncrementalCursorPlan> with None
+src/plan/contract.rs:191:13: delete match arm ExtractionStrategy::Incremental(p) in ExtractionStrategy::incremental_plan
+src/plan/contract.rs:198:9: replace ExtractionStrategy::cursor_extract_column -> Option<&str> with None
+src/plan/contract.rs:198:9: replace ExtractionStrategy::cursor_extract_column -> Option<&str> with Some("")
+src/plan/contract.rs:198:9: replace ExtractionStrategy::cursor_extract_column -> Option<&str> with Some("xyzzy")
+src/plan/contract.rs:199:13: delete match arm ExtractionStrategy::Incremental(p) in ExtractionStrategy::cursor_extract_column
+src/plan/contract.rs:202:13: delete match arm ExtractionStrategy::Keyset(k) in ExtractionStrategy::cursor_extract_column
 src/source/cdc/value.rs:100:9: replace RivetValue::to_json -> Json with Default::default()
 src/source/cdc/value.rs:222:21: delete match arm Some(V::UInt(u)) in build_column
 src/source/cdc/value.rs:222:59: replace != with == in build_column
@@ -183,6 +448,65 @@ src/source/cdc/value.rs:872:5: replace render_str -> String with "xyzzy".into()
 src/source/cdc/value.rs:872:5: replace render_str -> String with String::new()
 src/source/cdc/value.rs:93:94: replace + with * in RivetValue::estimated_bytes
 src/source/cdc/value.rs:93:94: replace + with - in RivetValue::estimated_bytes
+src/source/mongo/mod.rs:144:9: replace MongoSession::db -> &str with ""
+src/source/mongo/mod.rs:144:9: replace MongoSession::db -> &str with "xyzzy"
+src/source/mongo/mod.rs:218:9: replace MongoSource::id_span -> Result<Option<(Document, Document)>> with Ok(None)
+src/source/mongo/mod.rs:218:9: replace MongoSource::id_span -> Result<Option<(Document, Document)>> with Ok(Some((Default::default(), Default::default())))
+src/source/mongo/mod.rs:241:9: replace MongoSource::ensure_uniform_id_type -> Result<()> with Ok(())
+src/source/mongo/mod.rs:287:9: replace MongoSource::warn_if_heterogeneous_id with ()
+src/source/mongo/mod.rs:311:9: replace MongoSource::sample_id_ranges -> Result<Vec<(Bson, Bson)>> with Ok(vec![(Default::default(), Default::default())])
+src/source/mongo/mod.rs:311:9: replace MongoSource::sample_id_ranges -> Result<Vec<(Bson, Bson)>> with Ok(vec![])
+src/source/mongo/mod.rs:314:14: replace == with != in MongoSource::sample_id_ranges
+src/source/mongo/mod.rs:319:30: replace * with + in MongoSource::sample_id_ranges
+src/source/mongo/mod.rs:319:30: replace * with / in MongoSource::sample_id_ranges
+src/source/mongo/mod.rs:343:22: replace < with <= in MongoSource::sample_id_ranges
+src/source/mongo/mod.rs:343:22: replace < with == in MongoSource::sample_id_ranges
+src/source/mongo/mod.rs:343:22: replace < with > in MongoSource::sample_id_ranges
+src/source/mongo/mod.rs:352:31: replace * with + in MongoSource::sample_id_ranges
+src/source/mongo/mod.rs:352:31: replace * with / in MongoSource::sample_id_ranges
+src/source/mongo/mod.rs:352:43: replace / with % in MongoSource::sample_id_ranges
+src/source/mongo/mod.rs:352:43: replace / with * in MongoSource::sample_id_ranges
+src/source/mongo/mod.rs:360:30: replace != with == in MongoSource::sample_id_ranges
+src/source/mongo/mod.rs:463:5: replace hetero_id_guidance -> &'static str with ""
+src/source/mongo/mod.rs:463:5: replace hetero_id_guidance -> &'static str with "xyzzy"
+src/source/mongo/mod.rs:538:5: replace flush -> Result<()> with Ok(())
+src/source/mongo/mod.rs:549:9: replace <impl Source for MongoSource>::export -> Result<()> with Ok(())
+src/source/mongo/mod.rs:610:33: replace && with || in <impl Source for MongoSource>::export
+src/source/mongo/mod.rs:610:55: replace && with || in <impl Source for MongoSource>::export
+src/source/mongo/mod.rs:610:58: delete ! in <impl Source for MongoSource>::export
+src/source/mongo/mod.rs:621:33: replace && with || in <impl Source for MongoSource>::export
+src/source/mongo/mod.rs:670:29: replace += with *= in <impl Source for MongoSource>::export
+src/source/mongo/mod.rs:670:29: replace += with -= in <impl Source for MongoSource>::export
+src/source/mongo/mod.rs:670:41: replace + with * in <impl Source for MongoSource>::export
+src/source/mongo/mod.rs:670:41: replace + with - in <impl Source for MongoSource>::export
+src/source/mongo/mod.rs:676:26: replace += with *= in <impl Source for MongoSource>::export
+src/source/mongo/mod.rs:676:26: replace += with -= in <impl Source for MongoSource>::export
+src/source/mongo/mod.rs:677:23: replace += with *= in <impl Source for MongoSource>::export
+src/source/mongo/mod.rs:677:23: replace += with -= in <impl Source for MongoSource>::export
+src/source/mongo/mod.rs:678:29: replace >= with < in <impl Source for MongoSource>::export
+src/source/mongo/mod.rs:678:43: replace || with && in <impl Source for MongoSource>::export
+src/source/mongo/mod.rs:678:58: replace >= with < in <impl Source for MongoSource>::export
+src/source/mongo/mod.rs:684:25: replace > with < in <impl Source for MongoSource>::export
+src/source/mongo/mod.rs:684:25: replace > with == in <impl Source for MongoSource>::export
+src/source/mongo/mod.rs:684:25: replace > with >= in <impl Source for MongoSource>::export
+src/source/mongo/mod.rs:705:9: replace <impl Source for MongoSource>::type_mappings -> Result<Vec<TypeMapping>> with Ok(vec![])
+src/source/mongo/mod.rs:715:12: delete ! in <impl Source for MongoSource>::query_scalar
+src/source/mongo/mod.rs:715:9: replace <impl Source for MongoSource>::query_scalar -> Result<Option<String>> with Ok(None)
+src/source/mongo/mod.rs:715:9: replace <impl Source for MongoSource>::query_scalar -> Result<Option<String>> with Ok(Some("xyzzy".into()))
+src/source/mongo/mod.rs:715:9: replace <impl Source for MongoSource>::query_scalar -> Result<Option<String>> with Ok(Some(String::new()))
+src/source/mongo/mod.rs:766:9: delete match arm Some(Bson::Double(v)) in nested_i64
+src/source/mongo/mod.rs:819:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with None
+src/source/mongo/mod.rs:819:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![("xyzzy".into(), -1)])
+src/source/mongo/mod.rs:819:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![("xyzzy".into(), 0)])
+src/source/mongo/mod.rs:819:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![("xyzzy".into(), 1)])
+src/source/mongo/mod.rs:819:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![(String::new(), -1)])
+src/source/mongo/mod.rs:819:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![(String::new(), 0)])
+src/source/mongo/mod.rs:819:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![(String::new(), 1)])
+src/source/mongo/mod.rs:819:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![])
+src/source/mongo/mod.rs:837:5: replace estimated_count -> Option<i64> with None
+src/source/mongo/mod.rs:837:5: replace estimated_count -> Option<i64> with Some(-1)
+src/source/mongo/mod.rs:837:5: replace estimated_count -> Option<i64> with Some(0)
+src/source/mongo/mod.rs:837:5: replace estimated_count -> Option<i64> with Some(1)
 src/source/mssql/arrow_convert.rs:142:21: delete match arm RivetType::Unsupported{reason, ..} in mssql_columns_to_schema
 src/source/mssql/arrow_convert.rs:154:8: delete ! in mssql_columns_to_schema
 src/source/mssql/arrow_convert.rs:170:5: replace mssql_type_mappings -> Vec<TypeMapping> with vec![]
@@ -346,6 +670,116 @@ src/source/mssql/cdc.rs:99:45: replace % with / in MssqlChangeStream::open
 src/source/mssql/cdc.rs:99:49: replace != with == in MssqlChangeStream::open
 src/source/mssql/cdc.rs:99:54: replace || with && in MssqlChangeStream::open
 src/source/mssql/cdc.rs:99:57: delete ! in MssqlChangeStream::open
+src/source/mssql/mod.rs:1010:5: replace introspect_mssql_table_for_chunking -> Result<TableIntrospection> with Ok(Default::default())
+src/source/mssql/mod.rs:1074:29: delete ! in introspect_mssql_table_for_chunking
+src/source/mssql/mod.rs:166:26: replace match guard cfg.mode == TlsMode::Disable || cfg.accept_invalid_certs with false in MssqlSource::connect_with_tls
+src/source/mssql/mod.rs:166:26: replace match guard cfg.mode == TlsMode::Disable || cfg.accept_invalid_certs with true in MssqlSource::connect_with_tls
+src/source/mssql/mod.rs:166:35: replace == with != in MssqlSource::connect_with_tls
+src/source/mssql/mod.rs:166:55: replace || with && in MssqlSource::connect_with_tls
+src/source/mssql/mod.rs:268:9: replace MssqlSource::mssql_decimal_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with None
+src/source/mssql/mod.rs:268:9: replace MssqlSource::mssql_decimal_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::from_iter([("xyzzy".into(), (0, -1))]))
+src/source/mssql/mod.rs:268:9: replace MssqlSource::mssql_decimal_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::from_iter([("xyzzy".into(), (0, 0))]))
+src/source/mssql/mod.rs:268:9: replace MssqlSource::mssql_decimal_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::from_iter([("xyzzy".into(), (0, 1))]))
+src/source/mssql/mod.rs:268:9: replace MssqlSource::mssql_decimal_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::from_iter([("xyzzy".into(), (1, -1))]))
+src/source/mssql/mod.rs:268:9: replace MssqlSource::mssql_decimal_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::from_iter([("xyzzy".into(), (1, 0))]))
+src/source/mssql/mod.rs:268:9: replace MssqlSource::mssql_decimal_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::from_iter([("xyzzy".into(), (1, 1))]))
+src/source/mssql/mod.rs:268:9: replace MssqlSource::mssql_decimal_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::from_iter([(String::new(), (0, -1))]))
+src/source/mssql/mod.rs:268:9: replace MssqlSource::mssql_decimal_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::from_iter([(String::new(), (0, 0))]))
+src/source/mssql/mod.rs:268:9: replace MssqlSource::mssql_decimal_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::from_iter([(String::new(), (0, 1))]))
+src/source/mssql/mod.rs:268:9: replace MssqlSource::mssql_decimal_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::from_iter([(String::new(), (1, -1))]))
+src/source/mssql/mod.rs:268:9: replace MssqlSource::mssql_decimal_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::from_iter([(String::new(), (1, 0))]))
+src/source/mssql/mod.rs:268:9: replace MssqlSource::mssql_decimal_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::from_iter([(String::new(), (1, 1))]))
+src/source/mssql/mod.rs:268:9: replace MssqlSource::mssql_decimal_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::new())
+src/source/mssql/mod.rs:298:9: replace MssqlSource::fetch_mssql_decimal_catalog_hints -> Result<Option<HashMap<String, (u8, i8)>>> with Ok(None)
+src/source/mssql/mod.rs:298:9: replace MssqlSource::fetch_mssql_decimal_catalog_hints -> Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::from_iter([("xyzzy".into(), (0, -1))])))
+src/source/mssql/mod.rs:298:9: replace MssqlSource::fetch_mssql_decimal_catalog_hints -> Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::from_iter([("xyzzy".into(), (0, 0))])))
+src/source/mssql/mod.rs:298:9: replace MssqlSource::fetch_mssql_decimal_catalog_hints -> Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::from_iter([("xyzzy".into(), (0, 1))])))
+src/source/mssql/mod.rs:298:9: replace MssqlSource::fetch_mssql_decimal_catalog_hints -> Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::from_iter([("xyzzy".into(), (1, -1))])))
+src/source/mssql/mod.rs:298:9: replace MssqlSource::fetch_mssql_decimal_catalog_hints -> Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::from_iter([("xyzzy".into(), (1, 0))])))
+src/source/mssql/mod.rs:298:9: replace MssqlSource::fetch_mssql_decimal_catalog_hints -> Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::from_iter([("xyzzy".into(), (1, 1))])))
+src/source/mssql/mod.rs:298:9: replace MssqlSource::fetch_mssql_decimal_catalog_hints -> Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::from_iter([(String::new(), (0, -1))])))
+src/source/mssql/mod.rs:298:9: replace MssqlSource::fetch_mssql_decimal_catalog_hints -> Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::from_iter([(String::new(), (0, 0))])))
+src/source/mssql/mod.rs:298:9: replace MssqlSource::fetch_mssql_decimal_catalog_hints -> Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::from_iter([(String::new(), (0, 1))])))
+src/source/mssql/mod.rs:298:9: replace MssqlSource::fetch_mssql_decimal_catalog_hints -> Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::from_iter([(String::new(), (1, -1))])))
+src/source/mssql/mod.rs:298:9: replace MssqlSource::fetch_mssql_decimal_catalog_hints -> Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::from_iter([(String::new(), (1, 0))])))
+src/source/mssql/mod.rs:298:9: replace MssqlSource::fetch_mssql_decimal_catalog_hints -> Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::from_iter([(String::new(), (1, 1))])))
+src/source/mssql/mod.rs:298:9: replace MssqlSource::fetch_mssql_decimal_catalog_hints -> Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::new()))
+src/source/mssql/mod.rs:355:35: replace > with == in catalog_decimal_to_params
+src/source/mssql/mod.rs:355:35: replace > with >= in catalog_decimal_to_params
+src/source/mssql/mod.rs:483:27: replace || with && in mssql_joins_or_comma
+src/source/mssql/mod.rs:497:24: replace || with && in skip_mssql_optional_alias
+src/source/mssql/mod.rs:509:5: replace mssql_starts_clause_boundary -> bool with false
+src/source/mssql/mod.rs:509:5: replace mssql_starts_clause_boundary -> bool with true
+src/source/mssql/mod.rs:533:9: replace <impl Source for MssqlSource>::export -> Result<()> with Ok(())
+src/source/mssql/mod.rs:557:64: replace > with < in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:557:64: replace > with == in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:557:64: replace > with >= in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:570:28: replace > with < in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:570:28: replace > with == in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:570:28: replace > with >= in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:579:32: replace > with < in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:579:32: replace > with == in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:579:32: replace > with >= in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:606:42: replace > with < in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:606:42: replace > with == in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:606:42: replace > with >= in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:620:50: replace match guard columns.is_empty() with false in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:620:50: replace match guard columns.is_empty() with true in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:647:38: replace >= with < in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:663:32: delete ! in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:663:45: replace && with || in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:663:50: replace > with < in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:663:50: replace > with == in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:663:50: replace > with >= in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:664:66: replace / with % in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:664:66: replace / with * in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:669:56: replace * with + in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:669:56: replace * with / in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:669:63: replace * with + in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:669:63: replace * with / in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:669:71: replace / with % in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:669:71: replace / with * in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:694:16: delete ! in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:694:32: replace || with && in <impl Source for MssqlSource>::export
+src/source/mssql/mod.rs:711:9: replace <impl Source for MssqlSource>::query_scalar -> Result<Option<String>> with Ok(None)
+src/source/mssql/mod.rs:711:9: replace <impl Source for MssqlSource>::query_scalar -> Result<Option<String>> with Ok(Some("xyzzy".into()))
+src/source/mssql/mod.rs:711:9: replace <impl Source for MssqlSource>::query_scalar -> Result<Option<String>> with Ok(Some(String::new()))
+src/source/mssql/mod.rs:732:9: replace <impl Source for MssqlSource>::type_mappings -> Result<Vec<TypeMapping>> with Ok(vec![])
+src/source/mssql/mod.rs:759:9: replace <impl Source for MssqlSource>::sample_pressure -> Option<u64> with None
+src/source/mssql/mod.rs:759:9: replace <impl Source for MssqlSource>::sample_pressure -> Option<u64> with Some(0)
+src/source/mssql/mod.rs:759:9: replace <impl Source for MssqlSource>::sample_pressure -> Option<u64> with Some(1)
+src/source/mssql/mod.rs:76:12: delete ! in <impl Drop for MssqlSource>::drop
+src/source/mssql/mod.rs:76:9: replace <impl Drop for MssqlSource>::drop with ()
+src/source/mssql/mod.rs:786:9: replace MssqlSource::harm_counters -> Option<Vec<(String, i64)>> with None
+src/source/mssql/mod.rs:786:9: replace MssqlSource::harm_counters -> Option<Vec<(String, i64)>> with Some(vec![("xyzzy".into(), -1)])
+src/source/mssql/mod.rs:786:9: replace MssqlSource::harm_counters -> Option<Vec<(String, i64)>> with Some(vec![("xyzzy".into(), 0)])
+src/source/mssql/mod.rs:786:9: replace MssqlSource::harm_counters -> Option<Vec<(String, i64)>> with Some(vec![("xyzzy".into(), 1)])
+src/source/mssql/mod.rs:786:9: replace MssqlSource::harm_counters -> Option<Vec<(String, i64)>> with Some(vec![(String::new(), -1)])
+src/source/mssql/mod.rs:786:9: replace MssqlSource::harm_counters -> Option<Vec<(String, i64)>> with Some(vec![(String::new(), 0)])
+src/source/mssql/mod.rs:786:9: replace MssqlSource::harm_counters -> Option<Vec<(String, i64)>> with Some(vec![(String::new(), 1)])
+src/source/mssql/mod.rs:786:9: replace MssqlSource::harm_counters -> Option<Vec<(String, i64)>> with Some(vec![])
+src/source/mssql/mod.rs:805:9: replace MssqlSource::has_view_server_state -> Option<bool> with None
+src/source/mssql/mod.rs:805:9: replace MssqlSource::has_view_server_state -> Option<bool> with Some(false)
+src/source/mssql/mod.rs:805:9: replace MssqlSource::has_view_server_state -> Option<bool> with Some(true)
+src/source/mssql/mod.rs:817:44: replace == with != in MssqlSource::has_view_server_state
+src/source/mssql/mod.rs:853:78: replace != with == in MssqlSource::cdc_health
+src/source/mssql/mod.rs:903:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with None
+src/source/mssql/mod.rs:903:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![("xyzzy".into(), -1)])
+src/source/mssql/mod.rs:903:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![("xyzzy".into(), 0)])
+src/source/mssql/mod.rs:903:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![("xyzzy".into(), 1)])
+src/source/mssql/mod.rs:903:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![(String::new(), -1)])
+src/source/mssql/mod.rs:903:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![(String::new(), 0)])
+src/source/mssql/mod.rs:903:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![(String::new(), 1)])
+src/source/mssql/mod.rs:903:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![])
+src/source/mssql/mod.rs:912:5: replace sample_view_server_state -> Option<bool> with None
+src/source/mssql/mod.rs:912:5: replace sample_view_server_state -> Option<bool> with Some(false)
+src/source/mssql/mod.rs:912:5: replace sample_view_server_state -> Option<bool> with Some(true)
+src/source/mssql/mod.rs:934:5: replace emit_mssql_batch -> Result<usize> with Ok(0)
+src/source/mssql/mod.rs:934:5: replace emit_mssql_batch -> Result<usize> with Ok(1)
+src/source/mssql/mod.rs:945:8: delete ! in emit_mssql_batch
+src/source/mssql/mod.rs:958:5: replace scalar_to_string -> Option<String> with None
+src/source/mssql/mod.rs:958:5: replace scalar_to_string -> Option<String> with Some("xyzzy".into())
+src/source/mssql/mod.rs:958:5: replace scalar_to_string -> Option<String> with Some(String::new())
 src/source/mysql/arrow_convert.rs:1009:13: delete match arm Some(Value::Int(v)) in mysql_decimal_to_decimal256
 src/source/mysql/arrow_convert.rs:100:9: delete match arm MYSQL_TYPE_TIMESTAMP | MYSQL_TYPE_TIMESTAMP2 in mysql_native_type_name
 src/source/mysql/arrow_convert.rs:1020:13: delete match arm Some(Value::UInt(v)) in mysql_decimal_to_decimal256
@@ -685,6 +1119,83 @@ src/source/mysql/cdc.rs:98:9: replace MysqlChangeStream::current_coordinates -> 
 src/source/mysql/cdc.rs:98:9: replace MysqlChangeStream::current_coordinates -> Result<(String, u64)> with Ok(("xyzzy".into(), 1))
 src/source/mysql/cdc.rs:98:9: replace MysqlChangeStream::current_coordinates -> Result<(String, u64)> with Ok((String::new(), 0))
 src/source/mysql/cdc.rs:98:9: replace MysqlChangeStream::current_coordinates -> Result<(String, u64)> with Ok((String::new(), 1))
+src/source/mysql/mod.rs:109:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with None
+src/source/mysql/mod.rs:109:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![("xyzzy".into(), -1)])
+src/source/mysql/mod.rs:109:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![("xyzzy".into(), 0)])
+src/source/mysql/mod.rs:109:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![("xyzzy".into(), 1)])
+src/source/mysql/mod.rs:109:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![(String::new(), -1)])
+src/source/mysql/mod.rs:109:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![(String::new(), 0)])
+src/source/mysql/mod.rs:109:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![(String::new(), 1)])
+src/source/mysql/mod.rs:109:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![])
+src/source/mysql/mod.rs:151:26: replace match guard cfg.mode.is_enforced() with false in MysqlSource::connect_with_tls
+src/source/mysql/mod.rs:151:26: replace match guard cfg.mode.is_enforced() with true in MysqlSource::connect_with_tls
+src/source/mysql/mod.rs:186:22: replace match guard cfg.mode.is_enforced() with false in connect_pool
+src/source/mysql/mod.rs:186:22: replace match guard cfg.mode.is_enforced() with true in connect_pool
+src/source/mysql/mod.rs:252:5: replace introspect_mysql_table_for_chunking -> Result<crate::source::TableIntrospection> with Ok(Default::default())
+src/source/mysql/mod.rs:277:38: replace > with < in introspect_mysql_table_for_chunking
+src/source/mysql/mod.rs:277:38: replace > with == in introspect_mysql_table_for_chunking
+src/source/mysql/mod.rs:277:38: replace > with >= in introspect_mysql_table_for_chunking
+src/source/mysql/mod.rs:279:33: replace > with < in introspect_mysql_table_for_chunking
+src/source/mysql/mod.rs:279:33: replace > with == in introspect_mysql_table_for_chunking
+src/source/mysql/mod.rs:279:33: replace > with >= in introspect_mysql_table_for_chunking
+src/source/mysql/mod.rs:280:31: replace / with % in introspect_mysql_table_for_chunking
+src/source/mysql/mod.rs:280:31: replace / with * in introspect_mysql_table_for_chunking
+src/source/mysql/mod.rs:299:47: replace > with < in introspect_mysql_table_for_chunking
+src/source/mysql/mod.rs:299:47: replace > with == in introspect_mysql_table_for_chunking
+src/source/mysql/mod.rs:299:47: replace > with >= in introspect_mysql_table_for_chunking
+src/source/mysql/mod.rs:334:24: replace match guard matches!( t.as_str(), "tinyint" | "smallint" | "mediumint" | "int" | "bigint" ) with false in introspect_mysql_table_for_chunking
+src/source/mysql/mod.rs:334:24: replace match guard matches!( t.as_str(), "tinyint" | "smallint" | "mediumint" | "int" | "bigint" ) with true in introspect_mysql_table_for_chunking
+src/source/mysql/mod.rs:378:41: replace == with != in introspect_mysql_table_for_chunking
+src/source/mysql/mod.rs:379:27: replace == with != in introspect_mysql_table_for_chunking
+src/source/mysql/mod.rs:380:17: replace && with || in introspect_mysql_table_for_chunking
+src/source/mysql/mod.rs:381:17: replace && with || in introspect_mysql_table_for_chunking
+src/source/mysql/mod.rs:381:20: delete ! in introspect_mysql_table_for_chunking
+src/source/mysql/mod.rs:397:5: replace build_mysql_ssl_opts -> SslOpts with Default::default()
+src/source/mysql/mod.rs:471:9: replace <impl Drop for MysqlSessionGuard<'_>>::drop with ()
+src/source/mysql/mod.rs:499:5: replace mysql_run_export -> Result<usize> with Ok(0)
+src/source/mysql/mod.rs:499:5: replace mysql_run_export -> Result<usize> with Ok(1)
+src/source/mysql/mod.rs:552:26: replace >= with < in mysql_run_export
+src/source/mysql/mod.rs:553:24: replace += with *= in mysql_run_export
+src/source/mysql/mod.rs:553:24: replace += with -= in mysql_run_export
+src/source/mysql/mod.rs:562:16: delete ! in mysql_run_export
+src/source/mysql/mod.rs:562:36: replace && with || in mysql_run_export
+src/source/mysql/mod.rs:562:50: replace > with < in mysql_run_export
+src/source/mysql/mod.rs:562:50: replace > with == in mysql_run_export
+src/source/mysql/mod.rs:562:50: replace > with >= in mysql_run_export
+src/source/mysql/mod.rs:564:50: replace / with % in mysql_run_export
+src/source/mysql/mod.rs:564:50: replace / with * in mysql_run_export
+src/source/mysql/mod.rs:568:40: replace * with + in mysql_run_export
+src/source/mysql/mod.rs:568:40: replace * with / in mysql_run_export
+src/source/mysql/mod.rs:568:47: replace * with + in mysql_run_export
+src/source/mysql/mod.rs:568:47: replace * with / in mysql_run_export
+src/source/mysql/mod.rs:568:55: replace / with % in mysql_run_export
+src/source/mysql/mod.rs:568:55: replace / with * in mysql_run_export
+src/source/mysql/mod.rs:605:8: delete ! in mysql_run_export
+src/source/mysql/mod.rs:606:20: replace += with *= in mysql_run_export
+src/source/mysql/mod.rs:606:20: replace += with -= in mysql_run_export
+src/source/mysql/mod.rs:621:9: replace <impl super::Source for MysqlSource>::export -> Result<()> with Ok(())
+src/source/mysql/mod.rs:636:63: replace > with < in <impl super::Source for MysqlSource>::export
+src/source/mysql/mod.rs:636:63: replace > with == in <impl super::Source for MysqlSource>::export
+src/source/mysql/mod.rs:636:63: replace > with >= in <impl super::Source for MysqlSource>::export
+src/source/mysql/mod.rs:637:57: replace * with + in <impl super::Source for MysqlSource>::export
+src/source/mysql/mod.rs:637:57: replace * with / in <impl super::Source for MysqlSource>::export
+src/source/mysql/mod.rs:64:5: replace lean_pool_opts -> PoolOpts with Default::default()
+src/source/mysql/mod.rs:663:23: replace == with != in <impl super::Source for MysqlSource>::export
+src/source/mysql/mod.rs:671:9: replace <impl super::Source for MysqlSource>::query_scalar -> Result<Option<String>> with Ok(None)
+src/source/mysql/mod.rs:671:9: replace <impl super::Source for MysqlSource>::query_scalar -> Result<Option<String>> with Ok(Some("xyzzy".into()))
+src/source/mysql/mod.rs:671:9: replace <impl super::Source for MysqlSource>::query_scalar -> Result<Option<String>> with Ok(Some(String::new()))
+src/source/mysql/mod.rs:677:21: delete match arm Some(mysql::Value::Bytes(b)) in <impl super::Source for MysqlSource>::query_scalar
+src/source/mysql/mod.rs:680:21: delete match arm Some(mysql::Value::Int(v)) in <impl super::Source for MysqlSource>::query_scalar
+src/source/mysql/mod.rs:681:21: delete match arm Some(mysql::Value::UInt(v)) in <impl super::Source for MysqlSource>::query_scalar
+src/source/mysql/mod.rs:682:21: delete match arm Some(mysql::Value::Float(v)) in <impl super::Source for MysqlSource>::query_scalar
+src/source/mysql/mod.rs:683:21: delete match arm Some(mysql::Value::Double(v)) in <impl super::Source for MysqlSource>::query_scalar
+src/source/mysql/mod.rs:696:9: replace <impl super::Source for MysqlSource>::type_mappings -> Result<Vec<crate::types::TypeMapping>> with Ok(vec![])
+src/source/mysql/mod.rs:725:9: replace <impl super::Source for MysqlSource>::sample_pressure -> Option<u64> with None
+src/source/mysql/mod.rs:725:9: replace <impl super::Source for MysqlSource>::sample_pressure -> Option<u64> with Some(0)
+src/source/mysql/mod.rs:725:9: replace <impl super::Source for MysqlSource>::sample_pressure -> Option<u64> with Some(1)
+src/source/mysql/mod.rs:84:5: replace mysql_sample_extraction_pressure -> Option<u64> with None
+src/source/mysql/mod.rs:84:5: replace mysql_sample_extraction_pressure -> Option<u64> with Some(0)
+src/source/mysql/mod.rs:84:5: replace mysql_sample_extraction_pressure -> Option<u64> with Some(1)
 src/source/postgres/arrow_convert.rs:101:12: replace == with != in <impl PgFromSql<'a> for PgJsonRawText<'a>>::accepts
 src/source/postgres/arrow_convert.rs:101:27: replace || with && in <impl PgFromSql<'a> for PgJsonRawText<'a>>::accepts
 src/source/postgres/arrow_convert.rs:101:33: replace == with != in <impl PgFromSql<'a> for PgJsonRawText<'a>>::accepts
@@ -901,6 +1412,122 @@ src/source/postgres/cdc.rs:526:18: replace match guard u.starts_with("day") with
 src/source/postgres/cdc.rs:71:26: replace match guard cfg.mode.is_enforced() with false in PgChangeStream::open
 src/source/postgres/cdc.rs:71:26: replace match guard cfg.mode.is_enforced() with true in PgChangeStream::open
 src/source/postgres/cdc.rs:94:12: delete ! in PgChangeStream::open
+src/source/postgres/mod.rs:143:9: replace PgTxnGuard<'a>::commit -> Result<()> with Ok(())
+src/source/postgres/mod.rs:151:12: delete ! in <impl Drop for PgTxnGuard<'_>>::drop
+src/source/postgres/mod.rs:151:9: replace <impl Drop for PgTxnGuard<'_>>::drop with ()
+src/source/postgres/mod.rs:173:5: replace sample_temp_bytes -> Option<i64> with None
+src/source/postgres/mod.rs:173:5: replace sample_temp_bytes -> Option<i64> with Some(-1)
+src/source/postgres/mod.rs:173:5: replace sample_temp_bytes -> Option<i64> with Some(0)
+src/source/postgres/mod.rs:173:5: replace sample_temp_bytes -> Option<i64> with Some(1)
+src/source/postgres/mod.rs:199:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with None
+src/source/postgres/mod.rs:199:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![("xyzzy".into(), -1)])
+src/source/postgres/mod.rs:199:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![("xyzzy".into(), 0)])
+src/source/postgres/mod.rs:199:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![("xyzzy".into(), 1)])
+src/source/postgres/mod.rs:199:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![(String::new(), -1)])
+src/source/postgres/mod.rs:199:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![(String::new(), 0)])
+src/source/postgres/mod.rs:199:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![(String::new(), 1)])
+src/source/postgres/mod.rs:199:5: replace sample_harm_counters -> Option<Vec<(String, i64)>> with Some(vec![])
+src/source/postgres/mod.rs:240:5: replace pg_fetch_work_mem_bytes -> Option<i64> with None
+src/source/postgres/mod.rs:240:5: replace pg_fetch_work_mem_bytes -> Option<i64> with Some(-1)
+src/source/postgres/mod.rs:240:5: replace pg_fetch_work_mem_bytes -> Option<i64> with Some(0)
+src/source/postgres/mod.rs:240:5: replace pg_fetch_work_mem_bytes -> Option<i64> with Some(1)
+src/source/postgres/mod.rs:286:5: replace pg_sample_checkpoints_req -> Option<i64> with None
+src/source/postgres/mod.rs:286:5: replace pg_sample_checkpoints_req -> Option<i64> with Some(-1)
+src/source/postgres/mod.rs:286:5: replace pg_sample_checkpoints_req -> Option<i64> with Some(0)
+src/source/postgres/mod.rs:286:5: replace pg_sample_checkpoints_req -> Option<i64> with Some(1)
+src/source/postgres/mod.rs:309:5: replace introspect_pg_table_for_chunking -> Result<crate::source::TableIntrospection> with Ok(Default::default())
+src/source/postgres/mod.rs:329:41: replace > with < in introspect_pg_table_for_chunking
+src/source/postgres/mod.rs:329:41: replace > with == in introspect_pg_table_for_chunking
+src/source/postgres/mod.rs:329:41: replace > with >= in introspect_pg_table_for_chunking
+src/source/postgres/mod.rs:330:29: replace / with % in introspect_pg_table_for_chunking
+src/source/postgres/mod.rs:330:29: replace / with * in introspect_pg_table_for_chunking
+src/source/postgres/mod.rs:345:42: replace == with != in introspect_pg_table_for_chunking
+src/source/postgres/mod.rs:381:27: replace == with != in introspect_pg_table_for_chunking
+src/source/postgres/mod.rs:381:38: replace && with || in introspect_pg_table_for_chunking
+src/source/postgres/mod.rs:381:41: delete ! in introspect_pg_table_for_chunking
+src/source/postgres/mod.rs:408:22: replace match guard cfg.mode.is_enforced() with false in connect_client
+src/source/postgres/mod.rs:408:22: replace match guard cfg.mode.is_enforced() with true in connect_client
+src/source/postgres/mod.rs:436:5: replace pg_run_export -> Result<(usize, bool)> with Ok((0, false))
+src/source/postgres/mod.rs:436:5: replace pg_run_export -> Result<(usize, bool)> with Ok((0, true))
+src/source/postgres/mod.rs:436:5: replace pg_run_export -> Result<(usize, bool)> with Ok((1, false))
+src/source/postgres/mod.rs:436:5: replace pg_run_export -> Result<(usize, bool)> with Ok((1, true))
+src/source/postgres/mod.rs:437:35: replace > with < in pg_run_export
+src/source/postgres/mod.rs:437:35: replace > with == in pg_run_export
+src/source/postgres/mod.rs:437:35: replace > with >= in pg_run_export
+src/source/postgres/mod.rs:443:30: replace > with < in pg_run_export
+src/source/postgres/mod.rs:443:30: replace > with == in pg_run_export
+src/source/postgres/mod.rs:443:30: replace > with >= in pg_run_export
+src/source/postgres/mod.rs:515:20: replace += with *= in pg_run_export
+src/source/postgres/mod.rs:515:20: replace += with -= in pg_run_export
+src/source/postgres/mod.rs:528:12: delete ! in pg_run_export
+src/source/postgres/mod.rs:530:26: replace > with < in pg_run_export
+src/source/postgres/mod.rs:530:26: replace > with == in pg_run_export
+src/source/postgres/mod.rs:530:26: replace > with >= in pg_run_export
+src/source/postgres/mod.rs:533:46: replace / with % in pg_run_export
+src/source/postgres/mod.rs:533:46: replace / with * in pg_run_export
+src/source/postgres/mod.rs:534:46: replace * with + in pg_run_export
+src/source/postgres/mod.rs:534:46: replace * with / in pg_run_export
+src/source/postgres/mod.rs:534:52: replace / with % in pg_run_export
+src/source/postgres/mod.rs:534:52: replace / with * in pg_run_export
+src/source/postgres/mod.rs:535:38: replace * with + in pg_run_export
+src/source/postgres/mod.rs:535:38: replace * with / in pg_run_export
+src/source/postgres/mod.rs:535:54: replace / with % in pg_run_export
+src/source/postgres/mod.rs:535:54: replace / with * in pg_run_export
+src/source/postgres/mod.rs:538:44: replace * with + in pg_run_export
+src/source/postgres/mod.rs:538:44: replace * with / in pg_run_export
+src/source/postgres/mod.rs:538:51: replace * with + in pg_run_export
+src/source/postgres/mod.rs:538:51: replace * with / in pg_run_export
+src/source/postgres/mod.rs:538:59: replace / with % in pg_run_export
+src/source/postgres/mod.rs:538:59: replace / with * in pg_run_export
+src/source/postgres/mod.rs:572:22: replace < with <= in pg_run_export
+src/source/postgres/mod.rs:572:22: replace < with == in pg_run_export
+src/source/postgres/mod.rs:572:22: replace < with > in pg_run_export
+src/source/postgres/mod.rs:591:9: replace <impl super::Source for PostgresSource>::export -> Result<()> with Ok(())
+src/source/postgres/mod.rs:59:5: replace detect_pg_transaction_pooler -> bool with false
+src/source/postgres/mod.rs:59:5: replace detect_pg_transaction_pooler -> bool with true
+src/source/postgres/mod.rs:623:12: delete ! in <impl super::Source for PostgresSource>::export
+src/source/postgres/mod.rs:632:9: replace <impl super::Source for PostgresSource>::query_scalar -> Result<Option<String>> with Ok(None)
+src/source/postgres/mod.rs:632:9: replace <impl super::Source for PostgresSource>::query_scalar -> Result<Option<String>> with Ok(Some("xyzzy".into()))
+src/source/postgres/mod.rs:632:9: replace <impl super::Source for PostgresSource>::query_scalar -> Result<Option<String>> with Ok(Some(String::new()))
+src/source/postgres/mod.rs:667:9: replace <impl super::Source for PostgresSource>::type_mappings -> Result<Vec<TypeMapping>> with Ok(vec![])
+src/source/postgres/mod.rs:686:9: replace <impl super::Source for PostgresSource>::sample_pressure -> Option<u64> with None
+src/source/postgres/mod.rs:686:9: replace <impl super::Source for PostgresSource>::sample_pressure -> Option<u64> with Some(0)
+src/source/postgres/mod.rs:686:9: replace <impl super::Source for PostgresSource>::sample_pressure -> Option<u64> with Some(1)
+src/source/postgres/mod.rs:699:5: replace pg_numeric_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with None
+src/source/postgres/mod.rs:699:5: replace pg_numeric_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::from_iter([("xyzzy".into(), (0, -1))]))
+src/source/postgres/mod.rs:699:5: replace pg_numeric_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::from_iter([("xyzzy".into(), (0, 0))]))
+src/source/postgres/mod.rs:699:5: replace pg_numeric_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::from_iter([("xyzzy".into(), (0, 1))]))
+src/source/postgres/mod.rs:699:5: replace pg_numeric_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::from_iter([("xyzzy".into(), (1, -1))]))
+src/source/postgres/mod.rs:699:5: replace pg_numeric_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::from_iter([("xyzzy".into(), (1, 0))]))
+src/source/postgres/mod.rs:699:5: replace pg_numeric_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::from_iter([("xyzzy".into(), (1, 1))]))
+src/source/postgres/mod.rs:699:5: replace pg_numeric_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::from_iter([(String::new(), (0, -1))]))
+src/source/postgres/mod.rs:699:5: replace pg_numeric_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::from_iter([(String::new(), (0, 0))]))
+src/source/postgres/mod.rs:699:5: replace pg_numeric_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::from_iter([(String::new(), (0, 1))]))
+src/source/postgres/mod.rs:699:5: replace pg_numeric_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::from_iter([(String::new(), (1, -1))]))
+src/source/postgres/mod.rs:699:5: replace pg_numeric_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::from_iter([(String::new(), (1, 0))]))
+src/source/postgres/mod.rs:699:5: replace pg_numeric_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::from_iter([(String::new(), (1, 1))]))
+src/source/postgres/mod.rs:699:5: replace pg_numeric_catalog_hints_opt -> Option<HashMap<String, (u8, i8)>> with Some(HashMap::new())
+src/source/postgres/mod.rs:719:5: replace pg_fetch_numeric_catalog_hints -> crate::error::Result<Option<HashMap<String, (u8, i8)>>> with Ok(None)
+src/source/postgres/mod.rs:719:5: replace pg_fetch_numeric_catalog_hints -> crate::error::Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::from_iter([("xyzzy".into(), (0, -1))])))
+src/source/postgres/mod.rs:719:5: replace pg_fetch_numeric_catalog_hints -> crate::error::Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::from_iter([("xyzzy".into(), (0, 0))])))
+src/source/postgres/mod.rs:719:5: replace pg_fetch_numeric_catalog_hints -> crate::error::Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::from_iter([("xyzzy".into(), (0, 1))])))
+src/source/postgres/mod.rs:719:5: replace pg_fetch_numeric_catalog_hints -> crate::error::Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::from_iter([("xyzzy".into(), (1, -1))])))
+src/source/postgres/mod.rs:719:5: replace pg_fetch_numeric_catalog_hints -> crate::error::Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::from_iter([("xyzzy".into(), (1, 0))])))
+src/source/postgres/mod.rs:719:5: replace pg_fetch_numeric_catalog_hints -> crate::error::Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::from_iter([("xyzzy".into(), (1, 1))])))
+src/source/postgres/mod.rs:719:5: replace pg_fetch_numeric_catalog_hints -> crate::error::Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::from_iter([(String::new(), (0, -1))])))
+src/source/postgres/mod.rs:719:5: replace pg_fetch_numeric_catalog_hints -> crate::error::Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::from_iter([(String::new(), (0, 0))])))
+src/source/postgres/mod.rs:719:5: replace pg_fetch_numeric_catalog_hints -> crate::error::Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::from_iter([(String::new(), (0, 1))])))
+src/source/postgres/mod.rs:719:5: replace pg_fetch_numeric_catalog_hints -> crate::error::Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::from_iter([(String::new(), (1, -1))])))
+src/source/postgres/mod.rs:719:5: replace pg_fetch_numeric_catalog_hints -> crate::error::Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::from_iter([(String::new(), (1, 0))])))
+src/source/postgres/mod.rs:719:5: replace pg_fetch_numeric_catalog_hints -> crate::error::Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::from_iter([(String::new(), (1, 1))])))
+src/source/postgres/mod.rs:719:5: replace pg_fetch_numeric_catalog_hints -> crate::error::Result<Option<HashMap<String, (u8, i8)>>> with Ok(Some(HashMap::new()))
+src/source/postgres/mod.rs:750:12: delete ! in pg_fetch_numeric_catalog_hints
+src/source/postgres/mod.rs:774:5: replace is_pg_numeric_information_type -> bool with false
+src/source/postgres/mod.rs:774:5: replace is_pg_numeric_information_type -> bool with true
+src/source/postgres/mod.rs:776:9: replace || with && in is_pg_numeric_information_type
+src/source/postgres/mod.rs:777:9: replace || with && in is_pg_numeric_information_type
+src/source/postgres/mod.rs:95:26: replace match guard cfg.mode.is_enforced() with false in PostgresSource::connect_with_tls
+src/source/postgres/mod.rs:95:26: replace match guard cfg.mode.is_enforced() with true in PostgresSource::connect_with_tls
 src/types/target.rs:141:9: replace TargetStatus::label -> &'static str with ""
 src/types/target.rs:141:9: replace TargetStatus::label -> &'static str with "xyzzy"
 src/types/target.rs:266:5: replace unsupported_reason -> String with "xyzzy".into()

--- a/docs/mutants-baseline.txt
+++ b/docs/mutants-baseline.txt
@@ -1,0 +1,914 @@
+# Mutation-testing baseline — the ADJUDICATED missed-mutant ledger.
+#
+# Every line is a mutant the lib cycle does not catch, with a standing verdict:
+# either LIVE-GUARDED (orchestration / CDC adapters / arrow_convert — their
+# oracles are the live suites, exercised by the weekly live-cycle runs) or
+# ACCEPTED (operator-UX output, Display impls, log-only paths). Equivalent
+# mutants are NOT here — they are excluded with reasons in .cargo/mutants.toml.
+#
+# The nightly mutants job diffs its missed list against this file: a missed
+# mutant NOT listed here fails the job. This file only ever SHRINKS (delete
+# lines as tests close them); adding a line requires the same adjudication.
+# Corpus: 3766 mutants over 3 tiers, 2026-07-14 (docs/mutation-plan.md).
+src/manifest.rs:362:9: replace <impl std::fmt::Display for ManifestInconsistency>::fmt -> std::fmt::Result with Ok(Default::default())
+src/pipeline/chunked/resume_m8.rs:286:22: replace > with >= in apply_m8_resume_decisions
+src/pipeline/chunked/resume_m8.rs:296:22: replace > with >= in apply_m8_resume_decisions
+src/pipeline/finalize.rs:124:9: delete match arm "success" in finalize_manifest
+src/pipeline/finalize.rs:125:9: delete match arm "failed" in finalize_manifest
+src/pipeline/finalize.rs:156:25: delete ! in finalize_manifest
+src/pipeline/finalize.rs:156:25: replace match guard !s.is_empty() && !t.is_empty() with false in finalize_manifest
+src/pipeline/finalize.rs:156:25: replace match guard !s.is_empty() && !t.is_empty() with true in finalize_manifest
+src/pipeline/finalize.rs:156:39: replace && with || in finalize_manifest
+src/pipeline/finalize.rs:156:42: delete ! in finalize_manifest
+src/pipeline/finalize.rs:189:8: delete ! in finalize_manifest
+src/pipeline/finalize.rs:195:40: replace || with && in finalize_manifest
+src/pipeline/finalize.rs:262:5: replace finalize_validate_manifest with ()
+src/pipeline/finalize.rs:277:44: replace == with != in finalize_validate_manifest
+src/pipeline/finalize.rs:298:16: delete ! in finalize_validate_manifest
+src/pipeline/finalize.rs:298:26: replace && with || in finalize_validate_manifest
+src/pipeline/finalize.rs:298:46: replace && with || in finalize_validate_manifest
+src/pipeline/finalize.rs:298:67: replace == with != in finalize_validate_manifest
+src/pipeline/finalize.rs:344:5: replace check_success_gate_for_resume -> Result<()> with Ok(())
+src/pipeline/finalize.rs:348:44: replace == with != in check_success_gate_for_resume
+src/pipeline/finalize.rs:390:5: replace warn_if_prefix_has_completed_run with ()
+src/pipeline/finalize.rs:39:5: replace finalize_run_report with ()
+src/pipeline/finalize.rs:404:44: replace == with != in warn_if_prefix_has_completed_run
+src/pipeline/finalize.rs:453:5: replace destination_has_success -> bool with false
+src/pipeline/finalize.rs:453:5: replace destination_has_success -> bool with true
+src/pipeline/finalize.rs:458:41: replace == with != in destination_has_success
+src/pipeline/finalize.rs:67:16: replace && with || in finalize_run_report
+src/pipeline/finalize.rs:67:19: delete ! in finalize_run_report
+src/pipeline/finalize.rs:70:23: replace == with != in finalize_run_report
+src/pipeline/finalize.rs:70:35: replace && with || in finalize_run_report
+src/pipeline/finalize.rs:70:62: replace > with < in finalize_run_report
+src/pipeline/finalize.rs:70:62: replace > with == in finalize_run_report
+src/pipeline/finalize.rs:70:62: replace > with >= in finalize_run_report
+src/pipeline/finalize.rs:93:5: replace finalize_manifest with ()
+src/pipeline/keyset.rs:118:5: replace run_keyset -> Result<()> with Ok(())
+src/pipeline/keyset.rs:179:28: replace += with *= in run_keyset
+src/pipeline/keyset.rs:179:28: replace += with -= in run_keyset
+src/pipeline/keyset.rs:209:15: replace += with *= in run_keyset
+src/pipeline/keyset.rs:209:15: replace += with -= in run_keyset
+src/pipeline/keyset.rs:213:22: replace < with <= in run_keyset
+src/pipeline/keyset.rs:213:22: replace < with == in run_keyset
+src/pipeline/keyset.rs:213:22: replace < with > in run_keyset
+src/pipeline/keyset.rs:34:9: delete match arm ExtractionStrategy::Keyset(kp) in keyset_plan
+src/pipeline/keyset.rs:69:5: replace read_keyset_page -> Result<Option<KeysetPage>> with Ok(None)
+src/pipeline/keyset.rs:89:13: replace == with != in read_keyset_page
+src/pipeline/single.rs:171:5: replace run_export -> Result<()> with Ok(())
+src/pipeline/single.rs:175:36: replace == with != in run_export
+src/pipeline/single.rs:175:72: replace && with || in run_export
+src/pipeline/single.rs:175:94: replace > with < in run_export
+src/pipeline/single.rs:175:94: replace > with == in run_export
+src/pipeline/single.rs:175:94: replace > with >= in run_export
+src/pipeline/single.rs:274:24: replace += with *= in run_single_export
+src/pipeline/single.rs:274:24: replace += with -= in run_single_export
+src/pipeline/single.rs:28:5: replace run_with_reconnect -> Result<()> with Ok(())
+src/pipeline/single.rs:31:20: replace > with < in run_with_reconnect
+src/pipeline/single.rs:31:20: replace > with == in run_with_reconnect
+src/pipeline/single.rs:31:20: replace > with >= in run_with_reconnect
+src/pipeline/single.rs:342:23: replace > with < in run_single_export
+src/pipeline/single.rs:342:23: replace > with == in run_single_export
+src/pipeline/single.rs:342:23: replace > with >= in run_single_export
+src/pipeline/single.rs:365:48: replace > with < in run_single_export
+src/pipeline/single.rs:365:48: replace > with == in run_single_export
+src/pipeline/single.rs:365:48: replace > with >= in run_single_export
+src/pipeline/single.rs:38:46: replace * with + in run_with_reconnect
+src/pipeline/single.rs:38:46: replace * with / in run_with_reconnect
+src/pipeline/single.rs:38:65: replace - with + in run_with_reconnect
+src/pipeline/single.rs:38:65: replace - with / in run_with_reconnect
+src/pipeline/single.rs:38:70: replace + with * in run_with_reconnect
+src/pipeline/single.rs:38:70: replace + with - in run_with_reconnect
+src/pipeline/single.rs:460:8: delete ! in run_single_export
+src/pipeline/single.rs:473:37: replace > with < in run_single_export
+src/pipeline/single.rs:473:37: replace > with == in run_single_export
+src/pipeline/single.rs:473:37: replace > with >= in run_single_export
+src/pipeline/single.rs:474:12: delete ! in run_single_export
+src/pipeline/single.rs:538:9: replace || with && in is_port_closed
+src/pipeline/single.rs:539:9: replace || with && in is_port_closed
+src/pipeline/single.rs:540:9: replace || with && in is_port_closed
+src/pipeline/single.rs:541:9: replace || with && in is_port_closed
+src/pipeline/single.rs:74:28: replace == with != in run_with_reconnect
+src/pipeline/single.rs:74:33: replace && with || in run_with_reconnect
+src/pipeline/single.rs:79:28: replace < with <= in run_with_reconnect
+src/pipeline/single.rs:79:28: replace < with == in run_with_reconnect
+src/pipeline/single.rs:79:28: replace < with > in run_with_reconnect
+src/pipeline/single.rs:79:54: replace && with || in run_with_reconnect
+src/pipeline/validate_manifest.rs:141:32: replace > with >= in read_capped
+src/pipeline/validate_manifest.rs:210:5: replace default_depth_level -> String with "xyzzy".into()
+src/pipeline/validate_manifest.rs:210:5: replace default_depth_level -> String with String::new()
+src/pipeline/validate_manifest.rs:324:9: replace <impl std::fmt::Display for Failure>::fmt -> std::fmt::Result with Ok(Default::default())
+src/pipeline/validate_manifest.rs:55:47: replace * with +
+src/pipeline/validate_manifest.rs:55:54: replace * with +
+src/pipeline/validate_manifest.rs:565:17: delete field manifest_found from struct ManifestVerification expression in verify_at_destination
+src/pipeline/validate_manifest.rs:566:17: delete field failures from struct ManifestVerification expression in verify_at_destination
+src/pipeline/validate_manifest.rs:642:48: replace += with *= in verify_at_destination
+src/pipeline/validate_manifest.rs:642:48: replace += with -= in verify_at_destination
+src/pipeline/validate_manifest.rs:646:38: replace += with *= in verify_at_destination
+src/pipeline/validate_manifest.rs:662:38: replace += with *= in verify_at_destination
+src/pipeline/validate_manifest.rs:662:38: replace += with -= in verify_at_destination
+src/pipeline/validate_manifest.rs:762:5: replace preview -> String with "xyzzy".into()
+src/pipeline/validate_manifest.rs:762:5: replace preview -> String with String::new()
+src/pipeline/validate_manifest.rs:763:26: replace > with < in preview
+src/pipeline/validate_manifest.rs:763:26: replace > with == in preview
+src/pipeline/validate_manifest.rs:763:26: replace > with >= in preview
+src/source/cdc/value.rs:100:9: replace RivetValue::to_json -> Json with Default::default()
+src/source/cdc/value.rs:222:21: delete match arm Some(V::UInt(u)) in build_column
+src/source/cdc/value.rs:222:59: replace != with == in build_column
+src/source/cdc/value.rs:242:21: delete match arm Some(V::UInt(u)) in build_column
+src/source/cdc/value.rs:253:21: delete match arm Some(V::Int(i)) in build_column
+src/source/cdc/value.rs:31:5: replace epoch_days -> i32 with -1
+src/source/cdc/value.rs:31:5: replace epoch_days -> i32 with 0
+src/source/cdc/value.rs:31:5: replace epoch_days -> i32 with 1
+src/source/cdc/value.rs:357:21: delete match arm Some(V::Bytes(by)) in build_column
+src/source/cdc/value.rs:438:21: delete match arm V::UInt(u) in cells_checksum
+src/source/cdc/value.rs:438:43: replace != with == in cells_checksum
+src/source/cdc/value.rs:473:25: replace ^= with |= in cells_checksum
+src/source/cdc/value.rs:476:35: replace ^= with |= in cells_checksum
+src/source/cdc/value.rs:479:25: replace ^= with |= in cells_checksum
+src/source/cdc/value.rs:486:25: replace ^= with |= in cells_checksum
+src/source/cdc/value.rs:495:29: delete match arm (DataType::Boolean, V::Bool(b)) in cells_checksum
+src/source/cdc/value.rs:496:29: delete match arm (DataType::Int16, V::Int(i)) in cells_checksum
+src/source/cdc/value.rs:502:29: delete match arm (DataType::Int64, V::Int(i)) in cells_checksum
+src/source/cdc/value.rs:503:29: delete match arm (DataType::Float32, V::Float(x)) in cells_checksum
+src/source/cdc/value.rs:504:29: delete match arm (DataType::Float64, V::Float(x)) in cells_checksum
+src/source/cdc/value.rs:505:29: delete match arm (DataType::Float64, V::Int(i)) in cells_checksum
+src/source/cdc/value.rs:527:9: delete match arm RivetValue::Bool(b) in int_of
+src/source/cdc/value.rs:535:9: delete match arm RivetValue::Int(i) in float_of
+src/source/cdc/value.rs:649:5: replace decimal_to_i256 -> Option<arrow::datatypes::i256> with Some(Default::default())
+src/source/cdc/value.rs:651:9: delete match arm RivetValue::Int(i) in decimal_to_i256
+src/source/cdc/value.rs:652:9: delete match arm RivetValue::UInt(u) in decimal_to_i256
+src/source/cdc/value.rs:653:33: replace match guard f.is_finite() with false in decimal_to_i256
+src/source/cdc/value.rs:653:33: replace match guard f.is_finite() with true in decimal_to_i256
+src/source/cdc/value.rs:667:9: delete match arm RivetValue::UInt(u) in decimal_to_i128
+src/source/cdc/value.rs:671:33: replace match guard f.is_finite() with false in decimal_to_i128
+src/source/cdc/value.rs:671:33: replace match guard f.is_finite() with true in decimal_to_i128
+src/source/cdc/value.rs:73:36: replace * with + in RivetValue::from_mysql
+src/source/cdc/value.rs:73:36: replace * with / in RivetValue::from_mysql
+src/source/cdc/value.rs:73:45: replace + with * in RivetValue::from_mysql
+src/source/cdc/value.rs:73:45: replace + with - in RivetValue::from_mysql
+src/source/cdc/value.rs:73:57: replace * with + in RivetValue::from_mysql
+src/source/cdc/value.rs:73:57: replace * with / in RivetValue::from_mysql
+src/source/cdc/value.rs:73:65: replace + with * in RivetValue::from_mysql
+src/source/cdc/value.rs:73:65: replace + with - in RivetValue::from_mysql
+src/source/cdc/value.rs:73:78: replace * with + in RivetValue::from_mysql
+src/source/cdc/value.rs:73:78: replace * with / in RivetValue::from_mysql
+src/source/cdc/value.rs:73:83: replace + with * in RivetValue::from_mysql
+src/source/cdc/value.rs:73:83: replace + with - in RivetValue::from_mysql
+src/source/cdc/value.rs:74:25: replace * with + in RivetValue::from_mysql
+src/source/cdc/value.rs:74:25: replace * with / in RivetValue::from_mysql
+src/source/cdc/value.rs:75:25: replace + with * in RivetValue::from_mysql
+src/source/cdc/value.rs:75:25: replace + with - in RivetValue::from_mysql
+src/source/cdc/value.rs:767:40: replace + with * in parse_enum_labels
+src/source/cdc/value.rs:767:59: replace + with * in parse_enum_labels
+src/source/cdc/value.rs:76:50: delete - in RivetValue::from_mysql
+src/source/cdc/value.rs:814:62: replace != with == in MysqlCellFix::apply
+src/source/cdc/value.rs:815:63: replace != with == in MysqlCellFix::apply
+src/source/cdc/value.rs:816:53: replace match guard b.len() <= 8 with true in MysqlCellFix::apply
+src/source/cdc/value.rs:817:59: replace << with >> in MysqlCellFix::apply
+src/source/cdc/value.rs:817:65: replace | with ^ in MysqlCellFix::apply
+src/source/cdc/value.rs:826:29: replace >= with < in MysqlCellFix::apply
+src/source/cdc/value.rs:826:35: replace << with >> in MysqlCellFix::apply
+src/source/cdc/value.rs:826:46: replace - with + in MysqlCellFix::apply
+src/source/cdc/value.rs:826:46: replace - with / in MysqlCellFix::apply
+src/source/cdc/value.rs:826:51: replace << with >> in MysqlCellFix::apply
+src/source/cdc/value.rs:830:63: replace match guard b.len() <= 8 with true in MysqlCellFix::apply
+src/source/cdc/value.rs:835:51: replace | with ^ in MysqlCellFix::apply
+src/source/cdc/value.rs:835:66: replace << with >> in MysqlCellFix::apply
+src/source/cdc/value.rs:840:58: replace match guard b.len() < *w with true in MysqlCellFix::apply
+src/source/cdc/value.rs:840:66: replace < with <= in MysqlCellFix::apply
+src/source/cdc/value.rs:85:9: replace RivetValue::estimated_bytes -> usize with 0
+src/source/cdc/value.rs:85:9: replace RivetValue::estimated_bytes -> usize with 1
+src/source/cdc/value.rs:872:5: replace render_str -> String with "xyzzy".into()
+src/source/cdc/value.rs:872:5: replace render_str -> String with String::new()
+src/source/cdc/value.rs:93:94: replace + with * in RivetValue::estimated_bytes
+src/source/cdc/value.rs:93:94: replace + with - in RivetValue::estimated_bytes
+src/source/mssql/arrow_convert.rs:142:21: delete match arm RivetType::Unsupported{reason, ..} in mssql_columns_to_schema
+src/source/mssql/arrow_convert.rs:154:8: delete ! in mssql_columns_to_schema
+src/source/mssql/arrow_convert.rs:170:5: replace mssql_type_mappings -> Vec<TypeMapping> with vec![]
+src/source/mssql/arrow_convert.rs:230:5: replace cell -> Option<&ColumnData<'static>> with None
+src/source/mssql/arrow_convert.rs:237:5: replace decimal_scale_from_rows -> Option<u8> with None
+src/source/mssql/arrow_convert.rs:237:5: replace decimal_scale_from_rows -> Option<u8> with Some(0)
+src/source/mssql/arrow_convert.rs:237:5: replace decimal_scale_from_rows -> Option<u8> with Some(1)
+src/source/mssql/arrow_convert.rs:238:9: delete match arm Some(ColumnData::Numeric(Some(n))) in decimal_scale_from_rows
+src/source/mssql/arrow_convert.rs:320:21: delete match arm Some(ColumnData::String(Some(s))) in build_array
+src/source/mssql/arrow_convert.rs:336:21: delete match arm Some(ColumnData::Binary(Some(bytes))) in build_array
+src/source/mssql/arrow_convert.rs:349:21: delete match arm Some(ColumnData::Guid(Some(g))) in build_array
+src/source/mssql/arrow_convert.rs:360:21: delete match arm Some(ColumnData::Numeric(Some(n))) in build_array
+src/source/mssql/arrow_convert.rs:370:21: delete match arm Some(ColumnData::F64(Some(v))) in build_array
+src/source/mssql/arrow_convert.rs:385:29: replace + with * in build_array
+src/source/mssql/arrow_convert.rs:385:29: replace + with - in build_array
+src/source/mssql/arrow_convert.rs:448:62: replace * with + in build_array
+src/source/mssql/arrow_convert.rs:448:62: replace * with / in build_array
+src/source/mssql/arrow_convert.rs:449:29: replace + with * in build_array
+src/source/mssql/arrow_convert.rs:449:29: replace + with - in build_array
+src/source/mssql/arrow_convert.rs:449:54: replace / with % in build_array
+src/source/mssql/arrow_convert.rs:449:54: replace / with * in build_array
+src/source/mssql/arrow_convert.rs:485:47: replace - with + in rescale_i128
+src/source/mssql/arrow_convert.rs:494:49: replace - with + in rescale_i128
+src/source/mssql/arrow_convert.rs:550:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::num_rows -> usize with 0
+src/source/mssql/arrow_convert.rs:550:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::num_rows -> usize with 1
+src/source/mssql/arrow_convert.rs:553:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::boolean -> Option<bool> with None
+src/source/mssql/arrow_convert.rs:553:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::boolean -> Option<bool> with Some(false)
+src/source/mssql/arrow_convert.rs:553:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::boolean -> Option<bool> with Some(true)
+src/source/mssql/arrow_convert.rs:554:13: delete match arm Some(ColumnData::Bit(Some(v))) in <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::boolean
+src/source/mssql/arrow_convert.rs:559:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::int16 -> Option<i16> with None
+src/source/mssql/arrow_convert.rs:559:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::int16 -> Option<i16> with Some(-1)
+src/source/mssql/arrow_convert.rs:559:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::int16 -> Option<i16> with Some(0)
+src/source/mssql/arrow_convert.rs:559:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::int16 -> Option<i16> with Some(1)
+src/source/mssql/arrow_convert.rs:560:13: delete match arm Some(ColumnData::I16(Some(v))) in <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::int16
+src/source/mssql/arrow_convert.rs:561:13: delete match arm Some(ColumnData::U8(Some(v))) in <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::int16
+src/source/mssql/arrow_convert.rs:566:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::int32 -> Option<i32> with None
+src/source/mssql/arrow_convert.rs:566:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::int32 -> Option<i32> with Some(-1)
+src/source/mssql/arrow_convert.rs:566:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::int32 -> Option<i32> with Some(0)
+src/source/mssql/arrow_convert.rs:566:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::int32 -> Option<i32> with Some(1)
+src/source/mssql/arrow_convert.rs:567:13: delete match arm Some(ColumnData::I32(Some(v))) in <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::int32
+src/source/mssql/arrow_convert.rs:572:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::int64 -> Option<i64> with None
+src/source/mssql/arrow_convert.rs:572:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::int64 -> Option<i64> with Some(-1)
+src/source/mssql/arrow_convert.rs:572:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::int64 -> Option<i64> with Some(0)
+src/source/mssql/arrow_convert.rs:572:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::int64 -> Option<i64> with Some(1)
+src/source/mssql/arrow_convert.rs:573:13: delete match arm Some(ColumnData::I64(Some(v))) in <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::int64
+src/source/mssql/arrow_convert.rs:578:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::uint64 -> Option<u64> with Some(0)
+src/source/mssql/arrow_convert.rs:578:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::uint64 -> Option<u64> with Some(1)
+src/source/mssql/arrow_convert.rs:581:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::float32 -> Option<f32> with None
+src/source/mssql/arrow_convert.rs:581:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::float32 -> Option<f32> with Some(-1.0)
+src/source/mssql/arrow_convert.rs:581:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::float32 -> Option<f32> with Some(0.0)
+src/source/mssql/arrow_convert.rs:581:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::float32 -> Option<f32> with Some(1.0)
+src/source/mssql/arrow_convert.rs:582:13: delete match arm Some(ColumnData::F32(Some(v))) in <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::float32
+src/source/mssql/arrow_convert.rs:587:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::float64 -> Option<f64> with None
+src/source/mssql/arrow_convert.rs:587:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::float64 -> Option<f64> with Some(-1.0)
+src/source/mssql/arrow_convert.rs:587:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::float64 -> Option<f64> with Some(0.0)
+src/source/mssql/arrow_convert.rs:587:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::float64 -> Option<f64> with Some(1.0)
+src/source/mssql/arrow_convert.rs:588:13: delete match arm Some(ColumnData::F64(Some(v))) in <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::float64
+src/source/mssql/arrow_convert.rs:593:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::decimal128 -> Option<i128> with None
+src/source/mssql/arrow_convert.rs:593:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::decimal128 -> Option<i128> with Some(-1)
+src/source/mssql/arrow_convert.rs:593:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::decimal128 -> Option<i128> with Some(0)
+src/source/mssql/arrow_convert.rs:593:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::decimal128 -> Option<i128> with Some(1)
+src/source/mssql/arrow_convert.rs:596:13: delete match arm Some(ColumnData::Numeric(Some(n))) in <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::decimal128
+src/source/mssql/arrow_convert.rs:605:13: delete match arm Some(ColumnData::F64(Some(v))) in <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::decimal128
+src/source/mssql/arrow_convert.rs:610:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::date32 -> Option<i32> with None
+src/source/mssql/arrow_convert.rs:610:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::date32 -> Option<i32> with Some(-1)
+src/source/mssql/arrow_convert.rs:610:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::date32 -> Option<i32> with Some(0)
+src/source/mssql/arrow_convert.rs:610:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::date32 -> Option<i32> with Some(1)
+src/source/mssql/arrow_convert.rs:612:44: replace + with * in <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::date32
+src/source/mssql/arrow_convert.rs:612:44: replace + with - in <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::date32
+src/source/mssql/arrow_convert.rs:615:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::ts_micros -> Option<i64> with None
+src/source/mssql/arrow_convert.rs:615:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::ts_micros -> Option<i64> with Some(-1)
+src/source/mssql/arrow_convert.rs:615:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::ts_micros -> Option<i64> with Some(0)
+src/source/mssql/arrow_convert.rs:615:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::ts_micros -> Option<i64> with Some(1)
+src/source/mssql/arrow_convert.rs:625:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::binary -> Option<Cow<'_, [u8]>> with None
+src/source/mssql/arrow_convert.rs:625:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::binary -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(Vec::new())))
+src/source/mssql/arrow_convert.rs:625:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::binary -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(vec![0])))
+src/source/mssql/arrow_convert.rs:625:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::binary -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(vec![1])))
+src/source/mssql/arrow_convert.rs:625:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::binary -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(Vec::new()).to_owned()))
+src/source/mssql/arrow_convert.rs:625:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::binary -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(vec![0]).to_owned()))
+src/source/mssql/arrow_convert.rs:625:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::binary -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(vec![1]).to_owned()))
+src/source/mssql/arrow_convert.rs:626:13: delete match arm Some(ColumnData::Binary(Some(v))) in <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::binary
+src/source/mssql/arrow_convert.rs:631:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::utf8 -> Option<Cow<'_, [u8]>> with None
+src/source/mssql/arrow_convert.rs:631:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::utf8 -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(Vec::new())))
+src/source/mssql/arrow_convert.rs:631:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::utf8 -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(vec![0])))
+src/source/mssql/arrow_convert.rs:631:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::utf8 -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(vec![1])))
+src/source/mssql/arrow_convert.rs:631:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::utf8 -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(Vec::new()).to_owned()))
+src/source/mssql/arrow_convert.rs:631:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::utf8 -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(vec![0]).to_owned()))
+src/source/mssql/arrow_convert.rs:631:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::utf8 -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(vec![1]).to_owned()))
+src/source/mssql/arrow_convert.rs:632:13: delete match arm Some(ColumnData::String(Some(v))) in <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::utf8
+src/source/mssql/arrow_convert.rs:637:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::time64_micros -> Option<i64> with None
+src/source/mssql/arrow_convert.rs:637:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::time64_micros -> Option<i64> with Some(-1)
+src/source/mssql/arrow_convert.rs:637:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::time64_micros -> Option<i64> with Some(0)
+src/source/mssql/arrow_convert.rs:637:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::time64_micros -> Option<i64> with Some(1)
+src/source/mssql/arrow_convert.rs:642:54: replace * with + in <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::time64_micros
+src/source/mssql/arrow_convert.rs:642:54: replace * with / in <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::time64_micros
+src/source/mssql/arrow_convert.rs:642:66: replace + with * in <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::time64_micros
+src/source/mssql/arrow_convert.rs:642:66: replace + with - in <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::time64_micros
+src/source/mssql/arrow_convert.rs:642:90: replace / with % in <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::time64_micros
+src/source/mssql/arrow_convert.rs:642:90: replace / with * in <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::time64_micros
+src/source/mssql/arrow_convert.rs:646:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::fixed_binary -> Option<Cow<'_, [u8]>> with None
+src/source/mssql/arrow_convert.rs:646:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::fixed_binary -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(Vec::new())))
+src/source/mssql/arrow_convert.rs:646:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::fixed_binary -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(vec![0])))
+src/source/mssql/arrow_convert.rs:646:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::fixed_binary -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(vec![1])))
+src/source/mssql/arrow_convert.rs:646:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::fixed_binary -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(Vec::new()).to_owned()))
+src/source/mssql/arrow_convert.rs:646:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::fixed_binary -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(vec![0]).to_owned()))
+src/source/mssql/arrow_convert.rs:646:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::fixed_binary -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(vec![1]).to_owned()))
+src/source/mssql/arrow_convert.rs:647:13: delete match arm Some(ColumnData::Guid(Some(g))) in <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::fixed_binary
+src/source/mssql/arrow_convert.rs:653:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::decimal256 -> Option<arrow::datatypes::i256> with Some(Default::default())
+src/source/mssql/arrow_convert.rs:662:9: replace <impl crate::source::value_checksum::CellSource for MssqlCellSource<'_>>::list -> Option<Vec<crate::source::value_checksum::ListElem>> with Some(vec![])
+src/source/mssql/cdc.rs:188:9: replace MssqlChangeStream::fill -> Result<()> with Ok(())
+src/source/mssql/cdc.rs:249:26: replace match guard n.starts_with("__$") with false in MssqlChangeStream::fill
+src/source/mssql/cdc.rs:249:26: replace match guard n.starts_with("__$") with true in MssqlChangeStream::fill
+src/source/mssql/cdc.rs:256:16: delete ! in MssqlChangeStream::fill
+src/source/mssql/cdc.rs:262:17: delete match arm ChangeOp::Delete in MssqlChangeStream::fill
+src/source/mssql/cdc.rs:292:39: replace && with || in <impl ChangeStream for MssqlChangeStream>::next_change
+src/source/mssql/cdc.rs:292:42: delete ! in <impl ChangeStream for MssqlChangeStream>::next_change
+src/source/mssql/cdc.rs:292:9: replace <impl ChangeStream for MssqlChangeStream>::next_change -> Option<Result<ChangeEvent>> with None
+src/source/mssql/cdc.rs:304:5: replace map_op -> Option<ChangeOp> with None
+src/source/mssql/cdc.rs:305:9: delete match arm 1 in map_op
+src/source/mssql/cdc.rs:306:9: delete match arm 2 in map_op
+src/source/mssql/cdc.rs:307:9: delete match arm 4 in map_op
+src/source/mssql/cdc.rs:318:9: delete match arm ColumnData::Bit(Some(b)) in cell_to_rivet
+src/source/mssql/cdc.rs:319:9: delete match arm ColumnData::U8(Some(v)) in cell_to_rivet
+src/source/mssql/cdc.rs:320:9: delete match arm ColumnData::I16(Some(v)) in cell_to_rivet
+src/source/mssql/cdc.rs:321:9: delete match arm ColumnData::I32(Some(v)) in cell_to_rivet
+src/source/mssql/cdc.rs:322:9: delete match arm ColumnData::I64(Some(v)) in cell_to_rivet
+src/source/mssql/cdc.rs:323:9: delete match arm ColumnData::F32(Some(v)) in cell_to_rivet
+src/source/mssql/cdc.rs:324:9: delete match arm ColumnData::F64(Some(v)) in cell_to_rivet
+src/source/mssql/cdc.rs:325:9: delete match arm ColumnData::String(Some(s)) in cell_to_rivet
+src/source/mssql/cdc.rs:329:9: delete match arm ColumnData::Guid(Some(g)) in cell_to_rivet
+src/source/mssql/cdc.rs:330:9: delete match arm ColumnData::Binary(Some(b)) in cell_to_rivet
+src/source/mssql/cdc.rs:331:9: delete match arm ColumnData::Numeric(Some(n)) in cell_to_rivet
+src/source/mssql/cdc.rs:338:9: delete match arm ColumnData::DateTimeOffset(_) in cell_to_rivet
+src/source/mssql/cdc.rs:343:9: delete match arm ColumnData::DateTime(_) | ColumnData::DateTime2(_) | ColumnData::SmallDateTime(_) in cell_to_rivet
+src/source/mssql/cdc.rs:348:9: delete match arm ColumnData::Date(_) in cell_to_rivet
+src/source/mssql/cdc.rs:354:9: delete match arm ColumnData::Time(_) in cell_to_rivet
+src/source/mssql/cdc.rs:360:62: replace * with + in cell_to_rivet
+src/source/mssql/cdc.rs:360:62: replace * with / in cell_to_rivet
+src/source/mssql/cdc.rs:361:29: replace + with * in cell_to_rivet
+src/source/mssql/cdc.rs:361:29: replace + with - in cell_to_rivet
+src/source/mssql/cdc.rs:361:53: replace / with % in cell_to_rivet
+src/source/mssql/cdc.rs:361:53: replace / with * in cell_to_rivet
+src/source/mssql/cdc.rs:376:21: replace < with <= in numeric_to_decimal_string
+src/source/mssql/cdc.rs:388:5: replace hex -> String with "xyzzy".into()
+src/source/mssql/cdc.rs:388:5: replace hex -> String with String::new()
+src/source/mssql/cdc.rs:406:20: replace match guard c.mode == TlsMode::Disable || c.accept_invalid_certs with false in connect
+src/source/mssql/cdc.rs:406:20: replace match guard c.mode == TlsMode::Disable || c.accept_invalid_certs with true in connect
+src/source/mssql/cdc.rs:406:27: replace == with != in connect
+src/source/mssql/cdc.rs:406:47: replace || with && in connect
+src/source/mssql/cdc.rs:428:5: replace pin_checkpoint_at_max_lsn -> Result<()> with Ok(())
+src/source/mssql/cdc.rs:441:5: replace probe_max_lsn -> Option<String> with None
+src/source/mssql/cdc.rs:441:5: replace probe_max_lsn -> Option<String> with Some("xyzzy".into())
+src/source/mssql/cdc.rs:441:5: replace probe_max_lsn -> Option<String> with Some(String::new())
+src/source/mssql/cdc.rs:441:8: delete ! in probe_max_lsn
+src/source/mssql/cdc.rs:86:12: delete ! in MssqlChangeStream::open
+src/source/mssql/cdc.rs:89:48: replace || with && in MssqlChangeStream::open
+src/source/mssql/cdc.rs:89:53: replace == with != in MssqlChangeStream::open
+src/source/mssql/cdc.rs:99:32: replace || with && in MssqlChangeStream::open
+src/source/mssql/cdc.rs:99:45: replace % with + in MssqlChangeStream::open
+src/source/mssql/cdc.rs:99:45: replace % with / in MssqlChangeStream::open
+src/source/mssql/cdc.rs:99:49: replace != with == in MssqlChangeStream::open
+src/source/mssql/cdc.rs:99:54: replace || with && in MssqlChangeStream::open
+src/source/mssql/cdc.rs:99:57: delete ! in MssqlChangeStream::open
+src/source/mysql/arrow_convert.rs:1009:13: delete match arm Some(Value::Int(v)) in mysql_decimal_to_decimal256
+src/source/mysql/arrow_convert.rs:100:9: delete match arm MYSQL_TYPE_TIMESTAMP | MYSQL_TYPE_TIMESTAMP2 in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:1020:13: delete match arm Some(Value::UInt(v)) in mysql_decimal_to_decimal256
+src/source/mysql/arrow_convert.rs:103:27: replace match guard col.column_length() == 1 with false in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:103:27: replace match guard col.column_length() == 1 with true in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:103:47: replace == with != in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:104:9: delete match arm MYSQL_TYPE_BIT in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:105:9: delete match arm MYSQL_TYPE_YEAR in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:149:28: replace match guard col.column_length() == 1 with false in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:149:28: replace match guard col.column_length() == 1 with true in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:149:48: replace == with != in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:150:9: delete match arm MYSQL_TYPE_TINY in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:151:29: replace match guard col.flags().contains(ColumnFlags::UNSIGNED_FLAG) with false in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:151:29: replace match guard col.flags().contains(ColumnFlags::UNSIGNED_FLAG) with true in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:152:9: delete match arm MYSQL_TYPE_SHORT in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:153:29: replace match guard col.flags().contains(ColumnFlags::UNSIGNED_FLAG) with false in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:153:29: replace match guard col.flags().contains(ColumnFlags::UNSIGNED_FLAG) with true in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:154:28: replace match guard col.flags().contains(ColumnFlags::UNSIGNED_FLAG) with false in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:154:28: replace match guard col.flags().contains(ColumnFlags::UNSIGNED_FLAG) with true in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:155:9: delete match arm MYSQL_TYPE_INT24 in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:156:9: delete match arm MYSQL_TYPE_LONG in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:157:32: replace match guard col.flags().contains(ColumnFlags::UNSIGNED_FLAG) with false in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:157:32: replace match guard col.flags().contains(ColumnFlags::UNSIGNED_FLAG) with true in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:160:9: delete match arm MYSQL_TYPE_LONGLONG in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:161:9: delete match arm MYSQL_TYPE_FLOAT in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:162:9: delete match arm MYSQL_TYPE_DOUBLE in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:171:9: delete match arm MYSQL_TYPE_DECIMAL | MYSQL_TYPE_NEWDECIMAL in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:172:26: delete ! in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:189:16: replace match guard col.flags().contains(ColumnFlags::ENUM_FLAG) || col.flags().contains(ColumnFlags::SET_FLAG) with false in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:189:16: replace match guard col.flags().contains(ColumnFlags::ENUM_FLAG) || col.flags().contains(ColumnFlags::SET_FLAG) with true in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:190:17: replace || with && in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:194:9: delete match arm MYSQL_TYPE_VARCHAR | MYSQL_TYPE_VAR_STRING | MYSQL_TYPE_STRING in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:197:36: replace == with != in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:206:9: delete match arm MYSQL_TYPE_ENUM | MYSQL_TYPE_SET in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:207:9: delete match arm MYSQL_TYPE_JSON in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:209:9: delete match arm MYSQL_TYPE_TINY_BLOB | MYSQL_TYPE_MEDIUM_BLOB | MYSQL_TYPE_LONG_BLOB | MYSQL_TYPE_BLOB in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:211:36: replace == with != in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:218:9: delete match arm MYSQL_TYPE_DATE | MYSQL_TYPE_NEWDATE in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:220:9: delete match arm MYSQL_TYPE_TIME | MYSQL_TYPE_TIME2 in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:225:9: delete match arm MYSQL_TYPE_DATETIME | MYSQL_TYPE_DATETIME2 in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:232:9: delete match arm MYSQL_TYPE_TIMESTAMP | MYSQL_TYPE_TIMESTAMP2 in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:241:27: replace match guard col.column_length() == 1 with false in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:243:9: delete match arm MYSQL_TYPE_YEAR in mysql_type_to_rivet
+src/source/mysql/arrow_convert.rs:281:21: delete match arm RivetType::Unsupported{reason, ..} in mysql_schema_and_arrow_types
+src/source/mysql/arrow_convert.rs:361:9: replace MysqlCellSource<'_>::is_bit -> bool with true
+src/source/mysql/arrow_convert.rs:371:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::num_rows -> usize with 1
+src/source/mysql/arrow_convert.rs:374:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::boolean -> Option<bool> with None
+src/source/mysql/arrow_convert.rs:374:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::boolean -> Option<bool> with Some(false)
+src/source/mysql/arrow_convert.rs:374:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::boolean -> Option<bool> with Some(true)
+src/source/mysql/arrow_convert.rs:375:13: delete match arm Some(Value::Int(v)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::boolean
+src/source/mysql/arrow_convert.rs:375:44: replace != with == in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::boolean
+src/source/mysql/arrow_convert.rs:376:13: delete match arm Some(Value::UInt(v)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::boolean
+src/source/mysql/arrow_convert.rs:376:45: replace != with == in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::boolean
+src/source/mysql/arrow_convert.rs:377:13: delete match arm Some(Value::Bytes(bv)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::boolean
+src/source/mysql/arrow_convert.rs:377:65: replace != with == in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::boolean
+src/source/mysql/arrow_convert.rs:382:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::int16 -> Option<i16> with None
+src/source/mysql/arrow_convert.rs:382:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::int16 -> Option<i16> with Some(-1)
+src/source/mysql/arrow_convert.rs:382:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::int16 -> Option<i16> with Some(0)
+src/source/mysql/arrow_convert.rs:382:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::int16 -> Option<i16> with Some(1)
+src/source/mysql/arrow_convert.rs:383:13: delete match arm Some(Value::Int(v)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::int16
+src/source/mysql/arrow_convert.rs:384:13: delete match arm Some(Value::UInt(v)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::int16
+src/source/mysql/arrow_convert.rs:385:13: delete match arm Some(Value::Bytes(bv)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::int16
+src/source/mysql/arrow_convert.rs:390:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::int32 -> Option<i32> with None
+src/source/mysql/arrow_convert.rs:390:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::int32 -> Option<i32> with Some(-1)
+src/source/mysql/arrow_convert.rs:390:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::int32 -> Option<i32> with Some(0)
+src/source/mysql/arrow_convert.rs:390:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::int32 -> Option<i32> with Some(1)
+src/source/mysql/arrow_convert.rs:391:13: delete match arm Some(Value::Int(v)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::int32
+src/source/mysql/arrow_convert.rs:392:13: delete match arm Some(Value::UInt(v)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::int32
+src/source/mysql/arrow_convert.rs:393:13: delete match arm Some(Value::Bytes(bv)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::int32
+src/source/mysql/arrow_convert.rs:399:13: delete match arm Some(Value::Int(v)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::int64
+src/source/mysql/arrow_convert.rs:400:13: delete match arm Some(Value::UInt(v)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::int64
+src/source/mysql/arrow_convert.rs:406:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::uint64 -> Option<u64> with None
+src/source/mysql/arrow_convert.rs:406:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::uint64 -> Option<u64> with Some(0)
+src/source/mysql/arrow_convert.rs:406:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::uint64 -> Option<u64> with Some(1)
+src/source/mysql/arrow_convert.rs:407:13: delete match arm Some(Value::UInt(v)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::uint64
+src/source/mysql/arrow_convert.rs:408:36: replace match guard *v >= 0 with false in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::uint64
+src/source/mysql/arrow_convert.rs:408:36: replace match guard *v >= 0 with true in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::uint64
+src/source/mysql/arrow_convert.rs:408:39: replace >= with < in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::uint64
+src/source/mysql/arrow_convert.rs:409:13: delete match arm Some(Value::Bytes(bv)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::uint64
+src/source/mysql/arrow_convert.rs:414:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::float32 -> Option<f32> with None
+src/source/mysql/arrow_convert.rs:414:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::float32 -> Option<f32> with Some(-1.0)
+src/source/mysql/arrow_convert.rs:414:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::float32 -> Option<f32> with Some(0.0)
+src/source/mysql/arrow_convert.rs:414:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::float32 -> Option<f32> with Some(1.0)
+src/source/mysql/arrow_convert.rs:415:13: delete match arm Some(Value::Float(v)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::float32
+src/source/mysql/arrow_convert.rs:416:13: delete match arm Some(Value::Double(v)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::float32
+src/source/mysql/arrow_convert.rs:417:13: delete match arm Some(Value::Bytes(bv)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::float32
+src/source/mysql/arrow_convert.rs:422:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::float64 -> Option<f64> with None
+src/source/mysql/arrow_convert.rs:422:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::float64 -> Option<f64> with Some(-1.0)
+src/source/mysql/arrow_convert.rs:422:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::float64 -> Option<f64> with Some(0.0)
+src/source/mysql/arrow_convert.rs:422:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::float64 -> Option<f64> with Some(1.0)
+src/source/mysql/arrow_convert.rs:423:13: delete match arm Some(Value::Float(v)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::float64
+src/source/mysql/arrow_convert.rs:424:13: delete match arm Some(Value::Double(v)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::float64
+src/source/mysql/arrow_convert.rs:425:13: delete match arm Some(Value::Bytes(bv)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::float64
+src/source/mysql/arrow_convert.rs:430:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::decimal128 -> Option<i128> with None
+src/source/mysql/arrow_convert.rs:430:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::decimal128 -> Option<i128> with Some(-1)
+src/source/mysql/arrow_convert.rs:430:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::decimal128 -> Option<i128> with Some(0)
+src/source/mysql/arrow_convert.rs:430:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::decimal128 -> Option<i128> with Some(1)
+src/source/mysql/arrow_convert.rs:432:13: delete match arm Some(Value::Bytes(bv)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::decimal128
+src/source/mysql/arrow_convert.rs:433:13: delete match arm Some(Value::Int(v)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::decimal128
+src/source/mysql/arrow_convert.rs:434:13: delete match arm Some(Value::UInt(v)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::decimal128
+src/source/mysql/arrow_convert.rs:443:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::date32 -> Option<i32> with None
+src/source/mysql/arrow_convert.rs:443:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::date32 -> Option<i32> with Some(-1)
+src/source/mysql/arrow_convert.rs:443:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::date32 -> Option<i32> with Some(0)
+src/source/mysql/arrow_convert.rs:443:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::date32 -> Option<i32> with Some(1)
+src/source/mysql/arrow_convert.rs:444:13: delete match arm Some(Value::Date(y, m, d, _, _, _, _)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::date32
+src/source/mysql/arrow_convert.rs:447:13: delete match arm Some(Value::Bytes(bv)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::date32
+src/source/mysql/arrow_convert.rs:456:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::ts_micros -> Option<i64> with None
+src/source/mysql/arrow_convert.rs:456:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::ts_micros -> Option<i64> with Some(-1)
+src/source/mysql/arrow_convert.rs:456:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::ts_micros -> Option<i64> with Some(0)
+src/source/mysql/arrow_convert.rs:456:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::ts_micros -> Option<i64> with Some(1)
+src/source/mysql/arrow_convert.rs:457:13: delete match arm Some(Value::Date(y, mo, d, h, mi, sx, us)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::ts_micros
+src/source/mysql/arrow_convert.rs:461:13: delete match arm Some(Value::Bytes(bv)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::ts_micros
+src/source/mysql/arrow_convert.rs:468:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::binary -> Option<Cow<'_, [u8]>> with None
+src/source/mysql/arrow_convert.rs:468:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::binary -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(Vec::new())))
+src/source/mysql/arrow_convert.rs:468:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::binary -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(vec![0])))
+src/source/mysql/arrow_convert.rs:468:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::binary -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(vec![1])))
+src/source/mysql/arrow_convert.rs:468:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::binary -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(Vec::new()).to_owned()))
+src/source/mysql/arrow_convert.rs:468:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::binary -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(vec![0]).to_owned()))
+src/source/mysql/arrow_convert.rs:468:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::binary -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(vec![1]).to_owned()))
+src/source/mysql/arrow_convert.rs:469:13: delete match arm Some(Value::Bytes(bv)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::binary
+src/source/mysql/arrow_convert.rs:474:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::utf8 -> Option<Cow<'_, [u8]>> with None
+src/source/mysql/arrow_convert.rs:474:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::utf8 -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(Vec::new())))
+src/source/mysql/arrow_convert.rs:474:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::utf8 -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(vec![0])))
+src/source/mysql/arrow_convert.rs:474:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::utf8 -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(vec![1])))
+src/source/mysql/arrow_convert.rs:474:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::utf8 -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(Vec::new()).to_owned()))
+src/source/mysql/arrow_convert.rs:474:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::utf8 -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(vec![0]).to_owned()))
+src/source/mysql/arrow_convert.rs:474:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::utf8 -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(vec![1]).to_owned()))
+src/source/mysql/arrow_convert.rs:475:13: delete match arm Some(Value::Bytes(bv)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::utf8
+src/source/mysql/arrow_convert.rs:479:13: delete match arm Some(Value::Int(v)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::utf8
+src/source/mysql/arrow_convert.rs:47:5: replace mysql_native_type_name -> String with "xyzzy".into()
+src/source/mysql/arrow_convert.rs:47:5: replace mysql_native_type_name -> String with String::new()
+src/source/mysql/arrow_convert.rs:480:13: delete match arm Some(Value::UInt(v)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::utf8
+src/source/mysql/arrow_convert.rs:481:13: delete match arm Some(Value::Float(v)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::utf8
+src/source/mysql/arrow_convert.rs:482:13: delete match arm Some(Value::Double(v)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::utf8
+src/source/mysql/arrow_convert.rs:483:13: delete match arm Some(Value::Date(y, m, d, hh, mi, sx, us)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::utf8
+src/source/mysql/arrow_convert.rs:490:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::time64_micros -> Option<i64> with None
+src/source/mysql/arrow_convert.rs:490:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::time64_micros -> Option<i64> with Some(-1)
+src/source/mysql/arrow_convert.rs:490:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::time64_micros -> Option<i64> with Some(0)
+src/source/mysql/arrow_convert.rs:490:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::time64_micros -> Option<i64> with Some(1)
+src/source/mysql/arrow_convert.rs:491:13: delete match arm Some(Value::Time(neg, days, h, m, s, us)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::time64_micros
+src/source/mysql/arrow_convert.rs:493:35: replace * with + in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::time64_micros
+src/source/mysql/arrow_convert.rs:493:35: replace * with / in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::time64_micros
+src/source/mysql/arrow_convert.rs:493:44: replace + with * in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::time64_micros
+src/source/mysql/arrow_convert.rs:493:44: replace + with - in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::time64_micros
+src/source/mysql/arrow_convert.rs:493:56: replace * with + in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::time64_micros
+src/source/mysql/arrow_convert.rs:493:56: replace * with / in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::time64_micros
+src/source/mysql/arrow_convert.rs:493:64: replace + with * in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::time64_micros
+src/source/mysql/arrow_convert.rs:493:64: replace + with - in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::time64_micros
+src/source/mysql/arrow_convert.rs:493:76: replace * with + in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::time64_micros
+src/source/mysql/arrow_convert.rs:493:76: replace * with / in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::time64_micros
+src/source/mysql/arrow_convert.rs:493:81: replace + with * in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::time64_micros
+src/source/mysql/arrow_convert.rs:493:81: replace + with - in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::time64_micros
+src/source/mysql/arrow_convert.rs:494:25: replace * with + in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::time64_micros
+src/source/mysql/arrow_convert.rs:494:25: replace * with / in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::time64_micros
+src/source/mysql/arrow_convert.rs:495:25: replace + with * in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::time64_micros
+src/source/mysql/arrow_convert.rs:495:25: replace + with - in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::time64_micros
+src/source/mysql/arrow_convert.rs:496:32: delete - in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::time64_micros
+src/source/mysql/arrow_convert.rs:498:13: delete match arm Some(Value::Bytes(bv)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::time64_micros
+src/source/mysql/arrow_convert.rs:505:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::fixed_binary -> Option<Cow<'_, [u8]>> with None
+src/source/mysql/arrow_convert.rs:505:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::fixed_binary -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(Vec::new())))
+src/source/mysql/arrow_convert.rs:505:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::fixed_binary -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(vec![0])))
+src/source/mysql/arrow_convert.rs:505:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::fixed_binary -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(vec![1])))
+src/source/mysql/arrow_convert.rs:505:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::fixed_binary -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(Vec::new()).to_owned()))
+src/source/mysql/arrow_convert.rs:505:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::fixed_binary -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(vec![0]).to_owned()))
+src/source/mysql/arrow_convert.rs:505:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::fixed_binary -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(vec![1]).to_owned()))
+src/source/mysql/arrow_convert.rs:506:39: replace match guard bv.len() == 16 with false in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::fixed_binary
+src/source/mysql/arrow_convert.rs:506:39: replace match guard bv.len() == 16 with true in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::fixed_binary
+src/source/mysql/arrow_convert.rs:506:48: replace == with != in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::fixed_binary
+src/source/mysql/arrow_convert.rs:507:13: delete match arm Some(Value::Bytes(bv)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::fixed_binary
+src/source/mysql/arrow_convert.rs:514:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::decimal256 -> Option<arrow::datatypes::i256> with None
+src/source/mysql/arrow_convert.rs:514:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::decimal256 -> Option<arrow::datatypes::i256> with Some(Default::default())
+src/source/mysql/arrow_convert.rs:516:13: delete match arm Some(Value::Bytes(bv)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::decimal256
+src/source/mysql/arrow_convert.rs:519:13: delete match arm Some(Value::Int(v)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::decimal256
+src/source/mysql/arrow_convert.rs:520:13: delete match arm Some(Value::UInt(v)) in <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::decimal256
+src/source/mysql/arrow_convert.rs:531:9: replace <impl crate::source::value_checksum::CellSource for MysqlCellSource<'_>>::list -> Option<Vec<crate::source::value_checksum::ListElem>> with Some(vec![])
+src/source/mysql/arrow_convert.rs:536:5: replace bytes_to_str -> Option<&str> with None
+src/source/mysql/arrow_convert.rs:556:47: replace | with ^ in bit_bytes_to_u64
+src/source/mysql/arrow_convert.rs:581:5: replace parse_time_str_to_micros -> Option<i64> with None
+src/source/mysql/arrow_convert.rs:581:5: replace parse_time_str_to_micros -> Option<i64> with Some(-1)
+src/source/mysql/arrow_convert.rs:581:5: replace parse_time_str_to_micros -> Option<i64> with Some(0)
+src/source/mysql/arrow_convert.rs:581:5: replace parse_time_str_to_micros -> Option<i64> with Some(1)
+src/source/mysql/arrow_convert.rs:587:32: replace + with * in parse_time_str_to_micros
+src/source/mysql/arrow_convert.rs:587:32: replace + with - in parse_time_str_to_micros
+src/source/mysql/arrow_convert.rs:590:34: replace - with + in parse_time_str_to_micros
+src/source/mysql/arrow_convert.rs:590:34: replace - with / in parse_time_str_to_micros
+src/source/mysql/arrow_convert.rs:591:27: replace * with + in parse_time_str_to_micros
+src/source/mysql/arrow_convert.rs:591:27: replace * with / in parse_time_str_to_micros
+src/source/mysql/arrow_convert.rs:599:20: replace * with + in parse_time_str_to_micros
+src/source/mysql/arrow_convert.rs:599:20: replace * with / in parse_time_str_to_micros
+src/source/mysql/arrow_convert.rs:599:28: replace + with * in parse_time_str_to_micros
+src/source/mysql/arrow_convert.rs:599:28: replace + with - in parse_time_str_to_micros
+src/source/mysql/arrow_convert.rs:599:32: replace * with + in parse_time_str_to_micros
+src/source/mysql/arrow_convert.rs:599:32: replace * with / in parse_time_str_to_micros
+src/source/mysql/arrow_convert.rs:599:37: replace + with * in parse_time_str_to_micros
+src/source/mysql/arrow_convert.rs:599:37: replace + with - in parse_time_str_to_micros
+src/source/mysql/arrow_convert.rs:599:42: replace * with + in parse_time_str_to_micros
+src/source/mysql/arrow_convert.rs:599:42: replace * with / in parse_time_str_to_micros
+src/source/mysql/arrow_convert.rs:599:54: replace + with * in parse_time_str_to_micros
+src/source/mysql/arrow_convert.rs:599:54: replace + with - in parse_time_str_to_micros
+src/source/mysql/arrow_convert.rs:600:19: delete - in parse_time_str_to_micros
+src/source/mysql/arrow_convert.rs:619:9: delete match arm DataType::Boolean in build_array
+src/source/mysql/arrow_convert.rs:623:21: delete match arm Some(Value::Int(v)) in build_array
+src/source/mysql/arrow_convert.rs:623:62: replace != with == in build_array
+src/source/mysql/arrow_convert.rs:624:21: delete match arm Some(Value::UInt(v)) in build_array
+src/source/mysql/arrow_convert.rs:624:63: replace != with == in build_array
+src/source/mysql/arrow_convert.rs:626:21: delete match arm Some(Value::Bytes(bv)) in build_array
+src/source/mysql/arrow_convert.rs:626:83: replace != with == in build_array
+src/source/mysql/arrow_convert.rs:62:28: replace match guard col.column_length() == 1 with false in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:62:28: replace match guard col.column_length() == 1 with true in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:62:48: replace == with != in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:632:9: delete match arm DataType::Int16 in build_array
+src/source/mysql/arrow_convert.rs:636:21: delete match arm Some(Value::Int(v)) in build_array
+src/source/mysql/arrow_convert.rs:637:21: delete match arm Some(Value::UInt(v)) in build_array
+src/source/mysql/arrow_convert.rs:63:9: delete match arm MYSQL_TYPE_TINY in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:640:21: delete match arm Some(Value::Bytes(bv)) in build_array
+src/source/mysql/arrow_convert.rs:649:9: delete match arm DataType::Int32 in build_array
+src/source/mysql/arrow_convert.rs:64:9: delete match arm MYSQL_TYPE_SHORT in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:653:21: delete match arm Some(Value::Int(v)) in build_array
+src/source/mysql/arrow_convert.rs:654:21: delete match arm Some(Value::UInt(v)) in build_array
+src/source/mysql/arrow_convert.rs:655:21: delete match arm Some(Value::Bytes(bv)) in build_array
+src/source/mysql/arrow_convert.rs:65:9: delete match arm MYSQL_TYPE_INT24 | MYSQL_TYPE_LONG in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:664:9: delete match arm DataType::UInt64 in build_array
+src/source/mysql/arrow_convert.rs:668:21: delete match arm Some(Value::UInt(v)) in build_array
+src/source/mysql/arrow_convert.rs:669:44: replace match guard *v >= 0 with false in build_array
+src/source/mysql/arrow_convert.rs:669:44: replace match guard *v >= 0 with true in build_array
+src/source/mysql/arrow_convert.rs:669:47: replace >= with < in build_array
+src/source/mysql/arrow_convert.rs:66:9: delete match arm MYSQL_TYPE_LONGLONG in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:670:21: delete match arm Some(Value::Bytes(bv)) in build_array
+src/source/mysql/arrow_convert.rs:67:9: delete match arm MYSQL_TYPE_FLOAT in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:686:21: delete match arm Some(Value::Int(v)) in build_array
+src/source/mysql/arrow_convert.rs:68:9: delete match arm MYSQL_TYPE_DOUBLE in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:690:21: delete match arm Some(Value::UInt(v)) in build_array
+src/source/mysql/arrow_convert.rs:69:9: delete match arm MYSQL_TYPE_DECIMAL | MYSQL_TYPE_NEWDECIMAL in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:700:9: delete match arm DataType::Float32 in build_array
+src/source/mysql/arrow_convert.rs:704:21: delete match arm Some(Value::Float(v)) in build_array
+src/source/mysql/arrow_convert.rs:705:21: delete match arm Some(Value::Double(v)) in build_array
+src/source/mysql/arrow_convert.rs:706:21: delete match arm Some(Value::Bytes(bv)) in build_array
+src/source/mysql/arrow_convert.rs:715:9: delete match arm DataType::Float64 in build_array
+src/source/mysql/arrow_convert.rs:719:21: delete match arm Some(Value::Float(v)) in build_array
+src/source/mysql/arrow_convert.rs:720:21: delete match arm Some(Value::Double(v)) in build_array
+src/source/mysql/arrow_convert.rs:721:21: delete match arm Some(Value::Bytes(bv)) in build_array
+src/source/mysql/arrow_convert.rs:730:9: delete match arm DataType::Utf8 in build_array
+src/source/mysql/arrow_convert.rs:740:21: delete match arm Some(Value::Bytes(bv)) in build_array
+src/source/mysql/arrow_convert.rs:750:21: delete match arm Some(Value::Int(v)) in build_array
+src/source/mysql/arrow_convert.rs:751:21: delete match arm Some(Value::UInt(v)) in build_array
+src/source/mysql/arrow_convert.rs:752:21: delete match arm Some(Value::Float(v)) in build_array
+src/source/mysql/arrow_convert.rs:753:21: delete match arm Some(Value::Double(v)) in build_array
+src/source/mysql/arrow_convert.rs:754:21: delete match arm Some(Value::Date(y, m, d, h, mi, s, us)) in build_array
+src/source/mysql/arrow_convert.rs:764:9: delete match arm DataType::Binary in build_array
+src/source/mysql/arrow_convert.rs:768:21: delete match arm Some(Value::Bytes(bv)) in build_array
+src/source/mysql/arrow_convert.rs:76:16: replace match guard col.flags().contains(ColumnFlags::ENUM_FLAG) with false in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:76:16: replace match guard col.flags().contains(ColumnFlags::ENUM_FLAG) with true in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:784:9: delete match arm DataType::FixedSizeBinary(16) in build_array
+src/source/mysql/arrow_convert.rs:788:47: replace match guard bv.len() == 16 with false in build_array
+src/source/mysql/arrow_convert.rs:788:47: replace match guard bv.len() == 16 with true in build_array
+src/source/mysql/arrow_convert.rs:788:56: replace == with != in build_array
+src/source/mysql/arrow_convert.rs:793:21: delete match arm Some(Value::Bytes(bv)) in build_array
+src/source/mysql/arrow_convert.rs:807:9: delete match arm DataType::Time64(TimeUnit::Microsecond) in build_array
+src/source/mysql/arrow_convert.rs:812:21: delete match arm Some(Value::Time(neg, days, h, m, s, us)) in build_array
+src/source/mysql/arrow_convert.rs:813:54: replace * with + in build_array
+src/source/mysql/arrow_convert.rs:813:54: replace * with / in build_array
+src/source/mysql/arrow_convert.rs:814:29: replace + with * in build_array
+src/source/mysql/arrow_convert.rs:814:29: replace + with - in build_array
+src/source/mysql/arrow_convert.rs:814:41: replace * with + in build_array
+src/source/mysql/arrow_convert.rs:814:41: replace * with / in build_array
+src/source/mysql/arrow_convert.rs:815:29: replace + with * in build_array
+src/source/mysql/arrow_convert.rs:815:29: replace + with - in build_array
+src/source/mysql/arrow_convert.rs:815:41: replace * with + in build_array
+src/source/mysql/arrow_convert.rs:815:41: replace * with / in build_array
+src/source/mysql/arrow_convert.rs:816:29: replace + with * in build_array
+src/source/mysql/arrow_convert.rs:816:29: replace + with - in build_array
+src/source/mysql/arrow_convert.rs:817:29: replace * with + in build_array
+src/source/mysql/arrow_convert.rs:817:29: replace * with / in build_array
+src/source/mysql/arrow_convert.rs:818:29: replace + with * in build_array
+src/source/mysql/arrow_convert.rs:818:29: replace + with - in build_array
+src/source/mysql/arrow_convert.rs:819:50: delete - in build_array
+src/source/mysql/arrow_convert.rs:81:16: replace match guard col.flags().contains(ColumnFlags::SET_FLAG) with false in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:81:16: replace match guard col.flags().contains(ColumnFlags::SET_FLAG) with true in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:821:21: delete match arm Some(Value::Bytes(bv)) in build_array
+src/source/mysql/arrow_convert.rs:834:9: delete match arm DataType::Date32 in build_array
+src/source/mysql/arrow_convert.rs:838:21: delete match arm Some(Value::Date(y, m, d, _, _, _, _)) in build_array
+src/source/mysql/arrow_convert.rs:841:21: delete match arm Some(Value::Bytes(bv)) in build_array
+src/source/mysql/arrow_convert.rs:864:9: delete match arm DataType::Timestamp(TimeUnit::Microsecond, tz) in build_array
+src/source/mysql/arrow_convert.rs:869:21: delete match arm Some(Value::Date(y, mo, d, h, mi, s, us)) in build_array
+src/source/mysql/arrow_convert.rs:873:21: delete match arm Some(Value::Bytes(bv)) in build_array
+src/source/mysql/arrow_convert.rs:87:30: replace match guard col.character_set() == 63 with false in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:87:30: replace match guard col.character_set() == 63 with true in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:87:50: replace == with != in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:88:34: replace match guard col.character_set() == 63 with false in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:88:34: replace match guard col.character_set() == 63 with true in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:88:54: replace == with != in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:892:9: delete match arm DataType::Decimal128(p, s) in build_array
+src/source/mysql/arrow_convert.rs:893:9: delete match arm DataType::Decimal256(p, s) in build_array
+src/source/mysql/arrow_convert.rs:89:9: delete match arm MYSQL_TYPE_STRING in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:90:9: delete match arm MYSQL_TYPE_VARCHAR | MYSQL_TYPE_VAR_STRING in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:91:9: delete match arm MYSQL_TYPE_ENUM in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:924:13: delete match arm Some(Value::Bytes(bv)) in mysql_decimal_to_decimal128
+src/source/mysql/arrow_convert.rs:92:9: delete match arm MYSQL_TYPE_SET in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:938:13: delete match arm Some(Value::Int(v)) in mysql_decimal_to_decimal128
+src/source/mysql/arrow_convert.rs:93:9: delete match arm MYSQL_TYPE_JSON in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:949:13: delete match arm Some(Value::UInt(v)) in mysql_decimal_to_decimal128
+src/source/mysql/arrow_convert.rs:94:9: delete match arm MYSQL_TYPE_TINY_BLOB | MYSQL_TYPE_MEDIUM_BLOB | MYSQL_TYPE_LONG_BLOB | MYSQL_TYPE_BLOB in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:97:9: delete match arm MYSQL_TYPE_DATE | MYSQL_TYPE_NEWDATE in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:98:9: delete match arm MYSQL_TYPE_TIME | MYSQL_TYPE_TIME2 in mysql_native_type_name
+src/source/mysql/arrow_convert.rs:995:13: delete match arm Some(Value::Bytes(bv)) in mysql_decimal_to_decimal256
+src/source/mysql/arrow_convert.rs:99:9: delete match arm MYSQL_TYPE_DATETIME | MYSQL_TYPE_DATETIME2 in mysql_native_type_name
+src/source/mysql/cdc.rs:124:9: replace MysqlChangeStream::pin_checkpoint_at_current -> Result<()> with Ok(())
+src/source/mysql/cdc.rs:183:9: replace MysqlChangeStream::fill -> Result<bool> with Ok(false)
+src/source/mysql/cdc.rs:183:9: replace MysqlChangeStream::fill -> Result<bool> with Ok(true)
+src/source/mysql/cdc.rs:190:13: delete match arm Some(EventData::RotateEvent(re)) in MysqlChangeStream::fill
+src/source/mysql/cdc.rs:193:13: delete match arm Some(EventData::TableMapEvent(tme)) in MysqlChangeStream::fill
+src/source/mysql/cdc.rs:197:25: delete match arm Ok(mysql::binlog::events::OptionalMetadataField::ColumnName(names)) in MysqlChangeStream::fill
+src/source/mysql/cdc.rs:211:13: delete match arm Some(EventData::RowsEvent(re)) in MysqlChangeStream::fill
+src/source/mysql/cdc.rs:213:21: delete match arm RowsEventData::WriteRowsEvent(_) in MysqlChangeStream::fill
+src/source/mysql/cdc.rs:214:21: delete match arm RowsEventData::UpdateRowsEvent(_) in MysqlChangeStream::fill
+src/source/mysql/cdc.rs:215:21: delete match arm RowsEventData::DeleteRowsEvent(_) in MysqlChangeStream::fill
+src/source/mysql/cdc.rs:239:34: replace > with < in MysqlChangeStream::fill
+src/source/mysql/cdc.rs:239:34: replace > with == in MysqlChangeStream::fill
+src/source/mysql/cdc.rs:239:34: replace > with >= in MysqlChangeStream::fill
+src/source/mysql/cdc.rs:250:13: delete match arm Some(EventData::XidEvent(_)) in MysqlChangeStream::fill
+src/source/mysql/cdc.rs:256:38: replace + with * in MysqlChangeStream::fill
+src/source/mysql/cdc.rs:256:38: replace + with - in MysqlChangeStream::fill
+src/source/mysql/cdc.rs:256:42: replace == with != in MysqlChangeStream::fill
+src/source/mysql/cdc.rs:272:22: replace match guard cfg.mode.is_enforced() with false in connect_conn
+src/source/mysql/cdc.rs:272:22: replace match guard cfg.mode.is_enforced() with true in connect_conn
+src/source/mysql/cdc.rs:301:5: replace render_row -> Vec<RivetValue> with vec![]
+src/source/mysql/cdc.rs:324:5: replace mysql_style_json -> String with "xyzzy".into()
+src/source/mysql/cdc.rs:324:5: replace mysql_style_json -> String with String::new()
+src/source/mysql/cdc.rs:331:13: replace mysql_style_json::<impl serde_json::ser::Formatter for MySqlFmt>::begin_array_value -> std::io::Result<()> with Ok(())
+src/source/mysql/cdc.rs:331:16: delete ! in mysql_style_json::<impl serde_json::ser::Formatter for MySqlFmt>::begin_array_value
+src/source/mysql/cdc.rs:341:13: replace mysql_style_json::<impl serde_json::ser::Formatter for MySqlFmt>::begin_object_key -> std::io::Result<()> with Ok(())
+src/source/mysql/cdc.rs:341:16: delete ! in mysql_style_json::<impl serde_json::ser::Formatter for MySqlFmt>::begin_object_key
+src/source/mysql/cdc.rs:350:13: replace mysql_style_json::<impl serde_json::ser::Formatter for MySqlFmt>::begin_object_value -> std::io::Result<()> with Ok(())
+src/source/mysql/cdc.rs:366:9: replace <impl Iterator for MysqlChangeStream>::next -> Option<Self::Item> with None
+src/source/mysql/cdc.rs:381:9: replace <impl ChangeStream for MysqlChangeStream>::next_change -> Option<Result<ChangeEvent>> with None
+src/source/mysql/cdc.rs:98:9: replace MysqlChangeStream::current_coordinates -> Result<(String, u64)> with Ok(("xyzzy".into(), 0))
+src/source/mysql/cdc.rs:98:9: replace MysqlChangeStream::current_coordinates -> Result<(String, u64)> with Ok(("xyzzy".into(), 1))
+src/source/mysql/cdc.rs:98:9: replace MysqlChangeStream::current_coordinates -> Result<(String, u64)> with Ok((String::new(), 0))
+src/source/mysql/cdc.rs:98:9: replace MysqlChangeStream::current_coordinates -> Result<(String, u64)> with Ok((String::new(), 1))
+src/source/postgres/arrow_convert.rs:101:12: replace == with != in <impl PgFromSql<'a> for PgJsonRawText<'a>>::accepts
+src/source/postgres/arrow_convert.rs:101:27: replace || with && in <impl PgFromSql<'a> for PgJsonRawText<'a>>::accepts
+src/source/postgres/arrow_convert.rs:101:33: replace == with != in <impl PgFromSql<'a> for PgJsonRawText<'a>>::accepts
+src/source/postgres/arrow_convert.rs:101:9: replace <impl PgFromSql<'a> for PgJsonRawText<'a>>::accepts -> bool with false
+src/source/postgres/arrow_convert.rs:101:9: replace <impl PgFromSql<'a> for PgJsonRawText<'a>>::accepts -> bool with true
+src/source/postgres/arrow_convert.rs:108:30: replace == with != in <impl PgFromSql<'a> for PgJsonRawText<'a>>::from_sql
+src/source/postgres/arrow_convert.rs:110:17: delete match arm Some((&1, rest)) in <impl PgFromSql<'a> for PgJsonRawText<'a>>::from_sql
+src/source/postgres/arrow_convert.rs:121:5: replace pg_numeric_optional_utf8_string -> Result<Option<String>> with Ok(None)
+src/source/postgres/arrow_convert.rs:121:5: replace pg_numeric_optional_utf8_string -> Result<Option<String>> with Ok(Some("xyzzy".into()))
+src/source/postgres/arrow_convert.rs:121:5: replace pg_numeric_optional_utf8_string -> Result<Option<String>> with Ok(Some(String::new()))
+src/source/postgres/arrow_convert.rs:128:5: replace numeric_raw_to_optional_decimal_text -> Option<String> with None
+src/source/postgres/arrow_convert.rs:128:5: replace numeric_raw_to_optional_decimal_text -> Option<String> with Some("xyzzy".into())
+src/source/postgres/arrow_convert.rs:128:5: replace numeric_raw_to_optional_decimal_text -> Option<String> with Some(String::new())
+src/source/postgres/arrow_convert.rs:130:10: delete ! in numeric_raw_to_optional_decimal_text
+src/source/postgres/arrow_convert.rs:151:9: delete match arm Type::BOOL in pg_type_to_rivet
+src/source/postgres/arrow_convert.rs:152:9: delete match arm Type::INT2 in pg_type_to_rivet
+src/source/postgres/arrow_convert.rs:153:9: delete match arm Type::INT4 in pg_type_to_rivet
+src/source/postgres/arrow_convert.rs:154:9: delete match arm Type::INT8 in pg_type_to_rivet
+src/source/postgres/arrow_convert.rs:157:9: delete match arm Type::OID in pg_type_to_rivet
+src/source/postgres/arrow_convert.rs:158:9: delete match arm Type::FLOAT4 in pg_type_to_rivet
+src/source/postgres/arrow_convert.rs:159:9: delete match arm Type::FLOAT8 in pg_type_to_rivet
+src/source/postgres/arrow_convert.rs:165:9: delete match arm Type::NUMERIC in pg_type_to_rivet
+src/source/postgres/arrow_convert.rs:174:9: delete match arm Type::DATE in pg_type_to_rivet
+src/source/postgres/arrow_convert.rs:175:9: delete match arm Type::TIME in pg_type_to_rivet
+src/source/postgres/arrow_convert.rs:178:9: delete match arm Type::TIMESTAMP in pg_type_to_rivet
+src/source/postgres/arrow_convert.rs:183:9: delete match arm Type::TIMESTAMPTZ in pg_type_to_rivet
+src/source/postgres/arrow_convert.rs:188:9: delete match arm Type::TEXT | Type::VARCHAR | Type::BPCHAR | Type::NAME in pg_type_to_rivet
+src/source/postgres/arrow_convert.rs:189:9: delete match arm Type::BYTEA in pg_type_to_rivet
+src/source/postgres/arrow_convert.rs:192:9: delete match arm Type::JSON | Type::JSONB in pg_type_to_rivet
+src/source/postgres/arrow_convert.rs:194:9: delete match arm Type::UUID in pg_type_to_rivet
+src/source/postgres/arrow_convert.rs:197:9: delete match arm Type::INTERVAL in pg_type_to_rivet
+src/source/postgres/arrow_convert.rs:201:13: delete match arm Kind::Enum(_) in pg_type_to_rivet
+src/source/postgres/arrow_convert.rs:203:13: delete match arm Kind::Array(elem_type) in pg_type_to_rivet
+src/source/postgres/arrow_convert.rs:226:25: replace == with != in rivet_type_for_pg_column
+src/source/postgres/arrow_convert.rs:265:21: delete match arm RivetType::Unsupported{reason, ..} in pg_columns_to_schema
+src/source/postgres/arrow_convert.rs:276:8: delete ! in pg_columns_to_schema
+src/source/postgres/arrow_convert.rs:304:22: replace != with == in <impl postgres_types::FromSql<'a> for PgInterval>::from_sql
+src/source/postgres/arrow_convert.rs:317:13: replace == with != in <impl postgres_types::FromSql<'a> for PgInterval>::accepts
+src/source/postgres/arrow_convert.rs:317:9: replace <impl postgres_types::FromSql<'a> for PgInterval>::accepts -> bool with false
+src/source/postgres/arrow_convert.rs:317:9: replace <impl postgres_types::FromSql<'a> for PgInterval>::accepts -> bool with true
+src/source/postgres/arrow_convert.rs:343:32: replace < with <= in pg_interval_to_iso8601
+src/source/postgres/arrow_convert.rs:343:32: replace < with == in pg_interval_to_iso8601
+src/source/postgres/arrow_convert.rs:361:23: replace != with == in pg_interval_to_iso8601
+src/source/postgres/arrow_convert.rs:361:28: replace || with && in pg_interval_to_iso8601
+src/source/postgres/arrow_convert.rs:361:34: replace == with != in pg_interval_to_iso8601
+src/source/postgres/arrow_convert.rs:361:39: replace && with || in pg_interval_to_iso8601
+src/source/postgres/arrow_convert.rs:361:45: replace == with != in pg_interval_to_iso8601
+src/source/postgres/arrow_convert.rs:383:9: replace <impl postgres_types::FromSql<'a> for AnyAsString>::accepts -> bool with false
+src/source/postgres/arrow_convert.rs:410:28: replace != with == in rows_to_record_batch_typed
+src/source/postgres/arrow_convert.rs:447:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::num_rows -> usize with 0
+src/source/postgres/arrow_convert.rs:447:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::num_rows -> usize with 1
+src/source/postgres/arrow_convert.rs:450:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::int16 -> Option<i16> with None
+src/source/postgres/arrow_convert.rs:450:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::int16 -> Option<i16> with Some(-1)
+src/source/postgres/arrow_convert.rs:450:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::int16 -> Option<i16> with Some(0)
+src/source/postgres/arrow_convert.rs:450:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::int16 -> Option<i16> with Some(1)
+src/source/postgres/arrow_convert.rs:453:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::int32 -> Option<i32> with None
+src/source/postgres/arrow_convert.rs:453:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::int32 -> Option<i32> with Some(-1)
+src/source/postgres/arrow_convert.rs:453:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::int32 -> Option<i32> with Some(0)
+src/source/postgres/arrow_convert.rs:453:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::int32 -> Option<i32> with Some(1)
+src/source/postgres/arrow_convert.rs:456:32: replace == with != in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::int64
+src/source/postgres/arrow_convert.rs:456:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::int64 -> Option<i64> with None
+src/source/postgres/arrow_convert.rs:456:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::int64 -> Option<i64> with Some(-1)
+src/source/postgres/arrow_convert.rs:456:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::int64 -> Option<i64> with Some(0)
+src/source/postgres/arrow_convert.rs:456:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::int64 -> Option<i64> with Some(1)
+src/source/postgres/arrow_convert.rs:465:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::uint64 -> Option<u64> with Some(0)
+src/source/postgres/arrow_convert.rs:465:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::uint64 -> Option<u64> with Some(1)
+src/source/postgres/arrow_convert.rs:468:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::float32 -> Option<f32> with None
+src/source/postgres/arrow_convert.rs:468:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::float32 -> Option<f32> with Some(-1.0)
+src/source/postgres/arrow_convert.rs:468:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::float32 -> Option<f32> with Some(0.0)
+src/source/postgres/arrow_convert.rs:468:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::float32 -> Option<f32> with Some(1.0)
+src/source/postgres/arrow_convert.rs:471:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::float64 -> Option<f64> with None
+src/source/postgres/arrow_convert.rs:471:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::float64 -> Option<f64> with Some(-1.0)
+src/source/postgres/arrow_convert.rs:471:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::float64 -> Option<f64> with Some(0.0)
+src/source/postgres/arrow_convert.rs:471:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::float64 -> Option<f64> with Some(1.0)
+src/source/postgres/arrow_convert.rs:474:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::decimal128 -> Option<i128> with None
+src/source/postgres/arrow_convert.rs:474:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::decimal128 -> Option<i128> with Some(-1)
+src/source/postgres/arrow_convert.rs:474:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::decimal128 -> Option<i128> with Some(0)
+src/source/postgres/arrow_convert.rs:474:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::decimal128 -> Option<i128> with Some(1)
+src/source/postgres/arrow_convert.rs:483:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::date32 -> Option<i32> with None
+src/source/postgres/arrow_convert.rs:483:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::date32 -> Option<i32> with Some(-1)
+src/source/postgres/arrow_convert.rs:483:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::date32 -> Option<i32> with Some(0)
+src/source/postgres/arrow_convert.rs:483:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::date32 -> Option<i32> with Some(1)
+src/source/postgres/arrow_convert.rs:488:32: replace == with != in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::ts_micros
+src/source/postgres/arrow_convert.rs:488:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::ts_micros -> Option<i64> with None
+src/source/postgres/arrow_convert.rs:488:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::ts_micros -> Option<i64> with Some(-1)
+src/source/postgres/arrow_convert.rs:488:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::ts_micros -> Option<i64> with Some(0)
+src/source/postgres/arrow_convert.rs:488:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::ts_micros -> Option<i64> with Some(1)
+src/source/postgres/arrow_convert.rs:499:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::boolean -> Option<bool> with None
+src/source/postgres/arrow_convert.rs:499:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::boolean -> Option<bool> with Some(false)
+src/source/postgres/arrow_convert.rs:499:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::boolean -> Option<bool> with Some(true)
+src/source/postgres/arrow_convert.rs:502:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::binary -> Option<Cow<'_, [u8]>> with None
+src/source/postgres/arrow_convert.rs:502:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::binary -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(Vec::new())))
+src/source/postgres/arrow_convert.rs:502:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::binary -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(vec![0])))
+src/source/postgres/arrow_convert.rs:502:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::binary -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(vec![1])))
+src/source/postgres/arrow_convert.rs:502:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::binary -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(Vec::new()).to_owned()))
+src/source/postgres/arrow_convert.rs:502:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::binary -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(vec![0]).to_owned()))
+src/source/postgres/arrow_convert.rs:502:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::binary -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(vec![1]).to_owned()))
+src/source/postgres/arrow_convert.rs:507:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::utf8 -> Option<Cow<'_, [u8]>> with None
+src/source/postgres/arrow_convert.rs:507:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::utf8 -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(Vec::new())))
+src/source/postgres/arrow_convert.rs:507:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::utf8 -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(vec![0])))
+src/source/postgres/arrow_convert.rs:507:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::utf8 -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(vec![1])))
+src/source/postgres/arrow_convert.rs:507:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::utf8 -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(Vec::new()).to_owned()))
+src/source/postgres/arrow_convert.rs:507:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::utf8 -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(vec![0]).to_owned()))
+src/source/postgres/arrow_convert.rs:507:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::utf8 -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(vec![1]).to_owned()))
+src/source/postgres/arrow_convert.rs:509:13: delete match arm Type::TEXT | Type::VARCHAR | Type::BPCHAR | Type::NAME in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::utf8
+src/source/postgres/arrow_convert.rs:512:13: delete match arm Type::JSON | Type::JSONB in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::utf8
+src/source/postgres/arrow_convert.rs:513:17: delete match arm Ok(Some(PgJsonRawText(t))) in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::utf8
+src/source/postgres/arrow_convert.rs:516:13: delete match arm Type::NUMERIC in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::utf8
+src/source/postgres/arrow_convert.rs:517:17: delete match arm Ok(Some(t)) in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::utf8
+src/source/postgres/arrow_convert.rs:520:13: delete match arm Type::UUID in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::utf8
+src/source/postgres/arrow_convert.rs:521:17: delete match arm Ok(Some(PgUuidBytes(b))) in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::utf8
+src/source/postgres/arrow_convert.rs:526:13: delete match arm Type::INTERVAL in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::utf8
+src/source/postgres/arrow_convert.rs:535:22: replace match guard matches!(t.kind(), Kind::Enum(_)) with false in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::utf8
+src/source/postgres/arrow_convert.rs:535:22: replace match guard matches!(t.kind(), Kind::Enum(_)) with true in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::utf8
+src/source/postgres/arrow_convert.rs:544:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::time64_micros -> Option<i64> with None
+src/source/postgres/arrow_convert.rs:544:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::time64_micros -> Option<i64> with Some(-1)
+src/source/postgres/arrow_convert.rs:544:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::time64_micros -> Option<i64> with Some(0)
+src/source/postgres/arrow_convert.rs:544:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::time64_micros -> Option<i64> with Some(1)
+src/source/postgres/arrow_convert.rs:549:54: replace * with + in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::time64_micros
+src/source/postgres/arrow_convert.rs:549:54: replace * with / in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::time64_micros
+src/source/postgres/arrow_convert.rs:549:66: replace + with * in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::time64_micros
+src/source/postgres/arrow_convert.rs:549:66: replace + with - in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::time64_micros
+src/source/postgres/arrow_convert.rs:549:90: replace / with % in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::time64_micros
+src/source/postgres/arrow_convert.rs:549:90: replace / with * in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::time64_micros
+src/source/postgres/arrow_convert.rs:553:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::fixed_binary -> Option<Cow<'_, [u8]>> with None
+src/source/postgres/arrow_convert.rs:553:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::fixed_binary -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(Vec::new())))
+src/source/postgres/arrow_convert.rs:553:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::fixed_binary -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(vec![0])))
+src/source/postgres/arrow_convert.rs:553:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::fixed_binary -> Option<Cow<'_, [u8]>> with Some(Cow::Borrowed(Vec::leak(vec![1])))
+src/source/postgres/arrow_convert.rs:553:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::fixed_binary -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(Vec::new()).to_owned()))
+src/source/postgres/arrow_convert.rs:553:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::fixed_binary -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(vec![0]).to_owned()))
+src/source/postgres/arrow_convert.rs:553:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::fixed_binary -> Option<Cow<'_, [u8]>> with Some(Cow::Owned(Vec::leak(vec![1]).to_owned()))
+src/source/postgres/arrow_convert.rs:554:13: delete match arm Ok(Some(PgUuidBytes(b))) in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::fixed_binary
+src/source/postgres/arrow_convert.rs:559:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::decimal256 -> Option<arrow::datatypes::i256> with None
+src/source/postgres/arrow_convert.rs:559:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::decimal256 -> Option<arrow::datatypes::i256> with Some(Default::default())
+src/source/postgres/arrow_convert.rs:561:13: delete match arm Ok(Some(t)) in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::decimal256
+src/source/postgres/arrow_convert.rs:571:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::list -> Option<Vec<crate::source::value_checksum::ListElem>> with None
+src/source/postgres/arrow_convert.rs:571:9: replace <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::list -> Option<Vec<crate::source::value_checksum::ListElem>> with Some(vec![])
+src/source/postgres/arrow_convert.rs:588:13: delete match arm DataType::Boolean in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::list
+src/source/postgres/arrow_convert.rs:589:13: delete match arm DataType::Int16 in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::list
+src/source/postgres/arrow_convert.rs:590:13: delete match arm DataType::Int32 in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::list
+src/source/postgres/arrow_convert.rs:591:13: delete match arm DataType::Int64 in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::list
+src/source/postgres/arrow_convert.rs:592:13: delete match arm DataType::Float32 in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::list
+src/source/postgres/arrow_convert.rs:593:13: delete match arm DataType::Float64 in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::list
+src/source/postgres/arrow_convert.rs:594:13: delete match arm DataType::Utf8 in <impl crate::source::value_checksum::CellSource for PgCellSource<'_>>::list
+src/source/postgres/arrow_convert.rs:639:25: replace == with != in build_array
+src/source/postgres/arrow_convert.rs:66:12: replace == with != in <impl PgFromSql<'a> for PgUuidBytes>::accepts
+src/source/postgres/arrow_convert.rs:66:9: replace <impl PgFromSql<'a> for PgUuidBytes>::accepts -> bool with false
+src/source/postgres/arrow_convert.rs:66:9: replace <impl PgFromSql<'a> for PgUuidBytes>::accepts -> bool with true
+src/source/postgres/arrow_convert.rs:702:75: replace * with + in build_array
+src/source/postgres/arrow_convert.rs:702:75: replace * with / in build_array
+src/source/postgres/arrow_convert.rs:703:29: replace + with * in build_array
+src/source/postgres/arrow_convert.rs:703:29: replace + with - in build_array
+src/source/postgres/arrow_convert.rs:703:53: replace / with % in build_array
+src/source/postgres/arrow_convert.rs:703:53: replace / with * in build_array
+src/source/postgres/arrow_convert.rs:716:25: replace == with != in build_array
+src/source/postgres/arrow_convert.rs:73:22: replace == with != in <impl PgFromSql<'a> for PgUuidBytes>::from_sql
+src/source/postgres/arrow_convert.rs:777:9: delete match arm Type::TEXT | Type::VARCHAR | Type::BPCHAR | Type::NAME in build_pg_text_array
+src/source/postgres/arrow_convert.rs:799:9: delete match arm Type::JSON | Type::JSONB in build_pg_text_array
+src/source/postgres/arrow_convert.rs:811:9: delete match arm Type::NUMERIC in build_pg_text_array
+src/source/postgres/arrow_convert.rs:818:9: delete match arm Type::UUID in build_pg_text_array
+src/source/postgres/arrow_convert.rs:829:9: delete match arm Type::INTERVAL in build_pg_text_array
+src/source/postgres/arrow_convert.rs:840:14: replace match guard matches!(pg_type.kind(), Kind::Enum(_)) with false in build_pg_text_array
+src/source/postgres/arrow_convert.rs:840:14: replace match guard matches!(pg_type.kind(), Kind::Enum(_)) with true in build_pg_text_array
+src/source/postgres/arrow_convert.rs:964:5: replace pg_numeric_optional_plain -> Result<Option<String>> with Ok(None)
+src/source/postgres/arrow_convert.rs:964:5: replace pg_numeric_optional_plain -> Result<Option<String>> with Ok(Some("xyzzy".into()))
+src/source/postgres/arrow_convert.rs:964:5: replace pg_numeric_optional_plain -> Result<Option<String>> with Ok(Some(String::new()))
+src/source/postgres/arrow_convert.rs:968:21: delete ! in pg_numeric_optional_plain
+src/source/postgres/arrow_convert.rs:979:28: delete ! in pg_numeric_optional_plain
+src/source/postgres/arrow_convert.rs:987:5: replace pg_numeric_optional_scaled_i128 -> Result<Option<i128>> with Ok(None)
+src/source/postgres/arrow_convert.rs:987:5: replace pg_numeric_optional_scaled_i128 -> Result<Option<i128>> with Ok(Some(-1))
+src/source/postgres/arrow_convert.rs:987:5: replace pg_numeric_optional_scaled_i128 -> Result<Option<i128>> with Ok(Some(0))
+src/source/postgres/arrow_convert.rs:987:5: replace pg_numeric_optional_scaled_i128 -> Result<Option<i128>> with Ok(Some(1))
+src/source/postgres/cdc.rs:135:9: replace PgChangeStream::fill -> Result<()> with Ok(())
+src/source/postgres/cdc.rs:152:31: replace > with < in PgChangeStream::fill
+src/source/postgres/cdc.rs:152:31: replace > with == in PgChangeStream::fill
+src/source/postgres/cdc.rs:152:31: replace > with >= in PgChangeStream::fill
+src/source/postgres/cdc.rs:171:12: delete ! in PgChangeStream::fill
+src/source/postgres/cdc.rs:171:25: replace || with && in PgChangeStream::fill
+src/source/postgres/cdc.rs:171:35: replace < with <= in PgChangeStream::fill
+src/source/postgres/cdc.rs:171:35: replace < with == in PgChangeStream::fill
+src/source/postgres/cdc.rs:171:35: replace < with > in PgChangeStream::fill
+src/source/postgres/cdc.rs:182:5: replace parse_lsn -> Option<u64> with None
+src/source/postgres/cdc.rs:182:5: replace parse_lsn -> Option<u64> with Some(0)
+src/source/postgres/cdc.rs:182:5: replace parse_lsn -> Option<u64> with Some(1)
+src/source/postgres/cdc.rs:185:25: replace << with >> in parse_lsn
+src/source/postgres/cdc.rs:185:32: replace | with & in parse_lsn
+src/source/postgres/cdc.rs:185:32: replace | with ^ in parse_lsn
+src/source/postgres/cdc.rs:193:39: replace && with || in <impl ChangeStream for PgChangeStream>::next_change
+src/source/postgres/cdc.rs:193:42: delete ! in <impl ChangeStream for PgChangeStream>::next_change
+src/source/postgres/cdc.rs:193:9: replace <impl ChangeStream for PgChangeStream>::next_change -> Option<Result<ChangeEvent>> with None
+src/source/postgres/cdc.rs:205:9: replace <impl ChangeStream for PgChangeStream>::ack -> Result<()> with Ok(())
+src/source/postgres/cdc.rs:214:27: replace || with && in <impl ChangeStream for PgChangeStream>::ack
+src/source/postgres/cdc.rs:214:30: delete ! in <impl ChangeStream for PgChangeStream>::ack
+src/source/postgres/cdc.rs:214:73: replace || with && in <impl ChangeStream for PgChangeStream>::ack
+src/source/postgres/cdc.rs:214:78: replace == with != in <impl ChangeStream for PgChangeStream>::ack
+src/source/postgres/cdc.rs:324:13: replace < with <= in parse_value
+src/source/postgres/cdc.rs:330:36: replace + with * in parse_value
+src/source/postgres/cdc.rs:330:36: replace + with - in parse_value
+src/source/postgres/cdc.rs:343:16: replace < with <= in utf8_len
+src/source/postgres/cdc.rs:354:8: delete ! in map_pg_value
+src/source/postgres/cdc.rs:367:40: replace || with && in map_pg_value
+src/source/postgres/cdc.rs:367:59: replace || with && in map_pg_value
+src/source/postgres/cdc.rs:370:33: replace || with && in map_pg_value
+src/source/postgres/cdc.rs:374:51: replace == with != in map_pg_value
+src/source/postgres/cdc.rs:376:32: replace || with && in map_pg_value
+src/source/postgres/cdc.rs:449:21: replace < with <= in parse_pg_array_literal
+src/source/postgres/cdc.rs:450:39: replace + with * in parse_pg_array_literal
+src/source/postgres/cdc.rs:450:39: replace + with - in parse_pg_array_literal
+src/source/postgres/cdc.rs:450:43: replace < with <= in parse_pg_array_literal
+src/source/postgres/cdc.rs:493:31: replace || with && in parse_pg_time_micros
+src/source/postgres/cdc.rs:502:30: replace + with - in parse_pg_time_micros
+src/source/postgres/cdc.rs:515:29: delete - in parse_pg_interval
+src/source/postgres/cdc.rs:526:18: replace match guard u.starts_with("day") with true in parse_pg_interval
+src/source/postgres/cdc.rs:71:26: replace match guard cfg.mode.is_enforced() with false in PgChangeStream::open
+src/source/postgres/cdc.rs:71:26: replace match guard cfg.mode.is_enforced() with true in PgChangeStream::open
+src/source/postgres/cdc.rs:94:12: delete ! in PgChangeStream::open
+src/types/target.rs:141:9: replace TargetStatus::label -> &'static str with ""
+src/types/target.rs:141:9: replace TargetStatus::label -> &'static str with "xyzzy"
+src/types/target.rs:266:5: replace unsupported_reason -> String with "xyzzy".into()
+src/types/target.rs:266:5: replace unsupported_reason -> String with String::new()
+src/types/target.rs:267:9: delete match arm RivetType::Unsupported{reason, ..} in unsupported_reason
+src/types/target.rs:488:27: replace < with <= in duckdb::native
+src/types/target.rs:573:27: replace < with <= in snowflake::native
+src/types/target.rs:720:27: replace < with <= in clickhouse::native
+src/types/target.rs:77:9: replace ExportTarget::label -> &'static str with ""
+src/types/target.rs:77:9: replace ExportTarget::label -> &'static str with "xyzzy"
+src/types/target.rs:96:70: replace == with != in ExportTarget::resolve_column

--- a/docs/mutation-plan.md
+++ b/docs/mutation-plan.md
@@ -1,0 +1,61 @@
+# Mutation-testing plan — proving the tests can go RED
+
+The coverage matrices certify that a test EXISTS for every claimed behaviour;
+the drift-guard certifies coverage never silently regresses. Neither can
+certify that a test's assertions are ADEQUATE — the 2026-07 audit found 60+
+green tests that could never fail against the exact bug they guard (stale
+sleeps, self-oracles, wrong artifacts). The missing third factor of trust is
+measured empirically: mutate the product, and the suite must go RED.
+
+    trust = coverage-exists (guard) × assertions-adequate (mutants) × runs-in-CI (audit)
+
+Tool: `cargo-mutants` (>= 27). A "missed" mutant = a code change no test
+notices — either a test gap, an accepted non-oracle (operator UX), or an
+equivalent mutant. **Every missed mutant gets exactly one of those three
+verdicts**; an untriaged baseline is a landfill, not a ledger.
+
+## Tiers (risk × oracle × cycle cost)
+
+| Tier | Surface | Files | Test cycle | Cadence |
+|------|---------|-------|-----------|---------|
+| 0 | Manifest/ledger chain | `manifest.rs`, `pipeline/manifest_writer.rs`, `pipeline/manifest_reconcile.rs`, `pipeline/finalize.rs`, `pipeline/single.rs`, `pipeline/keyset.rs`, `pipeline/resume_decisions.rs`, `source/cdc/sink.rs` | `--lib` (~20-30s/mutant) | pilot done; nightly |
+| 1 | Value conversion (silent cell corruption) | `source/{postgres,mysql,mssql}/arrow_convert.rs`, `source/cdc/value.rs`, `types/target.rs`, `types/decimal.rs` | `--lib` | nightly rotation |
+| 2 | State / checkpoint / integrity | `state.rs`, `pipeline/chunked/resume_m8.rs`, `pipeline/validate_manifest.rs`, `source/value_checksum.rs`, `source/{postgres,mysql,mssql}/cdc.rs` | `--lib` | nightly rotation |
+| 3 | Orchestration (offline-blind — pilot proved lib tests cannot see it) | `pipeline/single.rs`, `pipeline/keyset.rs`, `pipeline/chunked/exec.rs`, `pipeline/cdc_job.rs`, `pipeline/mongo_parallel.rs` | live (`--test live_suite -- --ignored <narrow filter>`, minutes/mutant) | weekly, one module per run, devbox |
+| 4 | Destination commit protocol | `destination/local.rs` (+ cloud via minio/fake-gcs) | `--lib` + live | weekly rotation |
+
+Narrow live filters for Tier 3 (mutate X → run only its guards):
+`single.rs` → `live_resume live_crash_recovery`; `keyset.rs` → `live_keyset`;
+`cdc_job.rs`/`sink.rs` → the CDC suites; `chunked/exec.rs` → `live_chunked_recovery`.
+
+## Three enforcement loops
+
+1. **PR gate — `cargo mutants --in-diff` (minutes).** Mutates only the lines
+   the PR changed, `--lib` cycle. A NEW missed mutant in your own diff fails
+   the check. Cheapest and fairest: everyone pays only for their own code.
+2. **Nightly (devbox self-hosted runner).** Full `--lib` runs over Tier 0-2 in
+   rotation (~500-1000 mutants/night). Result diffed against the committed
+   baseline (`docs/mutants-baseline.txt`): any missed mutant NOT in the
+   baseline fails the job. The baseline only shrinks (gap-ratchet discipline).
+3. **Weekly (devbox).** One Tier-3 module against its narrow live filter.
+
+## Triage verdicts
+
+- **add-test** — write the unit test that kills it (e.g. the pilot's
+  `set_column_checksums`/`set_cursor_range`/part-id-max+1 finds, closed in
+  `manifest_writer.rs` tests). The killing test must itself be RED-proven:
+  apply the mutant, watch the new test fail, revert.
+- **accept** — real behaviour but not a data oracle (operator-UX stderr hints,
+  log lines). Excluded in `.cargo/mutants.toml` with a reason comment.
+- **equivalent** — semantically identical mutation (e.g. the 64*1024 stream
+  buffer size in `compute_part_checksums`: any chunking yields the same
+  digest). Excluded with a reason.
+
+## Pilot facts (2026-07, devbox M2 Max)
+
+- `--lib` cycle: build 13-27s + test 3-5s per mutant; -j2 ≈ 12-18s wall each.
+- Orchestration files are offline-blind by construction: `replace run_keyset
+  -> Ok(())` survives the whole lib suite — only live tests guard those paths.
+  This is WHY Tier 3 exists and why its cycle must be live.
+- The manifest ledger itself had 5 real gaps (checksums/cursor-range silently
+  droppable, part-id arithmetic) — closed same-day with RED-proven unit tests.

--- a/docs/mutation-plan.md
+++ b/docs/mutation-plan.md
@@ -51,6 +51,22 @@ Narrow live filters for Tier 3 (mutate X → run only its guards):
   buffer size in `compute_part_checksums`: any chunking yields the same
   digest). Excluded with a reason.
 
+## Disk hygiene (learned the expensive way)
+
+Each `-j N` run keeps N private tree copies with their own `target/` — ~10 GB
+each with default debuginfo, and `target/incremental` GROWS over hundreds of
+mutants. A killed run leaks its copies (a killed tier run left a 26 GB orphan
+in `$TMPDIR/cargo-mutants-rivet-*.tmp`). Rules for every runner:
+
+- `export CARGO_PROFILE_DEV_DEBUG=0` — mutants never need debuginfo; halves
+  the build dirs and speeds the link.
+- Clean `$TMPDIR/cargo-mutants-rivet-*.tmp` before AND after (nightly job
+  step, not trust in graceful exit).
+- `mutants.out/` is gitignored; the committed artifact is only the triaged
+  baseline list.
+- Budget check before launch: N jobs × ~5 GB (debug=0) + headroom; refuse on
+  low disk rather than fill it.
+
 ## Pilot facts (2026-07, devbox M2 Max)
 
 - `--lib` cycle: build 13-27s + test 3-5s per mutant; -j2 ≈ 12-18s wall each.

--- a/docs/resilience-matrix.yaml
+++ b/docs/resilience-matrix.yaml
@@ -75,8 +75,8 @@ scenarios:
   - id: part_name_no_clobber_batch
     what: "rapid consecutive runs into the same prefix don't clobber — millisecond part stamp (single.rs), proven under sub-second incremental deltas"
     postgres: { test: roast_rapid_incremental_runs_into_same_prefix_must_not_clobber_prior_parts }
-    mysql:    { test: mysql_full_mode_repeated_run_accumulates_manifest_entries }
-    mssql:    { test: mssql_full_mode_repeated_run_accumulates_manifest_entries }
+    mysql:    { test: mysql_roast_rapid_incremental_runs_into_same_prefix_must_not_clobber_prior_parts }
+    mssql:    { test: mssql_roast_rapid_incremental_runs_into_same_prefix_must_not_clobber_prior_parts }
     mongo:    { test: mongo_batch_two_rapid_runs_into_same_prefix_do_not_clobber }
 
   - id: part_name_no_clobber_keyset_checkpoint

--- a/src/format/csv.rs
+++ b/src/format/csv.rs
@@ -340,6 +340,78 @@ mod tests {
         String::from_utf8(buf).unwrap()
     }
 
+    // ── mutation-W5 gap closures ─────────────────────────────────────────────
+
+    #[test]
+    fn time64_renders_exact_wall_clock() {
+        // W5: the µs → hh:mm:ss.ffffff arithmetic (/, %) had no golden — a
+        // mutated divisor silently corrupts every TIME cell in CSV output.
+        use arrow::array::Time64MicrosecondArray;
+        assert_eq!(
+            cell(Time64MicrosecondArray::from(vec![86_399_999_999_i64]), 0),
+            "23:59:59.999999"
+        );
+        assert_eq!(
+            cell(Time64MicrosecondArray::from(vec![3_661_000_001_i64]), 0),
+            "01:01:01.000001"
+        );
+        assert_eq!(
+            cell(Time64MicrosecondArray::from(vec![0_i64]), 0),
+            "00:00:00.000000"
+        );
+    }
+
+    #[test]
+    fn write_batch_layout_and_byte_accounting_are_exact() {
+        // W5: `col_idx > 0` mutating to `>=` puts a LEADING comma on every row
+        // (corrupt CSV); the header `len + 1` and `bytes_written +=` mutants
+        // desync the rotation accounting. Pin the exact output AND the count.
+        use arrow::array::Int64Array;
+        use std::sync::{Arc as SArc, Mutex};
+
+        #[derive(Clone)]
+        struct SharedBuf(SArc<Mutex<Vec<u8>>>);
+        impl std::io::Write for SharedBuf {
+            fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(b);
+                Ok(b.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let schema: SchemaRef = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64, false),
+            Field::new("b", DataType::Int64, false),
+        ]));
+        let sink = SharedBuf(SArc::new(Mutex::new(Vec::new())));
+        use crate::format::Format as _;
+        let mut w = CsvFormat
+            .create_writer(&schema, Box::new(sink.clone()))
+            .unwrap();
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2])),
+                Arc::new(Int64Array::from(vec![10, 20])),
+            ],
+        )
+        .unwrap();
+        w.write_batch(&batch).unwrap();
+
+        let text = String::from_utf8(sink.0.lock().unwrap().clone()).unwrap();
+        assert_eq!(
+            text, "a,b\n1,10\n2,20\n",
+            "exact CSV layout (no leading commas)"
+        );
+        assert_eq!(
+            w.bytes_written(),
+            text.len() as u64,
+            "byte accounting must equal the physical output"
+        );
+    }
+
     // ── null handling ────────────────────────────────────────────────────────
 
     #[test]

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -44,6 +44,35 @@ pub const SUCCESS_FILENAME: &str = "_SUCCESS";
 /// Layout: `<prefix>/_quarantine/<run_id>/<original-name>`.
 pub const QUARANTINE_PREFIX: &str = "_quarantine";
 
+/// `manifest-<sanitized run_id>.json` — the immutable per-run COPY written
+/// beside the canonical [`MANIFEST_FILENAME`]. The canonical name is
+/// last-writer-wins (a pointer to the latest run); consecutive runs into one
+/// prefix would clobber it, so this copy preserves EACH run's manifest for a
+/// consumer that sums row counts across runs. Same run-token sanitizer the
+/// parts use: an RFC3339 run id carries `:`/`+` (illegal on Windows), so map
+/// anything outside `[A-Za-z0-9._-]` to `-`.
+pub fn run_unique_manifest_name(run_id: &str) -> String {
+    let token: String = run_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    format!("manifest-{token}.json")
+}
+
+/// True if `name` (a final path segment) is a [`run_unique_manifest_name`] copy
+/// — a Rivet-internal sidecar the validate/reconcile paths must NOT flag as an
+/// untracked foreign object. Excludes the canonical `manifest.json` (`manifest.`
+/// prefix, not `manifest-`).
+pub fn is_run_unique_manifest_name(name: &str) -> bool {
+    name.starts_with("manifest-") && name.ends_with(".json")
+}
+
 /// Writability probe `rivet doctor` drops at the destination prefix.  It is a
 /// Rivet-internal sidecar (like [`MANIFEST_FILENAME`] / [`SUCCESS_FILENAME`]),
 /// so the manifest-aware `--validate` pass must not flag it as an untracked
@@ -419,6 +448,18 @@ mod tests {
         assert_eq!(MANIFEST_FILENAME, "manifest.json");
         assert_eq!(SUCCESS_FILENAME, "_SUCCESS");
         assert_eq!(QUARANTINE_PREFIX, "_quarantine");
+    }
+
+    #[test]
+    fn run_unique_manifest_name_sanitizes_and_is_recognised() {
+        // A real CLI run id is RFC3339 — `:` and `+` are not filename-safe (`:`
+        // is illegal on Windows), so they map to `-`.
+        let n = run_unique_manifest_name("orders_2026-07-13T12:00:00+00:00");
+        assert_eq!(n, "manifest-orders_2026-07-13T12-00-00-00-00.json");
+        assert!(is_run_unique_manifest_name(&n));
+        // The canonical pointer is NOT a per-run copy (its stem is `manifest.`,
+        // not `manifest-`), so validate/reconcile still treat it distinctly.
+        assert!(!is_run_unique_manifest_name(MANIFEST_FILENAME));
     }
 
     // ── self-consistency ────────────────────────────────────────────────────

--- a/src/pipeline/apply_cmd.rs
+++ b/src/pipeline/apply_cmd.rs
@@ -341,6 +341,54 @@ mod tests {
         path.to_str().unwrap().to_string()
     }
 
+    // ── mutation-W6 gap closure ──────────────────────────────────────────────
+    // The unrecoverable-credentials gate (PA9) had no direct test: stubbing it
+    // to Ok(()) let a credential-stripped plan sail into an opaque driver auth
+    // error at apply time — the exact failure the gate exists to pre-empt.
+    #[test]
+    fn redacted_url_gate_requires_a_recovery_path() {
+        let set = |url: Option<&str>,
+                   url_env: Option<&str>,
+                   password_env: Option<&str>,
+                   host: Option<&str>,
+                   user: Option<&str>| {
+            let mut a = fresh_artifact();
+            let s = &mut a.resolved_plan.source;
+            s.url = url.map(str::to_string);
+            s.url_env = url_env.map(str::to_string);
+            s.url_file = None;
+            s.password_env = password_env.map(str::to_string);
+            s.host = host.map(str::to_string);
+            s.user = user.map(str::to_string);
+            a
+        };
+        let redacted = Some("postgresql://REDACTED@h/db");
+
+        // Un-redacted URL passes untouched.
+        reject_unrecoverable_inline_url(&set(
+            Some("postgresql://u:p@h/db"),
+            None,
+            None,
+            None,
+            None,
+        ))
+        .expect("plain url is appliable");
+        // Redacted with NO recovery path must refuse loudly.
+        let err = reject_unrecoverable_inline_url(&set(redacted, None, None, None, None))
+            .expect_err("stripped credentials with no recovery must refuse");
+        assert!(err.to_string().contains("cannot be"), "actionable: {err:#}");
+        // Each recovery path independently unblocks (`||` chain, not `&&`)…
+        reject_unrecoverable_inline_url(&set(redacted, Some("DB_URL"), None, None, None))
+            .expect("url_env recovers");
+        reject_unrecoverable_inline_url(&set(redacted, None, Some("PGPASS"), None, None))
+            .expect("password_env recovers");
+        reject_unrecoverable_inline_url(&set(redacted, None, None, Some("h"), Some("u")))
+            .expect("host+user recovers");
+        // …but host WITHOUT user is not enough (`&&`, not `||`).
+        reject_unrecoverable_inline_url(&set(redacted, None, None, Some("h"), None))
+            .expect_err("host without user cannot rebuild the connection");
+    }
+
     // ── staleness enforcement ────────────────────────────────────────────────
 
     #[test]

--- a/src/pipeline/chunked/detect.rs
+++ b/src/pipeline/chunked/detect.rs
@@ -913,6 +913,39 @@ mod tests {
         assert!(sparse_chunk_action(40, None, 100_000).is_none());
     }
 
+    // ── mutation-W4 boundary rows ────────────────────────────────────────────
+    // Every surviving mutant sat ON a threshold the tests jumped over. This is
+    // the CLAUDE.md sparse-key WARN rule's own guard: a `<` -> `<=` here
+    // silences the warning at exactly the documented floor.
+    #[test]
+    fn sparse_thresholds_are_exact() {
+        // chunk_count == SPARSE_WARN_MIN_CHUNKS (64) is the FIRST flaggable
+        // count: 64 windows for 10 rows is grossly sparse and must Bail.
+        assert!(
+            sparse_chunk_action(64, Some(10), 100_000).is_some(),
+            "exactly-at-floor sparse plan must flag (`<`, not `<=`)"
+        );
+        // A zero row estimate is NOT proof of density — it degrades to the
+        // no-estimate branch (silent at 64, needs the 1000 floor).
+        assert!(sparse_chunk_action(64, Some(0), 100_000).is_none());
+        // Exactly 4x the dense window count is the first provable blow-up:
+        // 100k rows / 1k = 100 dense windows; 400 actual must Bail…
+        assert!(sparse_chunk_action(400, Some(100_000), 1_000).is_some());
+        // …399 is "roughly dense" and stays silent.
+        assert!(sparse_chunk_action(399, Some(100_000), 1_000).is_none());
+        // The Bail message quantifies avg rows/window EXACTLY (rows / count):
+        // 100k rows over 400 windows = 250 — kills `/` -> `*` in the avg.
+        match sparse_chunk_action(400, Some(100_000), 1_000).unwrap() {
+            SparseAction::Bail(m) => {
+                assert!(m.contains("~250 rows/window"), "avg must be exact: {m}")
+            }
+            SparseAction::Warn(m) => panic!("provable blow-up must bail: {m}"),
+        }
+        // No estimate: exactly 1000 windows is the first warnable count.
+        assert!(sparse_chunk_action(1000, None, 100_000).is_some());
+        assert!(sparse_chunk_action(999, None, 100_000).is_none());
+    }
+
     #[test]
     fn chunk_count_larger_than_range_caps_at_range_size() {
         // min=1, max=5 (5 values), chunk_count=100 → chunk_size=1 → 5 chunks

--- a/src/pipeline/chunked/math.rs
+++ b/src/pipeline/chunked/math.rs
@@ -146,6 +146,48 @@ pub(crate) fn chunk_plan_fingerprint(
 mod tests {
     use super::*;
 
+    // ── mutation-W4 gap closure ──────────────────────────────────────────────
+    // The chunk_by_days date arithmetic had NO test (the BETWEEN branch did):
+    // `end + 1 -> end - 1` on the exclusive upper bound silently DROPS the
+    // last day of every window — the off-by-one row-loss class. Golden dates
+    // pin both the fast (table-ident) and the subquery-wrap branches.
+    #[test]
+    fn chunk_by_days_windows_use_exclusive_upper_bound() {
+        use crate::config::SourceType;
+        // Fast path: `SELECT * FROM t` keeps the bare-table form. A single-day
+        // window (start == end == day 0) must span exactly [1970-01-01,
+        // 1970-01-02) — an `end - 1` mutant produces an EMPTY window.
+        let q = build_chunk_query_sql(
+            "SELECT * FROM t",
+            "d",
+            0,
+            0,
+            false,
+            true,
+            SourceType::Postgres,
+        );
+        assert!(
+            q.contains(">= '1970-01-01'") && q.contains("< '1970-01-02'"),
+            "single-day window must be [day, day+1): {q}"
+        );
+        // Subquery-wrap path (arbitrary query), non-zero offsets: day 19000 =
+        // 2022-01-08 (start arithmetic), end 19001 -> upper bound 19002 =
+        // 2022-01-10.
+        let q = build_chunk_query_sql(
+            "SELECT a, d FROM t WHERE a > 0",
+            "d",
+            19000,
+            19001,
+            false,
+            true,
+            SourceType::Postgres,
+        );
+        assert!(
+            q.contains(">= '2022-01-08'") && q.contains("< '2022-01-10'"),
+            "window [19000, 19001] must render as [2022-01-08, 2022-01-10): {q}"
+        );
+    }
+
     #[test]
     fn test_generate_chunks() {
         let chunks = generate_chunks(1, 100, 30);

--- a/src/pipeline/chunked/resume_m8.rs
+++ b/src/pipeline/chunked/resume_m8.rs
@@ -375,6 +375,259 @@ mod tests {
     use super::*;
     use crate::state::ChunkTaskInfo;
 
+    // ── mutation-tier2 gap closure ───────────────────────────────────────────
+    // `apply_m8_resume_decisions` — the resume-decision CORE (skip / rewrite /
+    // quarantine per part) — had 38 missed mutants: even stubbing the whole
+    // function to `Ok(Default::default())` survived, because no test drove the
+    // full flow (real local destination + state + manifest). A wrong skip is a
+    // silently missing part; a wrong rewrite is duplicates.
+
+    fn m8_manifest(run_id: &str, parts: Vec<crate::manifest::ManifestPart>) -> RunManifest {
+        use crate::manifest::{ManifestDestination, ManifestSource, ManifestStatus};
+        let row_count = parts.iter().map(|p| p.rows).sum();
+        let part_count = parts.len() as u32;
+        RunManifest {
+            mode: "batch".to_string(),
+            manifest_version: crate::manifest::MANIFEST_VERSION,
+            run_id: run_id.into(),
+            export_name: "orders".into(),
+            started_at: "2026-07-14T00:00:00Z".into(),
+            finished_at: "2026-07-14T00:01:00Z".into(),
+            status: ManifestStatus::Success,
+            source: ManifestSource {
+                engine: "postgres".into(),
+                schema: None,
+                table: Some("orders".into()),
+                extraction: None,
+            },
+            destination: ManifestDestination {
+                kind: "local".into(),
+                uri: "file:///tmp/out/".into(),
+            },
+            format: "parquet".into(),
+            compression: "zstd".into(),
+            schema_fingerprint: "xxh3:00000000deadbeef".into(),
+            row_count,
+            part_count,
+            parts,
+            column_checksums: None,
+            checksum_key_column: None,
+        }
+    }
+
+    fn m8_part(path: &str, rows: i64, size: u64) -> crate::manifest::ManifestPart {
+        crate::manifest::ManifestPart {
+            part_id: 0, // ids are irrelevant to the M8 path match; keep distinct below
+            path: path.into(),
+            rows,
+            size_bytes: size,
+            content_fingerprint: "xxh3:1".into(),
+            content_md5: String::new(),
+            status: crate::manifest::PartStatus::Committed,
+        }
+    }
+
+    fn m8_plan(dest: &std::path::Path) -> crate::plan::ResolvedRunPlan {
+        use crate::config::{DestinationConfig, DestinationType, SourceConfig, SourceType};
+        use crate::tuning::SourceTuning;
+        crate::plan::ResolvedRunPlan {
+            export_name: "orders".into(),
+            base_query: "SELECT 1".into(),
+            strategy: crate::plan::ExtractionStrategy::Snapshot,
+            format: crate::config::FormatType::Parquet,
+            compression: crate::config::CompressionType::None,
+            compression_level: None,
+            max_file_size_bytes: None,
+            skip_empty: false,
+            meta_columns: Default::default(),
+            destination: DestinationConfig {
+                destination_type: DestinationType::Local,
+                path: Some(dest.to_string_lossy().into_owned()),
+                ..Default::default()
+            },
+            quality: None,
+            tuning: SourceTuning::from_config(None),
+            tuning_profile_label: "balanced".into(),
+            validate: false,
+            reconcile: false,
+            resume: true,
+            source: SourceConfig {
+                source_type: SourceType::Postgres,
+                url: Some("postgresql://nobody@127.0.0.1:9999/nonexistent".into()),
+                url_env: None,
+                url_file: None,
+                host: None,
+                port: None,
+                user: None,
+                password: None,
+                password_env: None,
+                database: None,
+                environment: None,
+                tuning: None,
+                tls: None,
+                mongo: None,
+            },
+            column_overrides: Default::default(),
+            verify: crate::config::VerifyMode::Size,
+            schema_drift_policy: Default::default(),
+            shape_drift_warn_factor: 0.0,
+            parquet: None,
+        }
+    }
+
+    /// Full-matrix flow: part A intact → Skip (+ summary hydration), part B
+    /// missing → Rewrite (task reset), part C size-diverged → Quarantine
+    /// (task reset + object moved), part D with no task → orphan. Also
+    /// hydrates the schema fingerprint from the prior manifest.
+    #[test]
+    fn apply_m8_full_matrix_skip_rewrite_quarantine_orphan() {
+        let run_id = "m8run";
+        let dir = tempfile::tempdir().unwrap();
+
+        // Destination objects: A matches its manifest size, C diverges, B absent.
+        std::fs::write(dir.path().join("part-a.parquet"), b"AAAAA").unwrap(); // 5
+        std::fs::write(dir.path().join("part-c.parquet"), b"CCC").unwrap(); // 3 != 9
+        let mut parts = vec![
+            m8_part("part-a.parquet", 10, 5),
+            m8_part("part-b.parquet", 10, 7),
+            m8_part("part-c.parquet", 10, 9),
+            m8_part("part-d.parquet", 10, 1), // no chunk_task → orphan
+        ];
+        for (i, p) in parts.iter_mut().enumerate() {
+            p.part_id = (i + 1) as u32;
+        }
+        let manifest = m8_manifest(run_id, parts);
+        std::fs::write(
+            dir.path().join(MANIFEST_FILENAME),
+            serde_json::to_vec_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        // State: tasks 0..2 completed with file names a/b/c.
+        let state_dir = tempfile::tempdir().unwrap();
+        let state =
+            crate::state::StateStore::open_at_path(&state_dir.path().join("state.db")).unwrap();
+        state
+            .insert_chunk_tasks(run_id, &[(0, 10), (10, 20), (20, 30)])
+            .unwrap();
+        for (idx, name) in [
+            (0, "part-a.parquet"),
+            (1, "part-b.parquet"),
+            (2, "part-c.parquet"),
+        ] {
+            // claim → completed so file_name is recorded like a real run.
+            state.claim_next_chunk_task(run_id).unwrap();
+            state
+                .complete_chunk_task(run_id, idx, 10, Some(name))
+                .unwrap();
+        }
+
+        let plan = m8_plan(dir.path());
+        let mut summary =
+            crate::pipeline::summary::RunSummary::stub_for_testing(run_id, String::from("orders"));
+        assert!(summary.schema_fingerprint.is_none(), "fixture precondition");
+
+        let stats = apply_m8_resume_decisions(&state, run_id, &plan, &mut summary).unwrap();
+
+        assert_eq!(stats.skipped, 1, "part A (intact) is skipped");
+        assert_eq!(
+            stats.reset_for_rewrite, 1,
+            "part B (missing) resets its task"
+        );
+        assert_eq!(
+            stats.reset_for_quarantine, 1,
+            "part C (size-diverged) resets its task"
+        );
+        assert_eq!(
+            stats.quarantined_moved, 1,
+            "part C's divergent object is moved to _quarantine/<run_id>/"
+        );
+        assert_eq!(stats.quarantine_move_failures, 0);
+        assert_eq!(stats.orphan_parts, 1, "part D has no chunk_task");
+        assert!(
+            dir.path()
+                .join(format!("{QUARANTINE_PREFIX}/{run_id}/part-c.parquet"))
+                .exists(),
+            "quarantined object relocated"
+        );
+
+        // Skip hydration: the summary carries the prior manifest's part A.
+        assert_eq!(
+            summary
+                .manifest_parts
+                .iter()
+                .map(|p| p.path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["part-a.parquet"],
+            "skipped parts hydrate into the resume summary (M4 cumulative manifest)"
+        );
+        assert_eq!(
+            summary.schema_fingerprint.as_deref(),
+            Some("xxh3:00000000deadbeef"),
+            "schema fingerprint hydrates from the prior manifest"
+        );
+
+        // State-side effects: A stays completed; B and C are pending again.
+        let tasks = state.list_chunk_tasks_for_run(run_id).unwrap();
+        let status_of = |i: i64| {
+            tasks
+                .iter()
+                .find(|t| t.chunk_index == i)
+                .unwrap()
+                .status
+                .clone()
+        };
+        assert_eq!(status_of(0), "completed");
+        assert_eq!(status_of(1), "pending", "rewrite resets the task");
+        assert_eq!(status_of(2), "pending", "quarantine resets the task");
+    }
+
+    /// A manifest from a DIFFERENT run_id must be ignored wholesale — resetting
+    /// chunk_tasks off a foreign manifest could destroy a healthy resume.
+    #[test]
+    fn apply_m8_ignores_foreign_manifest() {
+        let run_id = "m8run";
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("part-a.parquet"), b"AAAAA").unwrap();
+        let mut parts = vec![m8_part("part-a.parquet", 10, 5)];
+        parts[0].part_id = 1;
+        let manifest = m8_manifest("SOMEONE_ELSES_RUN", parts);
+        std::fs::write(
+            dir.path().join(MANIFEST_FILENAME),
+            serde_json::to_vec_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let state_dir = tempfile::tempdir().unwrap();
+        let state =
+            crate::state::StateStore::open_at_path(&state_dir.path().join("state.db")).unwrap();
+        state.insert_chunk_tasks(run_id, &[(0, 10)]).unwrap();
+        state.claim_next_chunk_task(run_id).unwrap();
+        state
+            .complete_chunk_task(run_id, 0, 10, Some("part-a.parquet"))
+            .unwrap();
+
+        let plan = m8_plan(dir.path());
+        let mut summary =
+            crate::pipeline::summary::RunSummary::stub_for_testing(run_id, String::from("orders"));
+        let stats = apply_m8_resume_decisions(&state, run_id, &plan, &mut summary).unwrap();
+
+        assert_eq!(
+            stats,
+            M8Stats::default(),
+            "foreign manifest: no action at all"
+        );
+        assert!(
+            summary.manifest_parts.is_empty(),
+            "no hydration from a foreign manifest"
+        );
+        assert_eq!(
+            state.list_chunk_tasks_for_run(run_id).unwrap()[0].status,
+            "completed",
+            "no task reset off a foreign manifest"
+        );
+    }
+
     #[test]
     fn m8stats_aggregates_default_to_zero() {
         // Pinning the wire shape — adding fields must not change the

--- a/src/pipeline/chunked/resume_m8.rs
+++ b/src/pipeline/chunked/resume_m8.rs
@@ -582,6 +582,45 @@ mod tests {
         assert_eq!(status_of(2), "pending", "quarantine resets the task");
     }
 
+    /// The fingerprint hydration guard is `summary is None AND manifest is not
+    /// the placeholder` — an `&& -> ||` mutant overwrites a LIVE summary's
+    /// fingerprint with the prior manifest's, silently rewriting this run's
+    /// schema evidence.
+    #[test]
+    fn apply_m8_never_overwrites_a_live_schema_fingerprint() {
+        let run_id = "m8run";
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("part-a.parquet"), b"AAAAA").unwrap();
+        let mut parts = vec![m8_part("part-a.parquet", 10, 5)];
+        parts[0].part_id = 1;
+        let manifest = m8_manifest(run_id, parts); // fingerprint xxh3:00000000deadbeef
+        std::fs::write(
+            dir.path().join(MANIFEST_FILENAME),
+            serde_json::to_vec_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let state_dir = tempfile::tempdir().unwrap();
+        let state =
+            crate::state::StateStore::open_at_path(&state_dir.path().join("state.db")).unwrap();
+        state.insert_chunk_tasks(run_id, &[(0, 10)]).unwrap();
+        state.claim_next_chunk_task(run_id).unwrap();
+        state
+            .complete_chunk_task(run_id, 0, 10, Some("part-a.parquet"))
+            .unwrap();
+
+        let plan = m8_plan(dir.path());
+        let mut summary =
+            crate::pipeline::summary::RunSummary::stub_for_testing(run_id, String::from("orders"));
+        summary.schema_fingerprint = Some("xxh3:1111111111111111".into()); // LIVE evidence
+        apply_m8_resume_decisions(&state, run_id, &plan, &mut summary).unwrap();
+        assert_eq!(
+            summary.schema_fingerprint.as_deref(),
+            Some("xxh3:1111111111111111"),
+            "a live fingerprint must never be overwritten by the prior manifest's"
+        );
+    }
+
     /// A manifest from a DIFFERENT run_id must be ignored wholesale — resetting
     /// chunk_tasks off a foreign manifest could destroy a healthy resume.
     #[test]

--- a/src/pipeline/finalize.rs
+++ b/src/pipeline/finalize.rs
@@ -539,6 +539,202 @@ mod tests {
         }
     }
 
+    // ── mutation-pilot gap closures ──────────────────────────────────────────
+    // finalize_manifest (18 missed) + the success gates (4) had NO driving
+    // test: stubbing finalize_manifest to () — i.e. never writing the manifest
+    // at end of run — survived the whole lib suite.
+
+    fn fin_plan(dest: &std::path::Path) -> crate::plan::ResolvedRunPlan {
+        use crate::config::{SourceConfig, SourceType};
+        crate::plan::ResolvedRunPlan {
+            export_name: "public.orders".into(),
+            base_query: "SELECT 1".into(),
+            strategy: crate::plan::ExtractionStrategy::Snapshot,
+            format: crate::config::FormatType::Parquet,
+            compression: crate::config::CompressionType::None,
+            compression_level: None,
+            max_file_size_bytes: None,
+            skip_empty: false,
+            meta_columns: Default::default(),
+            destination: cfg_local(Some(&dest.to_string_lossy()), None),
+            quality: None,
+            tuning: crate::tuning::SourceTuning::from_config(None),
+            tuning_profile_label: "balanced".into(),
+            validate: false,
+            reconcile: false,
+            resume: false,
+            source: SourceConfig {
+                source_type: SourceType::Postgres,
+                url: Some("postgresql://nobody@127.0.0.1:9999/nonexistent".into()),
+                url_env: None,
+                url_file: None,
+                host: None,
+                port: None,
+                user: None,
+                password: None,
+                password_env: None,
+                database: None,
+                environment: None,
+                tuning: None,
+                tls: None,
+                mongo: None,
+            },
+            column_overrides: Default::default(),
+            verify: crate::config::VerifyMode::Size,
+            schema_drift_policy: Default::default(),
+            shape_drift_warn_factor: 0.0,
+            parquet: None,
+        }
+    }
+
+    /// A summary that carries everything finalize_manifest is supposed to
+    /// surface into the manifest: a plan snapshot, one committed part, Form B
+    /// checksums, and a cursor range.
+    fn fin_summary(plan: &crate::plan::ResolvedRunPlan, status: &str) -> RunSummary {
+        let mut s = RunSummary::stub_for_testing("finrun", plan.export_name.clone());
+        s.status = status.into();
+        s.schema_fingerprint = Some("xxh3:00000000feedface".into());
+        s.manifest_parts.push(crate::manifest::ManifestPart {
+            part_id: 1,
+            path: "part-000001.parquet".into(),
+            rows: 5,
+            size_bytes: 7,
+            content_fingerprint: "xxh3:1".into(),
+            content_md5: String::new(),
+            status: crate::manifest::PartStatus::Committed,
+        });
+        s.column_checksums = vec![crate::manifest::ColumnChecksum {
+            name: "id".into(),
+            checksum: "42".into(),
+        }];
+        s.checksum_key_column = Some("id".into());
+        s.cursor_column = Some("updated_at".into());
+        s.cursor_low = Some("2026-01-01".into());
+        s.cursor_high = Some("2026-02-01".into());
+        s.journal.record(crate::journal::RunEvent::PlanResolved(
+            crate::journal::PlanSnapshot {
+                export_name: plan.export_name.clone(),
+                base_query: plan.base_query.clone(),
+                strategy: "snapshot".into(),
+                format: "parquet".into(),
+                compression: "none".into(),
+                destination_type: "local".into(),
+                tuning_profile: "balanced".into(),
+                batch_size: 1000,
+                validate: false,
+                reconcile: false,
+                resume: false,
+            },
+        ));
+        s
+    }
+
+    fn read_manifest(dir: &std::path::Path) -> crate::manifest::RunManifest {
+        serde_json::from_slice(&std::fs::read(dir.join("manifest.json")).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn finalize_manifest_success_writes_full_evidence() {
+        let dir = tempfile::tempdir().unwrap();
+        let plan = fin_plan(dir.path());
+        let state = crate::state::StateStore::open_in_memory().unwrap();
+        let summary = fin_summary(&plan, "success");
+
+        finalize_manifest(&plan, &state, &summary, "export");
+
+        let m = read_manifest(dir.path());
+        assert_eq!(m.status, crate::manifest::ManifestStatus::Success);
+        assert_eq!(m.run_id, "finrun");
+        assert_eq!(m.parts.len(), 1);
+        assert_eq!(m.row_count, 5);
+        assert_eq!(m.schema_fingerprint, "xxh3:00000000feedface");
+        assert_eq!(
+            m.column_checksums.as_ref().map(|c| c.len()),
+            Some(1),
+            "Form B checksums must land in the manifest"
+        );
+        assert_eq!(m.checksum_key_column.as_deref(), Some("id"));
+        let ex = m.source.extraction.as_ref().expect("extraction section");
+        assert_eq!(ex.cursor_low.as_deref(), Some("2026-01-01"));
+        assert_eq!(ex.cursor_high.as_deref(), Some("2026-02-01"));
+        assert_eq!(m.source.engine, "postgres");
+        assert_eq!(m.source.schema.as_deref(), Some("public"));
+        assert_eq!(m.source.table.as_deref(), Some("orders"));
+        assert!(
+            dir.path().join("_SUCCESS").exists(),
+            "success run gets _SUCCESS"
+        );
+        assert!(
+            dir.path().join("manifest-finrun.json").exists(),
+            "run-unique manifest copy beside the canonical"
+        );
+    }
+
+    #[test]
+    fn finalize_manifest_failed_run_records_failed_and_no_success_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let plan = fin_plan(dir.path());
+        let state = crate::state::StateStore::open_in_memory().unwrap();
+        let summary = fin_summary(&plan, "failed");
+
+        finalize_manifest(&plan, &state, &summary, "export");
+
+        let m = read_manifest(dir.path());
+        assert_eq!(m.status, crate::manifest::ManifestStatus::Failed);
+        assert!(
+            !dir.path().join("_SUCCESS").exists(),
+            "a failed run must never leave a _SUCCESS marker"
+        );
+    }
+
+    #[test]
+    fn finalize_manifest_splits_schema_table_only_on_a_real_dot() {
+        // "orders" (no dot) and "public." (empty table) must both yield
+        // None/None — a `guard -> true` or `&& -> ||` mutant fabricates
+        // Some("")/Some(...) fields from free-form export names.
+        for name in ["orders", "public.", ".orders"] {
+            let dir = tempfile::tempdir().unwrap();
+            let plan = fin_plan(dir.path());
+            let state = crate::state::StateStore::open_in_memory().unwrap();
+            let mut summary = fin_summary(&plan, "success");
+            summary.export_name = name.into();
+
+            finalize_manifest(&plan, &state, &summary, "export");
+
+            let m = read_manifest(dir.path());
+            assert_eq!(m.source.schema, None, "export_name {name:?}");
+            assert_eq!(m.source.table, None, "export_name {name:?}");
+        }
+    }
+
+    #[test]
+    fn success_gate_refuses_resume_over_a_completed_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let plan = fin_plan(dir.path());
+        // Empty prefix: resume proceeds.
+        check_success_gate_for_resume(&plan).expect("no _SUCCESS -> gate passes");
+        // Completed prefix: refuse loudly.
+        std::fs::write(dir.path().join("_SUCCESS"), b"xxh3:0\n").unwrap();
+        let err = check_success_gate_for_resume(&plan)
+            .expect_err("_SUCCESS present -> resume must be refused");
+        assert!(
+            err.to_string().contains("refused"),
+            "the refusal must be operator-actionable, got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn destination_has_success_probes_the_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = cfg_local(Some(&dir.path().to_string_lossy()), None);
+        assert!(!destination_has_success(&cfg), "no marker -> false");
+        std::fs::write(dir.path().join("_SUCCESS"), b"xxh3:0\n").unwrap();
+        assert!(destination_has_success(&cfg), "marker present -> true");
+        // An unopenable destination counts as "not complete" (re-run it).
+        let bad = cfg_local(Some("/nonexistent/definitely/missing"), None);
+        assert!(!destination_has_success(&bad));
+    }
+
     fn cfg_s3(bucket: &str, prefix: Option<&str>) -> DestinationConfig {
         DestinationConfig {
             destination_type: DestinationType::S3,

--- a/src/pipeline/manifest_reconcile.rs
+++ b/src/pipeline/manifest_reconcile.rs
@@ -22,7 +22,7 @@ use std::collections::BTreeMap;
 use crate::destination::ObjectMeta;
 use crate::manifest::{
     DOCTOR_PROBE_FILENAME, MANIFEST_FILENAME, PartStatus, QUARANTINE_PREFIX, RunManifest,
-    SUCCESS_FILENAME, join_key,
+    SUCCESS_FILENAME, is_run_unique_manifest_name, join_key,
 };
 
 /// Normalise a stored MD5 to its 16 raw digest bytes so encodings from
@@ -179,7 +179,11 @@ pub fn reconcile_manifest_against_listing(
         if *key == manifest_key || *key == success_key {
             continue;
         }
-        if key.rsplit('/').next() == Some(DOCTOR_PROBE_FILENAME) {
+        // Run-unique manifest copies (`manifest-<run_id>.json`) are Rivet
+        // sidecars written beside the canonical manifest so a cross-run consumer
+        // can sum across runs — not foreign data.
+        let base = key.rsplit('/').next().unwrap_or("");
+        if base == DOCTOR_PROBE_FILENAME || is_run_unique_manifest_name(base) {
             continue;
         }
         out.untracked.push((*meta).clone());
@@ -293,6 +297,10 @@ mod tests {
             obj(SUCCESS_FILENAME, 20),
             obj(DOCTOR_PROBE_FILENAME, 1),
             obj("_quarantine/r/old.parquet", 100),
+            // Run-unique manifest copies (this run's + a prior run's, sharing the
+            // prefix) are sidecars, not surplus.
+            obj("manifest-run_001.json", 50),
+            obj("manifest-run_000.json", 50),
             obj("stray.parquet", 7), // the only real surplus
         ];
         let rec = reconcile_manifest_against_listing(&m, &listing, "");

--- a/src/pipeline/manifest_writer.rs
+++ b/src/pipeline/manifest_writer.rs
@@ -358,6 +358,47 @@ pub fn write_manifest(dest: &dyn Destination, manifest: &RunManifest) -> Result<
     Ok(WriteOutcome::Written { success_marker })
 }
 
+/// `manifest-<sanitized run_id>.json` — the run-token discipline the PARTS
+/// already follow (`cdc-<run_token>-NNNN.parquet`) applied to the manifest
+/// sidecar. Same sanitizer: an RFC3339 run id carries `:`/`+`, illegal in a
+/// Windows filename, so map anything outside `[A-Za-z0-9._-]` to `-`.
+pub fn run_unique_manifest_name(run_id: &str) -> String {
+    let token: String = run_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    format!("manifest-{token}.json")
+}
+
+/// Write an immutable, run-unique COPY of the manifest alongside the canonical
+/// [`MANIFEST_FILENAME`]. The canonical name is last-writer-wins — a pointer to
+/// the LATEST run, which is what guard/validate/resume/repair want. But
+/// consecutive runs into one prefix (a CDC soak, the scheduler's
+/// `until_current` model) each clobber it, orphaning every prior run's manifest
+/// from any consumer that sums row counts ACROSS runs (the Pro loader's
+/// `reconcile`). The per-run copy survives, exactly as the run-token-named
+/// parts do. No guard / no `_SUCCESS`: this is a sidecar audit record, not the
+/// canonical pointer, so it must not gate on (or advance) run-shape state.
+pub fn write_run_unique_manifest_copy(
+    dest: &dyn Destination,
+    manifest: &RunManifest,
+) -> Result<()> {
+    if dest.capabilities().commit_protocol == WriteCommitProtocol::Streaming {
+        return Ok(());
+    }
+    let bytes = serde_json::to_vec_pretty(manifest)?;
+    let tmp = tempfile::NamedTempFile::new()?;
+    std::fs::write(tmp.path(), &bytes)?;
+    dest.write(tmp.path(), &run_unique_manifest_name(&manifest.run_id))?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/pipeline/manifest_writer.rs
+++ b/src/pipeline/manifest_writer.rs
@@ -29,7 +29,8 @@ use crate::error::Result;
 use crate::journal::PlanSnapshot;
 use crate::manifest::{
     ColumnChecksum, MANIFEST_FILENAME, ManifestDestination, ManifestPart, ManifestSource,
-    ManifestStatus, PartStatus, RunManifest, SUCCESS_FILENAME, success_marker_body,
+    ManifestStatus, PartStatus, RunManifest, SUCCESS_FILENAME, run_unique_manifest_name,
+    success_marker_body,
 };
 use crate::pipeline::summary::RunSummary;
 
@@ -346,6 +347,19 @@ pub fn write_manifest(dest: &dyn Destination, manifest: &RunManifest) -> Result<
     let manifest_tmp = tempfile::NamedTempFile::new()?;
     std::fs::write(manifest_tmp.path(), &bytes)?;
     dest.write(manifest_tmp.path(), MANIFEST_FILENAME)?;
+    // Immutable per-run copy beside the canonical (last-writer-wins) pointer.
+    // Consecutive runs into one prefix — a CDC soak, incremental batch, the
+    // scheduler's `until_current` model — each clobber `manifest.json`,
+    // orphaning every prior run's manifest from a consumer that sums row counts
+    // ACROSS runs (the Pro loader's reconcile). The parts already carry the run
+    // id in their names (`<export>_<stamp>.parquet`, `cdc-<run_token>-NNNN`);
+    // the manifest sidecar must too. Additive and mode-agnostic: guard / validate
+    // / resume / repair keep reading the canonical name unchanged, so no consumer
+    // moves — this is the ONE seam every pipeline shape writes through.
+    dest.write(
+        manifest_tmp.path(),
+        &run_unique_manifest_name(&manifest.run_id),
+    )?;
 
     let success_marker = matches!(manifest.status, ManifestStatus::Success);
     if success_marker {
@@ -356,47 +370,6 @@ pub fn write_manifest(dest: &dyn Destination, manifest: &RunManifest) -> Result<
     }
 
     Ok(WriteOutcome::Written { success_marker })
-}
-
-/// `manifest-<sanitized run_id>.json` — the run-token discipline the PARTS
-/// already follow (`cdc-<run_token>-NNNN.parquet`) applied to the manifest
-/// sidecar. Same sanitizer: an RFC3339 run id carries `:`/`+`, illegal in a
-/// Windows filename, so map anything outside `[A-Za-z0-9._-]` to `-`.
-pub fn run_unique_manifest_name(run_id: &str) -> String {
-    let token: String = run_id
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
-                c
-            } else {
-                '-'
-            }
-        })
-        .collect();
-    format!("manifest-{token}.json")
-}
-
-/// Write an immutable, run-unique COPY of the manifest alongside the canonical
-/// [`MANIFEST_FILENAME`]. The canonical name is last-writer-wins — a pointer to
-/// the LATEST run, which is what guard/validate/resume/repair want. But
-/// consecutive runs into one prefix (a CDC soak, the scheduler's
-/// `until_current` model) each clobber it, orphaning every prior run's manifest
-/// from any consumer that sums row counts ACROSS runs (the Pro loader's
-/// `reconcile`). The per-run copy survives, exactly as the run-token-named
-/// parts do. No guard / no `_SUCCESS`: this is a sidecar audit record, not the
-/// canonical pointer, so it must not gate on (or advance) run-shape state.
-pub fn write_run_unique_manifest_copy(
-    dest: &dyn Destination,
-    manifest: &RunManifest,
-) -> Result<()> {
-    if dest.capabilities().commit_protocol == WriteCommitProtocol::Streaming {
-        return Ok(());
-    }
-    let bytes = serde_json::to_vec_pretty(manifest)?;
-    let tmp = tempfile::NamedTempFile::new()?;
-    std::fs::write(tmp.path(), &bytes)?;
-    dest.write(tmp.path(), &run_unique_manifest_name(&manifest.run_id))?;
-    Ok(())
 }
 
 #[cfg(test)]
@@ -605,9 +578,13 @@ mod tests {
     // ── write_manifest ──────────────────────────────────────────────────────
 
     fn build_manifest(status: ManifestStatus) -> RunManifest {
+        build_manifest_with_run(status, "run_001")
+    }
+
+    fn build_manifest_with_run(status: ManifestStatus, run_id: &str) -> RunManifest {
         let mut b = ManifestBuilder::new(
             &plan_snapshot(),
-            "run_001",
+            run_id,
             chrono::Utc::now(),
             "xxh3:0123456789abcdef".into(),
             "postgres",
@@ -632,6 +609,73 @@ mod tests {
             String::new(),
         );
         b.finalize(status)
+    }
+
+    #[test]
+    fn write_manifest_leaves_a_run_unique_copy_beside_the_canonical() {
+        // The shared seam every pipeline shape writes through must leave an
+        // immutable per-run copy next to the last-writer-wins `manifest.json`,
+        // so a prefix accumulating several runs keeps EACH run's manifest for a
+        // cross-run consumer that sums row counts (the Pro loader's reconcile).
+        let dir = tempfile::tempdir().unwrap();
+        let dest = local_dest(dir.path());
+        let m = build_manifest(ManifestStatus::Success);
+        write_manifest(&dest, &m).unwrap();
+        assert!(
+            dir.path().join(MANIFEST_FILENAME).exists(),
+            "canonical latest-run pointer"
+        );
+        assert!(
+            dir.path()
+                .join(run_unique_manifest_name(&m.run_id))
+                .exists(),
+            "run-unique copy beside it"
+        );
+    }
+
+    #[test]
+    fn two_runs_into_one_prefix_leave_two_run_unique_manifests() {
+        // The canonical `manifest.json` is clobbered by the second run (fine —
+        // it is the latest-run pointer); the run-unique copies must BOTH survive
+        // so reconcile sums across runs. Mode-agnostic regression for the
+        // manifest-clobber the Pro oracle-fixture harness caught: a live soak
+        // loaded 30 parts (3599 rows) but the one surviving manifest declared 55.
+        let dir = tempfile::tempdir().unwrap();
+        let dest = local_dest(dir.path());
+        write_manifest(
+            &dest,
+            &build_manifest_with_run(ManifestStatus::Success, "run_aaa"),
+        )
+        .unwrap();
+        write_manifest(
+            &dest,
+            &build_manifest_with_run(ManifestStatus::Success, "run_bbb"),
+        )
+        .unwrap();
+
+        assert!(
+            dir.path()
+                .join(run_unique_manifest_name("run_aaa"))
+                .exists()
+        );
+        assert!(
+            dir.path()
+                .join(run_unique_manifest_name("run_bbb"))
+                .exists()
+        );
+        let copies = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                let n = e.file_name();
+                let n = n.to_string_lossy();
+                n.starts_with("manifest-") && n.ends_with(".json")
+            })
+            .count();
+        assert_eq!(
+            copies, 2,
+            "each run leaves its own run-unique manifest copy"
+        );
     }
 
     #[test]

--- a/src/pipeline/manifest_writer.rs
+++ b/src/pipeline/manifest_writer.rs
@@ -611,6 +611,110 @@ mod tests {
         b.finalize(status)
     }
 
+    // ── mutation-pilot gap closures ──────────────────────────────────────────
+    // The cargo-mutants pilot found these three silent-loss paths unguarded:
+    // a mutant emptying set_column_checksums / set_cursor_range, or corrupting
+    // the max+1 part-id arithmetic, survived the whole lib suite.
+
+    #[test]
+    fn builder_carries_column_checksums_and_key_into_the_manifest() {
+        // Mutant killed: `set_column_checksums with ()` — Form B checksums
+        // silently absent from the manifest strips validate of its value leg.
+        let mut b = ManifestBuilder::new(
+            &plan_snapshot(),
+            "run_ck",
+            chrono::Utc::now(),
+            "xxh3:0".into(),
+            "postgres",
+            None,
+            None,
+            "file:///tmp/out/".into(),
+        );
+        b.set_column_checksums(
+            vec![ColumnChecksum {
+                name: "id".into(),
+                checksum: "42".into(),
+            }],
+            Some("id".into()),
+        );
+        let m = b.finalize(ManifestStatus::Success);
+        assert_eq!(
+            m.column_checksums,
+            Some(vec![ColumnChecksum {
+                name: "id".into(),
+                checksum: "42".into(),
+            }]),
+            "recorded column checksums must land in the manifest"
+        );
+        assert_eq!(m.checksum_key_column, Some("id".into()));
+    }
+
+    #[test]
+    fn builder_carries_cursor_range_into_the_extraction_section() {
+        // Mutant killed: `set_cursor_range with ()` — a silently absent cursor
+        // range breaks the incremental continuity audit trail.
+        let mut b = ManifestBuilder::new(
+            &plan_snapshot(),
+            "run_cr",
+            chrono::Utc::now(),
+            "xxh3:0".into(),
+            "postgres",
+            None,
+            None,
+            "file:///tmp/out/".into(),
+        );
+        b.set_cursor_range(
+            Some("updated_at".into()),
+            Some("timestamptz".into()),
+            Some("2026-01-01".into()),
+            Some("2026-02-01".into()),
+            Some(123),
+        );
+        let m = b.finalize(ManifestStatus::Success);
+        let ex = m.source.extraction.expect("extraction section present");
+        assert_eq!(ex.cursor_column.as_deref(), Some("updated_at"));
+        assert_eq!(ex.cursor_type.as_deref(), Some("timestamptz"));
+        assert_eq!(ex.cursor_low.as_deref(), Some("2026-01-01"));
+        assert_eq!(ex.cursor_high.as_deref(), Some("2026-02-01"));
+        assert_eq!(ex.source_row_count, Some(123));
+    }
+
+    #[test]
+    fn record_committed_part_assigns_max_plus_one_over_id_gaps() {
+        // Mutants killed: `m + 1` → `m - 1` / `m * 1` in the part-id
+        // computation. The doc comment describes the exact hazard (hydrated
+        // ids [1,2,4] must yield 5, never a duplicate) — this pins it.
+        let mut s = crate::pipeline::summary::RunSummary::stub_for_testing(
+            "run_pid",
+            String::from("orders"),
+        );
+        for id in [1u32, 2, 4] {
+            s.manifest_parts.push(ManifestPart {
+                part_id: id,
+                path: format!("part-{id:06}.parquet"),
+                rows: 1,
+                size_bytes: 1,
+                content_fingerprint: "xxh3:0".into(),
+                content_md5: String::new(),
+                status: PartStatus::Committed,
+            });
+        }
+        record_committed_part_with_fingerprint(
+            &mut s,
+            "part-next.parquet".into(),
+            1,
+            1,
+            "xxh3:1".into(),
+            String::new(),
+        );
+        let ids: Vec<u32> = s.manifest_parts.iter().map(|p| p.part_id).collect();
+        assert_eq!(
+            ids,
+            vec![1, 2, 4, 5],
+            "next part id must be max+1 (5) — len-based or max-1 numbering collides"
+        );
+    }
+
     #[test]
     fn write_manifest_leaves_a_run_unique_copy_beside_the_canonical() {
         // The shared seam every pipeline shape writes through must leave an

--- a/src/pipeline/validate_manifest.rs
+++ b/src/pipeline/validate_manifest.rs
@@ -1072,6 +1072,77 @@ mod tests {
     // ── untracked objects ───────────────────────────────────────────────
 
     #[test]
+    fn verify_counters_track_present_and_failed_parts() {
+        // Mutation-tier2 gap: the verdict-shaping fields (manifest_found /
+        // passed / failures) and the per-part counters (parts_verified /
+        // parts_failed) had no assertion — `+= -> -=` survived. One present
+        // part + one missing part pin both counters and the verdict.
+        let dir = tempfile::tempdir().unwrap();
+        let m = build_manifest(
+            vec![
+                part(1, 10, 4, "xxh3:1111111111111111"),
+                part(2, 10, 4, "xxh3:2222222222222222"),
+            ],
+            ManifestStatus::Success,
+        );
+        // Only part 1 exists at the destination.
+        write_dataset(dir.path(), &m, &[("part-000001.parquet", b"AAAA")]);
+        let dest = local_dest(dir.path());
+
+        let v = verify_at_destination(&dest, "", ValidateDepth::Full).unwrap();
+        assert!(v.manifest_found, "manifest is at the prefix");
+        assert_eq!(v.parts_verified, 1, "part 1 is present at its size");
+        assert_eq!(v.parts_failed, 1, "part 2 is missing");
+        assert!(
+            v.failures
+                .iter()
+                .any(|f| matches!(f, Failure::PartMissing { part_id: 2, .. })),
+            "the missing part is named in failures: {:?}",
+            v.failures
+        );
+        assert!(!v.passed, "a missing part must fail the verdict");
+    }
+
+    #[test]
+    fn read_capped_boundary_is_exact() {
+        // `size > max` (not >=): a body exactly AT the cap must load; one
+        // byte over must be refused before materialising.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("at-cap.bin"), vec![0u8; 8]).unwrap();
+        std::fs::write(dir.path().join("over-cap.bin"), vec![0u8; 9]).unwrap();
+        let dest = local_dest(dir.path());
+        assert_eq!(
+            read_capped(&dest, "at-cap.bin", 8)
+                .expect("exactly at cap loads")
+                .len(),
+            8
+        );
+        let err = read_capped(&dest, "over-cap.bin", 8).expect_err("over cap refuses");
+        assert!(
+            err.to_string().contains("read cap"),
+            "actionable message: {err:#}"
+        );
+    }
+
+    #[test]
+    fn preview_truncates_only_past_forty_chars() {
+        let s39: String = "x".repeat(39);
+        let s40: String = "x".repeat(40);
+        let s41: String = "x".repeat(41);
+        assert_eq!(preview(&s39), s39, "under the limit: unchanged");
+        assert_eq!(
+            preview(&s40),
+            s40,
+            "exactly at the limit: unchanged (`>` not `>=`)"
+        );
+        assert_eq!(
+            preview(&s41),
+            format!("{s40}\u{2026}"),
+            "past the limit: 40 chars + ellipsis"
+        );
+    }
+
+    #[test]
     fn untracked_object_under_prefix_is_flagged() {
         let dir = tempfile::tempdir().unwrap();
         let m = build_manifest(

--- a/src/plan/build.rs
+++ b/src/plan/build.rs
@@ -323,6 +323,27 @@ fn resolve_chunked_strategy(
         )
     })?;
 
+    chunked_strategy_from_introspection(
+        config.source.source_type,
+        export,
+        tbl,
+        max_attempts,
+        &introspection,
+    )
+}
+
+/// Decision half of [`resolve_chunked_strategy`], split at the introspection
+/// seam so strategy selection is unit-testable with a synthetic
+/// [`crate::source::TableIntrospection`]. The W5 mutation run found its guards
+/// unguarded offline: the keyset-key refusal `!`, the ADR-0020 MySQL-only
+/// auto-keyset gate, the small-table escape, and the memory->rows arithmetic.
+fn chunked_strategy_from_introspection(
+    source_type: crate::config::SourceType,
+    export: &ExportConfig,
+    tbl: &str,
+    max_attempts: u32,
+    introspection: &crate::source::TableIntrospection,
+) -> Result<ExtractionStrategy> {
     // (1) Resolve chunk_size — explicit overrides the budget; otherwise compute
     // from the memory budget and the planner's row-width estimate. Shared by the
     // range-chunked and keyset paths.
@@ -457,7 +478,7 @@ fn resolve_chunked_strategy(
                 // of 'we technically can'." The escape hatch is explicit
                 // `chunk_by_key:` (which works since Layer 2). Do not flip
                 // without re-opening ADR-0020.
-                if config.source.source_type == crate::config::SourceType::Mysql
+                if source_type == crate::config::SourceType::Mysql
                     && let Some(key) = introspection.auto_keyset_key()
                 {
                     log::warn!(
@@ -920,6 +941,101 @@ mod tests {
         e.mode = ExportMode::Chunked;
         e.chunk_column = Some("id".into());
         e
+    }
+
+    // ── mutation-W5 gap closure ──────────────────────────────────────────────
+    // The strategy-selection guards had no offline test (the probe needed a
+    // live DB until the introspection seam split). Each case pins a decision
+    // whose mutant survived W5.
+    fn intro(
+        single_int_pk: Option<&str>,
+        keyset_keys: &[&str],
+        row_estimate: i64,
+        avg_row_bytes: Option<i64>,
+    ) -> crate::source::TableIntrospection {
+        crate::source::TableIntrospection {
+            single_int_pk: single_int_pk.map(str::to_string),
+            keyset_keys: keyset_keys.iter().map(|s| s.to_string()).collect(),
+            row_estimate,
+            avg_row_bytes,
+        }
+    }
+
+    #[test]
+    fn chunked_strategy_decision_gates() {
+        use crate::config::SourceType;
+        let resolve =
+            |source_type, export: &ExportConfig, i: &crate::source::TableIntrospection| {
+                chunked_strategy_from_introspection(source_type, export, "public.t", 3, i)
+            };
+        let base = || {
+            let mut e = chunked_export();
+            e.chunk_column = None; // let the resolver decide
+            e
+        };
+
+        // Small-table escape: rows <= chunk_size downgrades to Snapshot —
+        // INCLUSIVE boundary (row_estimate == chunk_size still snapshots).
+        let e = base();
+        let i = intro(Some("id"), &["id"], e.chunk_size as i64, Some(100));
+        assert!(matches!(
+            resolve(SourceType::Postgres, &e, &i).unwrap(),
+            ExtractionStrategy::Snapshot
+        ));
+        // …but any explicit chunk-shape knob must NOT be collapsed silently.
+        let mut e = base();
+        e.chunk_checkpoint = true;
+        assert!(
+            !matches!(
+                resolve(SourceType::Postgres, &e, &i).unwrap(),
+                ExtractionStrategy::Snapshot
+            ),
+            "chunk_checkpoint asks for resumability a snapshot cannot provide"
+        );
+
+        // Explicit chunk_by_key: a usable key keysets; an unknown key REFUSES
+        // (deleting the `!` accepts a full-scan+filesort key).
+        let mut e = base();
+        e.chunk_by_key = Some("uid".into());
+        let i = intro(None, &["uid"], 1_000_000, Some(100));
+        match resolve(SourceType::Postgres, &e, &i).unwrap() {
+            ExtractionStrategy::Keyset(k) => assert_eq!(k.key_column, "uid"),
+            other => panic!("usable chunk_by_key must keyset, got {other:?}"),
+        }
+        let mut e = base();
+        e.chunk_by_key = Some("nope".into());
+        let err =
+            resolve(SourceType::Postgres, &e, &i).expect_err("unusable chunk_by_key must refuse");
+        assert!(err.to_string().contains("not a usable keyset key"));
+
+        // Memory-budget chunk_size: 100 MB at 1024 B/row = 102_400 rows — the
+        // exact value pins the *,/ arithmetic; a 0-byte estimate must fall back
+        // to the defensive 512 B (100 MB / 512 = 204_800), never divide by 0.
+        let mut e = base();
+        e.chunk_size_memory_mb = Some(100);
+        let i = intro(Some("id"), &["id"], 10_000_000, Some(1024));
+        match resolve(SourceType::Postgres, &e, &i).unwrap() {
+            ExtractionStrategy::Chunked(p) => assert_eq!(p.chunk_size, 102_400),
+            other => panic!("expected chunked, got {other:?}"),
+        }
+        let i = intro(Some("id"), &["id"], 10_000_000, Some(0));
+        match resolve(SourceType::Postgres, &e, &i).unwrap() {
+            ExtractionStrategy::Chunked(p) => assert_eq!(p.chunk_size, 204_800),
+            other => panic!("expected chunked, got {other:?}"),
+        }
+
+        // ADR-0020: auto-keyset on a no-int-PK table is MYSQL-ONLY. The same
+        // introspection on Postgres must refuse with the no-safe-shape error —
+        // an `==` -> `!=` mutant flips the gate for every engine.
+        let e = base();
+        let i = intro(None, &["uuid_col"], 1_000_000, Some(100));
+        match resolve(SourceType::Mysql, &e, &i).unwrap() {
+            ExtractionStrategy::Keyset(k) => assert_eq!(k.key_column, "uuid_col"),
+            other => panic!("mysql auto-keyset expected, got {other:?}"),
+        }
+        let err =
+            resolve(SourceType::Postgres, &e, &i).expect_err("PG must not auto-keyset (ADR-0020)");
+        assert!(err.to_string().contains("no safe shape"));
     }
 
     #[test]

--- a/src/source/cdc/sink.rs
+++ b/src/source/cdc/sink.rs
@@ -34,7 +34,7 @@ use crate::manifest::{
     PartStatus, RunManifest,
 };
 use crate::pipeline::commit::{PartRecord, write_part_file};
-use crate::pipeline::manifest_writer::write_manifest;
+use crate::pipeline::manifest_writer::{write_manifest, write_run_unique_manifest_copy};
 use crate::source::cdc::value::{self, RivetValue};
 use crate::source::cdc::{ChangeEvent, ChangeOp, ChangeStream, Position, TxnSeq};
 use crate::types::{TypeMapping, build_arrow_field};
@@ -328,6 +328,10 @@ pub(crate) fn run_to_files(
             &s.parts,
         );
         write_manifest(s.out.dest, &manifest)?;
+        // The canonical `manifest.json` above is last-writer-wins; leave an
+        // immutable run-unique copy so a prefix accumulating several `until_current`
+        // cycles keeps EACH run's manifest for the Pro loader's cross-run reconcile.
+        write_run_unique_manifest_copy(s.out.dest, &manifest)?;
         manifests.push(manifest);
     }
     Ok(manifests)
@@ -910,6 +914,59 @@ mod tests {
             data_rows, 3,
             "run 2 must append its parts alongside run 1's in the same prefix — \
              a fixed part name silently overwrites already-acked changes"
+        );
+    }
+
+    // Sibling to the parts test above: the PARTS are run-token-named (they
+    // survive), but the manifest SIDECAR was fixed-name (`manifest.json`), so
+    // the second cycle clobbered the first's manifest. A consumer summing row
+    // counts ACROSS runs (the Pro loader's reconcile) then saw only the LAST
+    // run's `row_count` — a live 45-min soak loaded 30 parts (1650 rows) but the
+    // surviving manifest declared 55, and the count gate refused the load.
+    // Each run must leave its own immutable run-unique manifest copy.
+    #[test]
+    fn roast_second_run_into_same_prefix_must_not_clobber_prior_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        let dest = local_dest(&dir);
+        let cols = int_col();
+
+        let mut run1 = FakeStream {
+            events: VecDeque::from(vec![insert(1), insert(2)]),
+            acked: Vec::new(),
+        };
+        run_to_files(
+            &mut run1,
+            SinkConfig {
+                run_id: "t_cdc_20260702T100000000".into(),
+                ..cfg(dest.as_ref(), &cols, FormatType::Csv, 10)
+            },
+        )
+        .unwrap();
+
+        let mut run2 = FakeStream {
+            events: VecDeque::from(vec![insert(3)]),
+            acked: Vec::new(),
+        };
+        run_to_files(
+            &mut run2,
+            SinkConfig {
+                run_id: "t_cdc_20260702T100500000".into(),
+                ..cfg(dest.as_ref(), &cols, FormatType::Csv, 10)
+            },
+        )
+        .unwrap();
+
+        let run_unique: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.starts_with("manifest-") && n.ends_with(".json"))
+            .collect();
+        assert_eq!(
+            run_unique.len(),
+            2,
+            "each cycle must leave its own run-unique manifest copy so a \
+             cross-run consumer sums both — got {run_unique:?}"
         );
     }
 

--- a/src/source/cdc/sink.rs
+++ b/src/source/cdc/sink.rs
@@ -34,7 +34,7 @@ use crate::manifest::{
     PartStatus, RunManifest,
 };
 use crate::pipeline::commit::{PartRecord, write_part_file};
-use crate::pipeline::manifest_writer::{write_manifest, write_run_unique_manifest_copy};
+use crate::pipeline::manifest_writer::write_manifest;
 use crate::source::cdc::value::{self, RivetValue};
 use crate::source::cdc::{ChangeEvent, ChangeOp, ChangeStream, Position, TxnSeq};
 use crate::types::{TypeMapping, build_arrow_field};
@@ -327,11 +327,10 @@ pub(crate) fn run_to_files(
             &cfg.started_at,
             &s.parts,
         );
+        // write_manifest leaves the canonical `manifest.json` (latest-run pointer)
+        // AND an immutable run-unique copy, so a prefix accumulating several
+        // `until_current` cycles keeps EACH run's manifest for cross-run reconcile.
         write_manifest(s.out.dest, &manifest)?;
-        // The canonical `manifest.json` above is last-writer-wins; leave an
-        // immutable run-unique copy so a prefix accumulating several `until_current`
-        // cycles keeps EACH run's manifest for the Pro loader's cross-run reconcile.
-        write_run_unique_manifest_copy(s.out.dest, &manifest)?;
         manifests.push(manifest);
     }
     Ok(manifests)

--- a/src/source/mongo/mod.rs
+++ b/src/source/mongo/mod.rs
@@ -852,6 +852,17 @@ mod tests {
     use super::*;
     use mongodb::bson::oid::ObjectId;
 
+    // W4: the byte-cap multiplications had no exact-value test — `mb * 1024 *
+    // 1024` mutating to `+` or `/` silently shrinks (or explodes) the flush
+    // budget that keeps document batches under the i32 offset ceiling.
+    #[test]
+    fn batch_byte_cap_is_exact_mib() {
+        assert_eq!(super::mongo_batch_byte_cap(Some(10)), 10 * 1024 * 1024);
+        assert_eq!(super::mongo_batch_byte_cap(None), 256 * 1024 * 1024);
+        // Zero is not a valid budget — falls back to the default.
+        assert_eq!(super::mongo_batch_byte_cap(Some(0)), 256 * 1024 * 1024);
+    }
+
     // ── mutation-W4 gap closure ──────────────────────────────────────────────
     // Deleting any `id_bracket` arm survived the suite: the type falls to the
     // `None` catch-all and keyset is (conservatively) refused — a false refusal

--- a/src/source/mongo/mod.rs
+++ b/src/source/mongo/mod.rs
@@ -852,6 +852,71 @@ mod tests {
     use super::*;
     use mongodb::bson::oid::ObjectId;
 
+    // ── mutation-W4 gap closure ──────────────────────────────────────────────
+    // Deleting any `id_bracket` arm survived the suite: the type falls to the
+    // `None` catch-all and keyset is (conservatively) refused — a false refusal
+    // no test noticed. The same blindness would pass the DANGEROUS neighbour: a
+    // MERGE regression (two types sharing a band number) makes collide=false
+    // and keysets across a real server band — the silent bracket-loss class the
+    // heterogeneous-`_id` guard exists to prevent. Pin the WHOLE map.
+    #[test]
+    fn id_bracket_map_matches_the_server_sort_bands() {
+        use mongodb::bson::spec::BinarySubtype;
+        use mongodb::bson::{Binary, DateTime, Decimal128, Regex, Timestamp, doc};
+        let b = |v: &Bson| id_bracket(v);
+
+        // The four numeric types share band 0 — a mixed Int32/Int64/Double
+        // `_id` keysets fine by design.
+        assert_eq!(b(&Bson::Int32(1)), Some(0));
+        assert_eq!(b(&Bson::Int64(1)), Some(0));
+        assert_eq!(b(&Bson::Double(1.0)), Some(0));
+        assert_eq!(
+            b(&Bson::Decimal128("1".parse::<Decimal128>().unwrap())),
+            Some(0)
+        );
+        // Every other placeable type is its OWN band, in server sort order.
+        assert_eq!(b(&Bson::Null), Some(1));
+        assert_eq!(b(&Bson::String("s".into())), Some(2));
+        assert_eq!(b(&Bson::Document(doc! {"k": 1})), Some(3));
+        assert_eq!(b(&Bson::Array(vec![Bson::Int32(1)])), Some(4));
+        assert_eq!(
+            b(&Bson::Binary(Binary {
+                subtype: BinarySubtype::Generic,
+                bytes: vec![1],
+            })),
+            Some(5)
+        );
+        assert_eq!(b(&Bson::ObjectId(ObjectId::new())), Some(6));
+        assert_eq!(b(&Bson::Boolean(true)), Some(7));
+        assert_eq!(b(&Bson::DateTime(DateTime::from_millis(0))), Some(8));
+        assert_eq!(
+            b(&Bson::Timestamp(Timestamp {
+                time: 0,
+                increment: 0
+            })),
+            Some(9)
+        );
+        assert_eq!(
+            b(&Bson::RegularExpression(Regex {
+                pattern: "a".into(),
+                options: String::new(),
+            })),
+            Some(10)
+        );
+        // Unplaceable types refuse keyset rather than guess.
+        assert_eq!(b(&Bson::MaxKey), None);
+
+        // The collide relation derives from the map: same band never collides,
+        // different bands always do, unplaceable collides with everything.
+        assert!(!id_types_collide(&Bson::Int32(1), &Bson::Double(2.0)));
+        assert!(id_types_collide(
+            &Bson::Int64(2000),
+            &Bson::String("id-1".into())
+        ));
+        assert!(id_types_collide(&Bson::Null, &Bson::Document(doc! {})));
+        assert!(id_types_collide(&Bson::MaxKey, &Bson::MaxKey));
+    }
+
     #[test]
     fn id_string_covers_common_key_types() {
         let oid = ObjectId::parse_str("64b8f0000000000000000000").unwrap();

--- a/src/source/mssql/mod.rs
+++ b/src/source/mssql/mod.rs
@@ -1110,10 +1110,65 @@ pub(crate) fn introspect_mssql_table_for_chunking(
 
 #[cfg(test)]
 mod tests {
-    use super::{catalog_decimal_to_params, parse_mssql_simple_from_table};
+    use super::{
+        catalog_decimal_to_params, mssql_find_outer_from_keyword, parse_mssql_simple_from_table,
+        sql_keyword_at,
+    };
 
     fn parse(q: &str) -> Option<(String, String)> {
         parse_mssql_simple_from_table(q)
+    }
+
+    // ── mutation-W4 gap closure ──────────────────────────────────────────────
+    // 18 mutants survived in the FROM-finder (quote escapes, paren depth,
+    // identifier boundaries) — no direct test existed. A mis-found FROM feeds
+    // the table extraction for catalog lookups; golden byte OFFSETS pin the
+    // arithmetic, tricky shapes pin the state machine.
+    #[test]
+    fn outer_from_finder_golden_offsets() {
+        let f = mssql_find_outer_from_keyword;
+        // Exact offset (kills index arithmetic): "SELECT a " = 9 bytes.
+        assert_eq!(f("SELECT a FROM t"), Some(9));
+        // Case-insensitive.
+        assert_eq!(f("select a frOm t"), Some(9));
+        // Subquery FROM is nested — only the outer one counts.
+        let q = "SELECT (SELECT x FROM i) FROM t";
+        assert_eq!(f(q), Some(q.rfind("FROM").unwrap()));
+        // 'from' inside a string literal is skipped…
+        let q = "SELECT 'from' FROM t";
+        assert_eq!(f(q), Some(q.rfind("FROM").unwrap()));
+        // …including with a doubled-quote escape swallowing a fake closer.
+        let q = "SELECT 'it''s from x' FROM t";
+        assert_eq!(f(q), Some(q.rfind("FROM").unwrap()));
+        // Escape-skip arithmetic: with a long prefix the escape index i has
+        // 2*i PAST the string end, so an `i += 2` -> `i *= 2` mutant runs off
+        // the buffer and returns None (short fixtures let 2*i coincidentally
+        // land back on the closing quote — the fixture must break the
+        // coincidence, not rely on it).
+        let q = "SELECT aaaaaaaaaaaaaaaaaaaaaaaaaaaa, 'it''s' FROM t";
+        assert!(2 * q.find("''").unwrap() > q.len(), "fixture invariant");
+        assert_eq!(f(q), Some(q.rfind("FROM").unwrap()));
+        // Identifier boundaries: neither `a_from` nor `fromage` match.
+        let q = "SELECT a_from, fromage FROM t";
+        assert_eq!(f(q), Some(q.rfind("FROM").unwrap()));
+        // Unbalanced-close before FROM must not underflow depth below zero and
+        // hide the keyword.
+        assert_eq!(f(") FROM t"), Some(2));
+        // No FROM at all.
+        assert_eq!(f("SELECT 1"), None);
+        // FROM stuck inside parens only -> nested, not outer.
+        assert_eq!(f("SELECT (x FROM t)"), None);
+    }
+
+    #[test]
+    fn keyword_at_checks_both_identifier_boundaries() {
+        let k = |h: &str, i: usize| sql_keyword_at(h.as_bytes(), i, b"from");
+        assert!(k("from t", 0), "start of string is a boundary");
+        assert!(k("x from", 2), "end of string is a boundary");
+        assert!(!k("xfrom t", 1), "preceded by an identifier byte");
+        assert!(!k("from_x", 0), "followed by an identifier byte");
+        assert!(!k("fro", 0), "keyword longer than the remaining haystack");
+        assert!(k("x FROM y", 2), "case-insensitive");
     }
 
     #[test]

--- a/src/source/mssql/mod.rs
+++ b/src/source/mssql/mod.rs
@@ -951,6 +951,24 @@ fn emit_mssql_batch(
     Ok(0)
 }
 
+/// Render a T-SQL `NUMERIC` as exact decimal text: the unscaled value with a
+/// decimal point inserted at `scale` (zero-padded so `(5, scale 3)` is
+/// `"0.005"`, not `".5"`). Extracted from the `ColumnData::Numeric` arm so the
+/// digit arithmetic is unit-testable — `tiberius::Row` cannot be constructed
+/// outside the driver, and the W4 mutation run showed the split/pad arithmetic
+/// unguarded.
+fn numeric_to_display(raw: i128, scale: usize) -> String {
+    if scale == 0 {
+        raw.to_string()
+    } else {
+        let neg = raw < 0;
+        let digits = raw.unsigned_abs().to_string();
+        let digits = format!("{digits:0>width$}", width = scale + 1);
+        let (int, frac) = digits.split_at(digits.len() - scale);
+        format!("{}{int}.{frac}", if neg { "-" } else { "" })
+    }
+}
+
 /// Render a row's first column as a display string for `query_scalar`
 /// (min/max bounds, COUNT(*), SELECT 1). Covers the scalar shapes the planner
 /// asks for; richer typing flows through the export path, not here.
@@ -966,20 +984,7 @@ fn scalar_to_string(row: &tiberius::Row) -> Option<String> {
         ColumnData::F64(v) => v.map(|x| x.to_string()),
         ColumnData::Bit(v) => v.map(|x| x.to_string()),
         ColumnData::String(v) => v.as_ref().map(|s| s.to_string()),
-        ColumnData::Numeric(v) => v.map(|n| {
-            // unscaled value with an inserted decimal point at `scale`.
-            let raw = n.value();
-            let scale = n.scale() as usize;
-            if scale == 0 {
-                raw.to_string()
-            } else {
-                let neg = raw < 0;
-                let digits = raw.unsigned_abs().to_string();
-                let digits = format!("{digits:0>width$}", width = scale + 1);
-                let (int, frac) = digits.split_at(digits.len() - scale);
-                format!("{}{int}.{frac}", if neg { "-" } else { "" })
-            }
-        }),
+        ColumnData::Numeric(v) => v.map(|n| numeric_to_display(n.value(), n.scale() as usize)),
         ColumnData::Guid(v) => v.map(|g| g.to_string()),
         // Date/time: the Debug fallback rendered these as `Date(Some(Date(738520)))`,
         // which `scalar::parse_date_flexible` (chunk_by_days / date-keyset min/max)
@@ -1158,6 +1163,21 @@ mod tests {
         assert_eq!(f("SELECT 1"), None);
         // FROM stuck inside parens only -> nested, not outer.
         assert_eq!(f("SELECT (x FROM t)"), None);
+    }
+
+    #[test]
+    fn numeric_display_inserts_the_point_exactly() {
+        // W4: the split/pad arithmetic (digits.len() - scale, width scale+1)
+        // had no direct test. Goldens over the tricky shapes: sub-1 values
+        // needing zero-pad, negatives, scale 0.
+        use super::numeric_to_display as n;
+        assert_eq!(n(12345, 2), "123.45");
+        assert_eq!(n(5, 3), "0.005", "zero-pad below 1");
+        assert_eq!(n(-12345, 2), "-123.45");
+        assert_eq!(n(-5, 3), "-0.005");
+        assert_eq!(n(42, 0), "42", "scale 0 is the bare integer");
+        assert_eq!(n(0, 2), "0.00");
+        assert_eq!(n(10, 1), "1.0");
     }
 
     #[test]

--- a/src/source/postgres/mod.rs
+++ b/src/source/postgres/mod.rs
@@ -805,6 +805,20 @@ mod tests {
         assert!(catalog_numeric_to_decimal_params(0, 2).is_none());
         assert!(catalog_numeric_to_decimal_params(77, 0).is_none());
         assert!(catalog_numeric_to_decimal_params(18, 19).is_none());
+        // W4 boundary rows — the mutants lived exactly ON the bounds:
+        // precision 76 is the LAST valid (a `> 76` -> `>= 76` mutant rejects it);
+        assert_eq!(catalog_numeric_to_decimal_params(76, 0), Some((76, 0)));
+        // scale == precision is valid (`>` not `>=` on the third check);
+        assert_eq!(catalog_numeric_to_decimal_params(18, 18), Some((18, 18)));
+        // scale == i8::MIN is the last valid negative;
+        assert_eq!(
+            catalog_numeric_to_decimal_params(10, -128),
+            Some((10, -128))
+        );
+        assert!(catalog_numeric_to_decimal_params(10, -129).is_none());
+        // an `|| -> &&` mutant on the range check lets scale=200 reach the
+        // `as i8` cast, wrapping to -56 and CORRUPTING the params silently.
+        assert!(catalog_numeric_to_decimal_params(76, 200).is_none());
     }
 
     #[test]
@@ -822,5 +836,17 @@ mod tests {
         assert_eq!(parse_work_mem("garbage"), None);
         // We don't accept seconds / units PG would never emit for work_mem.
         assert_eq!(parse_work_mem("4s"), None);
+        // W4: the TB arm and the zero guard had no rows — deleting the "tb"
+        // arm and every `*` in its multiplier survived.
+        assert_eq!(
+            parse_work_mem("2TB"),
+            Some(2 * 1024 * 1024 * 1024 * 1024),
+            "terabytes are 1024^4"
+        );
+        // Fractional values exercise the float multiply exactly.
+        assert_eq!(parse_work_mem("0.5MB"), Some(512 * 1024));
+        // Zero is rejected (`> 0`, not `>= 0`) — callers fall back.
+        assert_eq!(parse_work_mem("0"), None);
+        assert_eq!(parse_work_mem("0MB"), None);
     }
 }

--- a/src/source/value_checksum.rs
+++ b/src/source/value_checksum.rs
@@ -801,6 +801,169 @@ mod tests {
     }
 
     #[test]
+    fn list_parity_holds_for_every_covered_element_type() {
+        // Verify-run find: the A<->B parity fixture exercised only List<Int64>,
+        // so deleting the Bool/I16/F32/F64 arms in `list_cell_elems` (the
+        // arrow-side list extraction) survived. One list column per covered
+        // element type, hashed through both independent paths.
+        use arrow::array::{
+            BooleanBuilder, Float32Builder, Float64Builder, Int16Builder, Int32Builder,
+            ListBuilder, StringBuilder,
+        };
+
+        struct ListCells;
+        impl CellSource for ListCells {
+            fn num_rows(&self) -> usize {
+                1
+            }
+            fn int16(&self, _c: usize, _r: usize) -> Option<i16> {
+                None
+            }
+            fn int32(&self, _c: usize, _r: usize) -> Option<i32> {
+                None
+            }
+            fn int64(&self, _c: usize, _r: usize) -> Option<i64> {
+                None
+            }
+            fn uint64(&self, _c: usize, _r: usize) -> Option<u64> {
+                None
+            }
+            fn float32(&self, _c: usize, _r: usize) -> Option<f32> {
+                None
+            }
+            fn float64(&self, _c: usize, _r: usize) -> Option<f64> {
+                None
+            }
+            fn decimal128(&self, _c: usize, _r: usize, _s: i8) -> Option<i128> {
+                None
+            }
+            fn date32(&self, _c: usize, _r: usize) -> Option<i32> {
+                None
+            }
+            fn ts_micros(&self, _c: usize, _r: usize) -> Option<i64> {
+                None
+            }
+            fn boolean(&self, _c: usize, _r: usize) -> Option<bool> {
+                None
+            }
+            fn utf8(&self, _c: usize, _r: usize) -> Option<std::borrow::Cow<'_, [u8]>> {
+                None
+            }
+            fn binary(&self, _c: usize, _r: usize) -> Option<std::borrow::Cow<'_, [u8]>> {
+                None
+            }
+            fn time64_micros(&self, _c: usize, _r: usize) -> Option<i64> {
+                None
+            }
+            fn fixed_binary(&self, _c: usize, _r: usize) -> Option<std::borrow::Cow<'_, [u8]>> {
+                None
+            }
+            fn decimal256(&self, _c: usize, _r: usize, _s: i8) -> Option<arrow::datatypes::i256> {
+                None
+            }
+            fn list(&self, c: usize, _r: usize, _elem: &DataType) -> Option<Vec<ListElem>> {
+                Some(match c {
+                    0 => vec![ListElem::Bool(true), ListElem::Bool(false), ListElem::Null],
+                    1 => vec![ListElem::I16(7), ListElem::I16(-8)],
+                    2 => vec![ListElem::I32(9), ListElem::I32(-10)],
+                    3 => vec![ListElem::F32(1.5), ListElem::F32(-2.5)],
+                    4 => vec![ListElem::F64(3.5), ListElem::F64(-4.5)],
+                    _ => vec![
+                        ListElem::Str("h\u{e9}y".as_bytes().to_vec()),
+                        ListElem::Null,
+                    ],
+                })
+            }
+        }
+
+        // Arrow-side twins, one ListArray per element type, same values.
+        let mut b_bool = ListBuilder::new(BooleanBuilder::new());
+        b_bool.values().append_value(true);
+        b_bool.values().append_value(false);
+        b_bool.values().append_null();
+        b_bool.append(true);
+        let mut b_i16 = ListBuilder::new(Int16Builder::new());
+        b_i16.values().append_value(7);
+        b_i16.values().append_value(-8);
+        b_i16.append(true);
+        let mut b_i32 = ListBuilder::new(Int32Builder::new());
+        b_i32.values().append_value(9);
+        b_i32.values().append_value(-10);
+        b_i32.append(true);
+        let mut b_f32 = ListBuilder::new(Float32Builder::new());
+        b_f32.values().append_value(1.5);
+        b_f32.values().append_value(-2.5);
+        b_f32.append(true);
+        let mut b_f64 = ListBuilder::new(Float64Builder::new());
+        b_f64.values().append_value(3.5);
+        b_f64.values().append_value(-4.5);
+        b_f64.append(true);
+        let mut b_str = ListBuilder::new(StringBuilder::new());
+        b_str.values().append_value("h\u{e9}y");
+        b_str.values().append_null();
+        b_str.append(true);
+
+        let arrays: Vec<arrow::array::ArrayRef> = vec![
+            Arc::new(b_bool.finish()),
+            Arc::new(b_i16.finish()),
+            Arc::new(b_i32.finish()),
+            Arc::new(b_f32.finish()),
+            Arc::new(b_f64.finish()),
+            Arc::new(b_str.finish()),
+        ];
+        let elem_types = [
+            DataType::Boolean,
+            DataType::Int16,
+            DataType::Int32,
+            DataType::Float32,
+            DataType::Float64,
+            DataType::Utf8,
+        ];
+        let fields: Vec<Field> = elem_types
+            .iter()
+            .enumerate()
+            .map(|(i, dt)| {
+                Field::new(
+                    format!("l{i}"),
+                    DataType::List(Arc::new(Field::new("item", dt.clone(), true))),
+                    true,
+                )
+            })
+            .collect();
+        let schema: SchemaRef = Arc::new(Schema::new(fields));
+
+        let a = source_checksums(&schema, &ListCells);
+        for (i, arr) in arrays.iter().enumerate() {
+            let b = column_xxh3(arr.as_ref(), None);
+            assert_eq!(
+                a[i], b,
+                "List<{:?}> column {i}: source(A) != arrow(B)",
+                elem_types[i]
+            );
+            assert_ne!(a[i], 0, "List<{:?}> must actually hash", elem_types[i]);
+        }
+    }
+
+    #[test]
+    fn is_covered_rejects_skipped_types() {
+        // `is_covered -> true` survived: the CDC sink consults this to keep
+        // its skip set aligned with the batch pass — a hardwired `true` makes
+        // the sink hash types the batch side skips, guaranteeing a false
+        // checksum mismatch on the next ns-timestamp/exotic-list export.
+        assert!(is_covered(&DataType::Int64));
+        assert!(is_covered(&DataType::Utf8));
+        assert!(!is_covered(&DataType::Timestamp(
+            TimeUnit::Nanosecond,
+            None
+        )));
+        assert!(!is_covered(&DataType::LargeList(Arc::new(Field::new(
+            "item",
+            DataType::Int64,
+            true
+        )))));
+    }
+
+    #[test]
     fn check_rule_gates_list_element_types() {
         // Kills the List-arm mutants in check_rule: dropping the guard (every
         // list "covered") silently checksums lists the encoder can't represent;

--- a/src/source/value_checksum.rs
+++ b/src/source/value_checksum.rs
@@ -540,6 +540,289 @@ mod tests {
         ]))
     }
 
+    // ── mutation-tier2 gap closures ──────────────────────────────────────────
+    // cargo-mutants found 78 missed mutants here — in the INTEGRITY layer whose
+    // last line of defense is exactly these lib tests. The four tests below
+    // pin: (1) source(A)↔arrow(B) parity per covered type through INDEPENDENT
+    // code paths, (2) the fold is XOR (an `|=` mutant saturates and passes any
+    // corruption), (3) the cross-part fold in validate is XOR too (a single-part
+    // fixture folds once — `0^s == 0|s` — and cannot see the operator), (4) the
+    // List coverage gate skips unmatched element types with the exact reason.
+
+    /// Fake source cells mirroring `covered_arrays()` row-for-row: 3 rows per
+    /// column, row 2 null. Each column has a distinct type, so each accessor
+    /// serves exactly one column and may ignore `col`.
+    struct FakeCells;
+
+    impl CellSource for FakeCells {
+        fn num_rows(&self) -> usize {
+            3
+        }
+        fn int16(&self, _c: usize, r: usize) -> Option<i16> {
+            [Some(1), Some(-2), None][r]
+        }
+        fn int32(&self, _c: usize, r: usize) -> Option<i32> {
+            [Some(3), Some(-4), None][r]
+        }
+        fn int64(&self, _c: usize, r: usize) -> Option<i64> {
+            [Some(5), Some(-6), None][r]
+        }
+        fn uint64(&self, _c: usize, r: usize) -> Option<u64> {
+            [Some(u64::MAX), Some(7), None][r]
+        }
+        fn float32(&self, _c: usize, r: usize) -> Option<f32> {
+            [Some(1.5), Some(-2.25), None][r]
+        }
+        fn float64(&self, _c: usize, r: usize) -> Option<f64> {
+            [Some(3.5), Some(-4.75), None][r]
+        }
+        fn decimal128(&self, _c: usize, r: usize, scale: i8) -> Option<i128> {
+            assert_eq!(scale, 2, "fixture declares Decimal128(10,2)");
+            [Some(12345), Some(-678), None][r]
+        }
+        fn date32(&self, _c: usize, r: usize) -> Option<i32> {
+            [Some(19000), Some(1), None][r]
+        }
+        fn ts_micros(&self, _c: usize, r: usize) -> Option<i64> {
+            [Some(1_700_000_000_000_000), Some(1), None][r]
+        }
+        fn boolean(&self, _c: usize, r: usize) -> Option<bool> {
+            [Some(true), Some(false), None][r]
+        }
+        fn utf8(&self, _c: usize, r: usize) -> Option<std::borrow::Cow<'_, [u8]>> {
+            ["h\u{e9}llo".as_bytes(), b"", b""]
+                .get(r)
+                .filter(|_| r < 2)
+                .map(|b| std::borrow::Cow::Borrowed(*b))
+        }
+        fn binary(&self, _c: usize, r: usize) -> Option<std::borrow::Cow<'_, [u8]>> {
+            [&[0xde_u8, 0xad][..], &[][..], &[][..]]
+                .get(r)
+                .filter(|_| r < 2)
+                .map(|b| std::borrow::Cow::Borrowed(*b))
+        }
+        fn time64_micros(&self, _c: usize, r: usize) -> Option<i64> {
+            [Some(86_399_999_999), Some(0), None][r]
+        }
+        fn fixed_binary(&self, _c: usize, r: usize) -> Option<std::borrow::Cow<'_, [u8]>> {
+            [&[1_u8, 2, 3, 4][..], &[5, 6, 7, 8][..], &[][..]]
+                .get(r)
+                .filter(|_| r < 2)
+                .map(|b| std::borrow::Cow::Borrowed(*b))
+        }
+        fn decimal256(&self, _c: usize, r: usize, scale: i8) -> Option<arrow::datatypes::i256> {
+            assert_eq!(scale, 10, "fixture declares Decimal256(50,10)");
+            [
+                Some(arrow::datatypes::i256::from_i128(123)),
+                Some(arrow::datatypes::i256::from_i128(-9)),
+                None,
+            ][r]
+        }
+        fn list(&self, _c: usize, r: usize, elem: &DataType) -> Option<Vec<ListElem>> {
+            assert_eq!(elem, &DataType::Int64, "fixture declares List<Int64>");
+            match r {
+                0 => Some(vec![ListElem::I64(1), ListElem::I64(2)]),
+                1 => Some(vec![]),
+                _ => None,
+            }
+        }
+    }
+
+    /// The arrow-side twins of [`FakeCells`], one array per covered type.
+    fn covered_arrays() -> (SchemaRef, Vec<arrow::array::ArrayRef>) {
+        use arrow::array::{
+            BinaryArray, BooleanArray, Date32Array, Decimal128Array, Decimal256Array,
+            FixedSizeBinaryArray, Float32Array, Float64Array, Int16Array, Int32Array, Int64Builder,
+            ListBuilder, StringArray, Time64MicrosecondArray, TimestampMicrosecondArray,
+            UInt64Array,
+        };
+        use arrow::datatypes::i256;
+
+        let mut lb = ListBuilder::new(Int64Builder::new());
+        lb.values().append_value(1);
+        lb.values().append_value(2);
+        lb.append(true);
+        lb.append(true); // empty, non-null
+        lb.append(false); // null list cell
+        let list = lb.finish();
+        let list_dt = DataType::List(Arc::new(Field::new("item", DataType::Int64, true)));
+
+        let arrays: Vec<arrow::array::ArrayRef> = vec![
+            Arc::new(Int16Array::from(vec![Some(1), Some(-2), None])),
+            Arc::new(Int32Array::from(vec![Some(3), Some(-4), None])),
+            Arc::new(Int64Array::from(vec![Some(5), Some(-6), None])),
+            Arc::new(UInt64Array::from(vec![Some(u64::MAX), Some(7), None])),
+            Arc::new(Float32Array::from(vec![Some(1.5), Some(-2.25), None])),
+            Arc::new(Float64Array::from(vec![Some(3.5), Some(-4.75), None])),
+            Arc::new(
+                Decimal128Array::from(vec![Some(12345), Some(-678), None])
+                    .with_precision_and_scale(10, 2)
+                    .unwrap(),
+            ),
+            Arc::new(Date32Array::from(vec![Some(19000), Some(1), None])),
+            Arc::new(TimestampMicrosecondArray::from(vec![
+                Some(1_700_000_000_000_000),
+                Some(1),
+                None,
+            ])),
+            Arc::new(BooleanArray::from(vec![Some(true), Some(false), None])),
+            Arc::new(StringArray::from(vec![Some("h\u{e9}llo"), Some(""), None])),
+            Arc::new(BinaryArray::from(vec![
+                Some(&[0xde_u8, 0xad][..]),
+                Some(&[][..]),
+                None,
+            ])),
+            Arc::new(Time64MicrosecondArray::from(vec![
+                Some(86_399_999_999),
+                Some(0),
+                None,
+            ])),
+            Arc::new(
+                FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+                    vec![Some([1_u8, 2, 3, 4]), Some([5, 6, 7, 8]), None].into_iter(),
+                    4,
+                )
+                .unwrap(),
+            ),
+            Arc::new(
+                Decimal256Array::from(vec![
+                    Some(i256::from_i128(123)),
+                    Some(i256::from_i128(-9)),
+                    None,
+                ])
+                .with_precision_and_scale(50, 10)
+                .unwrap(),
+            ),
+            Arc::new(list),
+        ];
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("c_i16", DataType::Int16, true),
+            Field::new("c_i32", DataType::Int32, true),
+            Field::new("c_i64", DataType::Int64, true),
+            Field::new("c_u64", DataType::UInt64, true),
+            Field::new("c_f32", DataType::Float32, true),
+            Field::new("c_f64", DataType::Float64, true),
+            Field::new("c_dec", DataType::Decimal128(10, 2), true),
+            Field::new("c_date", DataType::Date32, true),
+            Field::new(
+                "c_ts",
+                DataType::Timestamp(TimeUnit::Microsecond, None),
+                true,
+            ),
+            Field::new("c_bool", DataType::Boolean, true),
+            Field::new("c_str", DataType::Utf8, true),
+            Field::new("c_bin", DataType::Binary, true),
+            Field::new("c_time", DataType::Time64(TimeUnit::Microsecond), true),
+            Field::new("c_fsb", DataType::FixedSizeBinary(4), true),
+            Field::new("c_dec256", DataType::Decimal256(50, 10), true),
+            Field::new("c_list", list_dt, true),
+        ]));
+        (schema, arrays)
+    }
+
+    #[test]
+    fn source_checksums_match_arrow_side_for_every_covered_type() {
+        // Kills the 50+ missed mutants in `source_checksums` (stub -> vec![],
+        // every deleted per-type match arm): the source(A) pass must reproduce
+        // the arrow(B) fold for EVERY covered type, through independent code.
+        let (schema, arrays) = covered_arrays();
+        let a = source_checksums(&schema, &FakeCells);
+        assert_eq!(a.len(), arrays.len(), "one checksum per column");
+        for (i, arr) in arrays.iter().enumerate() {
+            let b = column_xxh3(arr.as_ref(), None);
+            assert_eq!(
+                a[i],
+                b,
+                "column {} ({:?}): source(A) != arrow(B)",
+                schema.field(i).name(),
+                schema.field(i).data_type()
+            );
+            assert_ne!(
+                a[i],
+                0,
+                "column {} must actually hash — a deleted match arm folds nothing and yields 0",
+                schema.field(i).name()
+            );
+        }
+    }
+
+    #[test]
+    fn column_fold_is_xor_of_per_cell_hashes() {
+        // Kills `^= -> |=` in column_xxh3: an OR fold saturates towards
+        // all-ones after a few rows and then ANY corruption produces the same
+        // "checksum" — false security. Pin the exact XOR fold and its
+        // order-independence.
+        use xxhash_rust::xxh3::xxh3_64;
+        let expect = xxh3_64(&10_i64.to_le_bytes())
+            ^ xxh3_64(&20_i64.to_le_bytes())
+            ^ xxh3_64(&30_i64.to_le_bytes());
+        let arr = Int64Array::from(vec![10_i64, 20, 30]);
+        assert_eq!(column_xxh3(&arr, None), expect, "fold must be XOR");
+        let shuffled = Int64Array::from(vec![30_i64, 10, 20]);
+        assert_eq!(
+            column_xxh3(&shuffled, None),
+            expect,
+            "XOR fold is order-independent"
+        );
+        let or_fold = xxh3_64(&10_i64.to_le_bytes())
+            | xxh3_64(&20_i64.to_le_bytes())
+            | xxh3_64(&30_i64.to_le_bytes());
+        assert_ne!(
+            expect, or_fold,
+            "fixture sanity: XOR and OR must differ here"
+        );
+    }
+
+    #[test]
+    fn validate_folds_multiple_parts_by_xor() {
+        // Kills `^= -> |=` in validate_recorded_checksums' cross-part fold: a
+        // one-part fixture folds once into 0 (`0^s == 0|s`) and cannot see the
+        // operator. Two parts with different rows expose it.
+        let b1 = batch3(2);
+        let b2 = batch3(7);
+        let dir = tempfile::tempdir().unwrap();
+        let p1 = dir.path().join("part1.parquet");
+        let p2 = dir.path().join("part2.parquet");
+        write_parquet(&b1, &p1);
+        write_parquet(&b2, &p2);
+        let s1 = arrow_batch_checksums(&b1);
+        let s2 = arrow_batch_checksums(&b2);
+        let recorded: Vec<crate::manifest::ColumnChecksum> = s1
+            .iter()
+            .zip(s2.iter())
+            .zip(b1.schema().fields())
+            .map(|((a, b), f)| crate::manifest::ColumnChecksum {
+                name: f.name().clone(),
+                checksum: (a ^ b).to_string(),
+            })
+            .collect();
+        validate_recorded_checksums(&recorded, &[p1, p2], None)
+            .expect("two matching parts must validate — the cross-part fold is XOR");
+    }
+
+    #[test]
+    fn check_rule_gates_list_element_types() {
+        // Kills the List-arm mutants in check_rule: dropping the guard (every
+        // list "covered") silently checksums lists the encoder can't represent;
+        // dropping the arm changes the skip REASON (lists must be named as
+        // list-skips, not lumped into the generic uncovered bucket).
+        let covered = DataType::List(Arc::new(Field::new("item", DataType::Int64, true)));
+        assert!(
+            matches!(check_rule(&covered), CheckRule::Covered),
+            "List<Int64> is covered"
+        );
+        let uncovered = DataType::List(Arc::new(Field::new("item", DataType::Binary, true)));
+        match check_rule(&uncovered) {
+            CheckRule::Skipped(reason) => assert_eq!(reason, "List element type not matched"),
+            CheckRule::Covered => panic!("List<Binary> must be Skipped, got Covered"),
+        }
+        let large = DataType::LargeList(Arc::new(Field::new("item", DataType::Int64, true)));
+        match check_rule(&large) {
+            CheckRule::Skipped(reason) => assert_eq!(reason, "List element type not matched"),
+            CheckRule::Covered => panic!("LargeList must be Skipped, got Covered"),
+        }
+    }
+
     #[test]
     fn coverage_skips_names_uncovered_columns_and_they_contribute_zero() {
         use arrow::array::TimestampNanosecondArray;

--- a/src/types/decimal.rs
+++ b/src/types/decimal.rs
@@ -205,6 +205,16 @@ mod tests {
     }
 
     #[test]
+    fn scaled_zero_formats_unsigned() {
+        // Mutation-pilot find: `negative = value < 0` mutated to `<=` survived
+        // the suite — zero would render as "-0.00" (the sign is computed before
+        // formatting). A signed zero leaks into CSV output and checksum inputs.
+        assert_eq!(scaled_i128_to_decimal_str(0, 2), "0.00");
+        assert_eq!(scaled_i128_to_decimal_str(0, 0), "0");
+        assert_eq!(scaled_i128_to_decimal_str(0, 6), "0.000000");
+    }
+
+    #[test]
     fn standard_financial_values() {
         assert_eq!(decimal_str_to_scaled_i128("0.10", 2), Some(10));
         assert_eq!(decimal_str_to_scaled_i128("0.20", 2), Some(20));

--- a/tests/cdc_conformance_gate.rs
+++ b/tests/cdc_conformance_gate.rs
@@ -351,18 +351,26 @@ fn every_cdc_engine_covers_every_conformance_case() {
 fn every_live_cdc_test_asserts_an_outcome() {
     let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
     let mut naked = Vec::new();
-    for file in [
-        "tests/live/live_cdc.rs",
-        "tests/live/live_cdc_mssql.rs",
-        "tests/live/gremlin_cdc.rs",
-        "tests/live/live_cdc_golden.rs",
-        "tests/live/live_cdc_oracle.rs",
-        "tests/live/live_cdc_mbt.rs",
-        "tests/live/live_cdc_property.rs",
-        "tests/live/live_batch_switch_golden.rs",
-        "tests/live/live_cdc_mongo.rs",
-    ] {
-        let src = fs::read_to_string(root.join(file)).unwrap();
+    // Every `tests/live/*cdc*.rs` file is scanned AUTOMATICALLY — a hardcoded
+    // list silently exempted `live_cdc_replica.rs` (its capture ran outside the
+    // gate for months; the matrix audit caught it). Files whose name does not
+    // carry `cdc` but still run CDC captures are listed explicitly.
+    let mut files: Vec<String> = fs::read_dir(root.join("tests/live"))
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n.ends_with(".rs") && n.contains("cdc"))
+        .map(|n| format!("tests/live/{n}"))
+        .collect();
+    files.push("tests/live/live_batch_switch_golden.rs".to_string());
+    files.sort();
+    assert!(
+        files.len() >= 10,
+        "glob found only {} cdc files — the discovery itself regressed",
+        files.len()
+    );
+    for file in files {
+        let src = fs::read_to_string(root.join(&file)).unwrap();
         // Split on test attributes; each chunk is one test body (plus tail).
         for chunk in src.split("#[test]").skip(1) {
             let name = chunk
@@ -391,7 +399,21 @@ fn every_live_cdc_test_asserts_an_outcome() {
                 || chunk.contains("read_csv(")
                 || chunk.contains("gcs list")
                 || chunk.contains("query_row")
-                || chunk.contains("status.success()")
+                // NOTE: `status.success()` is deliberately NOT a marker — it is
+                // exactly the "process exited 0" non-outcome this gate exists to
+                // reject (a 0-row capture exits 0). It sat in this dictionary for
+                // months, hollowing the gate; the matrix audit removed it. A
+                // must-fail test's NEGATIVE exit assert IS an outcome (below).
+                || chunk.contains("!out.status.success()")
+                || chunk.contains("!res.status.success()")
+                || chunk.contains("read_cdc_rows(") // replica-suite replay oracle
+                // `rivet validate` re-reads the destination (parts + manifest +
+                // checksums) — an independent read-back, not the capture's exit.
+                || chunk.contains("args([\"validate\"")
+                // External-warehouse oracles (the strongest read-back in the
+                // suite): the CDC parquet is loaded and queried by another engine.
+                || chunk.contains("duckdb_run_sql_json(")
+                || chunk.contains("clickhouse_run_sql_json(")
                 // Read-back helpers the newer suites use. This dictionary
                 // is INTENTIONALLY wide: the read-backs differ because the
                 // oracles differ (manifest vs parquet vs csv vs gcs listing

--- a/tests/common/parquet.rs
+++ b/tests/common/parquet.rs
@@ -134,6 +134,34 @@ pub fn dir_parquet_distinct_strings(dir: &Path, col: &str) -> BTreeSet<String> {
     out
 }
 
+/// Sum `row_count` across the run-unique manifest COPIES (`manifest-<run>.json`)
+/// in `dir` — the dest sidecars a cross-run consumer (the Pro loader's reconcile,
+/// a warehouse autoloader) reads. Unlike a parquet re-read, this goes **RED when
+/// a run's manifest CLOBBERS**: the payload survives (run-unique parts) but its
+/// manifest entry is lost, so pre-fix a shared prefix held ONE clobbered
+/// `manifest.json` and the sum was the LAST run's rows, not every run's. This is
+/// the oracle a run-uniqueness / accumulation claim must use — the `file_log`
+/// state-DB ledger accumulates regardless of the sidecar clobber, and a parquet
+/// re-read cannot see it. Ignores the canonical `manifest.json` pointer (it
+/// duplicates the latest copy; counting it would double the latest run).
+pub fn dir_manifest_copy_total_rows(dir: &Path) -> i64 {
+    let mut total = 0;
+    for path in files_with_extension(dir, "json") {
+        let name = path.file_name().unwrap_or_default().to_string_lossy();
+        if !(name.starts_with("manifest-") && name.ends_with(".json")) {
+            continue; // the bare `manifest.json` pointer, or a foreign file
+        }
+        let bytes = std::fs::read(&path).expect("read manifest copy");
+        let v: serde_json::Value =
+            serde_json::from_slice(&bytes).expect("parse manifest copy JSON");
+        total += v
+            .get("row_count")
+            .and_then(serde_json::Value::as_i64)
+            .unwrap_or(0);
+    }
+    total
+}
+
 /// True if any `.parquet` under `dir` carries a column named `col`.
 pub fn dir_parquet_has_column(dir: &Path, col: &str) -> bool {
     files_with_extension(dir, "parquet").iter().any(|p| {

--- a/tests/common/parquet.rs
+++ b/tests/common/parquet.rs
@@ -35,8 +35,8 @@ pub fn parquet_rows_from_bytes(bytes: Vec<u8>) -> usize {
 }
 
 /// The `i64` `id` column values of a single `.parquet` file, WITH multiplicity
-/// (so duplicates are observable). Panics if there is no `id` column or it does
-/// not decode as `Int64` — the canonical seeders all use a `BIGINT id`.
+/// (so duplicates are observable). Accepts `Int64` (the canonical `BIGINT id`
+/// seeders) or `Int32` (an `INT id` source column) — panics on anything else.
 pub fn parquet_ids(path: &Path) -> Vec<i64> {
     use arrow::array::{Array, AsArray};
     let bytes = std::fs::read(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
@@ -48,13 +48,24 @@ pub fn parquet_ids(path: &Path) -> Vec<i64> {
     for batch in reader {
         let batch = batch.unwrap();
         let col = batch.column_by_name("id").expect("id column present");
-        let a = col
-            .as_primitive_opt::<arrow::datatypes::Int64Type>()
-            .expect("id column decodes as Int64");
-        for i in 0..a.len() {
-            if !a.is_null(i) {
-                out.push(a.value(i));
+        match col.data_type() {
+            arrow::datatypes::DataType::Int64 => {
+                let a = col.as_primitive::<arrow::datatypes::Int64Type>();
+                for i in 0..a.len() {
+                    if !a.is_null(i) {
+                        out.push(a.value(i));
+                    }
+                }
             }
+            arrow::datatypes::DataType::Int32 => {
+                let a = col.as_primitive::<arrow::datatypes::Int32Type>();
+                for i in 0..a.len() {
+                    if !a.is_null(i) {
+                        out.push(i64::from(a.value(i)));
+                    }
+                }
+            }
+            other => panic!("id column: expected Int32/Int64, got {other:?}"),
         }
     }
     out
@@ -246,11 +257,25 @@ pub fn read_cdc_changes(dir: &Path) -> Vec<CdcChange> {
     for path in files_with_extension(dir, "parquet") {
         for batch in reader(&path) {
             let b = batch.unwrap();
-            let col_i64 = |name: &str| {
-                b.column_by_name(name)
-                    .unwrap_or_else(|| panic!("{name} column present"))
-                    .as_primitive::<arrow::datatypes::Int64Type>()
-                    .clone()
+            // Int32 OR Int64 → i64: an `INT` source column lands as Int32 in
+            // the CDC parquet; the original Int64-only downcast panicked on it.
+            let col_i64 = |name: &str| -> Vec<i64> {
+                let col = b
+                    .column_by_name(name)
+                    .unwrap_or_else(|| panic!("{name} column present"));
+                match col.data_type() {
+                    arrow::datatypes::DataType::Int64 => col
+                        .as_primitive::<arrow::datatypes::Int64Type>()
+                        .values()
+                        .to_vec(),
+                    arrow::datatypes::DataType::Int32 => col
+                        .as_primitive::<arrow::datatypes::Int32Type>()
+                        .values()
+                        .iter()
+                        .map(|v| i64::from(*v))
+                        .collect(),
+                    other => panic!("{name}: expected Int32/Int64, got {other:?}"),
+                }
             };
             let col_str = |name: &str| {
                 b.column_by_name(name)
@@ -262,16 +287,29 @@ pub fn read_cdc_changes(dir: &Path) -> Vec<CdcChange> {
             let (op, pos) = (col_str("__op"), col_str("__pos"));
             for r in 0..b.num_rows() {
                 out.push(CdcChange {
-                    id: id.value(r),
-                    v: v.value(r),
+                    id: id[r],
+                    v: v[r],
                     op: op.value(r).to_string(),
                     pos: pos.value(r).to_string(),
-                    seq: seq.value(r),
+                    seq: seq[r],
                 });
             }
         }
     }
     out
+}
+
+/// Sorted `(id, op)` pairs from the CDC parquet under `dir` — the independent
+/// re-read a capture-count assert needs. `manifest_rows(out) == 2` is rivet's
+/// OWN summary and cannot tell "the right 2 changes" from "the wrong 2"; this
+/// reads the payload itself (matrix audit: self-oracle class).
+pub fn cdc_id_ops(dir: &Path) -> Vec<(i64, String)> {
+    let mut v: Vec<(i64, String)> = read_cdc_changes(dir)
+        .into_iter()
+        .map(|c| (c.id, c.op))
+        .collect();
+    v.sort();
+    v
 }
 
 /// `__pos` → a single monotonic `u128`, per engine (`__seq` is the lower-order

--- a/tests/common/storage.rs
+++ b/tests/common/storage.rs
@@ -62,6 +62,86 @@ pub fn ensure_gcs_bucket(bucket: &str) {
     );
 }
 
+/// Download every `.parquet` under `bucket/prefix` from MinIO (via `mc cat`
+/// inside the container) and sum their row counts — the independent oracle an
+/// "all rows" claim on an S3 destination needs. An `mc ls | wc -l` file count
+/// proves presence, not content (matrix audit: wrong-artifact class).
+pub fn minio_parquet_total_rows(bucket: &str, prefix: &str) -> usize {
+    // List at BUCKET level: `mc ls` prints names relative to the listed path,
+    // and that differs between a directory-style prefix (`prefix/file`) and
+    // rivet's string-style concatenation (`prefixfile`). Bucket-level names are
+    // always full keys; filter by prefix ourselves.
+    let ls_script = format!(
+        "mc alias set local http://127.0.0.1:9000 {MINIO_ACCESS_KEY} {MINIO_SECRET_KEY} >/dev/null 2>&1 && \
+         mc ls --recursive local/{bucket} 2>/dev/null"
+    );
+    let ls = Command::new("docker")
+        .args(["compose", "exec", "-T", "minio", "sh", "-c", &ls_script])
+        .output()
+        .expect("mc ls");
+    assert!(ls.status.success(), "mc ls failed");
+    let mut total = 0usize;
+    for line in String::from_utf8_lossy(&ls.stdout).lines() {
+        // `mc ls` line: `[date] [time TZ] [size] [class] name` — name is last,
+        // and for a STRING prefix (rivet concatenates `{prefix}{file}`, no `/`)
+        // it is the full BUCKET-relative key, so cat under the bucket, not the
+        // prefix (double-prefixing 404s).
+        let Some(name) = line.split_whitespace().last() else {
+            continue;
+        };
+        if !name.starts_with(prefix) || !name.ends_with(".parquet") {
+            continue;
+        }
+        let cat_script = format!(
+            "mc alias set local http://127.0.0.1:9000 {MINIO_ACCESS_KEY} {MINIO_SECRET_KEY} >/dev/null 2>&1 && \
+             mc cat local/{bucket}/{name}"
+        );
+        let cat = Command::new("docker")
+            .args(["compose", "exec", "-T", "minio", "sh", "-c", &cat_script])
+            .output()
+            .expect("mc cat");
+        assert!(cat.status.success(), "mc cat {name} failed");
+        total += super::parquet_rows_from_bytes(cat.stdout);
+    }
+    total
+}
+
+/// Same independent oracle for fake-gcs: list the objects via the JSON API,
+/// then `GET ?alt=media` each `.parquet` and sum the row counts.
+pub fn fake_gcs_parquet_total_rows(bucket: &str, prefix: &str) -> usize {
+    use std::io::{Read, Write};
+    let http = |req: String| -> Vec<u8> {
+        let mut s = TcpStream::connect("127.0.0.1:4443").expect("connect fake-gcs");
+        s.write_all(req.as_bytes()).expect("write fake-gcs req");
+        let mut buf = Vec::new();
+        let _ = s.read_to_end(&mut buf);
+        // Strip the HTTP/1.0 header block: body starts after the first CRLFCRLF.
+        let sep = buf
+            .windows(4)
+            .position(|w| w == b"\r\n\r\n")
+            .expect("http header separator");
+        buf.split_off(sep + 4)
+    };
+    let list = http(format!(
+        "GET /storage/v1/b/{bucket}/o?prefix={prefix} HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+    ));
+    let list: serde_json::Value = serde_json::from_slice(&list).expect("fake-gcs list JSON");
+    let mut total = 0usize;
+    for item in list["items"].as_array().map(Vec::as_slice).unwrap_or(&[]) {
+        let name = item["name"].as_str().expect("object name");
+        if !name.ends_with(".parquet") {
+            continue;
+        }
+        // Object names carry `/`; the JSON API path wants them %2F-escaped.
+        let escaped = name.replace('/', "%2F");
+        let bytes = http(format!(
+            "GET /storage/v1/b/{bucket}/o/{escaped}?alt=media HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+        ));
+        total += super::parquet_rows_from_bytes(bytes);
+    }
+    total
+}
+
 /// Idempotently create `container` in the local Azurite emulator via the `az`
 /// CLI + the well-known dev connection string, with CONTAINER-level public
 /// read access. opendal's Azblob backend does not create the container, so

--- a/tests/live/audit_rerun.rs
+++ b/tests/live/audit_rerun.rs
@@ -132,10 +132,9 @@ fn audit_full_rerun_does_not_orphan_parts() {
         String::from_utf8_lossy(&first.stderr)
     );
 
-    // Sleep past a second boundary so the second run's %Y%m%d_%H%M%S timestamp
-    // differs from the first — otherwise the full-mode filename collides and the
-    // second write simply overwrites the first (no observable orphan).
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
 
     // Second run to the SAME prefix, no --resume.
     let second = run_rivet_with_warn_log(&[

--- a/tests/live/batch_memory_policy.rs
+++ b/tests/live/batch_memory_policy.rs
@@ -303,8 +303,9 @@ fn auto_shrink_incremental_cursor_is_correct() {
         "first incremental run must produce exactly one file"
     );
 
-    // Sleep 1 s so the second run's file timestamp differs (file name includes seconds).
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
 
     // Run #2 — source unchanged, cursor should be at last updated_at → zero new rows → no new file.
     let r2 = run_rivet_export(&cfgpath, &export_name);

--- a/tests/live/chunking_stand.rs
+++ b/tests/live/chunking_stand.rs
@@ -922,6 +922,11 @@ fn run_dest_gcs(eng: Eng) {
         count_gcs_parquet(bucket, &prefix) >= 1,
         "fake-gcs bucket must hold >=1 parquet under {prefix}"
     );
+    assert_eq!(
+        fake_gcs_parquet_total_rows(bucket, &prefix),
+        100,
+        "all rows: the downloaded gcs parquet must hold every seeded row (presence is not content)"
+    );
 }
 
 /// `destination: s3` (MinIO) — the export lands a parquet in the bucket (mc ls).
@@ -967,6 +972,11 @@ fn run_dest_s3(eng: Eng) {
     assert!(
         listing.matches(".parquet").count() >= 1,
         "minio must hold >=1 parquet under {prefix}; got:\n{listing}"
+    );
+    assert_eq!(
+        minio_parquet_total_rows(bucket, &prefix),
+        100,
+        "all rows: the downloaded s3 parquet must hold every seeded row (presence is not content)"
     );
 }
 
@@ -1089,6 +1099,11 @@ fn stand_dest_gcs_mongo() {
         count_gcs_parquet(bucket, &prefix) >= 1,
         "fake-gcs must hold >=1 parquet under {prefix}"
     );
+    assert_eq!(
+        fake_gcs_parquet_total_rows(bucket, &prefix),
+        100,
+        "all rows: the downloaded gcs parquet must hold every seeded row (presence is not content)"
+    );
 }
 
 #[test]
@@ -1135,6 +1150,11 @@ fn stand_dest_s3_mongo() {
     assert!(
         listing.matches(".parquet").count() >= 1,
         "minio must hold >=1 parquet under {prefix}; got:\n{listing}"
+    );
+    assert_eq!(
+        minio_parquet_total_rows(bucket, &prefix),
+        100,
+        "all rows: the downloaded s3 parquet must hold every seeded row (presence is not content)"
     );
 }
 

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -417,6 +417,11 @@ fn cdc_idle_first_run_then_change_is_captured_not_skipped() {
         1,
         "the change between an idle run and the next run must be captured, not skipped"
     );
+    assert_eq!(
+        cdc_id_ops(&out2),
+        vec![(1, "insert".to_string())],
+        "the captured parquet must hold exactly THE change (a count of 1 could be a wrong row)"
+    );
 }
 
 #[test]
@@ -463,6 +468,11 @@ fn cdc_crash_after_flush_before_ack_re_reads_on_resume() {
         manifest_rows(&out2),
         2,
         "resume after a crash before the checkpoint re-reads both changes (no loss)"
+    );
+    assert_eq!(
+        cdc_id_ops(&out2),
+        vec![(1, "insert".to_string()), (2, "insert".to_string())],
+        "the re-read parquet must hold exactly the un-acked changes"
     );
 }
 
@@ -528,6 +538,11 @@ fn pg_cdc_resume_captures_only_new_changes() {
         manifest_rows(&out2),
         2,
         "resume drains only the 2 new changes (slot advanced, no re-read)"
+    );
+    assert_eq!(
+        cdc_id_ops(&out2),
+        vec![(3, "insert".to_string()), (4, "insert".to_string())],
+        "the resumed parquet must hold exactly the NEW changes (count 2 cannot tell new-2 from wrong-2)"
     );
 }
 
@@ -1521,6 +1536,11 @@ exports:
         "pre-existing rows land in snapshot/"
     );
     assert_eq!(manifest_rows(&out), 0, "nothing to drain yet");
+    assert_eq!(
+        dir_parquet_id_set(&snap).into_iter().collect::<Vec<i64>>(),
+        vec![1, 2],
+        "snapshot parquet must hold exactly the pre-existing ids (independent re-read)"
+    );
     let snap_parts = || {
         std::fs::read_dir(&snap)
             .unwrap()
@@ -1540,6 +1560,11 @@ exports:
         .unwrap();
     run_rivet_ok(&cfg);
     assert_eq!(manifest_rows(&out), 1, "the post-snapshot change streams");
+    assert_eq!(
+        cdc_id_ops(&out),
+        vec![(3, "insert".to_string())],
+        "streamed parquet must hold exactly the post-snapshot change (not just a count of 1)"
+    );
     assert_eq!(snap_parts(), 1, "run 2 must NOT re-snapshot");
 }
 
@@ -1857,12 +1882,24 @@ exports:
     run_rivet_ok(&cfg);
     let _slot = Slot(slot.clone());
     assert_eq!(manifest_rows(&out.join("snapshot")), 2);
+    assert_eq!(
+        dir_parquet_id_set(&out.join("snapshot"))
+            .into_iter()
+            .collect::<Vec<i64>>(),
+        vec![1, 2],
+        "snapshot parquet must hold exactly the pre-existing ids (independent re-read)"
+    );
     assert_eq!(manifest_rows(&out), 0);
 
     c.execute(&format!("INSERT INTO {tbl} VALUES (3,30)"), &[])
         .unwrap();
     run_rivet_ok(&cfg);
     assert_eq!(manifest_rows(&out), 1, "the post-snapshot change streams");
+    assert_eq!(
+        cdc_id_ops(&out),
+        vec![(3, "insert".to_string())],
+        "streamed parquet must hold exactly the post-snapshot change (not just a count of 1)"
+    );
 }
 
 // `columns:` type overrides must apply to CDC exactly like batch — pinned for
@@ -2064,6 +2101,16 @@ exports:
     run_rivet_ok(&cfg);
     assert_eq!(manifest_rows(&out.join(&t1)), 2, "table 1 sub-prefix");
     assert_eq!(manifest_rows(&out.join(&t2)), 1, "table 2 sub-prefix");
+    assert_eq!(
+        cdc_id_ops(&out.join(&t1)),
+        vec![(1, "insert".to_string()), (2, "insert".to_string())],
+        "table 1 parquet holds exactly its own changes (routing, not just counts)"
+    );
+    assert_eq!(
+        cdc_id_ops(&out.join(&t2)),
+        vec![(7, "insert".to_string())],
+        "table 2 parquet holds exactly its own changes (routing, not just counts)"
+    );
 
     // Resume: the shared position advanced once for both tables.
     run_rivet_ok(&cfg);
@@ -2117,6 +2164,16 @@ exports:
     run_rivet_ok(&cfg);
     assert_eq!(manifest_rows(&out.join(&ta)), 2);
     assert_eq!(manifest_rows(&out.join(&tb)), 1);
+    assert_eq!(
+        cdc_id_ops(&out.join(&ta)),
+        vec![(1, "insert".to_string()), (2, "insert".to_string())],
+        "table a parquet holds exactly its own changes (routing, not just counts)"
+    );
+    assert_eq!(
+        cdc_id_ops(&out.join(&tb)),
+        vec![(7, "insert".to_string())],
+        "table b parquet holds exactly its own changes (routing, not just counts)"
+    );
 
     run_rivet_ok(&cfg);
     assert_eq!(manifest_rows(&out.join(&ta)), 0, "resume: no re-read");
@@ -2427,6 +2484,11 @@ fn pg_cdc_idle_first_run_then_change_is_captured_not_skipped() {
         1,
         "the change between an idle run and the next run must be captured, not skipped"
     );
+    assert_eq!(
+        cdc_id_ops(&out2),
+        vec![(1, "insert".to_string())],
+        "the captured parquet must hold exactly THE change (a count of 1 could be a wrong row)"
+    );
 }
 
 #[test]
@@ -2479,6 +2541,11 @@ fn pg_cdc_crash_after_flush_before_ack_does_not_advance_the_slot() {
         manifest_rows(&out2),
         2,
         "the slot stayed put across the crash → resume re-reads both (no loss)"
+    );
+    assert_eq!(
+        cdc_id_ops(&out2),
+        vec![(1, "insert".to_string()), (2, "insert".to_string())],
+        "the re-read parquet must hold exactly the un-acked changes"
     );
 }
 
@@ -2585,6 +2652,11 @@ fn cdc_resume_captures_only_new_changes() {
         manifest_rows(&out2),
         2,
         "resume must capture exactly the 2 changes since the checkpoint (no gap, no dup)"
+    );
+    assert_eq!(
+        cdc_id_ops(&out2),
+        vec![(3, "insert".to_string()), (4, "insert".to_string())],
+        "the resumed parquet must hold exactly the NEW changes (count 2 cannot tell new-2 from wrong-2)"
     );
 }
 

--- a/tests/live/live_cdc_mssql.rs
+++ b/tests/live/live_cdc_mssql.rs
@@ -90,6 +90,11 @@ fn mssql_cdc_resume_captures_only_new_changes() {
         2,
         "resume must capture only the 2 new changes (LSN resume), not re-read all 4"
     );
+    assert_eq!(
+        cdc_id_ops(&out2),
+        vec![(3, "insert".to_string()), (4, "insert".to_string())],
+        "the resumed parquet must hold exactly the NEW changes (count 2 cannot tell new-2 from wrong-2)"
+    );
 }
 
 #[test]
@@ -237,6 +242,11 @@ fn mssql_cdc_idle_first_run_then_change_is_captured_not_skipped() {
         manifest_rows(&out2),
         1,
         "the change between an idle run and the next run must be captured, not skipped"
+    );
+    assert_eq!(
+        cdc_id_ops(&out2),
+        vec![(1, "insert".to_string())],
+        "the captured parquet must hold exactly THE change (a count of 1 could be a wrong row)"
     );
 }
 
@@ -509,6 +519,13 @@ fn mssql_cdc_initial_snapshot_covers_preexisting_rows_then_streams() {
     run_rivet_ok(&cfg);
     assert_eq!(manifest_rows(&out.join("snapshot")), 2);
     assert_eq!(
+        dir_parquet_id_set(&out.join("snapshot"))
+            .into_iter()
+            .collect::<Vec<i64>>(),
+        vec![1, 2],
+        "snapshot parquet must hold exactly the pre-existing ids (independent re-read)"
+    );
+    assert_eq!(
         manifest_rows(&out),
         0,
         "anchor at max LSN ⇒ nothing to drain"
@@ -518,6 +535,11 @@ fn mssql_cdc_initial_snapshot_covers_preexisting_rows_then_streams() {
     wait_for_capture(&ci, 3);
     run_rivet_ok(&cfg);
     assert_eq!(manifest_rows(&out), 1, "the post-snapshot change streams");
+    assert_eq!(
+        cdc_id_ops(&out),
+        vec![(3, "insert".to_string())],
+        "streamed parquet must hold exactly the post-snapshot change (not just a count of 1)"
+    );
 }
 
 // RED test for the finding: MONEY/SMALLMONEY were typed correctly
@@ -689,6 +711,11 @@ fn mssql_cdc_crash_before_checkpoint_re_reads_on_resume() {
         manifest_rows(&out2),
         2,
         "crash before the checkpoint → resume re-reads exactly the 2 un-checkpointed changes"
+    );
+    assert_eq!(
+        cdc_id_ops(&out2),
+        vec![(3, "insert".to_string()), (4, "insert".to_string())],
+        "the re-read parquet must hold exactly the un-acked changes"
     );
 }
 

--- a/tests/live/live_chunked_recovery.rs
+++ b/tests/live/live_chunked_recovery.rs
@@ -273,8 +273,9 @@ fn chunked_crash_after_chunk_file_before_commit_resume_reruns_chunk_atleastonce(
         "exactly 1 manifest entry must exist after crash (chunk 0 file was recorded)"
     );
 
-    // Sleep so that the resumed chunk 0 write gets a distinct filename timestamp.
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
 
     // ── Resume run ────────────────────────────────────────────────────────────
     let resume = std::process::Command::new(RIVET_BIN)
@@ -451,9 +452,9 @@ fn parallel_chunked_crash_after_chunk_complete_resume_finishes_with_no_duplicate
         "no chunk_task should be 'failed' from a panic; got failed={failed_pre}"
     );
 
-    // Sleep so any chunk files re-written on resume get distinct timestamps
-    // in their filenames (filenames embed `%Y%m%d_%H%M%S`).
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
 
     // ── Resume run ────────────────────────────────────────────────────────────
     let resume = std::process::Command::new(RIVET_BIN)
@@ -589,7 +590,9 @@ fn parallel_chunked_crash_after_chunk_file_stuck_running_resume_reruns_chunk() {
         "exactly 1 manifest entry must exist after crash (chunk 0 file was recorded before panic)"
     );
 
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
 
     // ── Resume with parallel: 2 (exercises both reset path and parallel workers)
     //

--- a/tests/live/live_crash_recovery.rs
+++ b/tests/live/live_crash_recovery.rs
@@ -208,10 +208,9 @@ fn crash_after_file_write_leaves_file_but_no_manifest_or_cursor() {
     );
     assert_eq!(cursor_value(&cfg, &export), None);
 
-    // Recovery: second run sees no cursor so it re-exports everything,
-    // producing a second file (different timestamp).  Sleep to ensure a
-    // distinct timestamp (rivet uses 1-second granularity).
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
     let rec = std::process::Command::new(RIVET_BIN)
         .args([
             "run",
@@ -279,7 +278,9 @@ fn crash_after_manifest_update_leaves_file_and_manifest_but_no_cursor() {
     );
 
     // Recovery: re-run.  No cursor → full re-export; manifest grows by 1.
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
     let rec = std::process::Command::new(RIVET_BIN)
         .args([
             "run",
@@ -336,7 +337,9 @@ fn crash_after_cursor_commit_is_recoverable_with_full_state() {
     let _metric_after_crash = metric_count(&cfg, &export);
 
     // Recovery: re-run must see the cursor and export zero additional rows.
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
     let rec = std::process::Command::new(RIVET_BIN)
         .args([
             "run",

--- a/tests/live/live_crash_soak.rs
+++ b/tests/live/live_crash_soak.rs
@@ -82,8 +82,9 @@ exports:
         String::from_utf8_lossy(&crash.stderr)
     );
 
-    // Distinct filename timestamps for any re-run within the same second.
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
 
     // Resume to completion.
     let resume = rivet(&cfg, &export, true, None);

--- a/tests/live/live_destination_parity.rs
+++ b/tests/live/live_destination_parity.rs
@@ -144,6 +144,13 @@ fn s3_minio_destination_produces_one_parquet_with_all_rows() {
         parquet_count, 1,
         "s3 (MinIO) must produce exactly one parquet under the prefix;\nmc ls output:\n{listing}"
     );
+    // "all rows" needs a CONTENT oracle, not file presence: download the
+    // object(s) and count the physical rows (matrix audit: wrong-artifact).
+    assert_eq!(
+        minio_parquet_total_rows(bucket, &prefix),
+        25,
+        "the downloaded s3 parquet must hold every seeded row"
+    );
 }
 
 #[test]
@@ -191,6 +198,13 @@ fn gcs_fake_destination_produces_one_parquet_with_all_rows() {
     assert!(
         parquet_count >= 1,
         "fake-gcs bucket must contain at least one .parquet; response:\n{resp}"
+    );
+    // "all rows" needs a CONTENT oracle, not file presence: download the
+    // object(s) and count the physical rows (matrix audit: wrong-artifact).
+    assert_eq!(
+        fake_gcs_parquet_total_rows(bucket, &prefix),
+        25,
+        "the downloaded gcs parquet must hold every seeded row"
     );
 }
 
@@ -286,7 +300,11 @@ fn destination_parity_row_counts_match_across_local_s3_gcs() {
         assert!(ok, "gcs failed: {err}");
     }
 
-    // Structural parity: each backend must report at least one file.
+    // TRUE parity: the same physical row count downloaded back from every
+    // backend. The prior version counted FILES for s3 ("mc ls | wc -l") and
+    // settled for "no error" on gcs — trusting rivet's own summary is exactly
+    // the self-oracle the audit flagged; a backend silently writing a short
+    // parquet passed. Every leg now downloads and counts rows.
     assert_eq!(
         local_rows, ROWS as usize,
         "local backend row count mismatch"
@@ -295,6 +313,14 @@ fn destination_parity_row_counts_match_across_local_s3_gcs() {
         s3_file_count >= 1,
         "s3 backend must have at least one object under {s3_prefix}"
     );
-    // GCS file count checked via the dedicated test above; here we settle
-    // for "no error".
+    assert_eq!(
+        minio_parquet_total_rows(s3_bucket, &s3_prefix),
+        ROWS as usize,
+        "s3 (MinIO) downloaded row count must equal the seed"
+    );
+    assert_eq!(
+        fake_gcs_parquet_total_rows(gcs_bucket, &gcs_prefix),
+        ROWS as usize,
+        "gcs (fake-gcs) downloaded row count must equal the seed"
+    );
 }

--- a/tests/live/live_keyset.rs
+++ b/tests/live/live_keyset.rs
@@ -221,6 +221,14 @@ fn keyset_checkpoint_resume_second_run_captures_only_new_keys() {
         keys3, expected,
         "the union of all runs must equal the full source key set"
     );
+    // `read_uid_set` is a parquet re-read; assert the dest manifest COPIES
+    // (`manifest-<run>.json`, reconcile's artifact) span every run — a resumed
+    // run clobbering a prior manifest is silent to the parquet re-read.
+    assert_eq!(
+        dir_manifest_copy_total_rows(out_dir.path()),
+        1500,
+        "run-unique manifest copies must sum run 1 (1000) + run 3 (500); a clobbered manifest is silent to the parquet re-read"
+    );
 }
 
 /// PostgreSQL UUID PK is the most common non-integer PK in production
@@ -469,6 +477,12 @@ fn keyset_checkpoint_resume_pg_second_run_captures_only_new_keys() {
         keys3, expected,
         "union of all runs equals the full source key set"
     );
+    // Dest manifest copies (reconcile's artifact), not just the parquet re-read.
+    assert_eq!(
+        dir_manifest_copy_total_rows(out_dir.path()),
+        1200,
+        "run-unique manifest copies must sum run 1 (800) + run 3 (400); a clobbered manifest is silent to the parquet re-read"
+    );
 }
 
 /// SQL Server twin of the keyset-resume two-run test. Per the "one engine passing
@@ -549,6 +563,12 @@ fn keyset_checkpoint_resume_mssql_second_run_captures_only_new_keys() {
     assert_eq!(
         keys3, expected,
         "union of all runs equals the full source key set"
+    );
+    // Dest manifest copies (reconcile's artifact), not just the parquet re-read.
+    assert_eq!(
+        dir_manifest_copy_total_rows(out_dir.path()),
+        1500,
+        "run-unique manifest copies must sum run 1 (1000) + run 3 (500); a clobbered manifest is silent to the parquet re-read"
     );
 }
 

--- a/tests/live/live_keyset.rs
+++ b/tests/live/live_keyset.rs
@@ -191,7 +191,9 @@ fn keyset_checkpoint_resume_second_run_captures_only_new_keys() {
         );
         // Distinct millisecond part stamp so a resumed run's parts never clobber
         // the prior run's (run-uniqueness rule).
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+        // back-to-back sub-second runs must not collide — sleeping here would
+        // mask exactly that regression (matrix audit: sleep-masked class).
     };
 
     // Run 1: exports all 1000, persists high-water key id-001000.
@@ -448,7 +450,9 @@ fn keyset_checkpoint_resume_pg_second_run_captures_only_new_keys() {
             "{label} failed; stderr:\n{}",
             String::from_utf8_lossy(&out.stderr)
         );
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+        // back-to-back sub-second runs must not collide — sleeping here would
+        // mask exactly that regression (matrix audit: sleep-masked class).
     };
 
     run("run 1");
@@ -535,7 +539,9 @@ fn keyset_checkpoint_resume_mssql_second_run_captures_only_new_keys() {
             "{label} failed; stderr:\n{}",
             String::from_utf8_lossy(&out.stderr)
         );
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+        // back-to-back sub-second runs must not collide — sleeping here would
+        // mask exactly that regression (matrix audit: sleep-masked class).
     };
 
     run("run 1");

--- a/tests/live/live_mongo.rs
+++ b/tests/live/live_mongo.rs
@@ -154,6 +154,10 @@ fn mongo_batch_type_fidelity_document_is_verbatim_extjson() {
             "_id": 1_i64,
             "i64_big": 9_007_199_254_740_993_i64, // 2^53 + 1
             "dec": mongodb::bson::Bson::Decimal128("123456789.987654321012345".parse().unwrap()),
+            // Nested document — the `type_json` cell's claim (content fidelity
+            // of structured JSON through Parquet) needs its own evidence, not a
+            // ride on the scalar asserts.
+            "nested": doc! { "k": "v-\u{00e9}\u{4e2d}", "arr": [1_i32, 2_i32, 3_i32] },
         }],
     );
 
@@ -169,6 +173,11 @@ fn mongo_batch_type_fidelity_document_is_verbatim_extjson() {
     assert!(
         doc_text.contains("123456789.987654321012345"),
         "Decimal128 must be verbatim (type-tagged), got: {doc_text}"
+    );
+    // type_json: nested structure + non-ASCII content survive verbatim.
+    assert!(
+        doc_text.contains("v-\u{00e9}\u{4e2d}") && doc_text.contains("arr"),
+        "nested JSON (unicode value + array) must be verbatim, got: {doc_text}"
     );
 }
 
@@ -203,6 +212,13 @@ fn mongo_run_reconcile_matches_source_count() {
     assert!(
         summary.contains("MATCH") && !summary.contains("MISMATCH"),
         "reconcile must report a source/dest MATCH (not MISMATCH), got:\n{summary}"
+    );
+    // Independent oracle: the verdict is rivet's own counter chain — also
+    // physically re-read the destination (matrix audit: self-oracle class).
+    assert_eq!(
+        total_parquet_rows(&rig.out_dir()),
+        3000,
+        "destination parquet must physically hold every source document, independent of the reconcile verdict"
     );
 }
 

--- a/tests/live/live_mongo.rs
+++ b/tests/live/live_mongo.rs
@@ -240,6 +240,14 @@ fn mongo_batch_resume_reads_only_new_since_last_run() {
         2500,
         "resume must add only the new rows — 4500 would mean run 2 rescanned"
     );
+    // Dest manifest copies (reconcile's artifact), not just the parquet re-read:
+    // must span both runs (2000 + 500) — a resumed run clobbering a prior
+    // manifest is silent to the re-read but breaks reconcile.
+    assert_eq!(
+        dir_manifest_copy_total_rows(&rig.out_dir()),
+        2500,
+        "run-unique manifest copies must sum run 1 (2000) + run 2 (500); a clobbered manifest is silent to the parquet re-read"
+    );
 }
 
 #[test]

--- a/tests/live/live_mongo_crash_recovery.rs
+++ b/tests/live/live_mongo_crash_recovery.rs
@@ -88,4 +88,13 @@ fn mongo_batch_two_rapid_runs_into_same_prefix_do_not_clobber() {
         100,
         "both snapshots hold every source _id"
     );
+    // The parquet re-read above is a proxy; assert the dest manifest COPIES
+    // (`manifest-<run>.json`, what reconcile / a warehouse autoloader read) also
+    // span both runs. Summed row_count (not a file count) is robust to
+    // parts-per-run (page_size), and RED pre-fix (one clobbered manifest.json).
+    assert_eq!(
+        dir_manifest_copy_total_rows(&rig.out_dir()),
+        200,
+        "run-unique manifest copies must sum both rapid runs' rows; a clobbered manifest is silent to the parquet re-read"
+    );
 }

--- a/tests/live/live_mssql_chunked_recovery.rs
+++ b/tests/live/live_mssql_chunked_recovery.rs
@@ -264,7 +264,9 @@ exports:
         "exactly 1 manifest entry must exist after crash (chunk 0 file was recorded)"
     );
 
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
 
     let resume = std::process::Command::new(RIVET_BIN)
         .args([
@@ -395,7 +397,9 @@ exports:
         "no chunk_task should be 'failed' from a panic; got failed={failed_pre}"
     );
 
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
 
     let resume = std::process::Command::new(RIVET_BIN)
         .args([
@@ -528,7 +532,9 @@ exports:
         "exactly 1 manifest entry must exist after crash (chunk 0 file was recorded before panic)"
     );
 
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
 
     // Resume with parallel: 2 — proves reset works regardless of worker
     // count change between crash and resume.

--- a/tests/live/live_mssql_crash_recovery.rs
+++ b/tests/live/live_mssql_crash_recovery.rs
@@ -258,10 +258,9 @@ fn mssql_crash_after_file_write_leaves_file_but_no_manifest_or_cursor() {
     );
     assert_eq!(cursor_value(&cfg, &export), None);
 
-    // Recovery: second run sees no cursor so it re-exports everything,
-    // producing a second file (different timestamp). Sleep to ensure a
-    // distinct timestamp (rivet uses 1-second granularity).
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
     let rec = std::process::Command::new(RIVET_BIN)
         .args([
             "run",
@@ -321,7 +320,9 @@ fn mssql_crash_after_manifest_update_leaves_file_and_manifest_but_no_cursor() {
     );
 
     // Recovery: re-run. No cursor → full re-export; manifest grows by 1.
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
     let rec = std::process::Command::new(RIVET_BIN)
         .args([
             "run",
@@ -375,7 +376,9 @@ fn mssql_crash_after_cursor_commit_is_recoverable_with_full_state() {
     let _metric_after_crash = metric_count(&cfg, &export);
 
     // Recovery: re-run must see the cursor and export zero additional rows.
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
     let rec = std::process::Command::new(RIVET_BIN)
         .args([
             "run",

--- a/tests/live/live_mssql_reconcile_repair.rs
+++ b/tests/live/live_mssql_reconcile_repair.rs
@@ -89,7 +89,7 @@ exports:
 fn mssql_reconcile_all_match_exits_zero_with_pretty_output() {
     require_alive(LiveService::Mssql);
 
-    let (table, _out, _cfg_dir, cfg) = seed_and_run_chunked(100, 50);
+    let (table, out, _cfg_dir, cfg) = seed_and_run_chunked(100, 50);
 
     let result = std::process::Command::new(RIVET_BIN)
         .args([
@@ -116,6 +116,14 @@ fn mssql_reconcile_all_match_exits_zero_with_pretty_output() {
     assert!(
         stdout.contains("100"),
         "reconcile output must mention row count 100; got:\n{stdout}"
+    );
+    // Independent oracle: rivet's reconcile verdict is rivet's OWN counter
+    // chain. Re-read the destination parquet and count physically (matrix
+    // audit: self-oracle class) — the verdict and the physical rows must agree.
+    assert_eq!(
+        total_parquet_rows(out.path()),
+        100,
+        "destination parquet must physically hold every source row, independent of the reconcile verdict"
     );
 }
 

--- a/tests/live/live_mssql_resume.rs
+++ b/tests/live/live_mssql_resume.rs
@@ -120,6 +120,60 @@ fn mssql_full_mode_repeated_run_accumulates_manifest_entries() {
 
 #[test]
 #[ignore = "live: requires docker compose mssql"]
+fn mssql_roast_rapid_incremental_runs_into_same_prefix_must_not_clobber_prior_parts() {
+    // SQL Server twin of the pg roast_rapid test: run-uniqueness for the batch
+    // incremental path under SUB-SECOND back-to-back runs. The resilience
+    // matrix cell previously stood on the two-full-runs test, which never
+    // exercises rapid incremental deltas — the exact regime where a
+    // second-granularity part stamp silently loses a delta.
+    require_alive(LiveService::Mssql);
+    const N: i64 = 6;
+    let name = unique_name("ms_clobber_inc");
+    mssql_drop_table(&name);
+    mssql_exec(&format!(
+        "CREATE TABLE {name} (id BIGINT PRIMARY KEY, updated_at DATETIME2(6) NOT NULL);"
+    ));
+    let _guard = MssqlCursorCleanup(name.clone());
+
+    let export_name = unique_name("ms_clobber_exp");
+    let out = tempfile::tempdir().unwrap();
+    let yaml = Rig::mssql_batch(&export_name)
+        .query(&format!("SELECT id, updated_at FROM {name}"))
+        .mode("incremental")
+        .export_line("cursor_column: updated_at")
+        .dest_path(out.path().to_path_buf())
+        .yaml();
+    let (_cfgdir, cfg) = cfg_dir_with(&yaml);
+
+    // Each run inserts one new row (strictly increasing cursor) then exports
+    // just that delta — back to back, no sleep, so several runs share a second.
+    for k in 0..N {
+        mssql_exec(&format!(
+            "INSERT INTO {name} (id, updated_at) \
+             VALUES ({k}, DATEADD(SECOND, {k}, SYSUTCDATETIME()));"
+        ));
+        let r = run_rivet_export(&cfg, &export_name);
+        assert!(
+            r.status.success(),
+            "incremental run {k} failed:\n{}",
+            String::from_utf8_lossy(&r.stderr)
+        );
+    }
+
+    assert_eq!(
+        dir_parquet_id_set(out.path()),
+        (0..N).collect::<std::collections::BTreeSet<i64>>(),
+        "every incremental delta must survive; a clobbered part is silent data loss"
+    );
+    assert_eq!(
+        dir_manifest_copy_total_rows(out.path()),
+        N,
+        "run-unique manifest copies must sum every rapid run's row"
+    );
+}
+
+#[test]
+#[ignore = "live: requires docker compose mssql"]
 fn mssql_incremental_second_run_on_unchanged_source_exports_zero_new_rows() {
     require_alive(LiveService::Mssql);
 
@@ -182,7 +236,9 @@ fn mssql_incremental_third_run_picks_up_newly_inserted_rows() {
                 (9, SYSUTCDATETIME()), (10, SYSUTCDATETIME());"
     ));
 
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
 
     assert!(run_rivet_export(&cfg, &export_name).status.success());
     let files_2 = files_with_extension(out.path(), "parquet").len();

--- a/tests/live/live_mssql_resume.rs
+++ b/tests/live/live_mssql_resume.rs
@@ -88,10 +88,10 @@ fn mssql_full_mode_repeated_run_accumulates_manifest_entries() {
     let r1 = run_rivet_export(&cfg, &export_name);
     assert!(r1.status.success(), "first full run failed");
 
-    // Sleep so each run produces a distinct timestamped filename (rivet uses
-    // 1-second granularity in `<export>_<YYYYMMDD_HHMMSS>.parquet`).
-    std::thread::sleep(std::time::Duration::from_millis(1100));
-
+    // No sleep: `single.rs` stamps parts at millisecond granularity (`%3f`), so
+    // two back-to-back sub-second runs still get distinct names — that they do
+    // not clobber IS the run-uniqueness contract. A `sleep(1s)` here would only
+    // document the second-granularity gap the `%3f` fix already closed.
     let r2 = run_rivet_export(&cfg, &export_name);
     assert!(r2.status.success(), "second full run failed");
 
@@ -100,6 +100,21 @@ fn mssql_full_mode_repeated_run_accumulates_manifest_entries() {
         files.len(),
         2,
         "full mode must produce one file per run; got {files:?}"
+    );
+    // Files-count alone is the weakest oracle: assert the payload (both runs'
+    // rows survive) AND the dest manifest COPIES (`manifest-<run>.json`, what
+    // reconcile / a warehouse autoloader read) — a parquet re-read passes even
+    // when the manifest sidecar clobbers; the copies' summed row_count is RED
+    // pre-fix (one clobbered manifest.json held only the last run's rows).
+    assert_eq!(
+        total_parquet_rows(out.path()),
+        20,
+        "two full runs of 10 rows must materialise 20 physical rows"
+    );
+    assert_eq!(
+        dir_manifest_copy_total_rows(out.path()),
+        20,
+        "run-unique manifest copies must sum both runs' rows; a clobbered manifest is silent to a parquet re-read"
     );
 }
 

--- a/tests/live/live_mysql_chunked_recovery.rs
+++ b/tests/live/live_mysql_chunked_recovery.rs
@@ -256,7 +256,9 @@ exports:
         "exactly 1 manifest entry must exist after crash (chunk 0 file was recorded)"
     );
 
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
 
     let resume = std::process::Command::new(RIVET_BIN)
         .args([
@@ -383,7 +385,9 @@ exports:
         "no chunk_task should be 'failed' from a panic; got failed={failed_pre}"
     );
 
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
 
     let resume = std::process::Command::new(RIVET_BIN)
         .args([
@@ -512,7 +516,9 @@ exports:
         "exactly 1 manifest entry must exist after crash (chunk 0 file was recorded before panic)"
     );
 
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
 
     // Resume with parallel: 2 — proves reset works regardless of worker
     // count change between crash and resume.

--- a/tests/live/live_mysql_crash_recovery.rs
+++ b/tests/live/live_mysql_crash_recovery.rs
@@ -255,10 +255,9 @@ fn mysql_crash_after_file_write_leaves_file_but_no_manifest_or_cursor() {
     );
     assert_eq!(cursor_value(&cfg, &export), None);
 
-    // Recovery: second run sees no cursor so it re-exports everything,
-    // producing a second file (different timestamp). Sleep to ensure a
-    // distinct timestamp (rivet uses 1-second granularity).
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
     let rec = std::process::Command::new(RIVET_BIN)
         .args([
             "run",
@@ -320,7 +319,9 @@ fn mysql_crash_after_manifest_update_leaves_file_and_manifest_but_no_cursor() {
     );
 
     // Recovery: re-run. No cursor → full re-export; manifest grows by 1.
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
     let rec = std::process::Command::new(RIVET_BIN)
         .args([
             "run",
@@ -374,7 +375,9 @@ fn mysql_crash_after_cursor_commit_is_recoverable_with_full_state() {
     let _metric_after_crash = metric_count(&cfg, &export);
 
     // Recovery: re-run must see the cursor and export zero additional rows.
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
     let rec = std::process::Command::new(RIVET_BIN)
         .args([
             "run",

--- a/tests/live/live_mysql_reconcile_repair.rs
+++ b/tests/live/live_mysql_reconcile_repair.rs
@@ -86,7 +86,7 @@ exports:
 fn mysql_reconcile_all_match_exits_zero_with_pretty_output() {
     require_alive(LiveService::Mysql);
 
-    let (table, _out, _cfg_dir, cfg) = seed_and_run_chunked(100, 50);
+    let (table, out, _cfg_dir, cfg) = seed_and_run_chunked(100, 50);
 
     let result = std::process::Command::new(RIVET_BIN)
         .args([
@@ -113,6 +113,14 @@ fn mysql_reconcile_all_match_exits_zero_with_pretty_output() {
     assert!(
         stdout.contains("100"),
         "reconcile output must mention row count 100; got:\n{stdout}"
+    );
+    // Independent oracle: rivet's reconcile verdict is rivet's OWN counter
+    // chain. Re-read the destination parquet and count physically (matrix
+    // audit: self-oracle class) — the verdict and the physical rows must agree.
+    assert_eq!(
+        total_parquet_rows(out.path()),
+        100,
+        "destination parquet must physically hold every source row, independent of the reconcile verdict"
     );
 }
 

--- a/tests/live/live_mysql_resume.rs
+++ b/tests/live/live_mysql_resume.rs
@@ -91,10 +91,10 @@ fn mysql_full_mode_repeated_run_accumulates_manifest_entries() {
     let r1 = run_rivet_export(&cfg, &export_name);
     assert!(r1.status.success(), "first full run failed");
 
-    // Sleep so each run produces a distinct timestamped filename (rivet uses
-    // 1-second granularity in `<export>_<YYYYMMDD_HHMMSS>.parquet`).
-    std::thread::sleep(std::time::Duration::from_millis(1100));
-
+    // No sleep: `single.rs` stamps parts at millisecond granularity (`%3f`), so
+    // two back-to-back sub-second runs still get distinct names — that they do
+    // not clobber IS the run-uniqueness contract. A `sleep(1s)` here would only
+    // document the second-granularity gap the `%3f` fix already closed.
     let r2 = run_rivet_export(&cfg, &export_name);
     assert!(r2.status.success(), "second full run failed");
 
@@ -103,6 +103,21 @@ fn mysql_full_mode_repeated_run_accumulates_manifest_entries() {
         files.len(),
         2,
         "full mode must produce one file per run; got {files:?}"
+    );
+    // Files-count alone is the weakest oracle: assert the payload (both runs'
+    // rows survive) AND the dest manifest COPIES (`manifest-<run>.json`, what
+    // reconcile / a warehouse autoloader read) — a parquet re-read passes even
+    // when the manifest sidecar clobbers; the copies' summed row_count is RED
+    // pre-fix (one clobbered manifest.json held only the last run's rows).
+    assert_eq!(
+        total_parquet_rows(out.path()),
+        20,
+        "two full runs of 10 rows must materialise 20 physical rows"
+    );
+    assert_eq!(
+        dir_manifest_copy_total_rows(out.path()),
+        20,
+        "run-unique manifest copies must sum both runs' rows; a clobbered manifest is silent to a parquet re-read"
     );
 }
 

--- a/tests/live/live_mysql_resume.rs
+++ b/tests/live/live_mysql_resume.rs
@@ -123,6 +123,62 @@ fn mysql_full_mode_repeated_run_accumulates_manifest_entries() {
 
 #[test]
 #[ignore = "live: requires docker compose mysql"]
+fn mysql_roast_rapid_incremental_runs_into_same_prefix_must_not_clobber_prior_parts() {
+    // MySQL twin of the pg roast_rapid test: run-uniqueness for the batch
+    // incremental path under SUB-SECOND back-to-back runs. The resilience
+    // matrix cell previously stood on the two-full-runs test, which never
+    // exercises rapid incremental deltas — the exact regime where a
+    // second-granularity part stamp silently loses a delta.
+    require_alive(LiveService::Mysql);
+    const N: i64 = 6;
+    let name = unique_name("my_clobber_inc");
+    let mut c = mysql_connect();
+    c.query_drop(format!(
+        "CREATE TABLE {name} (id BIGINT PRIMARY KEY, updated_at DATETIME(6) NOT NULL) ENGINE=InnoDB"
+    ))
+    .unwrap();
+    let _guard = MysqlCleanup(name.clone());
+
+    let export_name = unique_name("my_clobber_exp");
+    let out = tempfile::tempdir().unwrap();
+    let yaml = Rig::mysql_batch(&export_name)
+        .query(&format!("SELECT id, updated_at FROM {name}"))
+        .mode("incremental")
+        .export_line("cursor_column: updated_at")
+        .dest_path(out.path().to_path_buf())
+        .yaml();
+    let (_cfgdir, cfg) = cfg_dir_with(&yaml);
+
+    // Each run inserts one new row (strictly increasing cursor) then exports
+    // just that delta — back to back, no sleep, so several runs share a second.
+    for k in 0..N {
+        c.query_drop(format!(
+            "INSERT INTO {name} (id, updated_at) \
+             VALUES ({k}, DATE_ADD(NOW(6), INTERVAL {k} SECOND))"
+        ))
+        .unwrap();
+        let r = run_rivet_export(&cfg, &export_name);
+        assert!(
+            r.status.success(),
+            "incremental run {k} failed:\n{}",
+            String::from_utf8_lossy(&r.stderr)
+        );
+    }
+
+    assert_eq!(
+        dir_parquet_id_set(out.path()),
+        (0..N).collect::<std::collections::BTreeSet<i64>>(),
+        "every incremental delta must survive; a clobbered part is silent data loss"
+    );
+    assert_eq!(
+        dir_manifest_copy_total_rows(out.path()),
+        N,
+        "run-unique manifest copies must sum every rapid run's row"
+    );
+}
+
+#[test]
+#[ignore = "live: requires docker compose mysql"]
 fn mysql_incremental_second_run_on_unchanged_source_exports_zero_new_rows() {
     require_alive(LiveService::Mysql);
 
@@ -186,7 +242,9 @@ fn mysql_incremental_third_run_picks_up_newly_inserted_rows() {
     ))
     .expect("insert new mysql rows");
 
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
 
     assert!(run_rivet_export(&cfg, &export_name).status.success());
     let files_2 = files_with_extension(out.path(), "parquet").len();

--- a/tests/live/live_mysql_schema_drift.rs
+++ b/tests/live/live_mysql_schema_drift.rs
@@ -95,7 +95,9 @@ exports:
     ))
     .unwrap();
 
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
 
     let r2 = run_rivet_export(&cfg, &export_name);
     assert!(
@@ -158,7 +160,9 @@ exports:
 
     c.query_drop(format!("ALTER TABLE {table_name} DROP COLUMN tmp_col;"))
         .unwrap();
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
 
     let r2 = run_rivet_export(&cfg, &export_name);
     assert!(
@@ -203,7 +207,9 @@ exports:
     let cfg = write_config(&cfg_dir, &yaml);
 
     assert!(run_rivet_export(&cfg, &export_name).status.success());
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
     assert!(run_rivet_export(&cfg, &export_name).status.success());
 
     let state_db = cfg.parent().unwrap().join(".rivet_state.db");

--- a/tests/live/live_reconcile_repair.rs
+++ b/tests/live/live_reconcile_repair.rs
@@ -82,7 +82,7 @@ exports:
 fn reconcile_all_match_exits_zero_with_pretty_output() {
     require_alive(LiveService::Postgres);
 
-    let (table, _out, _cfg_dir, cfg) = seed_and_run_chunked(100, 50);
+    let (table, out, _cfg_dir, cfg) = seed_and_run_chunked(100, 50);
 
     let result = std::process::Command::new(RIVET_BIN)
         .args([
@@ -110,6 +110,14 @@ fn reconcile_all_match_exits_zero_with_pretty_output() {
     assert!(
         stdout.contains("100"),
         "reconcile output must mention row count 100; got:\n{stdout}"
+    );
+    // Independent oracle: rivet's reconcile verdict is rivet's OWN counter
+    // chain. Re-read the destination parquet and count physically (matrix
+    // audit: self-oracle class) — the verdict and the physical rows must agree.
+    assert_eq!(
+        total_parquet_rows(out.path()),
+        100,
+        "destination parquet must physically hold every source row, independent of the reconcile verdict"
     );
 }
 

--- a/tests/live/live_resume.rs
+++ b/tests/live/live_resume.rs
@@ -326,7 +326,9 @@ fn incremental_third_run_picks_up_newly_inserted_rows() {
 
     // Sleep so file-name timestamp is distinct from run #1 (see
     // full_mode_repeated_run_accumulates_manifest_entries for rationale).
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
 
     // Run #2 — must pick up rows 6..10.
     assert!(run_rivet_export(&cfg, &export_name).status.success());
@@ -606,7 +608,9 @@ fn incremental_manifest_ships_contiguous_cursor_range() {
         "INSERT INTO {table_name} SELECT g, g*10 FROM generate_series(4,7) g;"
     ))
     .unwrap();
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
     assert!(run_rivet_export(&cfg, &export_name).status.success());
     let e2 = read_ex();
     assert_eq!(

--- a/tests/live/live_resume.rs
+++ b/tests/live/live_resume.rs
@@ -133,6 +133,17 @@ fn full_mode_repeated_run_accumulates_manifest_entries() {
         (0..10).collect::<std::collections::BTreeSet<i64>>(),
         "full re-export must hold every source id (0..10)"
     );
+    // The parquet re-read above passes even if the manifest sidecar clobbered.
+    // Assert the dest manifest COPIES (`manifest-<run>.json`, what reconcile / a
+    // warehouse autoloader read) sum BOTH runs: pre-fix a shared prefix held one
+    // clobbered `manifest.json` (last run's rows only) → RED. This is the oracle
+    // the cell's name ("accumulates manifest entries") demands — and it is
+    // fix-sensitive, unlike the `file_log` ledger which accumulates regardless.
+    assert_eq!(
+        dir_manifest_copy_total_rows(out.path()),
+        20,
+        "run-unique manifest copies must sum both runs' rows; a clobbered manifest is silent to the parquet re-read"
+    );
 }
 
 #[test]
@@ -191,6 +202,15 @@ fn roast_rapid_incremental_runs_into_same_prefix_must_not_clobber_prior_parts() 
         dir_parquet_id_set(out.path()),
         (0..N).collect::<std::collections::BTreeSet<i64>>(),
         "every incremental delta must survive; a clobbered part is silent data loss"
+    );
+    // Data survival above is a proxy: a manifest clobber leaves the parquet but
+    // loses the sidecar a warehouse autoloader reads. Sum the dest manifest
+    // copies — N rapid runs, 1 row each → N. Pre-fix the shared prefix held one
+    // clobbered manifest → RED.
+    assert_eq!(
+        dir_manifest_copy_total_rows(out.path()),
+        N,
+        "run-unique manifest copies must sum every rapid run's row; a clobbered manifest is silent to the parquet re-read"
     );
 }
 

--- a/tests/live/live_schema_drift.rs
+++ b/tests/live/live_schema_drift.rs
@@ -89,9 +89,9 @@ exports:
     ))
     .unwrap();
 
-    // Sleep so the run_id timestamp differs (state rows are keyed by run_id;
-    // we want a second metric row).
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
 
     // Run #2 — schema has drifted.  Must complete successfully.
     let r2 = run_rivet_export(&cfg, &export_name);
@@ -153,7 +153,9 @@ exports:
 
     c.batch_execute(&format!("ALTER TABLE {table_name} DROP COLUMN tmp_col;"))
         .unwrap();
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
 
     let r2 = run_rivet_export(&cfg, &export_name);
     assert!(
@@ -198,7 +200,9 @@ exports:
     let cfg = write_config(&cfg_dir, &yaml);
 
     assert!(run_rivet_export(&cfg, &export_name).status.success());
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
     assert!(run_rivet_export(&cfg, &export_name).status.success());
 
     let state_db = cfg.parent().unwrap().join(".rivet_state.db");

--- a/tests/live/live_wave_apply.rs
+++ b/tests/live/live_wave_apply.rs
@@ -154,8 +154,9 @@ exports:
     // filename is second-granularity (`<export>_<YYYYMMDD_HHMMSS>.parquet`), so
     // wait past the current second to guarantee a distinct name rather than an
     // overwrite of Phase 1's file (the failure when all three phases land in one
-    // second).
-    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // No sleep: parts and run_ids are millisecond-stamped (`%3f`), so
+    // back-to-back sub-second runs must not collide — sleeping here would
+    // mask exactly that regression (matrix audit: sleep-masked class).
     let rerun = run(&[]);
     assert!(
         rerun.status.success(),

--- a/tests/offline/chunking_matrix_guard.rs
+++ b/tests/offline/chunking_matrix_guard.rs
@@ -143,8 +143,24 @@ fn collect_fn_names(dir: &Path, out: &mut HashSet<String>) {
             };
             for line in text.lines() {
                 // Cheap `fn <ident>` scan — good enough to catch a mapped test
-                // name that no longer exists (the failure mode we guard).
-                if let Some(rest) = line.trim_start().strip_prefix("fn ")
+                // name that no longer exists (the failure mode we guard). Strip
+                // visibility/async modifiers first: a bare `fn `-only scan
+                // would false-orphan a matrix test declared `pub fn`/`async fn`
+                // (latent fragility the matrix audit flagged).
+                let mut rest = line.trim_start();
+                for prefix in [
+                    "pub(crate) ",
+                    "pub(super) ",
+                    "pub ",
+                    "async ",
+                    "const ",
+                    "unsafe ",
+                ] {
+                    if let Some(r) = rest.strip_prefix(prefix) {
+                        rest = r;
+                    }
+                }
+                if let Some(rest) = rest.strip_prefix("fn ")
                     && let Some(name) = rest
                         .split(|c: char| !c.is_alphanumeric() && c != '_')
                         .next()


### PR DESCRIPTION
## Product fixes (silent-loss class)

1. **Manifest clobber** — parts are named run-uniquely, but the `manifest.json` sidecar was fixed-name: N runs into one prefix (the `until_current` scheduler model, incremental batch) clobbered it. The first consumer that sums manifests across runs (the Pro loader's reconcile) under-counted a live soak's 30 parts as 55 rows. Fix at the shared `write_manifest` seam: an immutable `manifest-<run_id>.json` copy beside the canonical last-writer-wins pointer; guard/validate/resume keep reading the canonical name unchanged; the untracked-surplus classifier recognises the new sidecar. Live-verified: MySQL→BQ batch (2000/2000) and a CDC soak (26 manifests summing 3375 == rows loaded).
2. **CDC conformance gate was hollow**: `status.success()` sat in the outcome dictionary, vacuously passing any test that checked its exit code; the hardcoded file list never scanned `live_cdc_replica.rs`. Now: glob discovery (floor >= 10 files) + real oracles added by name.
3. **nightly-full** selected `stand_*_mongo` on a mongo-less stack (a module-prefix skip does not match `chunking_stand::*`) — a guaranteed red nightly, reproduced live. Fixed with a substring `--skip mongo`.

## Test de-compromising (audit: 63 green tests that could not fail against the exact bug they guard)

- 9 proxy-oracle cells ("accumulates manifest entries" asserted on parquet) → the oracle is now the manifest copies (`dir_manifest_copy_total_rows`), RED-proven by mutation.
- 35 masking sleeps (hid the second-granularity clobber; after the `%3f` fix they inverted into permanent blindness to a regression) → deleted; 14/15 affected live modules green sub-second.
- 14 CDC self-oracle tests (trusted `manifest_rows()` — rivet's own summary) → independent parquet id-set re-read (`cdc_id_ops`).
- 10 cloud-destination "all rows" cells (asserted file PRESENCE only) → download + physical row count (minio `mc cat`, fake-gcs `?alt=media`).
- 4 reconcile tests (trusted rivet's own verdict) → independent recount.

## Mutation-testing program (`docs/mutation-plan.md`)

**6,672 mutants** across every matrix-bearing surface; **~50 killer classes RED-proven** (mutant applied → new test observed failing → reverted) in 23 clusters. Worst blind spots caught: an OR-saturating checksum fold (any corruption "matches"), the untested source leg of Form A checksums, `end+1 → end-1` dropping the last day of every date window, an i8 wrap turning `scale=200` into `-56`, the M8 resume core stubbable to a no-op, a Mongo `_id` band merge (silent bracket loss), the ADR-0020 MySQL-only auto-keyset gate, a leading comma corrupting every CSV row.

Enforcement: a `cargo mutants --in-diff` PR gate (ci.yml), a nightly 3-group tier rotation ratcheting against `docs/mutants-baseline.txt` (1,524 adjudicated entries, shrink-only), and equivalent mutants excluded with reasons in `.cargo/mutants.toml`.

## Rules (CLAUDE.md)

Run-uniqueness extended to every per-run sidecar; new section "a green test that was never RED is unverified" (RED-prove data-loss tests, fixtures must cross the mechanism's activation threshold, a sleep compensating product behaviour is a product bug report).

Suites: lib 1903, offline 203, gates — all green; live validation per class on pg/mysql/mssql/mongo + minio/fake-gcs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AefyaoC77RnXmC7hUv8dEJ