### PR TITLE
Close all 10 OSS-readiness audit findings (3 HIGH / 3 MEDIUM / 4 LOW)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3548,6 +3548,7 @@ dependencies = [
  "native-tls",
  "opendal",
  "parquet",
+ "percent-encoding",
  "postgres",
  "postgres-native-tls",
  "postgres-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,11 @@ csv = "1"
 env_logger = "0.11"
 libc = "0.2"
 log = "0.4"
+# Percent-encode the user/password when building a connection URL from structured
+# `host/user/password` fields, so a credential containing `/ @ : ? #` can't make
+# the URL ambiguous (which both breaks the driver AND defeats password redaction
+# — a `/` in the password used to stop the userinfo scan early and leak the tail).
+percent-encoding = "2"
 # `native-tls` feature wires the same OpenSSL-backed TLS stack the rest of
 # the workspace already vendors (see `native-tls = { ... features = ["vendored"] }`
 # above) so MySQL configs with `tls.mode: require | verify-ca | verify-full`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,10 +30,20 @@ The following files may contain sensitive information even when credentials are 
 |---|---|
 | `rivet.yaml` | Source URL, query bodies, destination credentials (if inlined) |
 | `plan.json` | Table names, query SQL, chunk bounds, row estimates |
-| `.rivet_state.db` | Cursor values, manifest of exported files, run metrics |
-| `*.jsonl` journal | Per-run event timeline; includes export names, run IDs, chunk boundaries |
+| `.rivet_state.db` | Cursor values, manifest of exported files, run metrics, and **failed-run error text** (see the note below) |
+| `*.jsonl` journal | Per-run event timeline; includes export names, run IDs, chunk boundaries, and error text |
+| Run summary (`summary.json` / `summary.md`) | Per-export status, counts, and error text on failure |
 | Parquet / CSV outputs | The actual exported data |
 | Log output (stdout / `--log-format json`) | Query SQL (truncated), table names, row counts; redacted URLs |
+
+> **Redaction covers credentials only.** Rivet redacts connection-URL passwords
+> everywhere error text is persisted or emitted. It does **not** scrub source
+> *cell values* that a driver or library error may embed in its message — for
+> example, a value that violated a constraint, or a row echoed by a decode error.
+> That error text is stored (`.rivet_state.db`, the journal, the run summary) and,
+> if you configure notifications, emitted to the webhook. Treat failed-run error
+> text as potentially data-bearing, and scope your state-file / webhook access
+> accordingly.
 
 ### `.gitignore` recommendations
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -170,7 +170,7 @@ The pilot guide covers this end-to-end: [docs/pilot/production-checklist.md](doc
 
 | Control | Status | Notes |
 |---|---|---|
-| RustSec advisory audit | **Active** | `audit` job in [.github/workflows/ci.yml](.github/workflows/ci.yml) runs `rustsec/audit-check` on every PR |
+| RustSec advisory audit | **Active** | `audit` job in [.github/workflows/ci.yml](.github/workflows/ci.yml) runs `cargo audit` on every PR — honoring the documented advisory allow-list in [`.cargo/audit.toml`](.cargo/audit.toml) (the same tool the `.githooks/pre-commit` hook runs) |
 | Dependency review | **Active** | Cargo.lock is committed; bumps land in dedicated PRs |
 | Release checksums (`SHA256SUMS`) | **Active** | Every release publishes `SHA256SUMS.txt` as an asset ([`.github/workflows/release.yml`](.github/workflows/release.yml)); verification below |
 | Signed releases (cosign keyless) | **Active** | Every release signs `SHA256SUMS.txt` via Sigstore/cosign keyless (GitHub OIDC — no key to manage), published as `SHA256SUMS.txt.cosign.bundle`; verification below |

--- a/docs/adr/0004-destination-write-contracts.md
+++ b/docs/adr/0004-destination-write-contracts.md
@@ -10,7 +10,7 @@
 
 State and manifest writes (ADR-0001 invariants I2–I4) must happen only after the destination write is durably committed. But "committed" means different things for different backends:
 
-- Local `fs::copy` commits atomically from the caller's perspective, but may leave a partial file on failure.
+- Local writes stage into a dot-prefixed temp file in the target directory and commit with an atomic same-filesystem `rename` (OPT-6), so a failure leaves nothing at the final path — retry-safe, no partial-write risk.
 - S3 and GCS object writes are not committed until the writer handle is closed (`dst.close()`); a mid-upload failure leaves nothing at the destination.
 - stdout streams data immediately with no atomic commit point; a retry produces duplicate or corrupt output.
 
@@ -33,7 +33,7 @@ Add a `capabilities()` method to the `Destination` trait so each backend declare
 
 | Backend | `commit_protocol` | `idempotent_overwrite` | `retry_safe` | `partial_write_risk` |
 |---|---|---|---|---|
-| `LocalDestination` | `Atomic` | `true` | `false` | `true` |
+| `LocalDestination` | `Atomic` | `true` | `true` | `false` |
 | `S3Destination` | `FinalizeOnClose` | `true` | `true` | `false` |
 | `GcsDestination` | `FinalizeOnClose` | `true` | `true` | `false` |
 | `AzureDestination` | `FinalizeOnClose` | `true` | `true` | `false` |
@@ -81,7 +81,7 @@ The comment added to `pipeline/single.rs:run_single_export` immediately before t
 `pipeline/single.rs:run_single_export` inspects `dest.capabilities()` at runtime and logs the commit protocol for every run:
 
 ```
-export 'orders': destination commit_protocol=Atomic idempotent=true retry_safe=false partial_risk=true
+export 'orders': destination commit_protocol=Atomic idempotent=true retry_safe=true partial_risk=false
 ```
 
 When a destination that is not retry-safe (`retry_safe = false`) is used on a run that performed one or more retries, a `WARN` is emitted:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -7,6 +7,12 @@
 > samples, and the *why*. For the guaranteed-current flag list of any command,
 > trust the generated reference (or run `rivet <command> --help`).
 
+> **Machine-readable output.** Most commands emit JSON via a boolean `--json`
+> flag (`run`, `check`, `doctor`, `metrics`, `state …`); `validate` (and the
+> `reconcile` / `plan` report writers) instead take `--format json`. This split
+> is a known inconsistency to be unified in a future release — until then, pass
+> `--help` to confirm which idiom a given command uses.
+
 ## Global
 
 ```
@@ -338,8 +344,9 @@ By default `validate` resolves the destination prefix the same way `run` does (`
 |------|-------|------|-------------|
 | `--config` | `-c` | string | Path to YAML config file **(required)** |
 | `--export` | `-e` | string | Validate only a specific export by name |
-| `--format` | | string | Override the format used to resolve the part layout |
-| `--output` | `-o` | PATH | Write the verification report to this file as JSON |
+| `--format` | | `pretty`\|`json` | Output format: `pretty` (human summary) or `json` (machine-readable) |
+| `--depth` | | `light`\|`sample`\|`full` | Verification depth: `light` (manifest + `_SUCCESS`), `sample` (+ part reconcile + untracked surplus), `full` (+ value-checksum re-read of every part; **default**) |
+| `--output` | `-o` | PATH | Write the JSON report to this file (only with `--format json`) |
 | `--date` | | YYYY-MM-DD | Resolve `{date}` to this date instead of today (UTC) |
 | `--run-id` | | string | Point at a prior run's prefix by run id |
 | `--prefix` | | string | Point at an explicit destination prefix |

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -74,7 +74,7 @@ A retried batch starts from the **same cursor position** as the failed attempt �
 | Destination | `retry_safe` |
 |---|---|
 | S3, GCS, Azure | `true` (no partial visible objects; safe to retry) |
-| Local filesystem | `false` (a failed copy may leave a partial file; manual cleanup) |
+| Local filesystem | `true` (staged temp file + atomic `rename`; a failure leaves nothing at the final path) |
 | stdout | `false` (no commit boundary; retry produces duplicate/corrupt output) |
 
 When retries occur against a non-retry-safe destination, the pipeline logs a `WARN` so operators see the mismatch.
@@ -172,7 +172,7 @@ When `quality:` is configured, the pipeline evaluates row-count, null-ratio, and
 | Destination | Commit protocol | What "Ok" means |
 |---|---|---|
 | S3 / GCS / Azure | `FinalizeOnClose` | Object is committed only after writer close; a mid-upload failure leaves nothing visible |
-| Local filesystem | `Atomic` | `Ok` means the full file is present; a failure may leave a partial file (`partial_write_risk: true`) |
+| Local filesystem | `Atomic` | `Ok` means the full file is present; staged temp file + atomic `rename`, so a failure leaves nothing at the final path (`retry_safe: true`, `partial_write_risk: false`) |
 | stdout | `Streaming` | No atomic commit boundary; partial output may be observable before `write()` returns |
 
 Full per-backend table and rationale: **[ADR-0004 — Destination Write Contracts](adr/0004-destination-write-contracts.md)**.
@@ -187,7 +187,7 @@ Rivet does **not** currently guarantee:
 - **Continuous / near-real-time replication.** Rivet *does* capture CDC to files (`mode: cdc` — inserts/updates/deletes via a Postgres logical replication slot / MySQL binlog / SQL Server CDC change tables / MongoDB change streams, into typed Parquet/CSV — or the JSON-blob document image for MongoDB — resuming from the last committed log position each run), but it is not a continuously-running stream — changes are captured per invocation, not delivered live. For always-on near-real-time replication use Debezium or Estuary.
 - **Completeness of incremental cursors that can tie.** Incremental resume uses a strict `WHERE cursor > last_value`. If two rows share the high-watermark value and the second becomes visible only *after* the run that advanced the watermark past it — e.g. a low-resolution `updated_at` (second granularity) or rows committed at the same timestamp after the read snapshot — the next run skips them and they are never exported. (Keyset pagination is unaffected: its key is planner-enforced unique + NOT NULL.) Use a **strictly per-row-distinct, monotonic** cursor (a sequence/identity id, or a timestamp with sub-value uniqueness); when the cursor can tie, re-snapshot the affected window with `full`/`chunked` mode.
 - **Dense-chunking stability on a tied, concurrently-written `chunk_column`.** `chunk_dense: true` pages by `ROW_NUMBER() OVER (ORDER BY chunk_column)`, recomputed in an independent query per chunk. The ordinal partition itself never gaps or overlaps, but the ordinal→row mapping is only stable if the `ORDER BY` is deterministic. On a column with a large **tied** peer group straddling a chunk boundary *while the source is being written concurrently*, two chunk queries could order the tied band differently — duplicating or dropping a boundary row. Against a **static** table this does not occur on any tested engine (PG 16 / MySQL 8 / SQL Server 2022 — verified by `tests/live_chunked_dense.rs`). Prefer a `chunk_column` with no large tied groups, or **keyset** (`chunk_by_key`) on a unique key, when chunking a live-writing table.
-- **Automatic cleanup of partial artifacts** on `Atomic` destinations after a crash mid-write. A partial local file may persist and must be removed manually.
+- **Automatic cleanup of an interrupted write's temp file.** A crash mid-write on the local destination may leave a dot-prefixed temp file in the target directory — never a partial *final* file (the commit is an atomic `rename`, so the final path is the complete file or absent). The stray temp file is harmless and can be removed manually.
 - **Schema migration handling.** If the source schema changes between runs, Rivet does not migrate the destination; it surfaces a schema-drift error (see [tests/live_schema_drift.rs](https://github.com/panchenkoai/rivet/blob/main/tests/live_schema_drift.rs)).
 - **Correctness of user-authored SQL.** Rivet executes `query:` verbatim. A query that omits a `WHERE` clause or selects from the wrong table will export the wrong data — there is no semantic validation.
 - **Protection from poorly indexed source queries.** Preflight (`rivet doctor`, `rivet check`) warns about missing cursor indexes and unbounded `ORDER BY`, but it does not refuse to run. The operator decides.

--- a/src/config/export.rs
+++ b/src/config/export.rs
@@ -530,7 +530,7 @@ pub enum CdcInitialMode {
 /// Per-export CDC settings, required when `mode: cdc`. The output `table`,
 /// `destination`, and `format` come from the export itself; this carries only the
 /// CDC-specific knobs (resume + per-engine stream params).
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 pub struct CdcExportConfig {
     /// First-run behaviour: `snapshot` = anchor → full snapshot → drain (see
     /// [`CdcInitialMode`]). Omitted ⇒ capture changes only (the default; the
@@ -569,6 +569,31 @@ pub struct CdcExportConfig {
     /// SQL Server CDC capture instance, e.g. `dbo_orders` — required for
     /// `sqlserver://` sources.
     pub capture_instance: Option<String>,
+}
+
+// Hand-written so the Rust `Default` MATCHES the serde default: `until_current`
+// must be `true` (bounded). The derived `Default` would use `bool::default()` =
+// `false`, and serde's `default = "default_true"` only affects Deserialize — so
+// `CdcExportConfig::default()` would silently mean `DrainMode::Continuous`. That
+// default is reached on the drain path (`cdc_job.rs`: `export.cdc.clone()
+// .unwrap_or_default()`) whenever a `mode: cdc` export omits the whole `cdc:`
+// block (valid for PG/MySQL), turning a minimal bounded drain into a
+// never-terminating daemon that persists no resume position — the exact footgun
+// `default_true` was added to kill. Mirrors `MongoConfig`'s hand-written Default.
+impl Default for CdcExportConfig {
+    fn default() -> Self {
+        Self {
+            initial: None,
+            checkpoint: None,
+            until_current: true,
+            max_events: None,
+            rollover: None,
+            rollover_memory_mb: None,
+            server_id: None,
+            slot: None,
+            capture_instance: None,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq)]

--- a/src/config/source.rs
+++ b/src/config/source.rs
@@ -1,10 +1,21 @@
 //! Source-database connection config: URL/structured fields, TLS, environment hints.
 
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::resolve::resolve_env_vars;
 use crate::tuning::{TuningConfig, TuningProfile};
+
+/// Chars to percent-encode in a URL userinfo (user / password) component: encode
+/// everything except the RFC 3986 unreserved set (ALPHA / DIGIT / `- . _ ~`), so
+/// no credential byte can be mistaken for a URL delimiter. Over-encoding is
+/// harmless — the driver percent-decodes it back.
+const USERINFO: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~');
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
@@ -336,20 +347,19 @@ impl SourceConfig {
             SourceType::Mongo => "mongodb",
         };
 
+        // Percent-encode the userinfo so a credential containing `/ @ : ? #` can't
+        // make the URL ambiguous (breaking the driver) or defeat redaction.
+        let user_enc = utf8_percent_encode(user, USERINFO);
         if password.is_empty() {
             Ok(format!(
                 "{}://{}@{}:{}/{}",
-                scheme, user, host, port, database
+                scheme, user_enc, host, port, database
             ))
         } else {
+            let pw_enc = utf8_percent_encode(password.as_str(), USERINFO);
             Ok(format!(
                 "{}://{}:{}@{}:{}/{}",
-                scheme,
-                user,
-                password.as_str(),
-                host,
-                port,
-                database
+                scheme, user_enc, pw_enc, host, port, database
             ))
         }
     }
@@ -487,14 +497,14 @@ impl SourceType {
 fn find_userinfo(raw: &str) -> Option<(usize, usize)> {
     let scheme = raw.find("://")? + 3;
     let rest = &raw[scheme..];
-    // The authority ends at the first path/query/fragment delimiter; an `@`
-    // after that belongs to the path or query (`?foo=a@b`), not the userinfo.
+    // The userinfo `@` lives in the AUTHORITY, before the first `/ ? #` (a later
+    // `@` belongs to the path/query — e.g. `?filter=a@b` — and must NOT be treated
+    // as userinfo, or a credential-free URL is falsely redacted). Within the
+    // authority, take the LAST `@` (a password may contain `@`). This is correct
+    // for a well-formed URL; a RAW `/` in the password would make the URL
+    // ambiguous — which is why `build_url_from_fields` percent-encodes the userinfo
+    // (a `/` becomes `%2F`), so a Rivet-constructed URL never hits that case.
     let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
-    // Terminate userinfo at the LAST `@` within the authority: a password may
-    // itself contain `@` (`user:p@ssw0rd@host`), and splitting at the FIRST
-    // `@` would leak the tail after it into the persisted plan artifact.
-    // `rfind` mirrors `redact_pg_url` in state/mod.rs, which strips passwords
-    // the same way for the same reason.
     let at = rest[..authority_end].rfind('@')?;
     Some((scheme + at, scheme))
 }
@@ -712,6 +722,30 @@ mod tests {
         assert!(
             url.contains("@db.example.com:5432/orders"),
             "host and path must be retained: {url}"
+        );
+    }
+
+    #[test]
+    fn build_url_percent_encodes_userinfo_so_delimiters_cant_leak() {
+        // A2 (audit root fix): a password with URL delimiters (`/ @ : ? #` — `/` is
+        // a common base64 char) is percent-encoded when Rivet builds the connection
+        // URL from structured fields. Un-encoded, the raw `/`/`@` made the URL
+        // ambiguous: it broke the driver AND stopped the password-redaction scan
+        // early, leaking the tail. Encoding is the unambiguous root fix (redaction
+        // of a well-formed URL is then correct). RED before the encoding.
+        let mut src = make_source(SourceType::Postgres);
+        src.host = Some("db.example.com".into());
+        src.user = Some("rivet".into());
+        src.password = Some("pa/s:s@w?rd#x".into());
+        src.database = Some("orders".into());
+        let url = src.resolve_url().expect("url built from fields");
+        assert!(
+            !url.contains("pa/s:s@w?rd#x"),
+            "raw password with delimiters must not appear un-encoded: {url}"
+        );
+        assert!(
+            url.contains("pa%2Fs%3As%40w%3Frd%23x"),
+            "userinfo must be percent-encoded: {url}"
         );
     }
 }

--- a/src/config/tests/validation.rs
+++ b/src/config/tests/validation.rs
@@ -714,6 +714,31 @@ exports:
 }
 
 #[test]
+fn cdc_export_config_rust_default_is_bounded_not_a_daemon() {
+    // The serde default (test above) is NOT enough: `cdc_job` builds the effective
+    // CDC config with `export.cdc.clone().unwrap_or_default()`, so a `mode: cdc`
+    // export that omits the whole `cdc:` block (valid for PG/MySQL) reaches the
+    // RUST `Default`, not the serde one. A *derived* Default yields
+    // `until_current = false` (bool::default) = `DrainMode::Continuous` — a
+    // never-terminating daemon on a minimal config. RED before the hand-written
+    // `impl Default`; audit finding.
+    use crate::config::export::CdcExportConfig;
+    use crate::source::cdc::DrainMode;
+    let d = CdcExportConfig::default();
+    assert!(
+        d.until_current,
+        "CdcExportConfig::default().until_current must be true (bounded), not the daemon default"
+    );
+    assert!(
+        matches!(
+            DrainMode::from_until_current(d.until_current),
+            DrainMode::BoundedAtOpen
+        ),
+        "an omitted cdc: block (unwrap_or_default) must resolve to a bounded drain"
+    );
+}
+
+#[test]
 fn tables_outside_cdc_mode_is_rejected() {
     let yaml = r#"
 source: { type: postgres, url: "postgresql://localhost/test" }

--- a/src/destination/local.rs
+++ b/src/destination/local.rs
@@ -779,4 +779,19 @@ mod tests {
             "the staging temp is renamed away, leaving no symlink behind"
         );
     }
+
+    /// Pins the shipped OPT-6 temp-then-rename contract that ADR-0004 +
+    /// semantics.md document: local is retry-safe with no partial-write risk. The
+    /// docs had drifted to the OLD `fs::copy` values (retry_safe=false /
+    /// partial_write_risk=true) — audit finding. If the write path ever regresses
+    /// to a non-atomic copy, flip these AND both docs together.
+    #[test]
+    fn local_is_retry_safe_with_no_partial_write() {
+        let caps = dest().capabilities();
+        assert!(caps.retry_safe, "local temp-then-rename must be retry_safe");
+        assert!(
+            !caps.partial_write_risk,
+            "local temp-then-rename must have no partial_write_risk"
+        );
+    }
 }

--- a/src/pipeline/chunked/mod.rs
+++ b/src/pipeline/chunked/mod.rs
@@ -143,7 +143,11 @@ pub(super) fn prepare_chunk_plan_fresh(
     state: &StateStore,
     summary: &mut RunSummary,
 ) -> Result<Vec<(i64, i64)>> {
-    let mut src = crate::source::create_source(&plan.source)?;
+    // The chunked run's FIRST connect. Attach the same actionable hint (doctor
+    // pointer + auth/TLS category) the single-export path gives, so a bad-creds /
+    // unreachable / TLS failure here is not a raw driver error (audit finding).
+    let mut src = crate::source::create_source(&plan.source)
+        .map_err(|e| crate::pipeline::single::attach_connect_hint(e, &plan.source))?;
     prepare_chunk_plan(&mut *src, plan, Some(state), summary)
     // `src` drops here, closing the detect connection before workers open theirs.
 }

--- a/src/pipeline/single.rs
+++ b/src/pipeline/single.rs
@@ -522,7 +522,14 @@ pub(super) fn run_single_export(
 /// guidance instead of a bare driver error. `.context()` (not message
 /// replacement) keeps the original error — and the substrings classify_exit /
 /// retry classification rely on — intact underneath.
-fn attach_connect_hint(e: anyhow::Error, source: &crate::config::SourceConfig) -> anyhow::Error {
+// pub(crate) so the chunked/parallel runners attach the same actionable connect
+// hint (doctor pointer + auth/TLS category) their first `create_source` — the
+// single-export path had it, the parallel-chunked path (the default for large
+// tables) leaked the raw driver error. Audit finding.
+pub(crate) fn attach_connect_hint(
+    e: anyhow::Error,
+    source: &crate::config::SourceConfig,
+) -> anyhow::Error {
     let category = crate::preflight::categorize_source_error(&e);
     match crate::preflight::source_error_hint(category, &e, &source.source_type) {
         Some(hint) => e.context(format!("{category} — {hint}")),

--- a/src/pipeline/sink/cursor.rs
+++ b/src/pipeline/sink/cursor.rs
@@ -149,7 +149,16 @@ pub(crate) fn extract_last_cursor_value(
             ))
         }
         _ => {
-            log::warn!("cannot extract cursor for type {:?}", array.data_type());
+            // Actionable: an unsupported cursor type silently stalls incremental
+            // advancement (the cursor can't move, so every run re-reads from the
+            // last saved value). Name the consequence AND the fix. Audit finding.
+            log::warn!(
+                "incremental cursor: column type {:?} is not supported for cursor \
+                 extraction — the cursor cannot advance, so this export will re-read \
+                 from the last saved value each run. Use an integer or timestamp \
+                 cursor column, or switch this table to `mode: chunked` / `full`.",
+                array.data_type()
+            );
             None
         }
     }

--- a/src/redact.rs
+++ b/src/redact.rs
@@ -110,14 +110,15 @@ fn try_redact_at(bytes: &[u8], i: usize) -> Option<(String, usize)> {
         return None;
     }
     let userinfo_start = j + 3;
-    // Walk the authority until the path/query/fragment/whitespace
-    // terminator, tracking the LAST `@` we cross. A password may itself
-    // contain `@` (`user:p@ssw0rd@host`), so splitting at the FIRST `@`
-    // would leak the tail after it; the userinfo terminator is the last
-    // `@` before the path — mirroring `redact_pg_url` in state/mod.rs,
-    // which uses `rfind('@')` for the same reason. `has_colon` must reflect
-    // a `:` *within the userinfo* (before that last `@`), not a host:port
-    // colon after it, so we recompute it from the chosen `@`.
+    // Walk the authority until the path/query/fragment/whitespace terminator,
+    // tracking the LAST `@` we cross. A password may itself contain `@`
+    // (`user:p@ssw0rd@host`), so splitting at the FIRST `@` would leak the tail
+    // after it; the userinfo terminator is the last `@` before the path. A raw
+    // `/` in the password would make the URL ambiguous — which is why a
+    // Rivet-constructed URL percent-encodes the userinfo (`build_url_from_fields`),
+    // so the password's `/`/`?`/`#` never appears raw here. `has_colon` must reflect
+    // a `:` *within the userinfo* (before that last `@`), not a host:port colon
+    // after it, so we recompute it from the chosen `@`.
     let mut k = userinfo_start;
     let mut last_at: Option<usize> = None;
     while k < bytes.len() {


### PR DESCRIPTION
Closes every finding from the multi-agent OSS-readiness audit (design / security / usability), each adversarially verified. The two HIGH classes are patch-worthy — they exist in the shipped **0.21.0**.

## A — HIGH (`ab4700e`)

1. **CDC default footgun (regression of the 0.21.0 `until_current` fix).** `CdcExportConfig` derived `Default`, so `until_current` was `false` (bool::default), diverging from the serde `default_true`. `cdc_job` uses `export.cdc.unwrap_or_default()`, so a `mode: cdc` export that omits the `cdc:` block (valid for PG/MySQL) silently started a **never-terminating daemon** that persists no resume position. Fix: hand-written `impl Default` (until_current = true), mirroring `MongoConfig`. RED-proven.
2. **+ 3. Credential-URL leak.** Root cause: `build_url_from_fields` spliced the user/password **raw** into the URL, so a credential with `/ @ : ? #` (a `/` is a common base64 char) made the URL ambiguous — breaking the driver **and** defeating password redaction (a `/` stopped the userinfo scan before the `@`, leaking the tail into logs / summary / journal / plan.json). Fix: **percent-encode the userinfo at construction** (new `percent-encoding` dep) — the unambiguous root fix; bounded redaction of a well-formed URL is then correct. RED-proven.
   - The audit's suggested redaction fix (unbounded `rfind('@')`) was **not** taken — it false-positives on a credential-free `?filter=a@b` URL (the existing `redact_does_not_confuse_at_in_path` test proves it). A self-redacting URL newtype (also covering a malformed `url_env`) is the deferred deep follow-up.

## B — MEDIUM (`4fd8d69`)

1. **Local-destination contract drift.** ADR-0004 + semantics.md documented the OLD `fs::copy` (retry_safe=false, partial_write_risk=true) — the OPPOSITE of the shipped OPT-6 temp-then-rename. Reconciled both docs to the code + pinned the contract with a test.
2. **Undisclosed source-cell-value egress.** A driver error can embed a source cell value into text that is persisted (`.rivet_state.db`, journal, summary) and emitted to webhooks; redaction is credentials-only. Disclosed in SECURITY.md.
3. **Connect-hint parity.** The parallel-chunked path (default for large tables) leaked the raw driver error on connect failure while the single-export path gave a `doctor` hint. `attach_connect_hint` applied at the chunked run's first connect.

## C — LOW (`d43b554`)

Audit-gate wording (`rustsec/audit-check` → `cargo audit`), an actionable incremental-cursor-type warn, a corrected `validate --format`/`--depth` in cli.md, and a documented note on the `--json` vs `--format json` idiom split.

## Testing

New RED-proven regressions for the 3 HIGH (`cdc_export_config_rust_default_is_bounded_not_a_daemon`, `build_url_percent_encodes_userinfo_so_delimiters_cant_leak`) + the local-contract pin. Full offline suite green (pre-push); fmt / clippy / `cargo audit` clean; `cargo metadata --locked` OK.

Suggest tagging **v0.21.1** after merge (closes a shipped credential-leak + the daemon-default regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)