### PR TITLE
Post-0.21.1 hardening: keyset checkpoint split + preflight keyset + CDC poison defer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 ## Unreleased
 
+### Changed
+
+- **Keyset checkpoint is now crash-recovery only; append-only incremental is the new
+  opt-in `keyset_incremental`.** Previously `chunk_checkpoint: true` on a keyset
+  (`chunk_by_key`) export did double duty: crash-recovery AND incremental-by-key (a clean
+  re-run continued from the last exported key). The second meaning silently skips UPDATEd
+  rows on any non–append-only table, so `rivet init` could not safely default it on — a
+  crashed keyset run therefore left durable rows only recoverable via a checkpoint most
+  configs left off (the production tunnel-drop that stranded ~738K rows). The two concerns
+  are now split: `chunk_checkpoint` is crash-recovery only (a clean re-run does a full pass,
+  never skipping rows; detected via the in-progress run_id), and the append-only
+  "continue-from-key on a clean re-run" behaviour is the new, off-by-default
+  `keyset_incremental`. `rivet init` now defaults `chunk_checkpoint: true` on keyset exports
+  (safe) and emits `keyset_incremental` as a commented opt-in. **Migration:** a keyset export
+  that relied on `chunk_checkpoint: true` for incremental-by-key on clean re-runs must add
+  `keyset_incremental: true` to keep that behaviour; otherwise clean re-runs now re-read in
+  full (data-safe, but re-reads an append-only table each run). Mongo `source.mongo.resume`
+  is unchanged (it maps to both). RED-proven live on MySQL/PostgreSQL/SQL Server.
+
+### Fixed
+
+- **`rivet check` was blind to keyset (`chunk_by_key`) exports** — it resolved the read
+  column from `chunk_column`/`cursor_column` only, so every keyset table rendered
+  `chunked(?, size=…)`, probed the wrong (absent) column for an index, and reported a false
+  `UNSAFE` / "no index" / "create an index on chunk_column" verdict — even though the planner
+  GUARANTEES a keyset key is a unique index. Preflight now understands `chunk_by_key` across
+  all engines: correct `keyset(key, size=…)` strategy label, the index probe runs on the real
+  keyset key, keyset is reported sequential (no false `parallel` advice), and the sparse-range
+  warning (which keyset is immune to) no longer fires. A large production config of ~66 keyset
+  tables no longer emits 66 false alarms.
+
+### Added
+
+- **`rivet check` warns when a chunked/keyset export lacks `chunk_checkpoint`** (Medium) on a
+  large table — a crash then re-reads the whole table from the start. The sparse-key warning
+  now also leads with keyset (`chunk_by_key`) as the immune escape hatch.
+
 ## 0.21.1 — 2026-07-22
 
 A security- and durability-hardening release: thirteen adversarial audit rounds over the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -617,3 +617,53 @@ the CSV timestamp test recomputed `expected` with the same flawed split, and sid
 A of the value-checksum shares the writer's own rendering). A value-rendering
 test needs an INDEPENDENT oracle: a hard-coded expected string, or a re-read
 through a different reader (DuckDB).
+
+## A diagnostic must understand EVERY read strategy — the diagnostic-bypass class
+
+`rivet check` (preflight) resolves the column it probes from a SUBSET of the
+strategy fields, so a strategy keyed off a field it doesn't read is silently
+mis-analysed — the diagnostic sibling of the runner-bypass class (a feature
+wired into only some of the four runners). `range_col = chunk_column.or(cursor_
+column)` in all three engine `diagnose_*` paths OMITTED `chunk_by_key`, so EVERY
+keyset export rendered `chunked(?, size=…)` (the `?` = the absent chunk_column),
+probed the wrong/absent column for an index, and reported a false `UNSAFE` / "no
+index" / "create an index on chunk_column" — even though the planner GUARANTEES
+a keyset key is a unique index (`plan::build` bails otherwise). A production
+config of ~66 keyset tables emitted 66 false alarms; the real problem (if any)
+was lost in the noise. The fix teaches the shared `analysis.rs` seam AND each
+engine's `range_col` about `chunk_by_key` (correct `keyset(key, size)` label,
+index probe on the real key, keyset=sequential, sparse-warning suppressed since
+keyset is immune). Process rule: **a diagnostic/preflight that resolves its
+subject (the probed column, the row estimate, the strategy label) must enumerate
+EVERY strategy the runner can pick — `chunk_column` (range), `chunk_by_key`
+(keyset), `cursor_column` (incremental), date/dense/count — not a subset.** The
+tell is a `.or()` chain over strategy fields that is shorter than the strategy
+enum; a `?`/`unwrap_or("?")` placeholder surfacing in the output is the smell
+that a strategy fell through. Cross-check the label against `derive_strategy`'s
+arms and the planner's strategy constructors.
+
+## A flag you cannot safely auto-default is often OVERLOADED — split it
+
+When `rivet init` (or a `check --fix`) cannot safely turn a knob on by default,
+the reason is frequently that the knob means two things at once, only one of them
+safe. `chunk_checkpoint: true` on a keyset export meant crash-recovery AND
+incremental-by-key (a clean re-run continues from the last exported key). The
+second silently skips UPDATEd rows on any non–append-only table, so init left it
+OFF — which is why a crashed keyset run stranded ~738K durable rows behind a
+checkpoint most configs never enabled (the live tunnel-drop). The fix is NOT a
+band-aid that auto-enables the overloaded flag (a `--fix` would hit the SAME
+safety wall init did — neither can know append-only-ness) but to SPLIT it:
+`chunk_checkpoint` is now crash-recovery only (clean re-run does a full pass,
+never skipping; crash detected via the in-progress run_id), and the append-only
+"continue-from-key on a clean re-run" is the new off-by-default
+`keyset_incremental`. Now init defaults the SAFE half on (crash-recovery) and the
+738K-row gap closes at the SOURCE — the config is born correct, no `--fix`
+needed. Process rule: **before building a config-patching feature (`--fix`), ask
+why `init` doesn't already birth the config right; if the answer is "that knob
+isn't safe to default", the knob is overloaded — split the safe concern (which
+init CAN default) from the unsafe opt-in, rather than automating the unsafe
+default one layer up.** Every split of a semantic flag needs a three-way live
+proof: crash-recovery still resumes, a CLEAN re-run does NOT skip (RED against
+the old conflation), and the opt-in restores the old behaviour
+(`keyset_checkpoint_without_incremental_rereads_on_a_clean_rerun` +
+`..._second_run_captures_only_new_keys` with the opt-in + `..._crash_resume_...`).

--- a/docs/cdc-type-fidelity-matrix.yaml
+++ b/docs/cdc-type-fidelity-matrix.yaml
@@ -43,7 +43,7 @@ scenarios:
     what: "int16/32/64 + unsigned 64 (incl. BIGINT UNSIGNED > i64::MAX) survive CDC. MySQL cell is INDEPENDENT (DuckDB re-read vs the source literal), not a batch-differential"
     postgres: { test: pg_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mysql:    { test: mysql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
-    mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
+    mssql:    { test: mssql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mongo:    { test: mongo_cdc_change_stream_renders_tricky_bson_verbatim_like_batch, oracle: independent }
 
   - id: type_float
@@ -64,7 +64,7 @@ scenarios:
     what: "date + time-of-day survive the change stream with the batch Arrow types"
     postgres: { test: pg_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mysql:   { test: mysql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
-    mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
+    mssql:    { test: mssql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mongo:    { na: "BSON dates ride the verbatim document blob; the extJSON test pins the mechanism" }
 
   - id: type_timestamp_tz
@@ -78,14 +78,14 @@ scenarios:
     what: "varchar/char/text through CDC — value + encoding verbatim"
     postgres: { test: pg_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mysql:   { test: mysql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
-    mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
+    mssql:    { test: mssql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mongo:    { test: mongo_cdc_change_stream_renders_tricky_bson_verbatim_like_batch, oracle: independent }
 
   - id: type_binary
     what: "bytea/varbinary/binary through CDC as the same bytes"
     postgres: { test: pg_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mysql:   { test: mysql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
-    mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
+    mssql:    { test: mssql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mongo:    { na: "binary rides the verbatim document blob (BSON Binary → extJSON)" }
 
   - id: type_json

--- a/docs/cdc-type-fidelity-matrix.yaml
+++ b/docs/cdc-type-fidelity-matrix.yaml
@@ -31,9 +31,9 @@ scenarios:
     mongo:    { na: "boolean rides the verbatim document blob, not a typed column" }
 
   - id: type_integer_families
-    what: "int16/32/64 + unsigned 64 (incl. BIGINT UNSIGNED > i64::MAX) survive CDC"
+    what: "int16/32/64 + unsigned 64 (incl. BIGINT UNSIGNED > i64::MAX) survive CDC. MySQL cell is INDEPENDENT (DuckDB re-read vs the source literal), not a batch-differential"
     postgres: { test: pg_cdc_full_type_matrix_matches_batch }
-    mysql:    { test: cdc_full_type_matrix_matches_batch }
+    mysql:    { test: mysql_cdc_typed_values_match_source_via_duckdb_not_batch }
     mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
     mongo:    { test: mongo_cdc_change_stream_renders_tricky_bson_verbatim_like_batch }
 
@@ -45,9 +45,9 @@ scenarios:
     mongo:    { na: "float rides the verbatim document blob, not a typed column" }
 
   - id: type_decimal
-    what: "decimal(p,s) precision + scale through CDC; MSSQL MONEY past the f64-exact 2^53 range fails loud, not falsely-exact (finding #2)"
+    what: "decimal(p,s) precision + scale through CDC (MySQL cell INDEPENDENT: DuckDB re-read vs source literal); MSSQL MONEY past the f64-exact 2^53 range fails loud, not falsely-exact (finding #2)"
     postgres: { test: pg_cdc_full_type_matrix_matches_batch }
-    mysql:    { test: cdc_full_type_matrix_matches_batch }
+    mysql:    { test: mysql_cdc_typed_values_match_source_via_duckdb_not_batch }
     mssql:    { test: cdc_money_past_f64_exact_range_fails_loud_not_a_falsely_exact_decimal }
     mongo:    { test: mongo_cdc_change_stream_renders_tricky_bson_verbatim_like_batch }
 

--- a/docs/cdc-type-fidelity-matrix.yaml
+++ b/docs/cdc-type-fidelity-matrix.yaml
@@ -35,8 +35,8 @@ scenarios:
   - id: type_boolean
     what: "boolean rides through the change stream as the same Arrow Boolean as batch"
     postgres: { test: pg_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
-    mysql:    { test: cdc_full_type_matrix_matches_batch }
-    mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
+    mysql:   { test: mysql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
+    mssql:   { test: mssql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mongo:    { na: "boolean rides the verbatim document blob, not a typed column" }
 
   - id: type_integer_families
@@ -49,8 +49,8 @@ scenarios:
   - id: type_float
     what: "real/double through CDC — hostile floats (NaN/Inf) match batch or fail loud"
     postgres: { test: pg_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
-    mysql:    { test: cdc_full_type_matrix_matches_batch }
-    mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
+    mysql:   { test: mysql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
+    mssql:   { test: mssql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mongo:    { na: "float rides the verbatim document blob, not a typed column" }
 
   - id: type_decimal
@@ -90,16 +90,16 @@ scenarios:
 
   - id: type_json
     what: "json/jsonb content fidelity through the change stream"
-    postgres: { test: cdc_captures_json_as_valid_json }
-    mysql:    { test: cdc_full_type_matrix_matches_batch }
+    postgres: { test: pg_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
+    mysql:   { test: mysql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mssql:    { na: "SQL Server has no native JSON type; the CDC matrix fixture omits it by design" }
     mongo:    { test: mongo_cdc_change_stream_renders_tricky_bson_verbatim_like_batch, oracle: independent }
 
   - id: type_uuid
     what: "uuid — PG uuid / MySQL CHAR(36) / MSSQL uniqueidentifier → canonical value through CDC"
-    postgres: { test: pg_cdc_full_type_matrix_matches_batch }
+    postgres: { test: pg_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mysql:    { test: mysql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
-    mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
+    mssql:   { test: mssql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mongo:    { na: "a BSON uuid rides the verbatim document blob, not a typed column" }
 
   - id: type_enum
@@ -112,7 +112,7 @@ scenarios:
   - id: type_set
     what: "MySQL SET — the comma-joined labels (not the raw bitmask) through CDC"
     postgres: { na: "PostgreSQL has no SET type" }
-    mysql:    { test: cdc_full_type_matrix_matches_batch }
+    mysql:   { test: mysql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mssql:    { na: "SQL Server has no SET type" }
     mongo:    { na: "no SET type" }
 
@@ -120,7 +120,7 @@ scenarios:
     what: "BIT(n) through CDC — BIT(1) boolean, BIT(n>1) integer; a BIT(64) with bit 63 set fails loud, never a silent NULL (finding #4)"
     postgres: { na: "PG bit/varbit is not in the CDC type fixture; covered as a follow-up" }
     mysql:    { test: build_column_narrows_int_and_fails_loud_on_overflow, oracle: fail_loud }
-    mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
+    mssql:   { test: mssql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mongo:    { na: "no BIT type" }
 
   - id: type_money
@@ -132,7 +132,7 @@ scenarios:
 
   - id: type_interval
     what: "PostgreSQL interval — canonical ISO-8601 text through CDC, identical to batch"
-    postgres: { test: pg_cdc_update_and_delete_carry_full_types }
+    postgres: { test: pg_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mysql:    { na: "MySQL has no INTERVAL column type" }
     mssql:    { na: "SQL Server has no INTERVAL type" }
     mongo:    { na: "no interval type" }

--- a/docs/cdc-type-fidelity-matrix.yaml
+++ b/docs/cdc-type-fidelity-matrix.yaml
@@ -34,14 +34,14 @@ engines: [postgres, mysql, mssql, mongo]
 scenarios:
   - id: type_boolean
     what: "boolean rides through the change stream as the same Arrow Boolean as batch"
-    postgres: { test: pg_cdc_full_type_matrix_matches_batch }
+    postgres: { test: pg_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mysql:    { test: cdc_full_type_matrix_matches_batch }
     mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
     mongo:    { na: "boolean rides the verbatim document blob, not a typed column" }
 
   - id: type_integer_families
     what: "int16/32/64 + unsigned 64 (incl. BIGINT UNSIGNED > i64::MAX) survive CDC. MySQL cell is INDEPENDENT (DuckDB re-read vs the source literal), not a batch-differential"
-    postgres: { test: pg_cdc_full_type_matrix_matches_batch }
+    postgres: { test: pg_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mysql:    { test: mysql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
     mongo:    { test: mongo_cdc_change_stream_renders_tricky_bson_verbatim_like_batch, oracle: independent }
@@ -55,7 +55,7 @@ scenarios:
 
   - id: type_decimal
     what: "decimal(p,s) precision + scale through CDC (MySQL cell INDEPENDENT: DuckDB re-read vs source literal); MSSQL MONEY past the f64-exact 2^53 range fails loud, not falsely-exact (finding #2)"
-    postgres: { test: pg_cdc_full_type_matrix_matches_batch }
+    postgres: { test: pg_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mysql:    { test: mysql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mssql:    { test: cdc_money_past_f64_exact_range_fails_loud_not_a_falsely_exact_decimal, oracle: fail_loud }
     mongo:    { test: mongo_cdc_change_stream_renders_tricky_bson_verbatim_like_batch, oracle: independent }
@@ -76,7 +76,7 @@ scenarios:
 
   - id: type_text
     what: "varchar/char/text through CDC — value + encoding verbatim"
-    postgres: { test: pg_cdc_full_type_matrix_matches_batch }
+    postgres: { test: pg_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mysql:    { test: cdc_full_type_matrix_matches_batch }
     mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
     mongo:    { test: mongo_cdc_change_stream_renders_tricky_bson_verbatim_like_batch, oracle: independent }
@@ -104,7 +104,7 @@ scenarios:
 
   - id: type_enum
     what: "enum label (not the wire index) through CDC — incl. a CROSS-DATABASE MySQL capture enriched from the table's own schema (finding #3)"
-    postgres: { test: pg_cdc_full_type_matrix_matches_batch }
+    postgres: { test: pg_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mysql:    { test: cdc_cross_database_enum_enriches_from_the_tables_own_schema, oracle: independent }
     mssql:    { na: "SQL Server has no ENUM type" }
     mongo:    { na: "no enum type; a string rides the document blob" }

--- a/docs/cdc-type-fidelity-matrix.yaml
+++ b/docs/cdc-type-fidelity-matrix.yaml
@@ -1,0 +1,136 @@
+# CDC per-type value-fidelity matrix — does a source column TYPE ride through the
+# CHANGE-STREAM path (decode → typed RivetValue sink → Parquet) with correct
+# precision/encoding, per engine? The batch axis is docs/type-fidelity-matrix.yaml;
+# this is its CDC sibling. The audit found the per-type CDC axis un-systematized —
+# the class where findings #2 (MSSQL MONEY>2^53), #3 (MySQL ENUM cross-db) and #4
+# (BIT(64) bit 63) lived: the batch path was correct, the CDC/edge sibling was not.
+# Same shape + drift-guard as the other ledgers. Cell = { test } | { gap } | { na }.
+#
+# The workhorse cells cite each engine's `*_cdc_full_type_matrix_matches_batch`
+# test (a comprehensive type table exported BOTH ways, asserted equal by ArrayData
+# — type AND value). The edge scenarios (money/enum/bit) cite the dedicated tests
+# that cover the value RANGE the full-type tables use small, safe values for.
+#
+# Mongo is a JSON-blob model: a change document rides a verbatim extended-JSON
+# `document` column, so per-column Parquet type fidelity is n/a EXCEPT where a
+# value is explicitly asserted verbatim through the change stream (Int64,
+# Decimal128, text/json) by the CDC extJSON test.
+#
+# Every RivetType FAMILY must have a scenario row (enforced generatively by
+# matrix_cdc_type_rows_cover_every_rivet_type in the drift-guard, derived from the
+# RivetType enum): a new type cannot ship without a CDC-fidelity row.
+
+engines: [postgres, mysql, mssql, mongo]
+
+scenarios:
+  - id: type_boolean
+    what: "boolean rides through the change stream as the same Arrow Boolean as batch"
+    postgres: { test: pg_cdc_full_type_matrix_matches_batch }
+    mysql:    { test: cdc_full_type_matrix_matches_batch }
+    mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
+    mongo:    { na: "boolean rides the verbatim document blob, not a typed column" }
+
+  - id: type_integer_families
+    what: "int16/32/64 + unsigned 64 (incl. BIGINT UNSIGNED > i64::MAX) survive CDC"
+    postgres: { test: pg_cdc_full_type_matrix_matches_batch }
+    mysql:    { test: cdc_full_type_matrix_matches_batch }
+    mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
+    mongo:    { test: mongo_cdc_change_stream_renders_tricky_bson_verbatim_like_batch }
+
+  - id: type_float
+    what: "real/double through CDC — hostile floats (NaN/Inf) match batch or fail loud"
+    postgres: { test: pg_cdc_hostile_floats_match_batch_and_nan_numeric_fails_loudly }
+    mysql:    { test: cdc_full_type_matrix_matches_batch }
+    mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
+    mongo:    { na: "float rides the verbatim document blob, not a typed column" }
+
+  - id: type_decimal
+    what: "decimal(p,s) precision + scale through CDC; MSSQL MONEY past the f64-exact 2^53 range fails loud, not falsely-exact (finding #2)"
+    postgres: { test: pg_cdc_full_type_matrix_matches_batch }
+    mysql:    { test: cdc_full_type_matrix_matches_batch }
+    mssql:    { test: cdc_money_past_f64_exact_range_fails_loud_not_a_falsely_exact_decimal }
+    mongo:    { test: mongo_cdc_change_stream_renders_tricky_bson_verbatim_like_batch }
+
+  - id: type_date_time
+    what: "date + time-of-day survive the change stream with the batch Arrow types"
+    postgres: { test: pg_cdc_full_type_matrix_matches_batch }
+    mysql:    { test: cdc_full_type_matrix_matches_batch }
+    mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
+    mongo:    { na: "BSON dates ride the verbatim document blob; the extJSON test pins the mechanism" }
+
+  - id: type_timestamp_tz
+    what: "naive vs tz-aware timestamp — CDC preserves the UTC instant under a non-default session/DB timezone (the +9h render-time trap)"
+    postgres: { test: pg_cdc_non_utc_database_timezone_matches_batch }
+    mysql:    { test: cdc_non_utc_server_timezone_matches_batch_and_utc_instant }
+    mssql:    { test: mssql_cdc_datetimeoffset_value_is_preserved }
+    mongo:    { na: "BSON dates ride the verbatim document blob" }
+
+  - id: type_text
+    what: "varchar/char/text through CDC — value + encoding verbatim"
+    postgres: { test: pg_cdc_full_type_matrix_matches_batch }
+    mysql:    { test: cdc_full_type_matrix_matches_batch }
+    mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
+    mongo:    { test: mongo_cdc_change_stream_renders_tricky_bson_verbatim_like_batch }
+
+  - id: type_binary
+    what: "bytea/varbinary/binary through CDC as the same bytes"
+    postgres: { test: pg_cdc_full_type_matrix_matches_batch }
+    mysql:    { test: cdc_full_type_matrix_matches_batch }
+    mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
+    mongo:    { na: "binary rides the verbatim document blob (BSON Binary → extJSON)" }
+
+  - id: type_json
+    what: "json/jsonb content fidelity through the change stream"
+    postgres: { test: cdc_captures_json_as_valid_json }
+    mysql:    { test: cdc_full_type_matrix_matches_batch }
+    mssql:    { na: "SQL Server has no native JSON type; the CDC matrix fixture omits it by design" }
+    mongo:    { test: mongo_cdc_change_stream_renders_tricky_bson_verbatim_like_batch }
+
+  - id: type_uuid
+    what: "uuid — PG uuid / MySQL CHAR(36) / MSSQL uniqueidentifier → canonical value through CDC"
+    postgres: { test: pg_cdc_full_type_matrix_matches_batch }
+    mysql:    { test: cdc_full_type_matrix_matches_batch }
+    mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
+    mongo:    { na: "a BSON uuid rides the verbatim document blob, not a typed column" }
+
+  - id: type_enum
+    what: "enum label (not the wire index) through CDC — incl. a CROSS-DATABASE MySQL capture enriched from the table's own schema (finding #3)"
+    postgres: { test: pg_cdc_full_type_matrix_matches_batch }
+    mysql:    { test: cdc_cross_database_enum_enriches_from_the_tables_own_schema }
+    mssql:    { na: "SQL Server has no ENUM type" }
+    mongo:    { na: "no enum type; a string rides the document blob" }
+
+  - id: type_set
+    what: "MySQL SET — the comma-joined labels (not the raw bitmask) through CDC"
+    postgres: { na: "PostgreSQL has no SET type" }
+    mysql:    { test: cdc_full_type_matrix_matches_batch }
+    mssql:    { na: "SQL Server has no SET type" }
+    mongo:    { na: "no SET type" }
+
+  - id: type_bit
+    what: "BIT(n) through CDC — BIT(1) boolean, BIT(n>1) integer; a BIT(64) with bit 63 set fails loud, never a silent NULL (finding #4)"
+    postgres: { na: "PG bit/varbit is not in the CDC type fixture; covered as a follow-up" }
+    mysql:    { test: build_column_narrows_int_and_fails_loud_on_overflow }
+    mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
+    mongo:    { na: "no BIT type" }
+
+  - id: type_money
+    what: "MSSQL MONEY/SMALLMONEY — the exact scaled value through CDC (f64-delivered by tiberius), fails loud past the 2^53-exact range (finding #2)"
+    postgres: { na: "PostgreSQL money is discouraged and not in the CDC fixture" }
+    mysql:    { na: "MySQL has no MONEY type" }
+    mssql:    { test: mssql_money_values_survive_batch_and_cdc }
+    mongo:    { na: "no MONEY type" }
+
+  - id: type_interval
+    what: "PostgreSQL interval — canonical ISO-8601 text through CDC, identical to batch"
+    postgres: { test: pg_cdc_update_and_delete_carry_full_types }
+    mysql:    { na: "MySQL has no INTERVAL column type" }
+    mssql:    { na: "SQL Server has no INTERVAL type" }
+    mongo:    { na: "no interval type" }
+
+  - id: type_list
+    what: "PostgreSQL 1-D arrays (int[]/text[]/…) as a real Arrow List through CDC; a multi-dimensional array fails loud, never a flat NULL list (finding #6)"
+    postgres: { test: multidim_array_literal_is_refused_not_flattened_to_bogus_nulls }
+    mysql:    { na: "MySQL has no array column type" }
+    mssql:    { na: "SQL Server has no array column type" }
+    mongo:    { na: "arrays ride the verbatim document blob (BSON array → extJSON)" }

--- a/docs/cdc-type-fidelity-matrix.yaml
+++ b/docs/cdc-type-fidelity-matrix.yaml
@@ -19,6 +19,15 @@
 # Every RivetType FAMILY must have a scenario row (enforced generatively by
 # matrix_cdc_type_rows_cover_every_rivet_type in the drift-guard, derived from the
 # RivetType enum): a new type cannot ship without a CDC-fidelity row.
+#
+# ORACLE STRENGTH (matrix_oracle_strength_ratchet): a `test:` cell may carry
+# `oracle: independent|fail_loud|differential|self`. A bare `*_cdc_full_type_matrix_
+# matches_batch` cell is a DIFFERENTIAL self-oracle (CDC decode vs BATCH decode) —
+# it passes a bug both siblings SHARE (the class Form A misses). `oracle:
+# independent` marks a cell verified OUTSIDE rivet's decode family (a DuckDB /
+# source-vs-dest re-read, a hard-coded literal). An un-annotated test cell counts
+# as differential (weak) by default; the ratchet forbids the weak count from
+# growing and shrinks as cells are upgraded to independent.
 
 engines: [postgres, mysql, mssql, mongo]
 
@@ -33,9 +42,9 @@ scenarios:
   - id: type_integer_families
     what: "int16/32/64 + unsigned 64 (incl. BIGINT UNSIGNED > i64::MAX) survive CDC. MySQL cell is INDEPENDENT (DuckDB re-read vs the source literal), not a batch-differential"
     postgres: { test: pg_cdc_full_type_matrix_matches_batch }
-    mysql:    { test: mysql_cdc_typed_values_match_source_via_duckdb_not_batch }
+    mysql:    { test: mysql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
-    mongo:    { test: mongo_cdc_change_stream_renders_tricky_bson_verbatim_like_batch }
+    mongo:    { test: mongo_cdc_change_stream_renders_tricky_bson_verbatim_like_batch, oracle: independent }
 
   - id: type_float
     what: "real/double through CDC — hostile floats (NaN/Inf) match batch or fail loud"
@@ -47,9 +56,9 @@ scenarios:
   - id: type_decimal
     what: "decimal(p,s) precision + scale through CDC (MySQL cell INDEPENDENT: DuckDB re-read vs source literal); MSSQL MONEY past the f64-exact 2^53 range fails loud, not falsely-exact (finding #2)"
     postgres: { test: pg_cdc_full_type_matrix_matches_batch }
-    mysql:    { test: mysql_cdc_typed_values_match_source_via_duckdb_not_batch }
-    mssql:    { test: cdc_money_past_f64_exact_range_fails_loud_not_a_falsely_exact_decimal }
-    mongo:    { test: mongo_cdc_change_stream_renders_tricky_bson_verbatim_like_batch }
+    mysql:    { test: mysql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
+    mssql:    { test: cdc_money_past_f64_exact_range_fails_loud_not_a_falsely_exact_decimal, oracle: fail_loud }
+    mongo:    { test: mongo_cdc_change_stream_renders_tricky_bson_verbatim_like_batch, oracle: independent }
 
   - id: type_date_time
     what: "date + time-of-day survive the change stream with the batch Arrow types"
@@ -60,9 +69,9 @@ scenarios:
 
   - id: type_timestamp_tz
     what: "naive vs tz-aware timestamp — CDC preserves the UTC instant under a non-default session/DB timezone (the +9h render-time trap)"
-    postgres: { test: pg_cdc_non_utc_database_timezone_matches_batch }
-    mysql:    { test: cdc_non_utc_server_timezone_matches_batch_and_utc_instant }
-    mssql:    { test: mssql_cdc_datetimeoffset_value_is_preserved }
+    postgres: { test: pg_cdc_non_utc_database_timezone_matches_batch, oracle: independent }
+    mysql:    { test: cdc_non_utc_server_timezone_matches_batch_and_utc_instant, oracle: independent }
+    mssql:    { test: mssql_cdc_datetimeoffset_value_is_preserved, oracle: independent }
     mongo:    { na: "BSON dates ride the verbatim document blob" }
 
   - id: type_text
@@ -70,7 +79,7 @@ scenarios:
     postgres: { test: pg_cdc_full_type_matrix_matches_batch }
     mysql:    { test: cdc_full_type_matrix_matches_batch }
     mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
-    mongo:    { test: mongo_cdc_change_stream_renders_tricky_bson_verbatim_like_batch }
+    mongo:    { test: mongo_cdc_change_stream_renders_tricky_bson_verbatim_like_batch, oracle: independent }
 
   - id: type_binary
     what: "bytea/varbinary/binary through CDC as the same bytes"
@@ -84,7 +93,7 @@ scenarios:
     postgres: { test: cdc_captures_json_as_valid_json }
     mysql:    { test: cdc_full_type_matrix_matches_batch }
     mssql:    { na: "SQL Server has no native JSON type; the CDC matrix fixture omits it by design" }
-    mongo:    { test: mongo_cdc_change_stream_renders_tricky_bson_verbatim_like_batch }
+    mongo:    { test: mongo_cdc_change_stream_renders_tricky_bson_verbatim_like_batch, oracle: independent }
 
   - id: type_uuid
     what: "uuid — PG uuid / MySQL CHAR(36) / MSSQL uniqueidentifier → canonical value through CDC"
@@ -96,7 +105,7 @@ scenarios:
   - id: type_enum
     what: "enum label (not the wire index) through CDC — incl. a CROSS-DATABASE MySQL capture enriched from the table's own schema (finding #3)"
     postgres: { test: pg_cdc_full_type_matrix_matches_batch }
-    mysql:    { test: cdc_cross_database_enum_enriches_from_the_tables_own_schema }
+    mysql:    { test: cdc_cross_database_enum_enriches_from_the_tables_own_schema, oracle: independent }
     mssql:    { na: "SQL Server has no ENUM type" }
     mongo:    { na: "no enum type; a string rides the document blob" }
 
@@ -110,7 +119,7 @@ scenarios:
   - id: type_bit
     what: "BIT(n) through CDC — BIT(1) boolean, BIT(n>1) integer; a BIT(64) with bit 63 set fails loud, never a silent NULL (finding #4)"
     postgres: { na: "PG bit/varbit is not in the CDC type fixture; covered as a follow-up" }
-    mysql:    { test: build_column_narrows_int_and_fails_loud_on_overflow }
+    mysql:    { test: build_column_narrows_int_and_fails_loud_on_overflow, oracle: fail_loud }
     mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
     mongo:    { na: "no BIT type" }
 
@@ -118,7 +127,7 @@ scenarios:
     what: "MSSQL MONEY/SMALLMONEY — the exact scaled value through CDC (f64-delivered by tiberius), fails loud past the 2^53-exact range (finding #2)"
     postgres: { na: "PostgreSQL money is discouraged and not in the CDC fixture" }
     mysql:    { na: "MySQL has no MONEY type" }
-    mssql:    { test: mssql_money_values_survive_batch_and_cdc }
+    mssql:    { test: mssql_money_values_survive_batch_and_cdc, oracle: independent }
     mongo:    { na: "no MONEY type" }
 
   - id: type_interval
@@ -130,7 +139,7 @@ scenarios:
 
   - id: type_list
     what: "PostgreSQL 1-D arrays (int[]/text[]/…) as a real Arrow List through CDC; a multi-dimensional array fails loud, never a flat NULL list (finding #6)"
-    postgres: { test: multidim_array_literal_is_refused_not_flattened_to_bogus_nulls }
+    postgres: { test: multidim_array_literal_is_refused_not_flattened_to_bogus_nulls, oracle: fail_loud }
     mysql:    { na: "MySQL has no array column type" }
     mssql:    { na: "SQL Server has no array column type" }
     mongo:    { na: "arrays ride the verbatim document blob (BSON array → extJSON)" }

--- a/docs/cdc-type-fidelity-matrix.yaml
+++ b/docs/cdc-type-fidelity-matrix.yaml
@@ -98,7 +98,7 @@ scenarios:
   - id: type_uuid
     what: "uuid — PG uuid / MySQL CHAR(36) / MSSQL uniqueidentifier → canonical value through CDC"
     postgres: { test: pg_cdc_full_type_matrix_matches_batch }
-    mysql:    { test: cdc_full_type_matrix_matches_batch }
+    mysql:    { test: mysql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
     mongo:    { na: "a BSON uuid rides the verbatim document blob, not a typed column" }
 

--- a/docs/cdc-type-fidelity-matrix.yaml
+++ b/docs/cdc-type-fidelity-matrix.yaml
@@ -48,7 +48,7 @@ scenarios:
 
   - id: type_float
     what: "real/double through CDC — hostile floats (NaN/Inf) match batch or fail loud"
-    postgres: { test: pg_cdc_hostile_floats_match_batch_and_nan_numeric_fails_loudly }
+    postgres: { test: pg_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mysql:    { test: cdc_full_type_matrix_matches_batch }
     mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
     mongo:    { na: "float rides the verbatim document blob, not a typed column" }
@@ -62,8 +62,8 @@ scenarios:
 
   - id: type_date_time
     what: "date + time-of-day survive the change stream with the batch Arrow types"
-    postgres: { test: pg_cdc_full_type_matrix_matches_batch }
-    mysql:    { test: cdc_full_type_matrix_matches_batch }
+    postgres: { test: pg_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
+    mysql:   { test: mysql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
     mongo:    { na: "BSON dates ride the verbatim document blob; the extJSON test pins the mechanism" }
 
@@ -77,14 +77,14 @@ scenarios:
   - id: type_text
     what: "varchar/char/text through CDC — value + encoding verbatim"
     postgres: { test: pg_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
-    mysql:    { test: cdc_full_type_matrix_matches_batch }
+    mysql:   { test: mysql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
     mongo:    { test: mongo_cdc_change_stream_renders_tricky_bson_verbatim_like_batch, oracle: independent }
 
   - id: type_binary
     what: "bytea/varbinary/binary through CDC as the same bytes"
-    postgres: { test: pg_cdc_full_type_matrix_matches_batch }
-    mysql:    { test: cdc_full_type_matrix_matches_batch }
+    postgres: { test: pg_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
+    mysql:   { test: mysql_cdc_typed_values_match_source_via_duckdb_not_batch, oracle: independent }
     mssql:    { test: mssql_cdc_full_type_matrix_matches_batch }
     mongo:    { na: "binary rides the verbatim document blob (BSON Binary → extJSON)" }
 

--- a/docs/csv-fidelity-matrix.yaml
+++ b/docs/csv-fidelity-matrix.yaml
@@ -36,6 +36,11 @@ scenarios:
     no_silent_loss:          { test: timestamp_marks_instant_utc_but_leaves_naive_bare }
     no_corruption_on_escape: { na: "an ISO-8601 timestamp plus `Z` is `[0-9-T:.Z]` — no delimiter/quote can appear, nothing to escape" }
 
+  - id: negative_time_signed_duration
+    what: "MySQL TIME is a SIGNED duration (-838:59:59..838:59:59); the batch decoder emits negative micros. The old truncating `/`+`%` put a minus on EVERY field (`-1:-30:00`, `00:00:00.-00001`) — corrupt in every reader. One leading sign + magnitude formatting; a >24h duration still prints in full. True oracle: hard-coded expected strings."
+    no_silent_loss:          { test: negative_time_renders_one_leading_sign_not_a_minus_per_field }
+    no_corruption_on_escape: { na: "an HH:MM:SS.ffffff duration (± prefix) is `[-0-9:.]` — no delimiter/quote can appear, nothing to escape" }
+
   - id: float_non_finite
     what: "NaN / Inf / -Inf emit an explicit literal, never an empty cell that reads back as NULL."
     no_silent_loss:          { test: float_special_values_emit_literals_not_empty }

--- a/docs/durability-ordering-matrix.yaml
+++ b/docs/durability-ordering-matrix.yaml
@@ -80,3 +80,32 @@ scenarios:
     chunked:     { test: m8_does_not_quarantine_a_part_recorded_in_the_state_file_log }
     keyset:      { na: "keyset resumes via its own checkpoint (get_resume_run_id + file_log rehydration), not the chunked M8 destination-vs-listing quarantine preamble" }
     cdc:         { na: "CDC resumes by slot/checkpoint position, not a destination-object quarantine sweep" }
+
+  # ── This session: the keyset crash-recovery cursor lifecycle. The single mid-data
+  #    cell above (manifest_durable_before_state_advance) did NOT enumerate the
+  #    (fault-point × config-variant) sub-cross-product — crash-BEFORE-first-page,
+  #    crash-AFTER-data-complete, and the INCREMENTAL variant — and an adversarial
+  #    hunt found a HIGH silent-loss in (after-data-complete × incremental). These
+  #    three rows raise the keyset column's resolution to that sub-cross-product;
+  #    every cell asserts MANIFEST-DRIVEN (the orphaned parquet survives on disk, so
+  #    a glob masks the loss). `na` for the other shapes documents structural immunity.
+  - id: keyset_fresh_crash_before_first_page_rereads_not_skips
+    what: "a FRESH non-incremental keyset run that crashes after open but before its first page commit must re-read from the start on recovery, never resume from a prior completed run's stale high-water mark (whole-table silent skip)."
+    incremental: { na: "the stale-cursor skip is a NON-incremental keyset hazard; batch incremental (cursor mode) has no per-run keyset anchor to inherit" }
+    chunked:     { na: "chunked resume is --resume-gated over a [min,max] span recomputed each run; a plain re-run ignores the prior checkpoint, so a pre-first-chunk crash cannot inherit a stale cursor" }
+    keyset:      { test: keyset_fresh_run_crash_before_first_page_does_not_skip_the_table }
+    cdc:         { na: "CDC has no keyset cursor; resume is by slot/checkpoint position" }
+
+  - id: keyset_post_data_failure_non_incremental_clears_anchor
+    what: "a NON-incremental keyset run that commits all data then fails a post-data gate must NOT leave a resume anchor — the operator's intended full re-run must re-read, not resume-skip rows updated since."
+    incremental: { na: "for incremental a surviving anchor is by-design (the next run continues from the high-water mark) AND must survive to finalize — see the next row" }
+    chunked:     { na: "chunked clears completed-chunk state at finalize; a post-data gate failure re-runs the whole span, no cursor to strand" }
+    keyset:      { test: keyset_failure_after_data_complete_does_not_resume_and_skip_on_the_next_run }
+    cdc:         { na: "no keyset anchor" }
+
+  - id: keyset_incremental_crash_before_finalize_rehydrates_not_orphans
+    what: "an INCREMENTAL keyset run that commits all pages then crashes BEFORE finalize_manifest must KEEP its resume anchor so recovery rehydrates the committed pages into the manifest; clearing it early orphans them (the manifest-authoritative loader silently drops the rows — the parquet survives, so ONLY a manifest oracle catches it). Round-2-hunt HIGH regression of the crash-recovery/incremental split."
+    incremental: { na: "batch incremental (cursor mode) has no keyset run_id anchor; it re-runs from the persisted cursor" }
+    chunked:     { na: "chunked has no keyset_incremental variant; its anchor is per-chunk-task state cleared at finalize" }
+    keyset:      { test: keyset_incremental_crash_before_finalize_rehydrates_not_orphans_the_manifest }
+    cdc:         { na: "no keyset anchor" }

--- a/docs/modes/chunked.md
+++ b/docs/modes/chunked.md
@@ -308,13 +308,30 @@ query.
 **Required privileges:** read-only is sufficient — the introspection probe reads
 `information_schema` index metadata, no elevated grants needed.
 
+**Resumability (`chunk_checkpoint`).** `rivet init` defaults `chunk_checkpoint: true`
+on keyset exports. It is **crash-recovery**: a run that dies mid-stream resumes from
+its last committed key on the next run (its in-progress `run_id` is still open); a
+run that finished CLEANLY clears that marker, so a plain re-run does a full pass and
+never silently skips already-exported rows.
+
+**Append-only incremental (`keyset_incremental`).** Off by default. When set, a
+CLEAN re-run continues from the last exported key — pulling ONLY rows past the
+high-water mark. Correct **only for append-only tables**: on a mutable table a row
+whose key already passed is silently never re-read. For a mutable table use
+`mode: incremental` on a timestamp cursor instead.
+
+```yaml
+    chunk_by_key: event_uuid
+    chunk_checkpoint: true       # crash-recovery (default on for keyset)
+    keyset_incremental: true     # append-only ONLY: clean re-run pulls just new keys
+```
+
 **Limitations (current):**
 
 - **Sequential only** — each page depends on the previous page's last key, so
   keyset does not parallelize (`parallel` is ignored). Range chunking remains the
   parallel path for integer-PK tables.
 - **Single-column keys only** — composite unique keys are not yet supported.
-- **No `--resume` checkpoint yet** — a keyset run restarts from the first page.
 
 ## Troubleshooting
 

--- a/docs/reference/config-reference.md
+++ b/docs/reference/config-reference.md
@@ -92,7 +92,8 @@ Rendered from the JSON Schema `rivet schema config` emits (schemars ← the Rust
 | `meta_columns` | [MetaColumns](#metacolumns) |  |  |
 | `quality` | [QualityConfig](#qualityconfig) |  |  |
 | `max_file_size` | `string` |  | Rotate to a new part when the current file reaches this size. Accepts `B`/`KB`/`MB`/`GB` (case-insensitive) or a bare byte count; a fractional value is allowed (`1.5GB`). Units are binary (IEC-style): `KB` = 1024 bytes, `MB` = 1024 KB, `GB` = 1024 MB. Example: `256MB`. |
-| `chunk_checkpoint` | `boolean` |  |  |
+| `chunk_checkpoint` | `boolean` |  | Persist per-chunk / per-page progress so a **crashed** run resumes from the last durably committed point instead of re-reading from the start. This is pure crash-recovery: a *clean* re-run (the prior run finished) still does a full pass — it never silently skips already-exported rows. Safe to enable on any table; `rivet init` defaults it on for chunked and keyset exports. |
+| `keyset_incremental` | `boolean` |  | Keyset only (`chunk_by_key`): on a **clean** re-run, continue from the last exported key — pull ONLY rows with a key past the high-water mark. This is incremental-by-key, correct ONLY for APPEND-ONLY tables (a mutable row whose key already passed is silently never re-read). Opt-in and off by default; crash-recovery does not need it (that is `chunk_checkpoint`). For a mutable table use `mode: incremental` on a timestamp cursor instead. |
 | `chunk_max_attempts` | `integer` |  |  |
 | `tuning` | [TuningConfig](#tuningconfig) |  |  |
 | `source_group` | `string` |  | Optional logical group for shared source capacity (replica, host). Advisory prioritization only. |

--- a/docs/reference/tuning.md
+++ b/docs/reference/tuning.md
@@ -48,7 +48,7 @@ A profile sets sensible defaults for all tuning parameters. Individual fields ov
 | `batch_size` | adaptive: 64 MB/flush¹ | adaptive: 32 MB/flush¹ | 2,000 (static) |
 | `throttle_ms` | 0 | 50 | 500 |
 | `statement_timeout_s` | 0 (none) | 300 | 120 |
-| `max_retries` | 1 | 3 | 5 |
+| `max_retries` | 1 | 3 | 10 |
 | `retry_backoff_ms` | 1,000 | 2,000 | 5,000 |
 | `lock_timeout_s` | 0 (none) | 30 | 10 |
 | `memory_threshold_mb` | 0 (none) | 4,096 | 2,048 |

--- a/docs/type-fidelity-matrix.yaml
+++ b/docs/type-fidelity-matrix.yaml
@@ -16,63 +16,63 @@ engines: [postgres, mysql, mssql, mongo]
 scenarios:
   - id: type_decimal
     what: "decimal/numeric(p,s) — precision + scale preserved, never floated"
-    postgres: { test: golden_decimal_payments_exact_sums_and_decimal128_types }
-    mysql:    { test: mysql_golden_decimal_payments_exact_sums_and_decimal128_types }
-    mssql:    { test: roast_mssql_decimal_scale_survives_all_null_first_batch }
-    mongo:    { test: mongo_batch_type_fidelity_document_is_verbatim_extjson }
+    postgres: { test: golden_decimal_payments_exact_sums_and_decimal128_types, oracle: independent }
+    mysql:    { test: mysql_golden_decimal_payments_exact_sums_and_decimal128_types, oracle: independent }
+    mssql:    { test: roast_mssql_decimal_scale_survives_all_null_first_batch, oracle: independent }
+    mongo:    { test: mongo_batch_type_fidelity_document_is_verbatim_extjson, oracle: independent }
 
   - id: type_uuid
     what: "uuid — PG uuid, MySQL CHAR(36), MSSQL uniqueidentifier → canonical value"
-    postgres: { test: golden_uuid_fixed_size_binary_roundtrip_canonical_bytes }
-    mysql:    { test: mysql_golden_uuid_varchar_utf8_expected_canonical_lower }
-    mssql:    { test: duckdb_validates_mssql_type_matrix_parquet }
-    mongo:    { test: mongo_batch_parallel_objectid_and_string_id }
+    postgres: { test: golden_uuid_fixed_size_binary_roundtrip_canonical_bytes, oracle: independent }
+    mysql:    { test: mysql_golden_uuid_varchar_utf8_expected_canonical_lower, oracle: independent }
+    mssql:    { test: duckdb_validates_mssql_type_matrix_parquet, oracle: independent }
+    mongo:    { test: mongo_batch_parallel_objectid_and_string_id, oracle: independent }
 
   - id: type_json
     what: "json/jsonb — byte/content fidelity through Parquet"
-    postgres: { test: roast_pg_json_column_preserves_source_bytes_through_parquet }
-    mysql:    { test: mysql_edge_json_content_round_trip }
+    postgres: { test: roast_pg_json_column_preserves_source_bytes_through_parquet, oracle: independent }
+    mysql:    { test: mysql_edge_json_content_round_trip, oracle: independent }
     mssql:    { na: "SQL Server has no native JSON type; the matrix fixture omits it by design" }
-    mongo:    { test: mongo_batch_type_fidelity_document_is_verbatim_extjson }
+    mongo:    { test: mongo_batch_type_fidelity_document_is_verbatim_extjson, oracle: independent }
 
   - id: type_timestamp_tz
     what: "timestamp / timestamptz — timezone handling (naive vs UTC instant)"
-    postgres: { test: golden_timestamps_naive_vs_timestamptz_parquet_microsecond_semantics }
-    mysql:    { test: mysql_golden_datetime_vs_timestamp_parquet_microsecond_semantics }
-    mssql:    { test: mssql_batch_datetimeoffset_exports_the_utc_instant }
+    postgres: { test: golden_timestamps_naive_vs_timestamptz_parquet_microsecond_semantics, oracle: independent }
+    mysql:    { test: mysql_golden_datetime_vs_timestamp_parquet_microsecond_semantics, oracle: independent }
+    mssql:    { test: mssql_batch_datetimeoffset_exports_the_utc_instant, oracle: independent }
     mongo:    { na: "BSON dates ride the verbatim document blob; the extJSON test pins the mechanism" }
 
   - id: type_date_time
     what: "date / time — Date32, Time64(µs)"
     postgres: { test: pg_golden_full_type_matrix_schema_coverage }
     mysql:    { test: mysql_golden_full_type_matrix_schema_coverage }
-    mssql:    { test: duckdb_validates_mssql_type_matrix_parquet }
+    mssql:    { test: duckdb_validates_mssql_type_matrix_parquet, oracle: independent }
     mongo:    { na: "date/time ride the verbatim document blob" }
 
   - id: type_binary
     what: "binary / bytea / varbinary — stays Arrow Binary, not Utf8"
-    postgres: { test: golden_bytea_exact_binary_roundtrip }
-    mysql:    { test: mysql_golden_fixed_binary_four_is_arrow_binary_not_utf8 }
-    mssql:    { test: duckdb_validates_mssql_type_matrix_parquet }
+    postgres: { test: golden_bytea_exact_binary_roundtrip, oracle: independent }
+    mysql:    { test: mysql_golden_fixed_binary_four_is_arrow_binary_not_utf8, oracle: independent }
+    mssql:    { test: duckdb_validates_mssql_type_matrix_parquet, oracle: independent }
     mongo:    { na: "binary rides the verbatim document blob" }
 
   - id: type_boolean
     what: "boolean — incl NULL; MySQL BIT(1)/TINYINT(1) → Boolean, BIT(8) → Int"
     postgres: { test: pg_golden_full_type_matrix_schema_coverage }
     mysql:    { test: mysql_golden_full_type_matrix_schema_coverage }
-    mssql:    { test: duckdb_validates_mssql_type_matrix_parquet }
+    mssql:    { test: duckdb_validates_mssql_type_matrix_parquet, oracle: independent }
     mongo:    { na: "booleans ride the verbatim document blob" }
 
   - id: type_integer_families
     what: "int2/4/8 + unsigned widening (u64 > i64::MAX → UInt64, not overflow)"
     postgres: { test: pg_golden_full_type_matrix_schema_coverage }
     mysql:    { test: parquet_schema_pins_mysql_matrix_logical_types }
-    mssql:    { test: duckdb_validates_mssql_type_matrix_parquet }
-    mongo:    { test: mongo_batch_type_fidelity_document_is_verbatim_extjson }
+    mssql:    { test: duckdb_validates_mssql_type_matrix_parquet, oracle: independent }
+    mongo:    { test: mongo_batch_type_fidelity_document_is_verbatim_extjson, oracle: independent }
 
   - id: type_text
     what: "text / varchar / nvarchar — empty, whitespace, large (100KB), unicode"
-    postgres: { test: pg_edge_string_extremes_round_trip }
-    mysql:    { test: mysql_edge_string_extremes_round_trip }
-    mssql:    { test: duckdb_validates_mssql_type_matrix_parquet }
+    postgres: { test: pg_edge_string_extremes_round_trip, oracle: independent }
+    mysql:    { test: mysql_edge_string_extremes_round_trip, oracle: independent }
+    mssql:    { test: duckdb_validates_mssql_type_matrix_parquet, oracle: independent }
     mongo:    { na: "text rides the verbatim document blob" }

--- a/docs/type-fidelity-matrix.yaml
+++ b/docs/type-fidelity-matrix.yaml
@@ -44,8 +44,8 @@ scenarios:
 
   - id: type_date_time
     what: "date / time — Date32, Time64(µs)"
-    postgres: { test: pg_golden_full_type_matrix_schema_coverage }
-    mysql:    { test: mysql_golden_full_type_matrix_schema_coverage }
+    postgres: { test: duckdb_pg_matrix_per_column_null_profile_matches_source, oracle: independent }
+    mysql:   { test: duckdb_mysql_matrix_per_column_null_profile_matches_source, oracle: independent }
     mssql:    { test: duckdb_validates_mssql_type_matrix_parquet, oracle: independent }
     mongo:    { na: "date/time ride the verbatim document blob" }
 
@@ -58,15 +58,15 @@ scenarios:
 
   - id: type_boolean
     what: "boolean — incl NULL; MySQL BIT(1)/TINYINT(1) → Boolean, BIT(8) → Int"
-    postgres: { test: pg_golden_full_type_matrix_schema_coverage }
-    mysql:    { test: mysql_golden_full_type_matrix_schema_coverage }
+    postgres: { test: duckdb_pg_matrix_per_column_null_profile_matches_source, oracle: independent }
+    mysql:   { test: duckdb_mysql_matrix_per_column_null_profile_matches_source, oracle: independent }
     mssql:    { test: duckdb_validates_mssql_type_matrix_parquet, oracle: independent }
     mongo:    { na: "booleans ride the verbatim document blob" }
 
   - id: type_integer_families
     what: "int2/4/8 + unsigned widening (u64 > i64::MAX → UInt64, not overflow)"
-    postgres: { test: pg_golden_full_type_matrix_schema_coverage }
-    mysql:    { test: parquet_schema_pins_mysql_matrix_logical_types }
+    postgres: { test: duckdb_pg_matrix_per_column_null_profile_matches_source, oracle: independent }
+    mysql:   { test: duckdb_mysql_matrix_per_column_null_profile_matches_source, oracle: independent }
     mssql:    { test: duckdb_validates_mssql_type_matrix_parquet, oracle: independent }
     mongo:    { test: mongo_batch_type_fidelity_document_is_verbatim_extjson, oracle: independent }
 

--- a/schemas/latest/rivet.schema.json
+++ b/schemas/latest/rivet.schema.json
@@ -708,6 +708,12 @@
           ]
         },
         "chunk_checkpoint": {
+          "description": "Persist per-chunk / per-page progress so a **crashed** run resumes from the\nlast durably committed point instead of re-reading from the start. This is\npure crash-recovery: a *clean* re-run (the prior run finished) still does a\nfull pass — it never silently skips already-exported rows. Safe to enable\non any table; `rivet init` defaults it on for chunked and keyset exports.",
+          "type": "boolean",
+          "default": false
+        },
+        "keyset_incremental": {
+          "description": "Keyset only (`chunk_by_key`): on a **clean** re-run, continue from the last\nexported key — pull ONLY rows with a key past the high-water mark. This is\nincremental-by-key, correct ONLY for APPEND-ONLY tables (a mutable row whose\nkey already passed is silently never re-read). Opt-in and off by default;\ncrash-recovery does not need it (that is `chunk_checkpoint`). For a mutable\ntable use `mode: incremental` on a timestamp cursor instead.",
           "type": "boolean",
           "default": false
         },

--- a/schemas/rivet.schema.json
+++ b/schemas/rivet.schema.json
@@ -708,6 +708,12 @@
           ]
         },
         "chunk_checkpoint": {
+          "description": "Persist per-chunk / per-page progress so a **crashed** run resumes from the\nlast durably committed point instead of re-reading from the start. This is\npure crash-recovery: a *clean* re-run (the prior run finished) still does a\nfull pass — it never silently skips already-exported rows. Safe to enable\non any table; `rivet init` defaults it on for chunked and keyset exports.",
+          "type": "boolean",
+          "default": false
+        },
+        "keyset_incremental": {
+          "description": "Keyset only (`chunk_by_key`): on a **clean** re-run, continue from the last\nexported key — pull ONLY rows with a key past the high-water mark. This is\nincremental-by-key, correct ONLY for APPEND-ONLY tables (a mutable row whose\nkey already passed is silently never re-read). Opt-in and off by default;\ncrash-recovery does not need it (that is `chunk_checkpoint`). For a mutable\ntable use `mode: incremental` on a timestamp cursor instead.",
           "type": "boolean",
           "default": false
         },

--- a/src/config/export.rs
+++ b/src/config/export.rs
@@ -215,8 +215,21 @@ pub struct ExportConfig {
     /// a fractional value is allowed (`1.5GB`). Units are binary (IEC-style):
     /// `KB` = 1024 bytes, `MB` = 1024 KB, `GB` = 1024 MB. Example: `256MB`.
     pub max_file_size: Option<String>,
+    /// Persist per-chunk / per-page progress so a **crashed** run resumes from the
+    /// last durably committed point instead of re-reading from the start. This is
+    /// pure crash-recovery: a *clean* re-run (the prior run finished) still does a
+    /// full pass — it never silently skips already-exported rows. Safe to enable
+    /// on any table; `rivet init` defaults it on for chunked and keyset exports.
     #[serde(default)]
     pub chunk_checkpoint: bool,
+    /// Keyset only (`chunk_by_key`): on a **clean** re-run, continue from the last
+    /// exported key — pull ONLY rows with a key past the high-water mark. This is
+    /// incremental-by-key, correct ONLY for APPEND-ONLY tables (a mutable row whose
+    /// key already passed is silently never re-read). Opt-in and off by default;
+    /// crash-recovery does not need it (that is `chunk_checkpoint`). For a mutable
+    /// table use `mode: incremental` on a timestamp cursor instead.
+    #[serde(default)]
+    pub keyset_incremental: bool,
     pub chunk_max_attempts: Option<u32>,
     #[serde(default)]
     pub tuning: Option<TuningConfig>,
@@ -687,6 +700,7 @@ pub(crate) fn sample_export(name: &str) -> ExportConfig {
         quality: None,
         max_file_size: None,
         chunk_checkpoint: false,
+        keyset_incremental: false,
         chunk_max_attempts: None,
         tuning: None,
         source_group: None,

--- a/src/format/csv.rs
+++ b/src/format/csv.rs
@@ -274,11 +274,20 @@ fn write_csv_value(writer: &mut dyn Write, array: &dyn Array, idx: usize) -> Res
                 .downcast_ref::<Time64MicrosecondArray>()
                 .expect("DataType/Array mismatch");
             let micros = arr.value(idx);
-            let secs = micros / 1_000_000;
-            let frac_us = micros % 1_000_000;
+            // MySQL TIME is a SIGNED duration (-838:59:59 .. 838:59:59), so micros
+            // can be negative. Extract the sign ONCE and format the magnitude: the
+            // old truncating `/`+`%` on a negative value emitted a minus PER FIELD
+            // ("-1:-30:00", "00:00:00.-00001", "00:00:-1.-500000"), corrupt in every
+            // CSV/time reader. Hours are `{:02}` MINIMUM-width, so a >24h duration
+            // (up to 838h) still prints in full.
+            let neg = micros < 0;
+            let abs = micros.unsigned_abs();
+            let secs = abs / 1_000_000;
+            let frac_us = abs % 1_000_000;
             write!(
                 writer,
-                "{:02}:{:02}:{:02}.{:06}",
+                "{}{:02}:{:02}:{:02}.{:06}",
+                if neg { "-" } else { "" },
                 secs / 3600,
                 (secs % 3600) / 60,
                 secs % 60,
@@ -394,6 +403,28 @@ mod tests {
             cell(Time64MicrosecondArray::from(vec![0_i64]), 0),
             "00:00:00.000000"
         );
+    }
+
+    // MySQL TIME is a SIGNED duration; the batch decoder emits negative micros.
+    // The old truncating `/`+`%` put a minus on EVERY field ("-1:-30:00",
+    // "00:00:00.-00001") — corrupt in any reader. One leading sign, magnitude
+    // formatted; a >24h duration still prints in full.
+    #[test]
+    fn negative_time_renders_one_leading_sign_not_a_minus_per_field() {
+        use arrow::array::Time64MicrosecondArray;
+        for (micros, want) in [
+            (-5_400_000_000_i64, "-01:30:00.000000"),      // -1h30m
+            (-1_i64, "-00:00:00.000001"),                  // -1 microsecond
+            (-1_500_000_i64, "-00:00:01.500000"),          // -1.5s
+            (-3_020_399_000_000_i64, "-838:59:59.000000"), // MySQL TIME min (>24h)
+            (5_400_000_000_i64, "01:30:00.000000"),        // positive unaffected
+        ] {
+            assert_eq!(
+                cell(Time64MicrosecondArray::from(vec![micros]), 0),
+                want,
+                "micros={micros}"
+            );
+        }
     }
 
     #[test]

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -821,7 +821,8 @@ mod tests {
     fn generate_config_chunked_single_pk_uses_keyset() {
         // A single-column PK → keyset (`chunk_by_key`), immune to sparse keys —
         // NOT range `chunk_column` (which blows up on a huge/gappy id). Sequential,
-        // so no `parallel:`; checkpoint is a commented opt-in, not on by default.
+        // so no `parallel:`; chunk_checkpoint is ON by default (safe crash-recovery),
+        // and the append-only incremental behaviour is a commented `keyset_incremental`.
         let info = make_table(
             2_000_000,
             vec![col("id", "bigint", true), col("name", "text", false)],
@@ -841,15 +842,21 @@ mod tests {
             !yaml.contains("\n    chunk_column:"),
             "PK must keyset, not range-chunk:\n{yaml}"
         );
-        // keyset is sequential — no parallel workers emitted, and checkpoint is a
-        // commented opt-in (snapshot semantics by default), never an active knob.
+        // keyset is sequential — no parallel workers emitted.
         assert!(
             !yaml.contains("\n    parallel:"),
             "keyset must not emit parallel:\n{yaml}"
         );
+        // chunk_checkpoint is ON by default now (crash-recovery is safe: a clean
+        // re-run still does a full pass). The append-only incremental behaviour —
+        // the part that CAN skip rows — stays a commented `keyset_incremental` opt-in.
         assert!(
-            yaml.contains("# add `chunk_checkpoint: true`"),
-            "should hint the resume opt-in:\n{yaml}"
+            yaml.contains("\n    chunk_checkpoint: true"),
+            "keyset must default chunk_checkpoint on (safe crash-recovery):\n{yaml}"
+        );
+        assert!(
+            yaml.contains("# keyset_incremental: true"),
+            "append-only incremental must be a commented opt-in:\n{yaml}"
         );
         // Keyset needs the `table:` shortcut (planner introspects the unique index),
         // so the export emits `table:`, not a `SELECT … FROM` query.
@@ -1223,12 +1230,14 @@ mod tests {
         let exp = &parsed["exports"][0];
         assert_eq!(exp["name"].as_str(), Some("orders"));
         assert_eq!(exp["mode"].as_str(), Some("chunked"));
-        // Single-column PK → keyset via the `table:` shortcut; checkpoint is a
-        // commented opt-in, so it is absent from the parsed (active) config.
+        // Single-column PK → keyset via the `table:` shortcut; chunk_checkpoint is
+        // ON by default (safe crash-recovery), while keyset_incremental stays a
+        // commented opt-in (absent from the parsed active config).
         assert_eq!(exp["chunk_by_key"].as_str(), Some("id"));
         assert_eq!(exp["table"].as_str(), Some("orders"));
         assert!(exp["chunk_column"].is_null());
-        assert!(exp["chunk_checkpoint"].is_null());
+        assert_eq!(exp["chunk_checkpoint"].as_bool(), Some(true));
+        assert!(exp["keyset_incremental"].is_null());
         assert_eq!(exp["meta_columns"]["row_hash"].as_bool(), Some(true));
         assert_eq!(exp["destination"]["type"].as_str(), Some("s3"));
         assert_eq!(exp["destination"]["bucket"].as_str(), Some("ok-bucket"));

--- a/src/init/yaml_scaffold.rs
+++ b/src/init/yaml_scaffold.rs
@@ -479,7 +479,11 @@ fn export_block_lines(
                 ));
                 lines.push(format!("    chunk_size: {chunk_size}"));
                 lines.push(
-                    "    # add `chunk_checkpoint: true` to resume a crashed run + pull only new keys each run (append-only tables)"
+                    "    chunk_checkpoint: true  # crash-recovery: a crashed run resumes from the last committed key on the next run (a clean re-run still does a full pass — never skips rows)"
+                        .to_string(),
+                );
+                lines.push(
+                    "    # keyset_incremental: true  # append-only ONLY — a clean re-run pulls just NEW keys (skips already-exported). Silently misses updates on a mutable table; use `mode: incremental` there"
                         .to_string(),
                 );
                 lines.push(

--- a/src/load/bigquery.rs
+++ b/src/load/bigquery.rs
@@ -207,6 +207,21 @@ impl TargetLoader for BigQueryLoader {
                 self.cluster_by.len()
             );
         }
+        // Gate each clustering column: it splices raw into `CLUSTER BY <cols>`
+        // (an identifier list, no quoting) — the same is_safe_load_ident gate the
+        // table / column / pk names get. Config-derived, so operator self-harm,
+        // but gated for consistency with the round-5/6 injection surface.
+        // (`partition_by` is intentionally NOT gated here — it is a BigQuery
+        // partition EXPRESSION, e.g. `DATE(created_at)`, not a bare identifier.)
+        for c in &self.cluster_by {
+            if !super::is_safe_load_ident(c) {
+                bail!(
+                    "BigQuery load: clustering column `{}` is not a plain SQL identifier \
+                     ([A-Za-z_][A-Za-z0-9_]*) — it splices into CLUSTER BY. Rename it.",
+                    c.escape_default()
+                );
+            }
+        }
         let target = self.fqtn(table);
         let schema = build_schema(specs);
 
@@ -705,6 +720,23 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("clustering"), "{err}");
+    }
+
+    #[test]
+    fn materialize_refuses_a_non_identifier_cluster_column() {
+        // A clustering column splices raw into `CLUSTER BY <cols>`; a
+        // non-identifier name is an injection vector and must be refused in
+        // `materialize` before any `bq` call — the sibling of the table/column/pk
+        // gate for the BigQuery shape clause.
+        let l = BigQueryLoader::new("p", "d").cluster_by(vec!["id) FROM secrets; --".into()]);
+        let err = l
+            .materialize("t", &[spec("id", None, TargetStatus::Ok)], &uris())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("not a plain SQL identifier") && err.contains("CLUSTER BY"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/src/load/cdc.rs
+++ b/src/load/cdc.rs
@@ -276,7 +276,17 @@ pub fn inc_dedup_view_sql(
     cursor_column: &str,
 ) -> String {
     let partition = quote_partition(warehouse, pk);
-    let order = format!("{} DESC", warehouse.quote_ident(cursor_column));
+    // `<cursor> IS NOT NULL DESC` FIRST — the same NULL-baseline guard the CDC
+    // view uses for `__pos` (see dedup_view_sql). A nullable cursor lands NULL
+    // rows in `<table>__changes` (the first incremental run has no cursor bound,
+    // so it extracts every row, NULL cursor included). Without the guard the
+    // order is a bare `<cursor> DESC`, and Snowflake sorts NULLs FIRST in DESC —
+    // so a NULL-cursor baseline row would win ROW_NUMBER=1 and HIDE a later
+    // non-NULL-cursor update (stale current state; BigQuery sorts NULLs last, so
+    // it was correct only by luck). Ranking real cursor values above NULL makes
+    // the dedup deterministic across both dialects.
+    let cur = warehouse.quote_ident(cursor_column);
+    let order = format!("{cur} IS NOT NULL DESC, {cur} DESC");
     build_dedup_view(
         warehouse,
         view_fqtn,
@@ -484,10 +494,15 @@ mod tests {
                 sql.contains(&format!("PARTITION BY {}", wh.quote_ident("id"))),
                 "{wh:?}: {sql}"
             );
-            // Latest-per-PK is the greatest cursor value.
+            // Latest-per-PK is the greatest cursor value — but a NULL-cursor
+            // baseline row must NOT win the dedup. Rank real cursor values above
+            // NULL (the same `IS NOT NULL DESC` guard the CDC view uses for
+            // __pos), else Snowflake (NULLs sort FIRST in DESC) keeps the stale
+            // baseline over a later non-NULL-cursor update.
+            let cur = wh.quote_ident("updated_at");
             assert!(
-                sql.contains(&format!("ORDER BY {} DESC", wh.quote_ident("updated_at"))),
-                "{wh:?}: {sql}"
+                sql.contains(&format!("ORDER BY {cur} IS NOT NULL DESC, {cur} DESC")),
+                "{wh:?}: cursor order must guard NULL-baseline first: {sql}"
             );
             // Incremental can't observe deletes → the flag is a constant FALSE,
             // with none of CDC's `__op = 'delete'` logic.
@@ -548,10 +563,16 @@ mod tests {
         // unquoted/upper-cased loader columns).
         let bq = inc_dedup_view_sql(Warehouse::BigQuery, "v", "c", &["order"], "end");
         assert!(bq.contains("PARTITION BY `order`"), "{bq}");
-        assert!(bq.contains("ORDER BY `end` DESC"), "{bq}");
+        assert!(
+            bq.contains("ORDER BY `end` IS NOT NULL DESC, `end` DESC"),
+            "{bq}"
+        );
         let sf = inc_dedup_view_sql(Warehouse::Snowflake, "v", "c", &["order"], "end");
         assert!(sf.contains("PARTITION BY order"), "{sf}");
-        assert!(sf.contains("ORDER BY end DESC"), "{sf}");
+        assert!(
+            sf.contains("ORDER BY end IS NOT NULL DESC, end DESC"),
+            "{sf}"
+        );
         // CDC composite pk: each column quoted for BigQuery.
         let cdc = dedup_view_sql(
             Warehouse::BigQuery,

--- a/src/load/mod.rs
+++ b/src/load/mod.rs
@@ -264,6 +264,23 @@ fn append_and_view(
     if pk.is_empty() {
         bail!("{label} load of `{table}` needs a primary key for the dedup view (pass --pk)");
     }
+    // Gate the PK columns at the SHARED seam: both the CDC and the INCREMENTAL
+    // driver splice them into the dedup view's `PARTITION BY` via quote_ident
+    // (Snowflake emits them bare; BigQuery wraps in backticks WITHOUT escaping an
+    // internal backtick), so a name outside a plain identifier is an injection
+    // vector. Round-6 gated this inline in the CDC path only — the incremental
+    // path (`run_load_incremental`) reached the same splice UNGATED. Hoisting it
+    // here covers both, so no load driver can bypass it (the runner-bypass class).
+    for c in pk {
+        if !is_safe_load_ident(c) {
+            bail!(
+                "cannot load `{table}`: primary-key column `{}` is not a plain SQL identifier \
+                 ([A-Za-z_][A-Za-z0-9_]*) — it is spliced into the dedup view's PARTITION BY. \
+                 Rename or alias it in the export.",
+                c.escape_default()
+            );
+        }
+    }
     validate_specs(&format!("{table}__changes"), specs)?;
 
     let rows_appended = loader.append_changelog(table, specs, uris, pk)?;
@@ -943,6 +960,36 @@ mod tests {
         assert!(
             f.appended.borrow().is_empty(),
             "nothing appended before the bail"
+        );
+    }
+
+    // RED before the pk gate moved into append_and_view: the CDC path gated its
+    // PK columns (round-6), but the INCREMENTAL path spliced pk into the dedup
+    // view's PARTITION BY (via quote_ident — bare on Snowflake, unescaped
+    // backticks on BigQuery) WITHOUT the same gate. A non-identifier PK name is
+    // an injection vector, and it must be refused before the driver runs.
+    #[test]
+    fn incremental_hostile_pk_is_refused_before_the_view_splice() {
+        let f = FakeLoader::default();
+        let err = run_load_incremental(
+            &f,
+            "t",
+            &spec(TargetStatus::Ok), // exported column: `id`
+            &uris(),
+            &["id) OR (1=1) --".to_string()], // hostile PK spliced into PARTITION BY
+            "id",                             // valid cursor (in specs) so we reach the pk gate
+            None,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("not a plain SQL identifier") && err.contains("PARTITION BY"),
+            "incremental load must refuse a non-identifier PK before splicing it into the view; got: {err}"
+        );
+        assert!(
+            f.appended.borrow().is_empty() && f.views.borrow().is_empty(),
+            "must bail before appending or building the view"
         );
     }
 }

--- a/src/pipeline/chunked/exec.rs
+++ b/src/pipeline/chunked/exec.rs
@@ -478,7 +478,9 @@ pub(crate) fn run_chunked_parallel(
         }
     });
 
-    summary.total_rows = agg_rows.load(Ordering::Relaxed);
+    // Accumulate onto any pre-existing base (0 for this non-checkpoint path, but
+    // the shared seam keeps every parallel runner clobber-free by construction).
+    super::super::commit::accumulate_run_rows(summary, agg_rows.load(Ordering::Relaxed));
     pb.finish(summary.total_rows);
 
     // Drain governor decisions (recorded off-thread) into the run journal.

--- a/src/pipeline/chunked/parallel_checkpoint.rs
+++ b/src/pipeline/chunked/parallel_checkpoint.rs
@@ -238,9 +238,11 @@ pub(crate) fn run_chunked_parallel_checkpoint(
                                     .map(classify_error)
                                     .map(|c| c.extra_delay_ms())
                                     .unwrap_or(0);
-                                let backoff = plan_w.tuning.retry_backoff_ms
-                                    * 2u64.pow(attempt - 1)
-                                    + extra_delay;
+                                let backoff = crate::pipeline::retry::retry_backoff_ms(
+                                    plan_w.tuning.retry_backoff_ms,
+                                    attempt,
+                                    extra_delay,
+                                );
                                 std::thread::sleep(Duration::from_millis(backoff));
                             }
 

--- a/src/pipeline/chunked/parallel_checkpoint.rs
+++ b/src/pipeline/chunked/parallel_checkpoint.rs
@@ -443,7 +443,11 @@ pub(crate) fn run_chunked_parallel_checkpoint(
         }
     });
 
-    summary.total_rows = agg_rows.load(Ordering::Relaxed);
+    // Accumulate, never assign: on a checkpoint resume the summary already carries
+    // the rehydrated pre-crash row base (apply_m8_resume_decisions). A bare
+    // `= agg_rows` clobbered it, so total_rows under-reported while parts/bytes/
+    // files stayed cumulative — see accumulate_run_rows.
+    super::super::commit::accumulate_run_rows(summary, agg_rows.load(Ordering::Relaxed));
     summary.retries = summary
         .retries
         .saturating_add(agg_retries.load(Ordering::Relaxed));

--- a/src/pipeline/chunked/resume_m8.rs
+++ b/src/pipeline/chunked/resume_m8.rs
@@ -172,6 +172,11 @@ pub(crate) fn rehydrate_manifest_parts_from_file_log(
         summary.files_produced += rehydrated;
         summary.total_rows += rehydrated_rows;
         summary.bytes_written += rehydrated_bytes;
+        // These parts carry NO per-column checksum (file_log stores none), so the
+        // run-wide Form B XOR this run harvests cannot cover them. Mark it
+        // incomplete so harvest_column_checksums suppresses Form B rather than
+        // record a partial XOR that `validate` would flag as a false mismatch.
+        summary.column_checksums_incomplete = true;
         log::info!(
             "resume: reconstructed {rehydrated} committed part(s) ({rehydrated_rows} rows, \
              {rehydrated_bytes} bytes) into the manifest from the state DB file_log (no \
@@ -358,6 +363,12 @@ pub(crate) fn apply_m8_resume_decisions(
                 // and the manifest-authoritative `rivet load` lost its rows.
                 if let Some(p) = manifest_part_by_path.get(path.as_str()) {
                     summary.manifest_parts.push((*p).clone());
+                    // A skipped part's per-column checksum contribution is gone
+                    // (the prior manifest kept only the run-wide XOR, not per-part),
+                    // so this run's harvested XOR would cover only the re-exported
+                    // parts. Mark Form B incomplete → suppressed at harvest, never a
+                    // partial XOR that `validate --depth full` false-flags.
+                    summary.column_checksums_incomplete = true;
                 }
             }
             // Rewrite / Quarantine RE-EXPORT the owning chunk, so they DO need
@@ -658,6 +669,13 @@ mod tests {
             summary.total_rows - rows_before,
             50,
             "row aggregate bumped by the union"
+        );
+        // Finding #10: rehydrated parts carry no per-column checksum, so Form B
+        // must be flagged incomplete — harvest_column_checksums then suppresses it
+        // rather than record a partial XOR that `validate` would false-flag.
+        assert!(
+            summary.column_checksums_incomplete,
+            "rehydrating pre-crash parts must mark Form B incomplete (suppressed at harvest)"
         );
     }
 

--- a/src/pipeline/chunked/resume_m8.rs
+++ b/src/pipeline/chunked/resume_m8.rs
@@ -679,6 +679,86 @@ mod tests {
         );
     }
 
+    // Finding #9: a parallel-checkpoint RESUME must ACCUMULATE this invocation's
+    // rows onto the rehydrated pre-crash base, never clobber it. rehydrate bumps
+    // total_rows + manifest_parts cumulatively; the parallel runner then lands its
+    // workers' rows via commit::accumulate_run_rows and drains new parts via
+    // record_part. The coherence invariant total_rows == sum(manifest_parts.rows)
+    // must survive the whole sequence. RED against a `summary.total_rows = agg`
+    // clobber, which drops the 50-row base and leaves total_rows == 30 while the
+    // manifest lists 80 rows.
+    #[test]
+    fn parallel_resume_accumulates_rows_onto_rehydrated_base_not_clobbers() {
+        use crate::pipeline::commit::{PartKind, PartRecord, accumulate_run_rows, record_part};
+
+        let state_dir = tempfile::tempdir().unwrap();
+        let state =
+            crate::state::StateStore::open_at_path(&state_dir.path().join("state.db")).unwrap();
+        let dest_dir = tempfile::tempdir().unwrap();
+        let plan = m8_plan(dest_dir.path());
+        let run_id = "r_par_resume";
+        // Two pre-crash parts (50 rows) durably committed to file_log, no manifest.
+        state
+            .record_file(
+                run_id,
+                "orders",
+                "orders_chunk0.parquet",
+                30,
+                4096,
+                "parquet",
+                None,
+            )
+            .unwrap();
+        state
+            .record_file(
+                run_id,
+                "orders",
+                "orders_chunk1.parquet",
+                20,
+                2048,
+                "parquet",
+                None,
+            )
+            .unwrap();
+        let mut summary =
+            crate::pipeline::summary::RunSummary::stub_for_testing(run_id, String::from("orders"));
+
+        // ── Resume preamble: rehydrate the 50-row base from file_log.
+        rehydrate_manifest_parts_from_file_log(&state, run_id, &mut summary).unwrap();
+        assert_eq!(
+            summary.total_rows, 50,
+            "rehydrated base is the 50 pre-crash rows"
+        );
+
+        // ── This invocation re-exports one 30-row chunk: the runner lands the
+        // worker rows via accumulate_run_rows, then drains the new part.
+        accumulate_run_rows(&mut summary, 30);
+        record_part(
+            &plan,
+            &mut summary,
+            None,
+            &PartRecord {
+                file_name: "orders_chunk2.parquet".into(),
+                rows: 30,
+                bytes: 4096,
+                fingerprint: "xxh3:abc".into(),
+                md5: String::new(),
+            },
+            PartKind::Chunk { chunk_index: 2 },
+        );
+
+        let parts_rows: i64 = summary.manifest_parts.iter().map(|p| p.rows).sum();
+        assert_eq!(
+            parts_rows, 80,
+            "manifest lists all 80 rows (50 rehydrated + 30 new)"
+        );
+        assert_eq!(
+            summary.total_rows, parts_rows,
+            "resume must accumulate onto the rehydrated base — total_rows must equal \
+             sum(manifest_parts.rows), never under-report only this invocation's rows"
+        );
+    }
+
     /// Full-matrix flow: part A intact → Skip (+ summary hydration), part B
     /// missing → Rewrite (task reset), part C size-diverged → Quarantine
     /// (task reset + object moved), part D with no task → orphan. Also

--- a/src/pipeline/chunked/sequential_checkpoint.rs
+++ b/src/pipeline/chunked/sequential_checkpoint.rs
@@ -143,8 +143,11 @@ fn run_chunk_with_source_retries(
                 .as_ref()
                 .map(classify_error)
                 .unwrap_or(RetryClass::Permanent);
-            let backoff =
-                plan.tuning.retry_backoff_ms * 2u64.pow(attempt - 1) + class.extra_delay_ms();
+            let backoff = crate::pipeline::retry::retry_backoff_ms(
+                plan.tuning.retry_backoff_ms,
+                attempt,
+                class.extra_delay_ms(),
+            );
             log::warn!(
                 "export '{}': chunk {} retry {}/{} in {}ms",
                 plan.export_name,

--- a/src/pipeline/commit.rs
+++ b/src/pipeline/commit.rs
@@ -50,6 +50,22 @@ use crate::journal::RunEvent;
 use crate::plan::ResolvedRunPlan;
 use crate::state::StateStore;
 
+/// Add this invocation's row count onto the run's cumulative total. The parallel
+/// runners aggregate their workers' rows into an atomic and land it here at the
+/// end; on a checkpoint RESUME the summary already carries the rehydrated
+/// pre-crash base (`rehydrate_manifest_parts_from_file_log` bumps `total_rows`
+/// alongside `files_committed` / `bytes_written` / `manifest_parts`). This MUST
+/// accumulate (`+=`), never assign — a bare `summary.total_rows = agg` clobbers
+/// that base, so on resume `total_rows` under-reports (only this run's rows)
+/// while every other aggregate stays cumulative, breaking the
+/// `total_rows == sum(manifest_parts.rows)` coherence invariant and diverging from
+/// the sequential runner (which already `+=`s). The seam exists so no parallel
+/// runner can reintroduce the clobber — a future `= agg` is obviously wrong next
+/// to this call.
+pub(in crate::pipeline) fn accumulate_run_rows(summary: &mut RunSummary, this_run_rows: i64) {
+    summary.total_rows += this_run_rows;
+}
+
 /// XOR-accumulate one part/page/chunk sink's per-column value checksums into a
 /// run-wide map. Order-independent (XOR), so chunk/page/worker order and count do
 /// not change the result — the MULTI-PART runners (chunked / keyset / mongo_parallel)

--- a/src/pipeline/commit.rs
+++ b/src/pipeline/commit.rs
@@ -79,6 +79,24 @@ pub(in crate::pipeline) fn harvest_column_checksums(
     if acc.is_empty() {
         return;
     }
+    // A checkpoint resume that hydrated pre-crash parts (Skip clone / file_log
+    // rehydrate) whose per-column checksums are unrecoverable makes the run-wide
+    // XOR cover ONLY the re-exported parts, while the manifest lists ALL parts.
+    // Recording that partial XOR would make `validate --depth full` re-read every
+    // part, recompute the full XOR, and report a FALSE mismatch on correctly
+    // resumed data (and the authoritative manifest's integrity record would be
+    // objectively wrong). Suppress Form B instead — absent, not partial-and-lying,
+    // the same graceful degradation a rehydrated part's empty md5 gets.
+    if summary.column_checksums_incomplete {
+        log::warn!(
+            "export '{}': Form B value-checksums suppressed — a checkpoint resume hydrated \
+             pre-crash parts whose per-column checksums are not recoverable, so the run-wide \
+             checksum would cover only the re-exported parts. `validate` will size-verify parts \
+             but skip the Form B value re-read for this run.",
+            summary.export_name
+        );
+        return;
+    }
     summary.column_checksums = acc
         .into_iter()
         .map(|(name, checksum)| crate::manifest::ColumnChecksum {
@@ -721,6 +739,36 @@ mod tests {
             summary.files_committed,
             summary.manifest_parts.len(),
             "files_committed and manifest_parts.len() locked together by record_part"
+        );
+    }
+
+    // Finding #10: on a checkpoint resume that hydrated pre-crash parts, the
+    // run-wide Form B XOR would cover only the re-exported parts while the
+    // manifest lists ALL parts — a partial XOR that `validate --depth full`
+    // false-flags. harvest_column_checksums must SUPPRESS Form B (leave it empty)
+    // when the summary is flagged incomplete, never record the partial XOR. RED
+    // against a harvest that ignores the flag.
+    #[test]
+    fn harvest_suppresses_form_b_when_resume_left_checksums_incomplete() {
+        let plan = test_plan();
+        let mut acc = std::collections::BTreeMap::new();
+        acc.insert("id".to_string(), 0xdead_beefu64);
+
+        // Normal run: the accumulated checksums are recorded.
+        let mut ok = test_summary(&plan);
+        harvest_column_checksums(&mut ok, acc.clone(), Some("id".into()));
+        assert!(
+            !ok.column_checksums.is_empty(),
+            "a complete run must record Form B"
+        );
+
+        // Resume that hydrated pre-crash parts: Form B is suppressed, not partial.
+        let mut resumed = test_summary(&plan);
+        resumed.column_checksums_incomplete = true;
+        harvest_column_checksums(&mut resumed, acc, Some("id".into()));
+        assert!(
+            resumed.column_checksums.is_empty(),
+            "an incomplete-checksum resume must suppress Form B, never record a partial XOR"
         );
     }
 }

--- a/src/pipeline/job.rs
+++ b/src/pipeline/job.rs
@@ -714,6 +714,16 @@ pub(crate) fn run_export_job_with_chunk_source(
             e
         );
     }
+    // Clear the keyset in-progress anchor AFTER the manifest is durable — the SAME
+    // post-finalize clear run_export_job does (job.rs above). An INCREMENTAL keyset
+    // run no longer clears it in run_keyset (the clear must be post-finalize, or a
+    // crash orphans the pages — round-2 fix), so EVERY job wrapper must clear it
+    // here; a wrapper that skips it strands resume_run_id forever, so the next apply
+    // is misread as a resume, reuses the frozen run_id, and the run-unique manifest
+    // sidecar collides across runs (round-3 wrapper-bypass regression).
+    if !failed && matches!(plan.strategy, ExtractionStrategy::Keyset(_)) {
+        let _ = state.clear_resume_run_id(&summary.export_name);
+    }
     if plan.validate {
         finalize_validate_manifest(plan, &mut summary, "apply");
     }

--- a/src/pipeline/job.rs
+++ b/src/pipeline/job.rs
@@ -953,6 +953,7 @@ mod tests {
             key_column: "id".into(),
             chunk_size: 500,
             checkpoint: false,
+            incremental: false,
             parallel: 1,
         });
         let mut summary = fresh_summary(&plan, 42);

--- a/src/pipeline/job.rs
+++ b/src/pipeline/job.rs
@@ -317,6 +317,29 @@ pub(crate) fn synthetic_failed_summary(export_name: &str, err: &anyhow::Error) -
     }
 }
 
+/// Clear the keyset in-progress resume anchor after a SUCCESSFUL finalize, so the
+/// next run isn't misread as a resume of this finished one.
+///
+/// This is the TWO-ADAPTER seam for the post-finalize clear: BOTH job wrappers
+/// (`run_export_job` and `run_export_job_with_chunk_source`) must call it. An
+/// INCREMENTAL keyset run no longer clears the anchor in `run_keyset` (that clear
+/// must be post-finalize, or a crash between data-complete and the manifest write
+/// orphans the pages), so the responsibility moved up to the wrappers — and a
+/// wrapper that inlined its own copy and forgot it was the round-3 wrapper-bypass
+/// regression. A shared seam makes the wiring structural, not a per-wrapper
+/// checklist. No-op for a non-keyset strategy, and for a FAILED run (the anchor
+/// must survive a failure so the next run rehydrates rather than orphans).
+fn finalize_keyset_anchor(
+    state: &StateStore,
+    plan: &ResolvedRunPlan,
+    export_name: &str,
+    failed: bool,
+) {
+    if !failed && matches!(plan.strategy, ExtractionStrategy::Keyset(_)) {
+        let _ = state.clear_resume_run_id(export_name);
+    }
+}
+
 pub(super) fn run_export_job(
     config_path: &str,
     config: &Config,
@@ -596,9 +619,7 @@ pub(super) fn run_export_job(
     // later run isn't treated as a resume of this finished one. Clearing AFTER the
     // manifest write is the same ordering as the cursor advance: a crash before here
     // leaves resume_run_id set, so the next run rehydrates rather than orphans.
-    if !failed && matches!(plan.strategy, ExtractionStrategy::Keyset(_)) {
-        let _ = state.clear_resume_run_id(&summary.export_name);
-    }
+    finalize_keyset_anchor(state, &plan, &summary.export_name, failed);
     if plan.validate {
         finalize_validate_manifest(&plan, &mut summary, "export");
     }
@@ -721,9 +742,7 @@ pub(crate) fn run_export_job_with_chunk_source(
     // here; a wrapper that skips it strands resume_run_id forever, so the next apply
     // is misread as a resume, reuses the frozen run_id, and the run-unique manifest
     // sidecar collides across runs (round-3 wrapper-bypass regression).
-    if !failed && matches!(plan.strategy, ExtractionStrategy::Keyset(_)) {
-        let _ = state.clear_resume_run_id(&summary.export_name);
-    }
+    finalize_keyset_anchor(state, plan, &summary.export_name, failed);
     if plan.validate {
         finalize_validate_manifest(plan, &mut summary, "apply");
     }

--- a/src/pipeline/job.rs
+++ b/src/pipeline/job.rs
@@ -311,6 +311,7 @@ pub(crate) fn synthetic_failed_summary(export_name: &str, err: &anyhow::Error) -
         manifest_verification: None,
         apply_context: None,
         column_checksums: Vec::new(),
+        column_checksums_incomplete: false,
         checksum_key_column: None,
         journal,
     }

--- a/src/pipeline/keyset.rs
+++ b/src/pipeline/keyset.rs
@@ -140,13 +140,32 @@ pub(crate) fn run_keyset(
         kp.chunk_size
     );
 
-    // RESUME (opt-in via `kp.checkpoint`): continue from the last DURABLY
-    // committed key so a crashed run picks up where it left off instead of
-    // re-reading the whole collection. Reuses the incremental `export_state`
-    // store. Default OFF keeps `mode: full` re-reading the whole key range every
-    // run — resume is only correct when the caller wants it (a plain re-run of a
-    // full export must NOT silently skip already-exported rows).
-    let mut last: Option<String> = if kp.checkpoint {
+    // CRASH-RECOVERY vs INCREMENTAL — two distinct reasons to continue from the
+    // last committed key, kept SEPARATE so a clean re-run of a mutable table can
+    // never silently skip already-exported rows:
+    //
+    //   * Crash-recovery (`chunk_checkpoint`): the prior run died mid-stream, so
+    //     its in-progress run_id (set at open below, cleared at finalize) is still
+    //     present. Continuing from its last committed key picks up exactly where it
+    //     stopped — resuming already-committed data can never skip a row.
+    //   * Incremental (`keyset_incremental`): an append-only opt-in — a CLEAN
+    //     re-run pulls only keys past the high-water mark.
+    //
+    // A clean re-run (prior run finished → run_id cleared) WITHOUT the incremental
+    // opt-in loads no cursor and re-reads the whole range (full/snapshot
+    // semantics). This is the crash-recovery ⇄ incremental split (ADR: keyset
+    // checkpoint no longer implies incremental-by-key).
+    let resume_run_id: Option<String> = if kp.checkpoint {
+        match state {
+            Some(st) => st.get_resume_run_id(&plan.export_name)?,
+            None => None,
+        }
+    } else {
+        None
+    };
+    let recovering_crash = resume_run_id.is_some();
+
+    let mut last: Option<String> = if kp.checkpoint && (recovering_crash || kp.incremental) {
         state
             .and_then(|s| s.get(&plan.export_name).ok())
             .and_then(|cs| cs.last_cursor_value)
@@ -159,21 +178,40 @@ pub(crate) fn run_keyset(
     // file_log) with NO destination manifest; on resume the page loop continues from
     // the cursor and skips them, so finalize would write a manifest of ONLY this
     // run's pages, orphaning the pre-crash pages from the manifest-authoritative
-    // loader. export_state now persists the in-progress run_id: REUSE it across
-    // resumes so every page lives under ONE run_id in file_log, and reconstruct the
-    // already-committed pages into this run's manifest. Cleared by the caller once
-    // finalize writes the complete manifest.
+    // loader. export_state persists the in-progress run_id: REUSE it across resumes
+    // so every page lives under ONE run_id in file_log, and reconstruct the
+    // already-committed pages into this run's manifest. A first/clean run has no
+    // in-progress run_id → record a fresh one. Cleared by the caller once finalize
+    // writes the complete manifest.
     if kp.checkpoint
         && let Some(st) = state
     {
-        match st.get_resume_run_id(&plan.export_name)? {
+        match &resume_run_id {
             Some(rid) => {
                 summary.run_id = rid.clone();
-                super::chunked::rehydrate_manifest_parts_from_file_log(st, &rid, summary)?;
+                super::chunked::rehydrate_manifest_parts_from_file_log(st, rid, summary)?;
             }
-            None => st.set_resume_run_id(&plan.export_name, &summary.run_id)?,
+            None => {
+                // FRESH run. For crash-recovery-only (non-incremental) keyset, null
+                // the persisted high-water mark FIRST: it may still hold a prior
+                // COMPLETED run's final key, and if this fresh run crashes before
+                // its first page commits, the recovery run would load that stale
+                // key as this run's resume point and skip the entire table. Tying
+                // the cursor to this run makes a pre-first-commit crash re-read from
+                // the start. Incremental deliberately keeps it (that IS the point).
+                if !kp.incremental {
+                    st.clear_cursor_value(&plan.export_name)?;
+                }
+                st.set_resume_run_id(&plan.export_name, &summary.run_id)?;
+            }
         }
     }
+
+    // Fault point: a fresh run has opened (resume_run_id set, cursor cleared for
+    // non-incremental) but committed NO page yet. A crash here must, on the next
+    // run, re-read from the START — never resume from a prior completed run's
+    // stale high-water mark (the silent whole-table skip the cursor clear fixes).
+    crate::test_hook::maybe_panic_at("keyset_after_open_before_first_page");
 
     let mut pages: usize = 0;
     // Captured once from the first non-empty page for the post-run on_schema_drift
@@ -284,6 +322,27 @@ pub(crate) fn run_keyset(
 
     // Form B: record the run-wide XOR-combined checksums so finalize writes them.
     super::commit::harvest_column_checksums(summary, checksums_acc, checksum_key_column);
+
+    // DATA COMPLETE: the page loop exhausted the key range, so there is no
+    // uncommitted work left to resume — clear the in-progress run_id NOW, BEFORE
+    // the post-data gates (schema-drift below, and the quality gate in job.rs).
+    // A gate that fails AFTER all data is durable must not leave a resume anchor:
+    // otherwise the operator's intended full re-run would be treated as a
+    // crash-recovery and continue from the high-water mark, silently skipping
+    // rows updated since (the exact silent-skip the crash-recovery/incremental
+    // split exists to prevent). resume_run_id only ever means "a run died with
+    // work still outstanding".
+    if kp.checkpoint
+        && let Some(st) = state
+    {
+        st.clear_resume_run_id(&plan.export_name)?;
+    }
+
+    // Fault point: data is fully committed and the resume anchor is cleared, but a
+    // post-data gate (or any late failure) has not yet run. A crash here must NOT
+    // leave a resume anchor — the next run is a fresh full pass, never a
+    // crash-recovery that skips rows updated since (the #3 gate-failure class).
+    crate::test_hook::maybe_panic_at("keyset_after_data_complete");
 
     log::info!(
         "export '{}': keyset complete — {} page(s), {} rows",

--- a/src/pipeline/keyset.rs
+++ b/src/pipeline/keyset.rs
@@ -324,24 +324,36 @@ pub(crate) fn run_keyset(
     super::commit::harvest_column_checksums(summary, checksums_acc, checksum_key_column);
 
     // DATA COMPLETE: the page loop exhausted the key range, so there is no
-    // uncommitted work left to resume — clear the in-progress run_id NOW, BEFORE
-    // the post-data gates (schema-drift below, and the quality gate in job.rs).
-    // A gate that fails AFTER all data is durable must not leave a resume anchor:
-    // otherwise the operator's intended full re-run would be treated as a
-    // crash-recovery and continue from the high-water mark, silently skipping
-    // rows updated since (the exact silent-skip the crash-recovery/incremental
-    // split exists to prevent). resume_run_id only ever means "a run died with
-    // work still outstanding".
+    // uncommitted work left to resume — for a NON-INCREMENTAL run, clear the
+    // in-progress run_id NOW, BEFORE the post-data gates (schema-drift below, and
+    // the quality gate in job.rs). A gate that fails AFTER all data is durable must
+    // not leave a resume anchor, or the operator's intended full re-run would be
+    // treated as a crash-recovery and continue from the high-water mark, silently
+    // skipping rows updated since (the crash-recovery/incremental split's raison
+    // d'être).
+    //
+    // INCREMENTAL is gated OUT (`!kp.incremental`, mirroring the fresh-run
+    // clear_cursor_value above): its next run continues from the high-water mark
+    // regardless of the anchor, so clearing it yields NO benefit — and clearing it
+    // HERE, before finalize_manifest writes the destination manifest, would strand
+    // this run's committed pages. A crash in the [clear → finalize] window would
+    // then leave a run whose parquet is on the destination + file_log but referenced
+    // by NO manifest: the next incremental run reads only keys past the high-water
+    // mark (0 new rows) and never rehydrates those parts, so the manifest-
+    // authoritative loader silently drops them. The anchor must survive until
+    // finalize for the incremental path (job.rs clears it AFTER the manifest write).
     if kp.checkpoint
+        && !kp.incremental
         && let Some(st) = state
     {
         st.clear_resume_run_id(&plan.export_name)?;
     }
 
-    // Fault point: data is fully committed and the resume anchor is cleared, but a
-    // post-data gate (or any late failure) has not yet run. A crash here must NOT
-    // leave a resume anchor — the next run is a fresh full pass, never a
-    // crash-recovery that skips rows updated since (the #3 gate-failure class).
+    // Fault point: data is fully committed (and, for a non-incremental run, the
+    // resume anchor is cleared), but a post-data gate / late failure has not yet
+    // run. For non-incremental a crash here must leave NO anchor (next run is a
+    // fresh full pass); for incremental the anchor must SURVIVE (next run rehydrates
+    // the committed pages rather than orphaning them).
     crate::test_hook::maybe_panic_at("keyset_after_data_complete");
 
     log::info!(

--- a/src/pipeline/retry.rs
+++ b/src/pipeline/retry.rs
@@ -69,6 +69,25 @@ fn transient(needs_reconnect: bool, extra_delay_ms: u64) -> RetryClass {
     }
 }
 
+/// Ceiling on a single retry's exponential backoff. Without a cap the wait
+/// doubles unboundedly, so a `max_retries` set high enough to ride out a
+/// minutes-long flaky-tunnel outage becomes impractical (one retry would sleep
+/// for hours) — and `2u64.pow(attempt - 1)` PANICS once `attempt - 1 >= 64`, so a
+/// large `max_retries` aborted the export outright. Capping each wait keeps a
+/// generous retry budget usable and the arithmetic overflow-free.
+pub const MAX_RETRY_BACKOFF_MS: u64 = 60_000;
+
+/// Backoff (ms) for retry `attempt` (1-based): `base * 2^(attempt-1)`, clamped to
+/// [`MAX_RETRY_BACKOFF_MS`], then `extra` added. Saturating throughout so a large
+/// `attempt` can neither overflow nor panic. Shared by every per-attempt retry
+/// loop (single + parallel-checkpoint) so their backoff can't drift apart.
+pub fn retry_backoff_ms(base_ms: u64, attempt: u32, extra_ms: u64) -> u64 {
+    base_ms
+        .saturating_mul(2u64.saturating_pow(attempt.saturating_sub(1)))
+        .min(MAX_RETRY_BACKOFF_MS)
+        .saturating_add(extra_ms)
+}
+
 /// Classifies transient errors into retry categories.
 ///
 /// Order: a typed [`crate::source::StatementDurationTimeout`] marker
@@ -392,6 +411,24 @@ mod tests {
     fn test_is_transient_matches() {
         assert!(is_transient(&anyhow::anyhow!("statement timed out")));
         assert!(is_transient(&anyhow::anyhow!("connection reset")));
+    }
+
+    #[test]
+    fn retry_backoff_doubles_then_caps_and_never_overflows() {
+        // Exponential doubling below the cap.
+        assert_eq!(retry_backoff_ms(5_000, 1, 0), 5_000);
+        assert_eq!(retry_backoff_ms(5_000, 2, 0), 10_000);
+        assert_eq!(retry_backoff_ms(5_000, 3, 0), 20_000);
+        assert_eq!(retry_backoff_ms(5_000, 4, 0), 40_000);
+        // 5_000 * 2^4 = 80_000 → clamped to the 60s ceiling.
+        assert_eq!(retry_backoff_ms(5_000, 5, 0), MAX_RETRY_BACKOFF_MS);
+        assert_eq!(retry_backoff_ms(5_000, 10, 0), MAX_RETRY_BACKOFF_MS);
+        // extra_delay is added AFTER the cap.
+        assert_eq!(retry_backoff_ms(5_000, 10, 500), MAX_RETRY_BACKOFF_MS + 500);
+        // The load-bearing robustness property: a large attempt must NOT panic
+        // (the old `2u64.pow(attempt - 1)` aborted the export at attempt ≥ 65).
+        assert_eq!(retry_backoff_ms(5_000, 100, 0), MAX_RETRY_BACKOFF_MS);
+        assert_eq!(retry_backoff_ms(u64::MAX, u32::MAX, u64::MAX), u64::MAX);
     }
 
     #[test]

--- a/src/pipeline/single.rs
+++ b/src/pipeline/single.rs
@@ -34,8 +34,11 @@ pub(crate) fn run_with_reconnect(
                 .as_ref()
                 .map(classify_error)
                 .unwrap_or(RetryClass::Permanent);
-            let backoff =
-                plan.tuning.retry_backoff_ms * 2u64.pow(attempt - 1) + class.extra_delay_ms();
+            let backoff = super::retry::retry_backoff_ms(
+                plan.tuning.retry_backoff_ms,
+                attempt,
+                class.extra_delay_ms(),
+            );
             log::warn!(
                 "export '{}': retry {}/{} in {}ms{}({})",
                 plan.export_name,

--- a/src/pipeline/summary.rs
+++ b/src/pipeline/summary.rs
@@ -88,6 +88,17 @@ pub struct RunSummary {
     pub column_checksums: Vec<crate::manifest::ColumnChecksum>,
     /// The column the Form B checksum is keyed to (cursor/key column); `None` = un-keyed.
     pub checksum_key_column: Option<String>,
+    /// Set when a checkpoint RESUME hydrated pre-crash parts into
+    /// `manifest_parts` whose per-column checksum contribution is unrecoverable
+    /// (file_log stores no per-column checksums, and the prior manifest keeps
+    /// only the run-wide XOR, not per-part). The run-wide Form B XOR this run
+    /// harvests would then cover only the re-exported parts while the manifest
+    /// lists ALL parts, so `harvest_column_checksums` SUPPRESSES Form B entirely
+    /// rather than record a partial XOR that `validate --depth full` would flag
+    /// as a false mismatch — mirroring how a rehydrated part's empty md5 degrades
+    /// to a size-only check. An incomplete integrity record must be ABSENT, not
+    /// partial-and-lying.
+    pub column_checksums_incomplete: bool,
     /// Cursor range this run covered (incremental strategies) — travels to the
     /// manifest's extraction section for warehouse-side continuity checks.
     /// v1 ships column + low + high; cursor_type / source_row_count are
@@ -217,6 +228,7 @@ impl RunSummary {
             manifest_verification: None,
             apply_context: None,
             column_checksums: Vec::new(),
+            column_checksums_incomplete: false,
             checksum_key_column: None,
             cursor_column: None,
             cursor_low: None,
@@ -282,6 +294,7 @@ impl RunSummary {
             manifest_verification: None,
             apply_context: None,
             column_checksums: Vec::new(),
+            column_checksums_incomplete: false,
             checksum_key_column: None,
             cursor_column: None,
             cursor_low: None,

--- a/src/plan/build.rs
+++ b/src/plan/build.rs
@@ -161,6 +161,11 @@ fn full_strategy(config: &Config, export: &ExportConfig) -> ExtractionStrategy {
             chunk_size: page.max(1),
             // Resume is opt-in: default keeps `mode: full` re-reading each run.
             checkpoint: mongo.resume,
+            // Mongo `resume` has always meant "continue from the last _id each
+            // run" (incremental-append on an append-only _id stream), so map it to
+            // the incremental opt-in to preserve that behaviour under the
+            // crash-recovery/incremental split.
+            incremental: mongo.resume,
             // `parallel: N` fans N `_id`-range workers (Mongo reader only).
             parallel: export.parallel,
         });
@@ -429,13 +434,18 @@ fn chunked_strategy_from_introspection(
         return Ok(ExtractionStrategy::Keyset(KeysetPlan {
             key_column: key.to_string(),
             chunk_size,
-            // `chunk_checkpoint: true` makes SQL keyset resumable/incremental-by-key:
-            // the runner persists the last committed key and continues from it next
-            // run (crash-recovery + append). This is engine-agnostic — the same
-            // `keyset.rs` path Mongo uses, keyed off `export_state`. Default false =
-            // full re-read each run (snapshot semantics; a plain re-run must not
-            // silently skip already-exported rows).
-            checkpoint: export.chunk_checkpoint,
+            // `chunk_checkpoint: true` = crash-recovery only: a crashed run resumes
+            // from its last committed key (detected via the in-progress run_id),
+            // but a CLEAN re-run re-reads the whole range — it never silently skips
+            // already-exported rows. The append-only "continue from key on a clean
+            // re-run" behaviour is the separate `keyset_incremental` opt-in.
+            // `keyset_incremental` needs the high-water key persisted across runs,
+            // which IS the checkpoint machinery — so it implies checkpoint. Without
+            // this an incremental-only config (no chunk_checkpoint) would be a
+            // silent no-op: the cursor is never stored and every clean re-run
+            // re-reads the whole table.
+            checkpoint: export.chunk_checkpoint || export.keyset_incremental,
+            incremental: export.keyset_incremental,
             // SQL keyset is sequential; parallel `_id`-range is a Mongo capability.
             parallel: 1,
         }));
@@ -492,9 +502,13 @@ fn chunked_strategy_from_introspection(
                     return Ok(ExtractionStrategy::Keyset(KeysetPlan {
                         key_column: key.to_string(),
                         chunk_size,
-                        // Same as the explicit `chunk_by_key` path: `chunk_checkpoint`
-                        // opts into resumable/incremental-by-key keyset.
-                        checkpoint: export.chunk_checkpoint,
+                        // Same split as the explicit `chunk_by_key` path:
+                        // `chunk_checkpoint` = crash-recovery, `keyset_incremental`
+                        // = append-only continue-on-clean-re-run.
+                        // keyset_incremental implies checkpoint (it needs the
+                        // persisted cursor) — else it is a silent no-op.
+                        checkpoint: export.chunk_checkpoint || export.keyset_incremental,
+                        incremental: export.keyset_incremental,
                         parallel: 1,
                     }));
                 }
@@ -1036,6 +1050,62 @@ mod tests {
         let err =
             resolve(SourceType::Postgres, &e, &i).expect_err("PG must not auto-keyset (ADR-0020)");
         assert!(err.to_string().contains("no safe shape"));
+    }
+
+    #[test]
+    fn keyset_checkpoint_and_incremental_are_independent_plan_flags() {
+        // The crash-recovery ⇄ incremental split: `chunk_checkpoint` sets ONLY
+        // KeysetPlan.checkpoint (safe crash-recovery); the append-only
+        // continue-on-clean-re-run is the separate `keyset_incremental` →
+        // KeysetPlan.incremental. Before the split, checkpoint implied incremental
+        // and this test could not distinguish them.
+        use crate::config::SourceType;
+        let resolve = |export: &ExportConfig, i: &crate::source::TableIntrospection| {
+            chunked_strategy_from_introspection(SourceType::Postgres, export, "public.t", 3, i)
+        };
+        let i = intro(Some("id"), &["uid"], 1_000_000, Some(100));
+
+        // checkpoint on, incremental unset → crash-recovery only, NOT incremental.
+        let mut e = chunked_export();
+        e.chunk_column = None;
+        e.chunk_by_key = Some("uid".into());
+        e.chunk_checkpoint = true;
+        e.keyset_incremental = false;
+        match resolve(&e, &i).unwrap() {
+            ExtractionStrategy::Keyset(k) => {
+                assert!(k.checkpoint, "chunk_checkpoint must set checkpoint");
+                assert!(
+                    !k.incremental,
+                    "chunk_checkpoint alone must NOT imply incremental (the safety fix)"
+                );
+            }
+            other => panic!("expected keyset, got {other:?}"),
+        }
+
+        // incremental opt-in → both flags set.
+        e.keyset_incremental = true;
+        match resolve(&e, &i).unwrap() {
+            ExtractionStrategy::Keyset(k) => {
+                assert!(k.checkpoint && k.incremental, "opt-in must set both");
+            }
+            other => panic!("expected keyset, got {other:?}"),
+        }
+
+        // keyset_incremental WITHOUT chunk_checkpoint must still set checkpoint —
+        // incremental needs the persisted cursor, so it implies checkpoint. Before
+        // the fix this was KeysetPlan{checkpoint:false, incremental:true}, a silent
+        // no-op that re-read the whole table every run.
+        e.chunk_checkpoint = false;
+        e.keyset_incremental = true;
+        match resolve(&e, &i).unwrap() {
+            ExtractionStrategy::Keyset(k) => {
+                assert!(
+                    k.checkpoint && k.incremental,
+                    "keyset_incremental must imply checkpoint (else it is a silent no-op): {k:?}"
+                );
+            }
+            other => panic!("expected keyset, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/plan/contract.rs
+++ b/src/plan/contract.rs
@@ -34,13 +34,23 @@ pub struct ChunkedPlan {
 pub struct KeysetPlan {
     pub key_column: String,
     pub chunk_size: usize,
-    /// Persist the page's max key after each commit and resume from it next run
-    /// (crash-recovery / incremental-append). Opt-in — default `false` keeps
-    /// `mode: full` re-reading the whole key range every run (full semantics).
-    /// Set for a MongoDB source via `source.mongo.resume`. `#[serde(default)]`
-    /// so a pre-existing plan artifact (no field) deserializes as non-resumable.
+    /// Persist the page's max key after each commit so a **crashed** run resumes
+    /// from it (crash-recovery). Detected via the in-progress run_id: a run that
+    /// finished clears it, so a *clean* re-run does NOT continue from the key —
+    /// it re-reads the whole range (full semantics), never silently skipping
+    /// already-exported rows. The clean-re-run "continue from key" behaviour is
+    /// the separate opt-in [`incremental`](Self::incremental). Set for a MongoDB
+    /// source via `source.mongo.resume`. `#[serde(default)]` so a pre-existing
+    /// plan artifact (no field) deserializes as non-resumable.
     #[serde(default)]
     pub checkpoint: bool,
+    /// Append-only opt-in (SQL `keyset_incremental`, or Mongo `source.mongo.resume`):
+    /// on a CLEAN re-run, continue from the last exported key — pull only keys past
+    /// the high-water mark. Distinct from [`checkpoint`](Self::checkpoint) (which is
+    /// crash-recovery only): incremental is correct ONLY for append-only tables, so
+    /// it is off unless explicitly requested. `#[serde(default)]` for old artifacts.
+    #[serde(default)]
+    pub incremental: bool,
     /// Concurrent `_id`-range workers for a MongoDB parallel read (`export.
     /// parallel`): each worker keyset-pages a disjoint `$sample`-bounded slice.
     /// Only the Mongo reader acts on it; SQL keyset stays sequential and ignores

--- a/src/plan/validate.rs
+++ b/src/plan/validate.rs
@@ -850,6 +850,7 @@ mod tests {
             key_column: "uuid_pk".into(),
             chunk_size: 10_000,
             checkpoint: false,
+            incremental: false,
             parallel: 1,
         })
     }

--- a/src/preflight/analysis.rs
+++ b/src/preflight/analysis.rs
@@ -3,6 +3,14 @@ use crate::config::{ExportConfig, ExportMode};
 
 /// B1: Human-readable strategy name derived from mode + config.
 pub(crate) fn derive_strategy(export: &ExportConfig) -> String {
+    // `chunk_by_key` pins keyset (seek) pagination regardless of the nominal
+    // mode: page by ROWS on a unique index, not by key-span windows. The planner
+    // (plan::build) turns it into ExtractionStrategy::Keyset, so the diagnostic
+    // must label it keyset — not `chunked(?, …)`, whose `?` is the absent
+    // chunk_column that keyset does not use.
+    if let Some(key) = export.chunk_by_key.as_deref() {
+        return format!("keyset({}, size={})", key, export.chunk_size);
+    }
     match export.mode {
         ExportMode::Full => {
             if export.parallel > 1 {
@@ -49,6 +57,12 @@ pub(crate) fn derive_strategy(export: &ExportConfig) -> String {
 /// etc. Shared verbatim by all three engine `diagnose_*` paths, which differ
 /// only in their probes, not in this label.
 pub(crate) fn diagnose_mode_str(export: &ExportConfig) -> String {
+    // Keyset (chunk_by_key) is its own read strategy — surface the actual seek
+    // key + page size, not `chunked (column: ?, …)` (the `?` = the unused
+    // chunk_column). Mirrors the derive_strategy keyset branch above.
+    if let Some(key) = export.chunk_by_key.as_deref() {
+        return format!("keyset (key: {}, size: {})", key, export.chunk_size);
+    }
     match export.mode {
         ExportMode::Full => "full".to_string(),
         ExportMode::Incremental => format!(
@@ -161,6 +175,12 @@ pub(crate) fn check_sparse_range(
     if export.mode != ExportMode::Chunked {
         return None;
     }
+    // Keyset pages by ROWS on a unique index — immune to a sparse/gappy key by
+    // construction (there are no BETWEEN windows to leave empty). The
+    // sparse-range warning is a range-chunk (chunk_column) concept only.
+    if export.chunk_by_key.is_some() {
+        return None;
+    }
     if export.chunk_dense {
         return None;
     }
@@ -188,7 +208,9 @@ pub(crate) fn check_sparse_range(
     let empty_pct = ((1.0 - info.density).clamp(0.0, 1.0) * 100.0) as u32;
     Some(format!(
         "Sparse key range: ~{}% of chunk windows will be empty (range {}..{}, ~{} rows). \
-         Consider chunking on a dense surrogate (ROW_NUMBER) or switching to incremental mode.",
+         Switch to keyset pagination (`chunk_by_key: <unique key>`) — it pages by ROWS and is \
+         immune to a sparse/gappy key — or chunk on a dense surrogate (ROW_NUMBER), or use \
+         incremental mode.",
         empty_pct, min_val, max_val, rows
     ))
 }
@@ -225,8 +247,10 @@ pub(crate) fn check_oversized_chunk(
         return None;
     }
 
-    let rows_per_chunk: i64 = if export.chunk_dense {
-        // Dense ordinal windows hold exactly chunk_size rows (bar the last).
+    let rows_per_chunk: i64 = if export.chunk_dense || export.chunk_by_key.is_some() {
+        // Dense ordinal windows and keyset (seek) pages both hold exactly
+        // chunk_size rows (bar the last), independent of key density — no
+        // cursor_min/max span math applies.
         export.chunk_size as i64
     } else {
         let min_i: i64 = cursor_min?.parse().ok()?;
@@ -334,6 +358,17 @@ pub(crate) fn recommend_parallelism(
     row_estimate: Option<i64>,
     uses_index: bool,
 ) -> (u32, &'static str) {
+    // Keyset (seek) pagination is strictly sequential: each page's
+    // `WHERE key > $last` depends on the prior page's max key, so workers cannot
+    // be fanned out (KeysetPlan hard-codes parallel = 1). Recommending parallel
+    // for a chunk_by_key export would be misadvice, so answer before the
+    // mode-based ladder (keyset carries mode: chunked).
+    if export.chunk_by_key.is_some() {
+        return (
+            1,
+            "keyset pagination is sequential — parallelism does not apply",
+        );
+    }
     if export.mode != ExportMode::Chunked {
         return (1, "only chunked mode benefits from parallelism");
     }
@@ -404,6 +439,40 @@ impl Warning {
     }
 }
 
+/// A chunked/keyset export with no `chunk_checkpoint: true` cannot resume a
+/// crashed or interrupted run — the next attempt re-reads the whole table from
+/// the start. On the live GCS run this was the concrete cost of a flaky SSH
+/// tunnel: 738K durably-exported rows were only recoverable via a checkpoint the
+/// config had left commented out, so a re-run would have re-pulled everything.
+///
+/// Advisory (a checkpoint is not always wanted — enabling it gives re-runs
+/// incremental-by-key semantics rather than a fresh snapshot), and scoped to
+/// tables large enough for the re-read to hurt: skipped only when the estimate
+/// is KNOWN-small (`Some` below the threshold). An unknown estimate (MySQL) still
+/// nudges — the engine with the weakest stats is where the re-download is least
+/// visible.
+pub(crate) fn check_missing_checkpoint(
+    export: &ExportConfig,
+    row_estimate: Option<i64>,
+) -> Option<String> {
+    let chunked_or_keyset = export.mode == ExportMode::Chunked || export.chunk_by_key.is_some();
+    if !chunked_or_keyset || export.chunk_checkpoint {
+        return None;
+    }
+    if row_estimate.is_some_and(|r| r < SMALL_TABLE_ROW_THRESHOLD) {
+        return None;
+    }
+    Some(
+        "No chunk_checkpoint: a crashed or interrupted run re-reads the whole table \
+         from the start (no resume). Add `chunk_checkpoint: true` for crash-recovery — \
+         safe to enable on any table: it does NOT change your clean re-run semantics (a \
+         clean re-run still does a full pass and picks up updates). Recommended for large \
+         tables or unreliable links. (Keyset append-only incremental is the separate \
+         `keyset_incremental` opt-in.)"
+            .to_string(),
+    )
+}
+
 pub(super) fn collect_warnings(
     export: &ExportConfig,
     row_estimate: Option<i64>,
@@ -426,6 +495,7 @@ pub(super) fn collect_warnings(
             .map(|m| Warning::new(Severity::Medium, m)),
         check_dense_surrogate_cost(export).map(|m| Warning::new(Severity::Low, m)),
         check_parallel_memory_risk(export, row_estimate).map(|m| Warning::new(Severity::High, m)),
+        check_missing_checkpoint(export, row_estimate).map(|m| Warning::new(Severity::Medium, m)),
     ]
     .into_iter()
     .flatten()
@@ -534,7 +604,15 @@ pub(crate) fn build_suggestion(
                 // mysql}::column_has_*_*), so saying "create an index" when
                 // a btree already exists would be a false alarm.
                 ExportMode::Chunked if !uses_index => {
-                    let col = export.chunk_column.as_deref().unwrap_or("chunk_column");
+                    // Name the real read column: chunk_column for range chunking,
+                    // else the keyset key (chunk_by_key). A keyset key that is not
+                    // a unique index is exactly what the planner refuses at run
+                    // time — the check should name it, not the literal placeholder.
+                    let col = export
+                        .chunk_column
+                        .as_deref()
+                        .or(export.chunk_by_key.as_deref())
+                        .unwrap_or("chunk_column");
                     parts.push(format!(
                         "Create an index on '{}' to speed up range scans.",
                         col
@@ -569,11 +647,19 @@ pub(crate) fn build_suggestion(
                     parts.push("Add an indexed cursor column and use incremental mode to avoid full re-reads.".to_string());
                 }
                 ExportMode::Chunked => {
-                    let col = export.chunk_column.as_deref().unwrap_or("chunk_column");
-                    parts.push(format!(
-                        "Create an index on '{}'. Consider reducing chunk_size or adding parallel workers.",
-                        col
-                    ));
+                    let col = export
+                        .chunk_column
+                        .as_deref()
+                        .or(export.chunk_by_key.as_deref())
+                        .unwrap_or("chunk_column");
+                    // Keyset is sequential; only range chunking benefits from
+                    // "add parallel workers", so tailor the fix to the strategy.
+                    let fix = if export.chunk_by_key.is_some() {
+                        "Create an index on '{col}' (keyset needs a unique index), or use mode: full for one snapshot scan."
+                    } else {
+                        "Create an index on '{col}'. Consider reducing chunk_size or adding parallel workers."
+                    };
+                    parts.push(fix.replace("{col}", col));
                 }
                 ExportMode::TimeWindow => {
                     let col = export.time_column.as_deref().unwrap_or("time_column");
@@ -637,6 +723,34 @@ mod tests {
     fn derive_strategy_date_chunked() {
         let e = cfg("mode: chunked\nchunk_column: created_at\nchunk_by_days: 7\n");
         assert_eq!(derive_strategy(&e), "date-chunked(created_at, 7d)");
+    }
+
+    // ── keyset (chunk_by_key) must be labelled keyset, never `chunked(?, …)` ──
+    //
+    // Regression for the preflight keyset-blindness class: a `mode: chunked` +
+    // `chunk_by_key: id` export (the production `table:`-shortcut shape) is
+    // ExtractionStrategy::Keyset. Before the fix, derive_strategy fell through to
+    // the Chunked arm, read the absent chunk_column, and rendered
+    // `chunked(?, size=…)` — the `?` that made 66 production keyset tables read as
+    // misconfigured. The strategy label must name the seek key.
+    #[test]
+    fn derive_strategy_keyset_names_the_seek_key_not_a_question_mark() {
+        let e = cfg("mode: chunked\nchunk_by_key: id\nchunk_size: 250000\n");
+        assert_eq!(derive_strategy(&e), "keyset(id, size=250000)");
+        assert!(
+            !derive_strategy(&e).contains('?'),
+            "keyset must never render the chunk_column '?' placeholder"
+        );
+    }
+
+    #[test]
+    fn diagnose_mode_str_renders_keyset_with_its_key() {
+        assert_eq!(
+            diagnose_mode_str(&cfg(
+                "mode: chunked\nchunk_by_key: ref_id\nchunk_size: 100000\n"
+            )),
+            "keyset (key: ref_id, size: 100000)"
+        );
     }
 
     // ── diagnose_mode_str / resolve_preflight_base_query (hoisted from the
@@ -769,6 +883,30 @@ mod tests {
         assert!(check_sparse_range(&e, Some(10_000), Some("0"), Some("10000")).is_none());
     }
 
+    #[test]
+    fn check_sparse_range_keyset_is_immune_even_on_a_sparse_span() {
+        // Same 100-rows-in-5M-span shape that fires for chunk_column, but under
+        // chunk_by_key: keyset pages by ROWS, so a gappy key can never leave an
+        // empty window. The sparse warning must NOT fire (it is range-only).
+        let e = cfg("mode: chunked\nchunk_by_key: id\nchunk_size: 100000\n");
+        assert!(
+            check_sparse_range(&e, Some(100), Some("1"), Some("5000000")).is_none(),
+            "keyset must be immune to the sparse-range warning"
+        );
+    }
+
+    // ── recommend_parallelism: keyset is sequential ─────────────────────────
+    #[test]
+    fn recommend_parallelism_keyset_is_sequential_never_advises_parallel() {
+        // A ~1M-row keyset export: the old code fell through the chunked ladder
+        // and advised parallel: 2 ("no index"), which is doubly wrong — keyset
+        // is index-backed AND sequential (KeysetPlan pins parallel = 1).
+        let e = cfg("mode: chunked\nchunk_by_key: id\nchunk_size: 250000\n");
+        let (level, reason) = recommend_parallelism(&e, Some(1_000_000), true);
+        assert_eq!(level, 1, "keyset must recommend a single worker: {reason}");
+        assert!(reason.contains("sequential"), "got: {reason}");
+    }
+
     // ── check_oversized_chunk ───────────────────────────────────────────────
 
     #[test]
@@ -862,6 +1000,58 @@ mod tests {
         assert!(check_dense_surrogate_cost(&e).is_none());
     }
 
+    // ── check_missing_checkpoint (resumability nudge) ───────────────────────
+    #[test]
+    fn check_missing_checkpoint_keyset_without_checkpoint_warns() {
+        // The production shape: a large keyset export with chunk_checkpoint left
+        // off — a crash re-reads the whole table (the 738K-row re-download pain).
+        let e = cfg("mode: chunked\nchunk_by_key: id\nchunk_size: 250000\n");
+        let w = check_missing_checkpoint(&e, Some(1_000_000));
+        assert!(w.is_some(), "expected a checkpoint nudge");
+        let msg = w.unwrap();
+        assert!(msg.contains("chunk_checkpoint"), "names the fix");
+        // The message must NOT advise the removed conflated semantics — post-split
+        // chunk_checkpoint is crash-recovery ONLY and does not change clean-re-run
+        // behaviour, so it must never tell operators to OMIT it for a fresh snapshot
+        // (that would disable crash-recovery for the exact case it protects).
+        assert!(
+            !msg.contains("incremental-by-key") && !msg.to_lowercase().contains("omit"),
+            "must not advise the removed incremental semantics: {msg}"
+        );
+        assert!(
+            msg.contains("does NOT change") || msg.contains("full pass"),
+            "must reassure that clean re-run semantics are unchanged: {msg}"
+        );
+    }
+
+    #[test]
+    fn check_missing_checkpoint_range_chunk_unknown_size_warns() {
+        // MySQL has no trustworthy estimate (None) — still nudge, since that is
+        // exactly the engine where the re-download is least visible.
+        let e = cfg("mode: chunked\nchunk_column: ref_id\nchunk_size: 250000\n");
+        assert!(check_missing_checkpoint(&e, None).is_some());
+    }
+
+    #[test]
+    fn check_missing_checkpoint_present_is_silent() {
+        let e = cfg("mode: chunked\nchunk_by_key: id\nchunk_checkpoint: true\n");
+        assert!(check_missing_checkpoint(&e, Some(5_000_000)).is_none());
+    }
+
+    #[test]
+    fn check_missing_checkpoint_known_small_table_is_silent() {
+        // A known-small chunked table re-reads cheaply — no nudge.
+        let e = cfg("mode: chunked\nchunk_column: id\nchunk_size: 1000\n");
+        assert!(check_missing_checkpoint(&e, Some(5_000)).is_none());
+    }
+
+    #[test]
+    fn check_missing_checkpoint_non_chunked_is_silent() {
+        // Full/incremental have no per-chunk progress to checkpoint.
+        let e = cfg("mode: full\n");
+        assert!(check_missing_checkpoint(&e, Some(10_000_000)).is_none());
+    }
+
     // ── check_connection_limit ──────────────────────────────────────────────
 
     #[test]
@@ -918,10 +1108,11 @@ mod tests {
     #[test]
     fn collect_warnings_assembles_applicable_checks_in_registry_order() {
         // The manifest rewrite must keep display order AND aggregate every
-        // applicable check. This config trips three at once: connection-limit
-        // (parallel >= max_connections), sparse-range (density < 0.1), and
-        // parallel-memory (> 5M rows). oversized-chunk and dense-surrogate stay
-        // None, so the survivors must be the other three, in array order.
+        // applicable check. This config trips four at once: connection-limit
+        // (parallel >= max_connections), sparse-range (density < 0.1),
+        // parallel-memory (> 5M rows), and missing-checkpoint (chunked, large, no
+        // chunk_checkpoint). oversized-chunk and dense-surrogate stay None, so the
+        // survivors must be those four, in array order.
         let e = cfg("mode: chunked\nchunk_column: id\nchunk_size: 100000\nparallel: 20\n");
         let warnings = collect_warnings(
             &e,
@@ -931,7 +1122,7 @@ mod tests {
             Some("1000000000"), // wide span → sparse range
             Some(20),           // db max_connections → connection-limit trips
         );
-        assert_eq!(warnings.len(), 3, "three checks apply: {warnings:?}");
+        assert_eq!(warnings.len(), 4, "four checks apply: {warnings:?}");
         assert!(
             warnings[0].message.contains("max_connections")
                 && warnings[0].severity == Severity::High,
@@ -943,7 +1134,12 @@ mod tests {
         );
         assert!(
             warnings[2].message.contains("memory") && warnings[2].severity == Severity::High,
-            "parallel-memory is last, High: {warnings:?}"
+            "parallel-memory is third, High: {warnings:?}"
+        );
+        assert!(
+            warnings[3].message.contains("chunk_checkpoint")
+                && warnings[3].severity == Severity::Medium,
+            "missing-checkpoint is last, Medium: {warnings:?}"
         );
     }
 

--- a/src/preflight/analysis.rs
+++ b/src/preflight/analysis.rs
@@ -456,7 +456,10 @@ pub(crate) fn check_missing_checkpoint(
     row_estimate: Option<i64>,
 ) -> Option<String> {
     let chunked_or_keyset = export.mode == ExportMode::Chunked || export.chunk_by_key.is_some();
-    if !chunked_or_keyset || export.chunk_checkpoint {
+    // `keyset_incremental` implies checkpoint at plan build (it needs the persisted
+    // cursor), so a config that sets it already HAS crash-recovery — do not warn
+    // "no chunk_checkpoint" for it, or the nudge contradicts the plan.
+    if !chunked_or_keyset || export.chunk_checkpoint || export.keyset_incremental {
         return None;
     }
     if row_estimate.is_some_and(|r| r < SMALL_TABLE_ROW_THRESHOLD) {
@@ -1035,6 +1038,14 @@ mod tests {
     #[test]
     fn check_missing_checkpoint_present_is_silent() {
         let e = cfg("mode: chunked\nchunk_by_key: id\nchunk_checkpoint: true\n");
+        assert!(check_missing_checkpoint(&e, Some(5_000_000)).is_none());
+    }
+
+    #[test]
+    fn check_missing_checkpoint_keyset_incremental_implies_checkpoint_is_silent() {
+        // keyset_incremental implies checkpoint at plan build, so the "no
+        // chunk_checkpoint" nudge must NOT fire — it would contradict the plan.
+        let e = cfg("mode: chunked\nchunk_by_key: id\nkeyset_incremental: true\n");
         assert!(check_missing_checkpoint(&e, Some(5_000_000)).is_none());
     }
 

--- a/src/preflight/mssql.rs
+++ b/src/preflight/mssql.rs
@@ -72,9 +72,14 @@ fn diagnose_mssql(conn: &mut MssqlSource, export: &ExportConfig) -> Result<Expor
         return Err(fail);
     }
 
+    // chunk_column (range) OR chunk_by_key (keyset) OR cursor_column
+    // (incremental) — the run's real read column. Without chunk_by_key a keyset
+    // table's range_col is None, so the index probe below never runs and the
+    // verdict falls to a false "no index".
     let range_col = export
         .chunk_column
         .as_deref()
+        .or(export.chunk_by_key.as_deref())
         .or(export.cursor_column.as_deref());
 
     // Recover the base relation (`[schema.]table`) the probes key on. `init`
@@ -121,7 +126,8 @@ fn diagnose_mssql(conn: &mut MssqlSource, export: &ExportConfig) -> Result<Expor
     // drives the verdict, the same way the PG/MySQL catalog probe overrides
     // their EXPLAIN hint.
     let scan_type = None;
-    let uses_index = if matches!(export.mode, ExportMode::Chunked | ExportMode::Incremental)
+    let uses_index = if (matches!(export.mode, ExportMode::Chunked | ExportMode::Incremental)
+        || export.chunk_by_key.is_some())
         && let Some(col) = range_col
         && let Some(table) = base_table
     {

--- a/src/preflight/mysql.rs
+++ b/src/preflight/mysql.rs
@@ -77,9 +77,15 @@ fn diagnose_mysql(
 
     let base_query = resolve_preflight_base_query(export);
     let base_query = base_query.as_str();
+    // The column the run actually reads on: chunk_column for range chunking,
+    // chunk_by_key for keyset (seek) — a keyset table has neither chunk_column
+    // nor cursor_column, so without chunk_by_key here range_col is None and every
+    // downstream probe (min/max, the index override) silently degrades keyset to
+    // a false unindexed full-scan verdict. cursor_column last for incremental.
     let range_col = export
         .chunk_column
         .as_deref()
+        .or(export.chunk_by_key.as_deref())
         .or(export.cursor_column.as_deref());
     let effective_query = if let Some(order) = incremental_key_expr(export, SourceType::Mysql) {
         format!(
@@ -173,7 +179,8 @@ fn diagnose_mysql(
     // issues `WHERE chunk_col >= $lo AND chunk_col < $hi`, which would use
     // the index. Override `uses_index` from the catalog when the column is
     // the leading key of some index on the table.
-    let uses_index = if matches!(export.mode, ExportMode::Chunked | ExportMode::Incremental)
+    let uses_index = if (matches!(export.mode, ExportMode::Chunked | ExportMode::Incremental)
+        || export.chunk_by_key.is_some())
         && let Some(col) = range_col
         && let Some(table) = export
             .table

--- a/src/preflight/postgres.rs
+++ b/src/preflight/postgres.rs
@@ -53,9 +53,14 @@ fn diagnose_pg(
     let base_query = resolve_preflight_base_query(export);
     let base_query = base_query.as_str();
 
+    // chunk_column (range) OR chunk_by_key (keyset) OR cursor_column
+    // (incremental) — the column the run actually reads on. Omitting
+    // chunk_by_key leaves keyset tables with range_col = None, which the index
+    // override below reads as "no index" and reports a false UNSAFE.
     let range_col = export
         .chunk_column
         .as_deref()
+        .or(export.chunk_by_key.as_deref())
         .or(export.cursor_column.as_deref());
 
     let effective_query = if let Some(order) = incremental_key_expr(export, SourceType::Postgres) {
@@ -117,7 +122,8 @@ fn diagnose_pg(
     // whose leading column is the range column? If yes, treat it as
     // indexed regardless of what EXPLAIN said for the base query. This
     // collapses the most common false-DEGRADED case (chunked on a PK).
-    let uses_index = if matches!(export.mode, ExportMode::Chunked | ExportMode::Incremental)
+    let uses_index = if (matches!(export.mode, ExportMode::Chunked | ExportMode::Incremental)
+        || export.chunk_by_key.is_some())
         && let Some(col) = range_col
         && let Some(table) = export
             .table

--- a/src/source/cdc/mod.rs
+++ b/src/source/cdc/mod.rs
@@ -169,6 +169,20 @@ impl ChangeEvent {
         };
         self.schema.len() + self.table.len() + img(&self.before) + img(&self.after) + 32
     }
+
+    /// Surface this event's DEFERRED decode error ([`poison`](Self::poison)) if it
+    /// carries one. EVERY consumer that turns a captured event into output MUST
+    /// call this right after confirming the event is captured — the deferral only
+    /// holds because an uncaptured table's poison is dropped, so a driver that
+    /// forgets to raise it on a CAPTURED event would emit corrupt data (the class
+    /// the round-1 hunt caught on the NDJSON driver). A discoverable method the
+    /// next sink calls, not a rule two drivers must each remember to inline.
+    pub(crate) fn raise_poison(&self) -> Result<()> {
+        if let Some(poison) = &self.poison {
+            anyhow::bail!("{poison}");
+        }
+        Ok(())
+    }
 }
 
 /// The seam every engine reader satisfies: a blocking pull of canonical changes.
@@ -231,14 +245,9 @@ pub(crate) fn run(
         // file sink. Without this the NDJSON path would print the raw
         // `unchanged-toast-datum` sentinel verbatim as the column value (silent
         // corruption). An uncaptured table's poison was already dropped above.
-        // Surface a deferred decode error (e.g. PG unchanged-TOAST with no
-        // pre-image) only now that the event is confirmed captured — mirrors the
-        // file sink. Without this the NDJSON path would print the raw
-        // `unchanged-toast-datum` sentinel verbatim as the column value (silent
-        // corruption). An uncaptured table's poison was already dropped above.
-        if let Some(poison) = &ev.poison {
-            anyhow::bail!("{poison}");
-        }
+        // Confirmed captured → surface any deferred decode error before emitting
+        // (an uncaptured table's poison was already dropped by the filter above).
+        ev.raise_poison()?;
         let to_json = |img: &Option<Vec<RivetValue>>| {
             img.as_ref()
                 .map(|vs| vs.iter().map(RivetValue::to_json).collect::<Vec<_>>())

--- a/src/source/cdc/mod.rs
+++ b/src/source/cdc/mod.rs
@@ -115,6 +115,15 @@ pub(crate) struct ChangeEvent {
     /// touched more than once per transaction. `(position, seq)` is the total
     /// order; being log-derived it is identical on an at-least-once re-emit.
     pub(crate) seq: u64,
+    /// A DEFERRED per-event decode error, surfaced by the sink **only when this
+    /// event routes to a captured table**. A single logical stream (one PG
+    /// `test_decoding` slot) decodes EVERY table in the database, so an
+    /// unrecoverable decode on an UN-captured table (e.g. an unchanged-TOAST datum
+    /// with no pre-image) must not bail the whole run — it would poison capture of
+    /// unrelated tables sharing the slot. The source records the error here instead
+    /// of bailing; the sink raises it iff the event matches a captured table (the
+    /// single routing authority), and drops it silently otherwise. `None` = clean.
+    pub(crate) poison: Option<String>,
 }
 
 /// Stamps each change with its intra-transaction ordinal ([`ChangeEvent::seq`]).
@@ -216,6 +225,19 @@ pub(crate) fn run(
                 .any(|t| sink::table_matches(t, &ev.schema, &ev.table))
         {
             continue;
+        }
+        // Surface a deferred decode error (e.g. PG unchanged-TOAST with no
+        // pre-image) only now that the event is confirmed captured — mirrors the
+        // file sink. Without this the NDJSON path would print the raw
+        // `unchanged-toast-datum` sentinel verbatim as the column value (silent
+        // corruption). An uncaptured table's poison was already dropped above.
+        // Surface a deferred decode error (e.g. PG unchanged-TOAST with no
+        // pre-image) only now that the event is confirmed captured — mirrors the
+        // file sink. Without this the NDJSON path would print the raw
+        // `unchanged-toast-datum` sentinel verbatim as the column value (silent
+        // corruption). An uncaptured table's poison was already dropped above.
+        if let Some(poison) = &ev.poison {
+            anyhow::bail!("{poison}");
         }
         let to_json = |img: &Option<Vec<RivetValue>>| {
             img.as_ref()
@@ -947,5 +969,54 @@ mod tests {
         assert_eq!(ts.next(&pb), 2);
         // A new position resets.
         assert_eq!(ts.next(&Position(serde_json::json!({ "lsn": "C" }))), 0);
+    }
+
+    // ── NDJSON driver honours ChangeEvent.poison (silent-corruption guard) ──
+    struct OneShot(Option<super::ChangeEvent>);
+    impl super::ChangeStream for OneShot {
+        fn next_change(&mut self) -> Option<Result<super::ChangeEvent>> {
+            self.0.take().map(Ok)
+        }
+    }
+
+    fn poison_event(table: &str) -> super::ChangeEvent {
+        super::ChangeEvent {
+            op: super::ChangeOp::Update,
+            schema: "public".into(),
+            table: table.into(),
+            before: None,
+            after: Some(vec![RivetValue::Bytes(b"unchanged-toast-datum".to_vec())]),
+            position: Position(serde_json::json!({ "lsn": "0/ABC" })),
+            committed: true,
+            image_names: None,
+            seq: 0,
+            poison: Some(
+                "pg cdc: public.orders: column [big] unchanged-TOAST — REPLICA IDENTITY FULL"
+                    .into(),
+            ),
+        }
+    }
+
+    // The NDJSON path (`rivet cdc` without --output) must surface a deferred poison
+    // for a CAPTURED table — never print the raw `unchanged-toast-datum` sentinel as
+    // data. RED against the pre-fix loop, which had no poison check and emitted it.
+    #[test]
+    fn ndjson_run_raises_poison_for_a_captured_table() {
+        let mut s = OneShot(Some(poison_event("orders")));
+        let err = super::run(&mut s, None, vec!["orders".into()], None)
+            .expect_err("captured poison must bail");
+        assert!(
+            format!("{err:#}").contains("REPLICA IDENTITY FULL"),
+            "got: {err:#}"
+        );
+    }
+
+    // An UNCAPTURED table's poison must be dropped (parallel-slot contamination
+    // fix): the run succeeds, never bailing on a table we do not capture.
+    #[test]
+    fn ndjson_run_drops_poison_for_an_uncaptured_table() {
+        let mut s = OneShot(Some(poison_event("audit_log")));
+        super::run(&mut s, None, vec!["orders".into()], None)
+            .expect("uncaptured poison must not bail the NDJSON run");
     }
 }

--- a/src/source/cdc/mod.rs
+++ b/src/source/cdc/mod.rs
@@ -659,11 +659,24 @@ impl CdcSchemaResolver {
         // stay untouched.
         if let Some(conn) = self.enrich.as_mut() {
             use mysql::prelude::Queryable;
-            let bare = table.rsplit('.').next().unwrap_or(table);
+            // A qualified `db.table` carries its OWN schema, which may differ from
+            // the connection's DATABASE() (a cross-database capture), and a db-less
+            // URL has no DATABASE() at all. The old query dropped the qualifier and
+            // pinned `TABLE_SCHEMA = DATABASE()`, so both cases enriched NOTHING —
+            // ENUM/SET columns then kept their raw wire index / bitmask instead of
+            // the `enum('a',…)` / `set('x',…)` labels the binlog cell fixes need,
+            // silently corrupting every such column. Split like the batch path
+            // (mysql::mod) and query the EXPLICIT schema.
+            let default_db: Option<String> = if table.contains('.') {
+                None
+            } else {
+                conn.query_first("SELECT DATABASE()")?
+            };
+            let (schema, bare) = enrich_schema_and_table(table, default_db.as_deref());
             let full: Vec<(String, String)> = conn.exec(
                 "SELECT COLUMN_NAME, COLUMN_TYPE FROM information_schema.COLUMNS \
-                 WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?",
-                (bare,),
+                 WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?",
+                (&schema, &bare),
             )?;
             for m in &mut mappings {
                 if let Some((_, ct)) = full.iter().find(|(n, _)| *n == m.column_name) {
@@ -672,6 +685,25 @@ impl CdcSchemaResolver {
             }
         }
         Ok(mappings)
+    }
+}
+
+/// Split a possibly-qualified `db.table` into the `(schema, bare_table)` the
+/// MySQL `information_schema.COLUMNS` enrichment query needs. A qualified name
+/// carries its OWN schema — which may differ from the connection's default DB (a
+/// cross-database capture) — so its qualifier wins; an unqualified name falls
+/// back to `default_db` (the connection's `DATABASE()`, `""` when the URL has no
+/// default database). Mirrors the batch introspection split (mysql::mod), so CDC
+/// and batch resolve the same schema for the same table. `default_db` is only
+/// consulted for an unqualified name (the caller passes `None` for a qualified
+/// one to skip the extra `SELECT DATABASE()` round-trip).
+fn enrich_schema_and_table(table: &str, default_db: Option<&str>) -> (String, String) {
+    match table.split_once('.') {
+        Some((s, t)) => (s.to_string(), t.to_string()),
+        None => (
+            default_db.unwrap_or_default().to_string(),
+            table.to_string(),
+        ),
     }
 }
 
@@ -782,6 +814,34 @@ mod tests {
     // otherwise exercised only through I/O paths (dispatch, cdc_job, adapter
     // opens), so an inverted mapping would survive the CI mutants gate's
     // `--lib` run.
+    // Finding #3: MySQL CDC enriched ENUM/SET labels from
+    // information_schema.COLUMNS pinned to `TABLE_SCHEMA = DATABASE()` while
+    // dropping any `db.` qualifier — so a cross-database (or db-less-URL) capture
+    // enriched nothing and every ENUM/SET column kept its raw wire index/bitmask.
+    // enrich_schema_and_table must resolve a qualified name's OWN schema, not the
+    // connection default. RED against the old `rsplit('.').next()` + DATABASE()
+    // pinning (which yielded schema == default_db even for `otherdb.orders`).
+    #[test]
+    fn enrich_uses_the_qualified_schema_not_the_connection_default() {
+        use super::enrich_schema_and_table;
+        // Cross-database capture: the qualifier wins over the connection default.
+        assert_eq!(
+            enrich_schema_and_table("otherdb.orders", Some("conndb")),
+            ("otherdb".to_string(), "orders".to_string())
+        );
+        // Unqualified: falls back to the connection's DATABASE().
+        assert_eq!(
+            enrich_schema_and_table("orders", Some("conndb")),
+            ("conndb".to_string(), "orders".to_string())
+        );
+        // Db-less URL (DATABASE() is NULL) unqualified → empty schema (query
+        // matches nothing, but never the WRONG database's same-named table).
+        assert_eq!(
+            enrich_schema_and_table("orders", None),
+            (String::new(), "orders".to_string())
+        );
+    }
+
     #[test]
     fn drain_mode_maps_the_config_bool_and_bounds() {
         use super::DrainMode;

--- a/src/source/cdc/sink.rs
+++ b/src/source/cdc/sink.rs
@@ -308,14 +308,9 @@ pub(crate) fn run_to_files(
             else {
                 continue; // not a captured table — its deferred poison never applies
             };
-            // Surface a deferred decode error (e.g. PG unchanged-TOAST with no
-            // pre-image) ONLY now that the event is confirmed to route to a
-            // captured table. An uncaptured table's poison was dropped by the
-            // `continue` above, so one mis-configured table can no longer bail
-            // capture of unrelated tables sharing the slot.
-            if let Some(poison) = &ev.poison {
-                anyhow::bail!("{poison}");
-            }
+            // Confirmed routed to a captured table → surface any deferred decode
+            // error (uncaptured tables' poison was dropped by the `continue`).
+            ev.raise_poison()?;
             total_bytes += ev.estimated_bytes();
             sink.buf.push(ev);
             total_rows += 1;

--- a/src/source/cdc/sink.rs
+++ b/src/source/cdc/sink.rs
@@ -306,8 +306,16 @@ pub(crate) fn run_to_files(
                 .iter_mut()
                 .find(|s| table_matches(&s.out.table, &ev.schema, &ev.table))
             else {
-                continue; // not a captured table
+                continue; // not a captured table — its deferred poison never applies
             };
+            // Surface a deferred decode error (e.g. PG unchanged-TOAST with no
+            // pre-image) ONLY now that the event is confirmed to route to a
+            // captured table. An uncaptured table's poison was dropped by the
+            // `continue` above, so one mis-configured table can no longer bail
+            // capture of unrelated tables sharing the slot.
+            if let Some(poison) = &ev.poison {
+                anyhow::bail!("{poison}");
+            }
             total_bytes += ev.estimated_bytes();
             sink.buf.push(ev);
             total_rows += 1;
@@ -798,6 +806,54 @@ mod tests {
         assert_eq!(stream.acked.len(), 1, "and the source must be acked");
     }
 
+    // Parallel-CDC contamination fix: a deferred `poison` (e.g. PG unchanged-TOAST
+    // with no pre-image) on a table this run does NOT capture must be dropped WITH
+    // the event, never surfaced. One mis-configured table sharing the slot (a
+    // DEFAULT-replica-identity TOAST table) previously bailed capture of every
+    // unrelated table — the class that RED'd two live PG CDC tests off a foreign
+    // fixture. RED against a pre-fix build: the poison bails at the source.
+    #[test]
+    fn poison_on_an_uncaptured_table_is_dropped_never_bails_the_run() {
+        let d = tempfile::tempdir().unwrap();
+        let dest = local_dest(&d);
+        let cols = int_col();
+        let mut foreign = insert(2);
+        foreign.table = "audit_log".into(); // NOT captured (captured table is "t")
+        foreign.poison = Some("pg cdc: s.audit_log: column [big] unchanged-TOAST".into());
+        let captured = insert(1); // captured table "t", clean
+        let mut stream = FakeStream {
+            events: vec![foreign, captured].into(),
+            acked: Vec::new(),
+        };
+        let cfg = cfg(dest.as_ref(), &cols, FormatType::Parquet, 10);
+        run_to_files(&mut stream, cfg)
+            .expect("poison on an uncaptured table must be dropped, never bail the run");
+    }
+
+    // The safety half: a poison on a CAPTURED table still fails loud (the deferral
+    // must not swallow a real integrity refusal for a table we DO write).
+    #[test]
+    fn poison_on_a_captured_table_bails_with_its_message() {
+        let d = tempfile::tempdir().unwrap();
+        let dest = local_dest(&d);
+        let cols = int_col();
+        let mut poisoned = insert(1); // captured table "t"
+        poisoned.poison = Some(
+            "pg cdc: s.t: column [big] unchanged-TOAST — ALTER TABLE ... REPLICA IDENTITY FULL"
+                .into(),
+        );
+        let mut stream = FakeStream {
+            events: vec![poisoned].into(),
+            acked: Vec::new(),
+        };
+        let cfg = cfg(dest.as_ref(), &cols, FormatType::Parquet, 10);
+        let err = run_to_files(&mut stream, cfg).expect_err("poison on a captured table must bail");
+        assert!(
+            format!("{err:#}").contains("REPLICA IDENTITY FULL"),
+            "must surface the deferred message, got: {err:#}"
+        );
+    }
+
     // Ultrareview bug_004: a schema-qualified config (`table: public.orders`)
     // compared verbatim against the adapter's BARE event table matched zero
     // events — the whole stream silently dropped into a 0-row success.
@@ -939,6 +995,7 @@ mod tests {
             committed: true,
             image_names: None,
             seq: 0,
+            poison: None,
         }
     }
 
@@ -1128,6 +1185,7 @@ mod tests {
             committed: true,
             image_names: None,
             seq: 0,
+            poison: None,
         };
         let mut cols = vec![
             decimal_col("placeholder", 38, 0), // SQL Server: scale unknown at resolve

--- a/src/source/cdc/value.rs
+++ b/src/source/cdc/value.rs
@@ -191,21 +191,44 @@ pub(crate) fn build_column(dt: &DataType, cells: &[Option<&RivetValue>]) -> Resu
     let cells: &[Option<&RivetValue>] = &normalized;
 
     // Integers: the binlog/driver value is always the widest signed/unsigned, so
-    // narrow to the column's declared width — `try_from` nulls on the (impossible
-    // for a correctly-typed column) overflow rather than silently wrapping.
+    // narrow to the column's declared width. An overflow is NOT silently nulled —
+    // it fails LOUD, exactly like the batch export's `narrow` (mysql::arrow_convert).
+    // The real trigger is a BIT(64) with bit 63 set (BIT(n>1) resolves to Int64,
+    // and the BitUint fix widens it to u64 > i64::MAX) or a BIGINT UNSIGNED past
+    // i64::MAX; the batch export errors and tells the operator to map the column to
+    // decimal(20,0), so a silent NULL here — which the value-checksum could not even
+    // see (int_of agrees and skips) — would drop the value on CDC while batch
+    // surfaced it. A genuine NULL cell still builds a null.
     macro_rules! int_col {
         ($builder:ty, $ty:ty) => {{
             let mut b = <$builder>::with_capacity(cells.len());
             for c in cells {
-                let v = match c {
-                    Some(V::Int(i)) => <$ty>::try_from(*i).ok(),
-                    Some(V::UInt(u)) => <$ty>::try_from(*u).ok(),
-                    Some(V::Bool(x)) => Some(*x as $ty),
-                    _ => None,
-                };
-                match v {
-                    Some(v) => b.append_value(v),
-                    None => b.append_null(),
+                match c {
+                    None | Some(V::Null) => b.append_null(),
+                    Some(V::Bool(x)) => b.append_value(*x as $ty),
+                    Some(V::Int(i)) => match <$ty>::try_from(*i) {
+                        Ok(v) => b.append_value(v),
+                        Err(_) => anyhow::bail!(
+                            "cdc: integer value {i} overflows the declared {} column \
+                             (a BIT(64) with bit 63 set, or a BIGINT UNSIGNED > i64::MAX); \
+                             map the column to decimal(20,0) or a wider type. The batch \
+                             export fails identically, never a silent null.",
+                            stringify!($ty)
+                        ),
+                    },
+                    Some(V::UInt(u)) => match <$ty>::try_from(*u) {
+                        Ok(v) => b.append_value(v),
+                        Err(_) => anyhow::bail!(
+                            "cdc: integer value {u} overflows the declared {} column \
+                             (a BIT(64) with bit 63 set, or a BIGINT UNSIGNED > i64::MAX); \
+                             map the column to decimal(20,0) or a wider type. The batch \
+                             export fails identically, never a silent null.",
+                            stringify!($ty)
+                        ),
+                    },
+                    // A non-integer variant in an integer column is a separate
+                    // type-mismatch case, not an overflow — keep the null fallback.
+                    _ => b.append_null(),
                 }
             }
             Arc::new(b.finish())
@@ -1027,10 +1050,11 @@ mod tests {
             ),
             (
                 DataType::Int16,
-                // 40000 overflows i16 → builder nulls; the fold must too.
+                // In-range narrowing from the wide driver value (20000 fits i16);
+                // an OVERFLOW is a loud error now, covered by the narrows test.
                 vec![
                     Some(V::Int(-5)),
-                    Some(V::Int(40_000)),
+                    Some(V::Int(20_000)),
                     Some(V::UInt(7)),
                     None,
                 ],
@@ -1038,11 +1062,13 @@ mod tests {
             (DataType::Int32, vec![Some(V::Int(-8_388_608)), None]),
             (
                 DataType::Int64,
-                vec![Some(V::Int(i64::MIN)), Some(V::UInt(u64::MAX)), None],
+                // 9e9 fits i64 (narrowed from the u64 driver value); a u64 past
+                // i64::MAX is a loud error (build_column_narrows_int test).
+                vec![Some(V::Int(i64::MIN)), Some(V::UInt(9_000_000_000)), None],
             ),
             (
                 DataType::UInt64,
-                vec![Some(V::UInt(u64::MAX)), Some(V::Int(-1)), None],
+                vec![Some(V::UInt(u64::MAX)), Some(V::UInt(1)), None],
             ),
             (
                 DataType::Float32,
@@ -1301,16 +1327,35 @@ mod tests {
         );
     }
 
+    // Finding #4: an integer that fits the declared width builds; a genuine NULL
+    // stays null; but an OVERFLOW must fail LOUD (batch parity via `narrow`), never
+    // the silent null it used to be — a BIT(64) with bit 63 set was dropped on CDC
+    // while the batch export surfaced it.
     #[test]
-    fn build_column_narrows_int_to_declared_width() {
+    fn build_column_narrows_int_and_fails_loud_on_overflow() {
         use arrow::array::{Array, Int32Array};
-        let (v7, vmax) = (RivetValue::Int(7), RivetValue::Int(i64::MAX));
-        let cells = [Some(&v7), None, Some(&vmax)];
-        let arr = build_column(&DataType::Int32, &cells).unwrap();
+        // In-range values + a genuine null build cleanly.
+        let (v7, vnull_src) = (RivetValue::Int(7), RivetValue::Int(-5));
+        let arr = build_column(&DataType::Int32, &[Some(&v7), None, Some(&vnull_src)]).unwrap();
         let a = arr.as_any().downcast_ref::<Int32Array>().unwrap();
         assert_eq!(a.value(0), 7);
-        assert!(a.is_null(1)); // null stays null
-        assert!(a.is_null(2)); // overflow → null, never a silent wrap
+        assert!(a.is_null(1)); // null cell stays null
+        assert_eq!(a.value(2), -5);
+        // Overflow → loud error, not a silent null wrap.
+        let vmax = RivetValue::Int(i64::MAX);
+        let err = build_column(&DataType::Int32, &[Some(&vmax)])
+            .expect_err("an integer overflowing the declared width must fail loud");
+        assert!(
+            err.to_string().to_lowercase().contains("overflow"),
+            "message names the overflow: {err}"
+        );
+        // The reported case: a BIT(64) with bit 63 set arrives as u64 > i64::MAX
+        // and must fail loud in an Int64 column, exactly like the batch export.
+        let bit64 = RivetValue::UInt(u64::MAX);
+        assert!(
+            build_column(&DataType::Int64, &[Some(&bit64)]).is_err(),
+            "a BIT(64) value past i64::MAX must fail loud, never a silent CDC null"
+        );
     }
 
     // Finding #6: a one-dimensional List column must never silently null a

--- a/src/source/cdc/value.rs
+++ b/src/source/cdc/value.rs
@@ -307,9 +307,10 @@ pub(crate) fn build_column(dt: &DataType, cells: &[Option<&RivetValue>]) -> Resu
                         // in a Parquet decimal — fail LOUD, exactly like the
                         // batch export does, never a silent NULL.
                         None => anyhow::bail!(
-                            "cdc: unsupported decimal payload {:?} (NaN/Infinity \
-                             is not representable in a decimal column; batch \
-                             fails identically)",
+                            "cdc: unsupported decimal payload {:?} (NaN/Infinity, \
+                             or a MONEY value past the f64-exact 2^53 range that \
+                             tiberius already rounded, is not representable in a \
+                             decimal column; batch fails identically)",
                             render_str(v)
                         ),
                     },
@@ -327,9 +328,10 @@ pub(crate) fn build_column(dt: &DataType, cells: &[Option<&RivetValue>]) -> Resu
                     Some(v) => match decimal_to_i256(v, *s) {
                         Some(i) => b.append_value(i),
                         None => anyhow::bail!(
-                            "cdc: unsupported decimal payload {:?} (NaN/Infinity \
-                             is not representable in a decimal column; batch \
-                             fails identically)",
+                            "cdc: unsupported decimal payload {:?} (NaN/Infinity, \
+                             or a MONEY value past the f64-exact 2^53 range that \
+                             tiberius already rounded, is not representable in a \
+                             decimal column; batch fails identically)",
                             render_str(v)
                         ),
                     },
@@ -659,15 +661,32 @@ fn build_list_column(
     }
 }
 
+/// The scaled-integer magnitude past which an f64 can no longer hold a
+/// fixed-point value exactly (2^53). A MONEY/SMALLMONEY value (delivered as f64
+/// by tiberius) whose scaled magnitude reaches this was ALREADY rounded by the
+/// driver, so materialising it as an "exact" Decimal would present rounding as
+/// exact. The batch export (`mssql::arrow_convert::f64_to_scaled_i128`) fails
+/// loud at exactly this bound; the CDC path must match it.
+const F64_EXACT_SCALED_LIMIT: f64 = 9_007_199_254_740_992.0; // 2^53
+
+/// A finite fixed-point f64 rendered at `scale` decimal places, or `None` when
+/// its scaled magnitude is past the f64-exact range (already rounded → refuse,
+/// so `build_column` fails loud instead of storing a falsely-exact decimal).
+fn f64_fixed_point_str(f: f64, scale: i8) -> Option<String> {
+    let prec = scale.max(0) as usize;
+    if f.abs() * 10f64.powi(prec as i32) >= F64_EXACT_SCALED_LIMIT {
+        return None;
+    }
+    Some(format!("{f:.prec$}"))
+}
+
 /// As [`decimal_to_i128`] but into `i256` for `Decimal256` columns.
 fn decimal_to_i256(v: &RivetValue, scale: i8) -> Option<arrow::datatypes::i256> {
     let s = match v {
         RivetValue::Bytes(b) => std::str::from_utf8(b).ok()?.trim().to_string(),
         RivetValue::Int(i) => i.to_string(),
         RivetValue::UInt(u) => u.to_string(),
-        RivetValue::Float(f) if f.is_finite() => {
-            format!("{f:.prec$}", prec = scale.max(0) as usize)
-        }
+        RivetValue::Float(f) if f.is_finite() => f64_fixed_point_str(*f, scale)?,
         _ => return None,
     };
     crate::types::decimal::decimal_str_to_scaled_i256(&s, scale)
@@ -682,10 +701,10 @@ fn decimal_to_i128(v: &RivetValue, scale: i8) -> Option<i128> {
         RivetValue::UInt(u) => u.to_string(),
         // Fixed-point values some drivers deliver as floats (SQL Server MONEY
         // via tiberius): render at the column scale first, then the shared
-        // digit-exact parse below.
-        RivetValue::Float(f) if f.is_finite() => {
-            format!("{f:.prec$}", prec = scale.max(0) as usize)
-        }
+        // digit-exact parse below. Past 2^53 the f64 was already rounded by the
+        // driver — f64_fixed_point_str returns None so build_column fails loud,
+        // exactly like the batch export, never a silently-rounded "exact" value.
+        RivetValue::Float(f) if f.is_finite() => f64_fixed_point_str(*f, scale)?,
         _ => return None,
     };
     // ONE decimal-string canon for the whole codebase (types::decimal) — the
@@ -1231,6 +1250,39 @@ mod tests {
         assert_eq!(
             decimal_to_i128(&RivetValue::Bytes(b"42".to_vec()), 0),
             Some(42)
+        );
+    }
+
+    // Finding #2: SQL Server MONEY/SMALLMONEY arrive as f64 (tiberius). The CDC
+    // schema types them Decimal128(19,4), and the Float→decimal conversion had NO
+    // 2^53 guard — so a MONEY value past the f64-exact range (already rounded by
+    // the driver) was stored as a falsely-EXACT decimal, while the batch export
+    // fails loud on the identical value. Parity: refuse it here too. RED against
+    // the pre-fix `format!("{f:.prec$}")` with no guard.
+    #[test]
+    fn cdc_money_past_f64_exact_range_fails_loud_not_a_falsely_exact_decimal() {
+        use arrow::datatypes::DataType;
+        // 2^53 / 10^4 ≈ 9.007e11 — a value just under stays exact, 1e12 is past.
+        assert_eq!(
+            decimal_to_i128(&RivetValue::Float(9.0e11), 4),
+            Some(900_000_000_000_i128 * 10_000)
+        );
+        assert_eq!(decimal_to_i128(&RivetValue::Float(1e12), 4), None);
+        // Decimal256 (wide numeric) carries the same guard.
+        assert!(decimal_to_i256(&RivetValue::Float(1e12), 4).is_none());
+        // A small MONEY value still builds.
+        let small = RivetValue::Float(12.34);
+        let ok = build_column(&DataType::Decimal128(19, 4), &[Some(&small)])
+            .expect("a small MONEY value builds");
+        assert_eq!(ok.len(), 1);
+        // A huge MONEY value in a Decimal column fails loud with the 2^53 message.
+        let huge = RivetValue::Float(1e12);
+        let err = build_column(&DataType::Decimal128(19, 4), &[Some(&huge)])
+            .expect_err("a MONEY value past f64-exact range must fail loud, not round silently");
+        let msg = err.to_string().to_lowercase();
+        assert!(
+            msg.contains("2^53") && msg.contains("money"),
+            "message must name the 2^53 range and MONEY: {msg}"
         );
     }
 

--- a/src/source/cdc/value.rs
+++ b/src/source/cdc/value.rs
@@ -562,7 +562,22 @@ fn build_list_column(
                         }
                         lb.append(true);
                     }
-                    _ => lb.append(false),
+                    // NULL cell / inner NULL → a null list (empty array stays a
+                    // non-null empty list, handled by the Array arm above).
+                    None | Some(V::Null) => lb.append(false),
+                    // A non-null, non-array cell can only reach a one-dimensional
+                    // List column as a MULTI-dimensional PG array literal
+                    // (`{{1,2},{3,4}}`), which parse_pg_array_literal refuses to
+                    // flatten and preserves as raw text. rivet's List is 1-D and
+                    // cannot hold it — fail LOUD, exactly like the batch export
+                    // (arrow_convert.rs), never a silent null list.
+                    Some(other) => anyhow::bail!(
+                        "cdc: multi-dimensional / non-representable array value {:?} \
+                         cannot be stored in a one-dimensional list column; cast the \
+                         column to text in the source export (e.g. col::text). The \
+                         batch export fails identically.",
+                        render_str(other)
+                    ),
                 }
             }
             Ok(Arc::new(lb.finish()) as ArrayRef)
@@ -1244,6 +1259,29 @@ mod tests {
         assert_eq!(a.value(0), 7);
         assert!(a.is_null(1)); // null stays null
         assert!(a.is_null(2)); // overflow → null, never a silent wrap
+    }
+
+    // Finding #6: a one-dimensional List column must never silently null a
+    // non-array cell. parse_pg_array_literal preserves a multi-dimensional PG
+    // literal as raw text bytes (never a flat Array of NULLs); build_list_column
+    // then fails LOUD on that non-array cell — batch parity — instead of writing
+    // a silent null list. RED against the pre-fix `_ => lb.append(false)`.
+    #[test]
+    fn list_column_fails_loud_on_a_non_array_cell_not_a_silent_null() {
+        use arrow::datatypes::Field;
+        let list_i32 = DataType::List(Arc::new(Field::new("item", DataType::Int32, true)));
+        // A NULL cell is a valid null list — must still succeed.
+        let none: Option<&RivetValue> = None;
+        build_column(&list_i32, &[none]).expect("a null cell builds a null list");
+        // The raw multi-dim literal (as text bytes) must fail loud.
+        let raw = RivetValue::Bytes(b"{{1,2},{3,4}}".to_vec());
+        let err = build_column(&list_i32, &[Some(&raw)])
+            .expect_err("a non-array cell in a list column must fail loud");
+        let msg = err.to_string().to_lowercase();
+        assert!(
+            msg.contains("multi-dimensional") && msg.contains("::text"),
+            "message must name the multi-dim cause and the ::text remediation: {msg}"
+        );
     }
 
     #[test]

--- a/src/source/mongo/cdc.rs
+++ b/src/source/mongo/cdc.rs
@@ -408,6 +408,7 @@ fn to_change_event(
         committed: true,
         image_names: Some(std::sync::Arc::clone(&IMAGE_NAMES)),
         seq: 0, // stamped by TxnSeq as the stream is consumed
+        poison: None,
     })
 }
 

--- a/src/source/mongo/mod.rs
+++ b/src/source/mongo/mod.rs
@@ -255,7 +255,7 @@ impl MongoSource {
             // in the numeric band, so the min probe always sees it (the max
             // probe covers the all-NaN corner).
             for id in [lo_id, hi_id] {
-                if matches!(id, Bson::Double(f) if f.is_nan()) {
+                if is_id_nan(id) {
                     anyhow::bail!(
                         "collection '{collection}' has a NaN `_id`: MongoDB range \
                          operators never match NaN, so keyset paging / parallel \
@@ -434,6 +434,22 @@ fn id_to_string(id: Option<&Bson>) -> String {
 /// guard and silently lost a band (bug-hunt find). `None` = a type we cannot
 /// place (MinKey/MaxKey/JS/DbPointer/…) — the caller refuses keyset rather than
 /// guessing. Two `_id`s in different brackets ⟹ un-keyset-able.
+/// A numeric `_id` that is NaN. MongoDB range operators (`$gt`/`$gte`/`$lt`)
+/// never match NaN against any operand, so a keyset page boundary landing on it
+/// drops the rest of the collection and every parallel range excludes it. BOTH
+/// forms must be caught: a 64-bit-float NaN (`Bson::Double`) AND a Decimal128 NaN
+/// (`NumberDecimal("NaN")`) — the latter lands in the numeric band via
+/// [`id_bracket`] but slipped past a Double-only check and was silently dropped.
+/// A finite decimal renders as digits/sign/`.`/`E`, so a lowercased `"nan"`
+/// substring is an unambiguous NaN test (covers `NaN`, `-NaN`, signaling `sNaN`).
+fn is_id_nan(id: &Bson) -> bool {
+    match id {
+        Bson::Double(f) => f.is_nan(),
+        Bson::Decimal128(d) => d.to_string().to_ascii_lowercase().contains("nan"),
+        _ => false,
+    }
+}
+
 fn id_bracket(v: &Bson) -> Option<u8> {
     Some(match v {
         Bson::Double(_) | Bson::Int32(_) | Bson::Int64(_) | Bson::Decimal128(_) => 0,
@@ -887,6 +903,28 @@ mod tests {
         }
         // The clamp doesn't shrink a safe sub-ceiling value.
         assert_eq!(super::mongo_batch_byte_cap(Some(256)), 256 * 1024 * 1024);
+    }
+
+    // Finding #1: the NaN `_id` guard caught only a Bson::Double NaN, so a
+    // Decimal128 NaN (`NumberDecimal("NaN")`) — which id_bracket places in the
+    // numeric band — slipped past and was silently dropped from every keyset /
+    // parallel range (its $gt/$lt never matches). is_id_nan must catch BOTH.
+    #[test]
+    fn nan_id_detected_for_double_and_decimal128() {
+        use mongodb::bson::Decimal128;
+        // 64-bit-float NaN.
+        assert!(is_id_nan(&Bson::Double(f64::NAN)));
+        // Decimal128 NaN (the form that used to slip past).
+        let dec_nan: Decimal128 = "NaN".parse().expect("bson parses NumberDecimal NaN");
+        assert!(
+            is_id_nan(&Bson::Decimal128(dec_nan)),
+            "a Decimal128 NaN _id must be caught, not silently keyset-dropped"
+        );
+        // Finite numeric _ids are NOT NaN (no false positive).
+        assert!(!is_id_nan(&Bson::Double(1.5)));
+        assert!(!is_id_nan(&Bson::Int64(1001)));
+        let dec_finite: Decimal128 = "1234.5".parse().unwrap();
+        assert!(!is_id_nan(&Bson::Decimal128(dec_finite)));
     }
 
     // ── mutation-W4 gap closure ──────────────────────────────────────────────

--- a/src/source/mssql/cdc.rs
+++ b/src/source/mssql/cdc.rs
@@ -341,6 +341,7 @@ impl MssqlChangeStream {
                 committed: false,
                 image_names: Some(std::sync::Arc::from(names)),
                 seq: 0, // stamped by TxnSeq as the stream is consumed
+                poison: None,
             };
             batch_bytes = batch_bytes.saturating_add(ev.estimated_bytes());
             batch.push((lsn.clone(), ev));

--- a/src/source/mysql/cdc.rs
+++ b/src/source/mysql/cdc.rs
@@ -264,6 +264,7 @@ impl MysqlChangeStream {
                         committed: false,
                         image_names: image_names.clone(),
                         seq: 0, // stamped by TxnSeq as the stream is consumed
+                        poison: None,
                     };
                     self.tx_bytes = self.tx_bytes.saturating_add(ev.estimated_bytes());
                     self.tx.push(ev);

--- a/src/source/postgres/arrow_convert.rs
+++ b/src/source/postgres/arrow_convert.rs
@@ -858,11 +858,31 @@ fn build_pg_text_array(
     Ok(Arc::new(b.finish()))
 }
 
+/// A PostgreSQL array cell failed to decode into a 1-D `Vec<Option<T>>` — almost
+/// always a MULTI-dimensional value in a `x[]` column (the OID does not encode
+/// dimensionality). Fail loud, naming the column and the fix, rather than the
+/// old `.ok().flatten()` that wrote a silent whole-cell NULL.
+fn pg_array_decode_error(rows: &[Row], col_idx: usize, e: &postgres::Error) -> anyhow::Error {
+    let col = rows
+        .first()
+        .and_then(|r| r.columns().get(col_idx))
+        .map(|c| c.name())
+        .unwrap_or("?");
+    anyhow::anyhow!(
+        "column '{col}': a PostgreSQL array value could not be decoded as a one-dimensional \
+         Arrow List ({e}). The usual cause is a MULTI-dimensional (nested) array value — an \
+         `integer[]` column may legally hold 2-D+ matrices, but Arrow's List is one-dimensional \
+         and has no flat mapping. Cast the column to text in the export query (e.g. `{col}::text`) \
+         to export the array literal, or flatten it to a 1-D array."
+    )
+}
+
 /// Build an Arrow `ListArray` from a PostgreSQL array column.
 ///
 /// Dispatches to `Vec<T>` deserialization based on the Arrow element type.
-/// Supports: bool, int16/32/64, float32/64, text. Other element types fall
-/// back to a null list.
+/// Supports: bool, int16/32/64, float32/64, text. A decode error (e.g. a
+/// multi-dimensional value) FAILS LOUD via [`pg_array_decode_error`] rather than
+/// silently NULLing the cell; unsupported element types bail in the match tail.
 fn build_pg_list_array(
     target_type: &DataType,
     col_idx: usize,
@@ -874,22 +894,24 @@ fn build_pg_list_array(
         anyhow::bail!("build_pg_list_array called with non-List target type");
     };
 
-    // PG arrays can legally contain NULL elements (`ARRAY[1, NULL, 3]`).
-    // The `postgres` crate's `Vec<T>` deserializer rejects such arrays with
-    // an error; `try_get::<Vec<T>>` then returns `Err`, the `.ok().flatten()`
-    // collapses that to `None`, and a *whole-row NULL* gets written — silent
-    // data loss. The fix is to deserialize as `Vec<Option<T>>` so NULL inner
-    // elements survive into the Arrow `ListBuilder` via `append_null()`.
+    // PG arrays can legally contain NULL elements (`ARRAY[1, NULL, 3]`); the
+    // `Vec<Option<T>>` element type below carries those inner NULLs into the
+    // Arrow `ListBuilder`.
+    //
+    // But a decode ERROR must NOT be conflated with a NULL cell. The `postgres`
+    // crate's `Vec<Option<T>>` deserializer is ONE-DIMENSIONAL: a legal
+    // MULTI-dimensional value (`'{{1,2},{3,4}}'` — the OID `_int4` is shared by
+    // `integer[]` and `integer[][]`, so a 2-D value routes here) fails with
+    // "array contains too many dimensions". Swallowing that Err via
+    // `.ok().flatten()` wrote a WHOLE-CELL NULL — silent data loss the value-
+    // checksum can't catch (its side reads the same `try_get`). So match `Err`
+    // explicitly and FAIL LOUD, naming the fix (Arrow List is 1-D — cast to text).
     macro_rules! list_of {
         ($T:ty, $Builder:ty) => {{
             let mut lb = ListBuilder::new(<$Builder>::new());
             for row in rows {
-                match row
-                    .try_get::<_, Option<Vec<Option<$T>>>>(col_idx)
-                    .ok()
-                    .flatten()
-                {
-                    Some(v) => {
+                match row.try_get::<_, Option<Vec<Option<$T>>>>(col_idx) {
+                    Ok(Some(v)) => {
                         for x in &v {
                             match x {
                                 Some(val) => lb.values().append_value(*val),
@@ -898,7 +920,8 @@ fn build_pg_list_array(
                         }
                         lb.append(true);
                     }
-                    None => lb.append(false),
+                    Ok(None) => lb.append(false),
+                    Err(e) => return Err(pg_array_decode_error(rows, col_idx, &e)),
                 }
             }
             Ok(Arc::new(lb.finish()))
@@ -915,12 +938,8 @@ fn build_pg_list_array(
         DataType::Utf8 => {
             let mut lb = ListBuilder::new(StringBuilder::new());
             for row in rows {
-                match row
-                    .try_get::<_, Option<Vec<Option<String>>>>(col_idx)
-                    .ok()
-                    .flatten()
-                {
-                    Some(v) => {
+                match row.try_get::<_, Option<Vec<Option<String>>>>(col_idx) {
+                    Ok(Some(v)) => {
                         for s in &v {
                             match s {
                                 Some(val) => lb.values().append_value(val),
@@ -929,7 +948,8 @@ fn build_pg_list_array(
                         }
                         lb.append(true);
                     }
-                    None => lb.append(false),
+                    Ok(None) => lb.append(false),
+                    Err(e) => return Err(pg_array_decode_error(rows, col_idx, &e)),
                 }
             }
             Ok(Arc::new(lb.finish()))

--- a/src/source/postgres/cdc.rs
+++ b/src/source/postgres/cdc.rs
@@ -840,7 +840,17 @@ fn parse_pg_time_micros(val: &str) -> Option<i64> {
     let h: i64 = parts.next()?.parse().ok()?;
     let m: i64 = parts.next()?.parse().ok()?;
     let s: i64 = parts.next()?.parse().ok()?;
-    if parts.next().is_some() || !(0..24).contains(&h) {
+    // Range-validate EVERY field, not just the hour: `m`/`s` were parsed as
+    // unbounded i64, so an untrusted `12:9999999999999999:00` overflowed `m * 60`
+    // (fuzz-found panic, cdc.rs — a `panic=abort` DoS on the CDC stream). Bounding
+    // h∈0..24, m∈0..60, s∈0..60 both rejects a malformed time (→ None, handled by
+    // the caller) AND makes the arithmetic below unconditionally overflow-free
+    // (max 23*3600+59*60+59 = 86399, ×1e6 = 8.6e10, well within i64).
+    if parts.next().is_some()
+        || !(0..24).contains(&h)
+        || !(0..60).contains(&m)
+        || !(0..60).contains(&s)
+    {
         return None;
     }
     let us: i64 = if frac.is_empty() {
@@ -866,14 +876,17 @@ fn parse_pg_interval(val: &str) -> Option<(i32, i32, i64)> {
                 None => (1i64, tok),
             };
             let t = parse_pg_time_micros_unbounded(rest)?;
-            micros = sign * t;
+            micros = t.checked_mul(sign)?;
             continue;
         }
+        // Checked arithmetic on the untrusted count: `n` is an unbounded i32 from
+        // the wire, so `n * 12` (years→months) and the running accumulation could
+        // overflow — the same fuzz-found panic class as the time parsers above.
         let n: i32 = tok.parse().ok()?;
         match tokens.next()? {
-            u if u.starts_with("year") => months += n * 12,
-            u if u.starts_with("mon") => months += n,
-            u if u.starts_with("day") => days += n,
+            u if u.starts_with("year") => months = months.checked_add(n.checked_mul(12)?)?,
+            u if u.starts_with("mon") => months = months.checked_add(n)?,
+            u if u.starts_with("day") => days = days.checked_add(n)?,
             _ => return None,
         }
     }
@@ -899,7 +912,16 @@ fn parse_pg_time_micros_unbounded(val: &str) -> Option<i64> {
     } else {
         format!("{frac:0<6}").get(..6)?.parse().ok()?
     };
-    Some(((h * 3600 + m * 60 + s) * 1_000_000) + us)
+    // Interval time tails are genuinely unbounded (h may exceed 24: "25:00:00"), so
+    // the fields cannot be range-bounded like a time-of-day. Use CHECKED arithmetic
+    // instead — a value so large its microseconds overflow i64 cannot be
+    // represented, so return None (fail the parse) rather than panic=abort the
+    // stream. Same fuzz-found overflow class as parse_pg_time_micros.
+    let secs = h
+        .checked_mul(3600)?
+        .checked_add(m.checked_mul(60)?)?
+        .checked_add(s)?;
+    secs.checked_mul(1_000_000)?.checked_add(us)
 }
 
 /// Decode an even-length hex string to bytes; `None` on any non-hex input.
@@ -1412,6 +1434,36 @@ mod tests {
             "a full pre-image recovers the value → no poison: {:?}",
             ev.poison
         );
+    }
+
+    // Fuzz-found (nightly pg_test_decoding): an untrusted time/interval with an
+    // out-of-range or huge field overflowed the `* 1_000_000` / `n * 12` arithmetic
+    // → `attempt to multiply with overflow` → panic=abort DoS on the CDC stream.
+    // Every parser must now return None (reject the value), never panic.
+    #[test]
+    fn hostile_time_and_interval_text_never_panics_returns_none() {
+        // time-of-day: m/s out of 0..60 range is rejected before the multiply.
+        assert_eq!(parse_pg_time_micros("12:9999999999999999:00"), None);
+        assert_eq!(parse_pg_time_micros("12:00:9999999999999999"), None);
+        assert_eq!(parse_pg_time_micros("99:00:00"), None); // hour out of range too
+        // A valid time still parses.
+        assert_eq!(parse_pg_time_micros("01:02:03"), Some(3_723_000_000));
+        // Unbounded interval time tail: huge hours can't be range-bounded, so the
+        // checked arithmetic returns None instead of overflowing.
+        assert_eq!(
+            parse_pg_time_micros_unbounded("9999999999999999:00:00"),
+            None
+        );
+        assert_eq!(
+            parse_pg_time_micros_unbounded("25:00:00"),
+            Some(90_000_000_000)
+        ); // valid >24h
+        // Interval count overflow (years→months, and the running accumulation).
+        assert_eq!(parse_pg_interval("9999999999 years"), None);
+        assert_eq!(parse_pg_interval("2 years 3 mons 4 days"), Some((27, 4, 0)));
+        // And the top-level fuzz entry point must not panic on the hostile time.
+        let line = "table public.t: INSERT: id[integer]:1 t[time]:12:9999999999999999:00";
+        let _ = parse_test_decoding("0/ABC", line); // must not panic
     }
 
     // A genuine text value that happens to equal the marker is QUOTED on the

--- a/src/source/postgres/cdc.rs
+++ b/src/source/postgres/cdc.rs
@@ -465,9 +465,14 @@ pub(crate) fn parse_test_decoding(lsn: &str, data: &str) -> Result<Option<Change
     // glues them into one over-long image (the arity guard then bricks the
     // stream on a perfectly legal operation, permanently, with a misleading
     // "DDL" diagnosis). Split them: old-key → before, new-tuple → after.
+    // Split at the TOP-LEVEL ` new-tuple: ` — outside any quoted value. Finding
+    // #7: a quote-blind split_once matches the FIRST occurrence, so a text key
+    // whose value literally contains ` new-tuple: ` (e.g. `name[text]:'a new-tuple:
+    // b'`) is cut mid-value, garbling BOTH the before and after images.
+    const SEP: &str = " new-tuple: ";
     let (old_key_part, new_part) = match body.strip_prefix("old-key: ") {
-        Some(rest) => match rest.split_once(" new-tuple: ") {
-            Some((old, new)) => (Some(old), new),
+        Some(rest) => match find_outside_quotes(rest, SEP) {
+            Some(pos) => (Some(&rest[..pos]), &rest[pos + SEP.len()..]),
             None => (None, rest),
         },
         None => (None, body),
@@ -601,6 +606,39 @@ fn recover_unchanged_toast(
 }
 
 /// Parse one value at the start of `s`. Returns `(value, quoted, bytes_consumed)`.
+/// Find `needle` in `haystack` at the TOP LEVEL — outside any single-quoted
+/// value. test_decoding quotes text as `'…'` and doubles an embedded quote
+/// (`''`); the section separator ` new-tuple: ` can appear literally inside such
+/// a value, and a quote-blind `split_once` would cut there (finding #7). Mirrors
+/// [`parse_value`]'s `''`-aware quote scan. `needle` is ASCII (its lead byte
+/// `0x20` can never be a UTF-8 continuation/lead byte), so the byte scan never
+/// false-matches inside a multi-byte column name.
+fn find_outside_quotes(haystack: &str, needle: &str) -> Option<usize> {
+    let (b, nb) = (haystack.as_bytes(), needle.as_bytes());
+    let mut i = 0;
+    let mut in_quote = false;
+    while i < b.len() {
+        if in_quote {
+            if b[i] == b'\'' {
+                if b.get(i + 1) == Some(&b'\'') {
+                    i += 2; // doubled quote → an escaped literal quote
+                    continue;
+                }
+                in_quote = false;
+            }
+            i += 1;
+        } else if b[i] == b'\'' {
+            in_quote = true;
+            i += 1;
+        } else if b[i..].starts_with(nb) {
+            return Some(i);
+        } else {
+            i += 1;
+        }
+    }
+    None
+}
+
 fn parse_value(s: &str) -> (String, bool, usize) {
     let b = s.as_bytes();
     if b.first() != Some(&b'\'') {
@@ -1109,6 +1147,28 @@ mod tests {
             Some(vec![RivetValue::Int(1), RivetValue::Bytes(b"b".to_vec())])
         );
         assert_eq!(ev.before, None);
+    }
+
+    // Finding #7: the old-key/new-tuple split must be quote-aware. A text key
+    // whose value literally contains ` new-tuple: ` (a legal string) must NOT
+    // split the images there — a quote-blind split_once cut mid-value, garbling
+    // BOTH before and after. The real separator is the top-level one.
+    #[test]
+    fn pk_change_split_ignores_new_tuple_literal_inside_a_quoted_key() {
+        // The old key's text value contains the section-separator substring.
+        let line = "table public.t: UPDATE: old-key: k[text]:'a new-tuple: b' \
+                    new-tuple: k[text]:'c' v[integer]:9";
+        let ev = parse_test_decoding("0/ABC", line).unwrap().unwrap();
+        assert_eq!(
+            ev.before,
+            Some(vec![RivetValue::Bytes(b"a new-tuple: b".to_vec())]),
+            "the old key keeps its FULL text value, separator substring included"
+        );
+        assert_eq!(
+            ev.after,
+            Some(vec![RivetValue::Bytes(b"c".to_vec()), RivetValue::Int(9)]),
+            "the after-image is the real new tuple only, not cut mid-value"
+        );
     }
 
     // RED for finding #24 (non-UTC session): test_decoding renders timestamptz

--- a/src/source/postgres/cdc.rs
+++ b/src/source/postgres/cdc.rs
@@ -759,6 +759,16 @@ fn parse_pg_array_literal(inner_type: &str, val: &str) -> Option<Vec<RivetValue>
             } else {
                 break;
             }
+        } else if b.get(i) == Some(&b'{') {
+            // A top-level `{` where a scalar token is expected is a NESTED
+            // (multi-dimensional) array literal, e.g. `{{1,2},{3,4}}`. rivet's
+            // List column is one-dimensional and cannot hold it, so return None:
+            // the caller preserves the raw literal as text bytes and the sink
+            // fails LOUD (batch parity, src/source/postgres/arrow_convert.rs),
+            // never flattening it to a bogus flat array of NULLs. A `{` inside a
+            // quoted text element is handled by the quoted branch above, so this
+            // arm fires only on genuine nesting.
+            return None;
         } else {
             let end = body[i..].find(',').map(|p| i + p).unwrap_or(body.len());
             let tok = &body[i..end];
@@ -1223,6 +1233,43 @@ mod tests {
             ])
         );
         assert_eq!(after[2], RivetValue::Array(Vec::new()));
+    }
+
+    // Finding #6 (CDC sibling of the batch #5 multi-dim array fix): a nested /
+    // multi-dimensional array literal must NOT flatten into a bogus flat array
+    // of NULLs — rivet's List column is one-dimensional and cannot represent it.
+    // parse_pg_array_literal returns None on nesting so the caller keeps the raw
+    // literal as text bytes and the sink fails LOUD (batch parity), while a
+    // legitimate 1-D array still parses. RED against the pre-fix flatten:
+    // `{{1,2},{3,4}}` used to return Some([Null, Null, Null, Null]).
+    #[test]
+    fn multidim_array_literal_is_refused_not_flattened_to_bogus_nulls() {
+        // Nested integer / text arrays → None (unrepresentable, fail open to text).
+        assert_eq!(parse_pg_array_literal("integer", "{{1,2},{3,4}}"), None);
+        assert_eq!(parse_pg_array_literal("text", "{{a,b},{c,d}}"), None);
+        // A one-dimensional array is unaffected.
+        assert_eq!(
+            parse_pg_array_literal("integer", "{1,2,3}"),
+            Some(vec![
+                RivetValue::Int(1),
+                RivetValue::Int(2),
+                RivetValue::Int(3),
+            ])
+        );
+        // A `{` INSIDE a quoted text element is a literal brace, not nesting.
+        assert_eq!(
+            parse_pg_array_literal("text", "{\"{not nested}\"}"),
+            Some(vec![RivetValue::Bytes(b"{not nested}".to_vec())])
+        );
+        // The full test_decoding row keeps the raw literal (Bytes), never a
+        // flat Array of NULLs, so the sink can fail loud on it.
+        let line = "table public.t: INSERT: grid[integer[]]:'{{1,2},{3,4}}'";
+        let ev = parse_test_decoding("0/ABC", line).unwrap().unwrap();
+        assert_eq!(
+            ev.after.unwrap()[0],
+            RivetValue::Bytes(b"{{1,2},{3,4}}".to_vec()),
+            "multi-dim literal preserved as text, not flattened to Array([Null; 4])"
+        );
     }
 
     #[test]

--- a/src/source/postgres/cdc.rs
+++ b/src/source/postgres/cdc.rs
@@ -487,9 +487,14 @@ pub(crate) fn parse_test_decoding(lsn: &str, data: &str) -> Result<Option<Change
     // the pre-image (`old-key`), so recover it by name; otherwise the value is
     // genuinely unavailable and we must NOT write the literal marker as data
     // (silent corruption — same class as the uuid→null loss caught live on GCS).
+    // An unrecoverable unchanged-TOAST column is a refusal — but a DEFERRED one.
+    // The slot decodes every table in the database, so bailing here would poison
+    // capture of unrelated tables that merely share the slot. Record it as the
+    // event's `poison`; the sink raises it ONLY if this event routes to a captured
+    // table (uncaptured tables are dropped without ever surfacing it).
     let unrecovered = recover_unchanged_toast(&mut named, old_named.as_deref());
-    if !unrecovered.is_empty() {
-        anyhow::bail!(
+    let poison = (!unrecovered.is_empty()).then(|| {
+        format!(
             "pg cdc: {schema}.{table}: column(s) [{}] arrived as an unchanged-TOAST \
              datum with no pre-image value — logical decoding does not re-log an \
              externally stored value that an UPDATE leaves unchanged, so rivet cannot \
@@ -497,8 +502,8 @@ pub(crate) fn parse_test_decoding(lsn: &str, data: &str) -> Result<Option<Change
              as data. Capture the full pre-image so the value is preserved: \
              ALTER TABLE {schema}.{table} REPLICA IDENTITY FULL;",
             unrecovered.join(", ")
-        );
-    }
+        )
+    });
 
     let names: std::sync::Arc<[String]> = named.iter().map(|c| c.name.clone()).collect();
     let cols: Vec<RivetValue> = named.into_iter().map(|c| c.value).collect();
@@ -530,6 +535,7 @@ pub(crate) fn parse_test_decoding(lsn: &str, data: &str) -> Result<Option<Change
         // would not trigger a premature roll.
         committed: false,
         seq: 0, // stamped by TxnSeq as the stream is consumed
+        poison,
     }))
 }
 
@@ -1370,19 +1376,41 @@ mod tests {
     }
 
     // The DEFAULT replica-identity case: no pre-image value for the toasted
-    // column exists anywhere in the WAL, so the parser MUST fail loud (never
-    // fabricate the marker as data) and name the upstream fix.
+    // column exists anywhere in the WAL, so the parser must refuse to fabricate
+    // the marker as data — but as a DEFERRED `poison`, not an immediate bail. The
+    // slot decodes every table in the DB; bailing here would poison capture of
+    // unrelated tables sharing the slot (the parallel-CDC contamination that RED'd
+    // two live PG CDC tests off one un-captured DEFAULT-identity table). The sink
+    // raises the poison only when the event routes to a captured table.
     #[test]
-    fn unchanged_toast_without_pre_image_is_refused() {
+    fn unchanged_toast_without_pre_image_is_deferred_to_poison_not_an_immediate_bail() {
         let line = "table public.t: UPDATE: \
                     id[integer]:1 small[text]:'b' big[text]:unchanged-toast-datum";
-        let err = parse_test_decoding("0/ABC", line).unwrap_err();
-        let msg = format!("{err:#}");
+        let ev = parse_test_decoding("0/ABC", line)
+            .expect("must NOT bail — the refusal is deferred to the sink")
+            .expect("the event is still produced (for commit-boundary tracking)");
+        let msg = ev
+            .poison
+            .expect("an unrecoverable TOAST column must set poison");
         assert!(msg.contains("unchanged-TOAST"), "got: {msg}");
         assert!(msg.contains("big"), "must name the column, got: {msg}");
         assert!(
             msg.contains("REPLICA IDENTITY FULL"),
             "must name the upstream fix, got: {msg}"
+        );
+    }
+
+    // The clean case: a recoverable/absent TOAST column leaves `poison` None, so
+    // the sink never raises anything for this event.
+    #[test]
+    fn recoverable_toast_update_leaves_poison_none() {
+        let line = "table public.t: UPDATE: old-key: id[integer]:1 big[text]:'real' \
+                    new-tuple: id[integer]:1 small[text]:'b' big[text]:unchanged-toast-datum";
+        let ev = parse_test_decoding("0/ABC", line).unwrap().unwrap();
+        assert!(
+            ev.poison.is_none(),
+            "a full pre-image recovers the value → no poison: {:?}",
+            ev.poison
         );
     }
 

--- a/src/state/cursor.rs
+++ b/src/state/cursor.rs
@@ -125,6 +125,32 @@ impl StateStore {
         Ok(())
     }
 
+    /// Null ONLY the persisted keyset high-water mark (`last_cursor_value`),
+    /// leaving `resume_run_id` and the progression boundary intact.
+    ///
+    /// Crash-recovery-only (non-incremental) keyset needs this at the start of a
+    /// FRESH run: `last_cursor_value` is a run-independent persistent field, so a
+    /// prior COMPLETED run leaves its final high-water mark behind. If this fresh
+    /// run then crashes BEFORE its first page commits, the recovery run would load
+    /// that stale mark as this run's "resume point" and skip the whole table
+    /// (`WHERE key > <prior-max>` → 0 rows → a successful empty manifest). Clearing
+    /// it here ties crash-recovery to THIS run's committed progress only.
+    /// Incremental keyset deliberately does NOT clear it — continuing from the
+    /// prior high-water mark is the whole point of `keyset_incremental`.
+    pub fn clear_cursor_value(&self, export_name: &str) -> Result<()> {
+        let sql = "UPDATE export_state SET last_cursor_value = NULL WHERE export_name = ?1";
+        match &self.conn {
+            StateConn::Sqlite(c) => {
+                c.execute(sql, [export_name])?;
+            }
+            StateConn::Postgres(client) => {
+                let mut c = client.borrow_mut();
+                c.execute(&pg_sql(sql), &[&export_name])?;
+            }
+        }
+        Ok(())
+    }
+
     /// Return an export to a "never ran" state.
     ///
     /// Clears the incremental cursor (`export_state`) **and** the committed /
@@ -219,6 +245,27 @@ mod tests {
         s.update("orders", "100").unwrap();
         s.reset("orders").unwrap();
         assert!(s.get("orders").unwrap().last_cursor_value.is_none());
+    }
+
+    #[test]
+    fn clear_cursor_value_nulls_the_cursor_but_keeps_the_resume_run_id() {
+        // The keyset stale-cursor fix: a fresh non-incremental run must null the
+        // prior COMPLETED run's high-water mark so a pre-first-commit crash cannot
+        // resume from it (skipping the whole table) — WITHOUT dropping the fresh
+        // resume_run_id it is about to set (crash-recovery needs that).
+        let s = store();
+        s.update("orders", "9000000").unwrap();
+        s.set_resume_run_id("orders", "run_2").unwrap();
+        s.clear_cursor_value("orders").unwrap();
+        assert!(
+            s.get("orders").unwrap().last_cursor_value.is_none(),
+            "cursor must be nulled"
+        );
+        assert_eq!(
+            s.get_resume_run_id("orders").unwrap().as_deref(),
+            Some("run_2"),
+            "resume_run_id must survive"
+        );
     }
 
     #[test]

--- a/src/test_hook.rs
+++ b/src/test_hook.rs
@@ -21,6 +21,9 @@
 //! | `after_cursor_commit` | `single.rs` | `RIVET_TEST_PANIC_AT=after_cursor_commit` |
 //! | `after_chunk_file:{N}` | `chunked/mod.rs` (sequential & parallel checkpoint) | `RIVET_TEST_PANIC_AT=after_chunk_file:0` |
 //! | `after_chunk_complete:{N}` | `chunked/mod.rs` (sequential & parallel checkpoint) | `RIVET_TEST_PANIC_AT=after_chunk_complete:0` |
+//! | `after_keyset_page:{N}` | `keyset.rs` | `RIVET_TEST_PANIC_AT=after_keyset_page:0` |
+//! | `keyset_after_open_before_first_page` | `keyset.rs` (fresh run opened, no page committed — stale-cursor recovery guard) | `RIVET_TEST_PANIC_AT=keyset_after_open_before_first_page` |
+//! | `keyset_after_data_complete` | `keyset.rs` (all pages committed, resume anchor cleared — post-data-failure guard) | `RIVET_TEST_PANIC_AT=keyset_after_data_complete` |
 //!
 //! # Test usage
 //!

--- a/src/tuning/profile.rs
+++ b/src/tuning/profile.rs
@@ -263,7 +263,13 @@ impl SourceTuning {
                 batch_size_memory_mb: None,
                 throttle_ms: 500,
                 statement_timeout_s: 120,
-                max_retries: 5,
+                // Safe is the Production-environment default and the profile for
+                // long unattended exports over flaky links (SSH tunnels, VPNs). A
+                // reconnect-class blip can last tens of seconds, so retry patiently:
+                // 10 attempts with the capped backoff (5s,10s,20s,40s,60s×6) rides
+                // out a ~7 min outage instead of giving up in ~2.5 min. The cap
+                // (MAX_RETRY_BACKOFF_MS) is what makes a budget this large practical.
+                max_retries: 10,
                 retry_backoff_ms: 5_000,
                 lock_timeout_s: 10,
                 memory_threshold_mb: 2_048,
@@ -436,7 +442,7 @@ mod tests {
         assert_eq!(t.batch_size, 2_000);
         assert_eq!(t.throttle_ms, 500);
         assert_eq!(t.statement_timeout_s, 120);
-        assert_eq!(t.max_retries, 5);
+        assert_eq!(t.max_retries, 10);
         assert_eq!(t.retry_backoff_ms, 5_000);
         assert_eq!(t.lock_timeout_s, 10);
     }
@@ -457,7 +463,7 @@ mod tests {
             "non-overridden field stays at safe default"
         );
         assert_eq!(
-            t.max_retries, 5,
+            t.max_retries, 10,
             "non-overridden field stays at safe default"
         );
     }

--- a/tests/common/parquet.rs
+++ b/tests/common/parquet.rs
@@ -173,6 +173,22 @@ pub fn dir_manifest_copy_total_rows(dir: &Path) -> i64 {
     total
 }
 
+/// Count the DISTINCT run-unique manifest copies (`manifest-<run_id>.json`) in
+/// `dir` — one per run_id. Two runs into the same prefix that each rotate their
+/// run_id leave two files; a run that reuses (freezes) a prior run_id overwrites
+/// the same filename, leaving one. The oracle for "the run_id rotates across
+/// repeated runs" (a frozen run_id collapses the sidecars and a run_id-deduping
+/// loader then skips later deltas). Ignores the canonical `manifest.json` pointer.
+pub fn dir_manifest_copy_count(dir: &Path) -> usize {
+    files_with_extension(dir, "json")
+        .into_iter()
+        .filter(|p| {
+            let name = p.file_name().unwrap_or_default().to_string_lossy();
+            name.starts_with("manifest-") && name.ends_with(".json")
+        })
+        .count()
+}
+
 /// True if any `.parquet` under `dir` carries a column named `col`.
 pub fn dir_parquet_has_column(dir: &Path, col: &str) -> bool {
     files_with_extension(dir, "parquet").iter().any(|p| {

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -4271,7 +4271,8 @@ fn mysql_cdc_typed_values_match_source_via_duckdb_not_batch() {
     c.query_drop(format!("DROP TABLE IF EXISTS {tbl}")).unwrap();
     c.query_drop(format!(
         "CREATE TABLE {tbl} (id INT PRIMARY KEY, amount DECIMAL(18,4), \
-         en ENUM('active','shipped','off'), big BIGINT UNSIGNED)"
+         en ENUM('active','shipped','off'), big BIGINT UNSIGNED, \
+         note VARCHAR(20), d DATE, vb VARBINARY(4))"
     ))
     .unwrap();
     let _guard = Table(tbl.clone());
@@ -4281,17 +4282,19 @@ fn mysql_cdc_typed_values_match_source_via_duckdb_not_batch() {
     let rig = Rig::mysql_cdc(&tbl).dest_path(host_dir.clone());
     rig.run_ok();
     c.query_drop(format!(
-        "INSERT INTO {tbl} VALUES (1, 12345.6789, 'off', 18000000000000000000)"
+        "INSERT INTO {tbl} VALUES (1, 12345.6789, 'off', 18000000000000000000, \
+         'hello', '2024-03-15', 0xDEADBEEF)"
     ))
     .unwrap();
     rig.run_ok();
 
     // DuckDB re-reads the __changes parquet and compares each value to the SOURCE
-    // literal — independent of any rivet re-decode. A single boolean: true iff the
-    // decimal, the ENUM LABEL (not the index 3), and the unsigned-64 (> i64::MAX)
-    // all survived the change stream exactly.
+    // literal — independent of any rivet re-decode. A single boolean, true iff the
+    // decimal, the ENUM LABEL (not index 3), the unsigned-64 (> i64::MAX), the text,
+    // the date, and the binary (hex) all survived the change stream exactly.
     let res = duckdb_run_sql_json(&format!(
         "SELECT (amount = 12345.6789) AND (en = 'off') AND (big = 18000000000000000000) \
+         AND (note = 'hello') AND (d = DATE '2024-03-15') AND (lower(to_hex(vb)) = 'deadbeef') \
          FROM read_parquet('{container_dir}/cdc-*.parquet') WHERE id = 1"
     ));
     let rows = res["rows"].as_array().expect("duckdb rows");
@@ -4327,7 +4330,8 @@ fn pg_cdc_typed_values_match_source_via_duckdb_not_batch() {
     c.batch_execute(&format!(
         "CREATE TYPE {tbl}_status AS ENUM ('active','shipped','off'); \
          CREATE TABLE {tbl} (id INT PRIMARY KEY, amount NUMERIC(18,4), \
-         status {tbl}_status, note TEXT, big BIGINT, flag BOOLEAN)"
+         status {tbl}_status, note TEXT, big BIGINT, flag BOOLEAN, \
+         fl DOUBLE PRECISION, d DATE, rb BYTEA)"
     ))
     .unwrap();
 
@@ -4336,7 +4340,10 @@ fn pg_cdc_typed_values_match_source_via_duckdb_not_batch() {
         .dest_path(host_dir.clone());
     rig.run_ok(); // anchor (creates the slot)
     c.execute(
-        &format!("INSERT INTO {tbl} VALUES (1, 12345.6789, 'off', 'hello', 9000000000000, true)"),
+        &format!(
+            "INSERT INTO {tbl} VALUES (1, 12345.6789, 'off', 'hello', 9000000000000, true, \
+             1.5, '2024-03-15', '\\xDEADBEEF')"
+        ),
         &[],
     )
     .unwrap();
@@ -4344,7 +4351,8 @@ fn pg_cdc_typed_values_match_source_via_duckdb_not_batch() {
 
     let res = duckdb_run_sql_json(&format!(
         "SELECT (amount = 12345.6789) AND (status = 'off') AND (note = 'hello') \
-         AND (big = 9000000000000) AND (flag = true) \
+         AND (big = 9000000000000) AND (flag = true) AND (fl = 1.5) \
+         AND (d = DATE '2024-03-15') AND (lower(to_hex(rb)) = 'deadbeef') \
          FROM read_parquet('{container_dir}/cdc-*.parquet') WHERE id = 1"
     ));
     let rows = res["rows"].as_array().expect("duckdb rows");

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -1726,8 +1726,12 @@ exports:
 
     let snap = out.join("snapshot");
     let snap_cols: Vec<String> = parquet_fields(&snap).into_iter().map(|(n, _)| n).collect();
+    // The meta columns are `_rivet_exported_at` / `_rivet_row_hash` (SINGLE
+    // underscore, src/enrich.rs) — a `__rivet` (double) check silently never
+    // matched, so this assertion was VACUOUS (green even if the leg leaked them).
+    // Caught while RED-proving the sibling cdc→warehouse DuckDB-load test.
     assert!(
-        !snap_cols.iter().any(|c| c.starts_with("__rivet")),
+        !snap_cols.iter().any(|c| c.starts_with("_rivet")),
         "snapshot leg must NOT carry batch meta columns (load parity with the CDC \
          stream's __changes append); got {snap_cols:?}"
     );
@@ -4121,5 +4125,130 @@ fn cdc_cross_database_enum_enriches_from_the_tables_own_schema() {
         "off",
         "a cross-database ENUM must enrich to its LABEL from the table's own schema, \
          not the connection's default DATABASE()"
+    );
+}
+
+/// Closes the CDC/incremental → warehouse LOAD quadrant (the coverage-audit HIGH
+/// blind spot: every load suite sourced `mode: full` parquet, so no test ever
+/// LOADED rivet's CDC `__changes` output). DuckDB is the independent-reader proxy
+/// for the warehouse load: `read_parquet(union_by_name=true)` over BOTH the
+/// `initial: snapshot` leg AND the CDC change leg mimics the loader's
+/// declared-schema LOAD-by-name into one `<table>__changes` table (snapshot rows
+/// get `__op`/`__pos`/`__seq` = NULL). It is the exact `fda1653` class: a
+/// snapshot leg that KEPT its batch `meta_columns` would leak a column the CDC
+/// stream lacks — silent under count/sum checks, breaks the warehouse load one
+/// layer up. The current-state dedup is then verified against the SOURCE's actual
+/// rows (an independent oracle, not rivet's own output).
+#[test]
+#[ignore = "live: requires docker compose --profile cdc mysql-cdc + duckdb"]
+fn cdc_changes_parquet_loads_into_a_warehouse_and_dedups_to_current_state() {
+    let d = tempfile::tempdir().unwrap();
+    let (host_dir, container_dir) = duckdb_shared_workdir(&unique_name("cdc_load"));
+    let tbl = unique_name("cdc_load");
+    let mut c = conn();
+    c.query_drop(format!("DROP TABLE IF EXISTS {tbl}")).unwrap();
+    c.query_drop(format!("CREATE TABLE {tbl} (id INT PRIMARY KEY, v INT)"))
+        .unwrap();
+    let _guard = Table(tbl.clone());
+    // Pre-snapshot rows — the initial:snapshot backfill leg.
+    c.query_drop(format!("INSERT INTO {tbl} VALUES (1,10),(2,20)"))
+        .unwrap();
+
+    let ckpt = d.path().join("cdc.ckpt");
+    // meta_columns are REQUESTED: the fda1653 trap. They must be dropped from the
+    // snapshot leg so both legs' data columns match in the shared __changes append.
+    let yaml = format!(
+        r#"source: {{type: mysql, url: "{MYSQL_CDC_URL}"}}
+exports:
+  - name: {tbl}
+    table: {tbl}
+    mode: cdc
+    format: parquet
+    meta_columns: {{ exported_at: true, row_hash: true }}
+    cdc: {{ initial: snapshot, checkpoint: "{ckpt}", until_current: true, server_id: {sid} }}
+    destination: {{ type: local, path: "{out}" }}
+"#,
+        ckpt = ckpt.display(),
+        out = host_dir.display(),
+        sid = server_id_for(&tbl),
+    );
+    let cfg = write_config(&d, &yaml);
+    run_rivet_ok(&cfg); // snapshot leg → host_dir/snapshot/*.parquet
+
+    // Post-snapshot changes: an UPDATE (dedup must pick the new value over the
+    // snapshot baseline) and an INSERT (a PK present ONLY in the change leg).
+    c.query_drop(format!("UPDATE {tbl} SET v = 100 WHERE id = 1"))
+        .unwrap();
+    c.query_drop(format!("INSERT INTO {tbl} VALUES (3,30)"))
+        .unwrap();
+    run_rivet_ok(&cfg); // CDC leg → host_dir/cdc-*.parquet
+
+    // DuckDB = the independent warehouse-load proxy. union_by_name mimics the
+    // loader's declared-schema LOAD-by-name (snapshot's missing __op/__pos/__seq
+    // become NULL). A LIST of globs unions the two legs into one __changes table.
+    let changes = format!(
+        "read_parquet(['{c}/snapshot/*.parquet','{c}/cdc-*.parquet'], union_by_name=true)",
+        c = container_dir,
+    );
+
+    // (1) LOADABILITY / fda1653: the unioned __changes carries EXACTLY the three
+    //     meta columns + the source data columns — NO leaked batch meta_column
+    //     from the snapshot leg (which would break a real warehouse load).
+    let desc = duckdb_run_sql_json(&format!("DESCRIBE SELECT * FROM {changes}"));
+    let cols = duckdb_parse_describe(&desc);
+    // The unioned __changes must be EXACTLY {__op, __pos, __seq} + the source data
+    // columns — any other column is a leaked snapshot-leg meta_column. The meta
+    // columns are `_rivet_exported_at` / `_rivet_row_hash` (SINGLE underscore, see
+    // src/enrich.rs) — a `__rivet` (double) check silently never matches and is
+    // vacuous (which is exactly how the sibling snapshot-parity test's assertion
+    // reads today). Assert the whole set instead of a prefix so any leak is caught.
+    let mut got_cols: Vec<String> = cols.keys().cloned().collect();
+    got_cols.sort();
+    assert_eq!(
+        got_cols,
+        vec![
+            "__op".to_string(),
+            "__pos".to_string(),
+            "__seq".to_string(),
+            "id".to_string(),
+            "v".to_string(),
+        ],
+        "the unioned __changes must carry EXACTLY the 3 meta columns + the source \
+         data columns; an extra column is a leaked snapshot-leg meta_column (fda1653 \
+         — breaks the warehouse load, silent under count/sum checks)"
+    );
+
+    // (2) CURRENT-STATE: an INDEPENDENT dedup (latest change per PK wins; the
+    //     snapshot baseline has __pos NULL = oldest) reconstructs current state.
+    //     The oracle is the SOURCE's actual rows {1:100, 2:20, 3:30}.
+    let sql = format!(
+        "SELECT id, v FROM (
+           SELECT id, v, ROW_NUMBER() OVER (
+             PARTITION BY id ORDER BY (__pos IS NOT NULL) DESC, __seq DESC
+           ) AS rn FROM {changes}
+         ) WHERE rn = 1 ORDER BY id"
+    );
+    let res = duckdb_run_sql_json(&sql);
+    let got: Vec<(String, String)> = res["rows"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| {
+            let a = r.as_array().unwrap();
+            (
+                a[0].as_str().unwrap().to_string(),
+                a[1].as_str().unwrap().to_string(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        got,
+        vec![
+            ("1".into(), "100".into()),
+            ("2".into(), "20".into()),
+            ("3".into(), "30".into()),
+        ],
+        "CDC __changes must LOAD (both legs into one table) and DEDUP to the source's \
+         current state — id=1 updated to 100, id=2 unchanged, id=3 insert-only"
     );
 }

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -4252,3 +4252,60 @@ exports:
          current state — id=1 updated to 100, id=2 unchanged, id=3 insert-only"
     );
 }
+
+/// Independent CDC per-type oracle (option A's real upgrade, via the canonical
+/// Rig): the workhorse `*_cdc_full_type_matrix_matches_batch` cells are a
+/// DIFFERENTIAL self-oracle — they compare CDC's decode to BATCH's decode, so a
+/// bug SHARED by both (both agree on a wrong value) passes, exactly the class the
+/// value-checksum Form A also misses. This reads the CDC `__changes` parquet with
+/// DuckDB — a reader OUTSIDE rivet's decode family — and asserts each typed value
+/// equals the SOURCE literal, not a batch re-decode. A shared-decode corruption
+/// (enum index instead of label, an unsigned mangle, a decimal float) is caught
+/// here where matches_batch cannot see it.
+#[test]
+#[ignore = "live: requires docker compose --profile cdc mysql-cdc + duckdb"]
+fn mysql_cdc_typed_values_match_source_via_duckdb_not_batch() {
+    let (host_dir, container_dir) = duckdb_shared_workdir(&unique_name("cdc_typed"));
+    let tbl = unique_name("cdc_typed");
+    let mut c = conn();
+    c.query_drop(format!("DROP TABLE IF EXISTS {tbl}")).unwrap();
+    c.query_drop(format!(
+        "CREATE TABLE {tbl} (id INT PRIMARY KEY, amount DECIMAL(18,4), \
+         en ENUM('active','shipped','off'), big BIGINT UNSIGNED)"
+    ))
+    .unwrap();
+    let _guard = Table(tbl.clone());
+
+    // Canonical Rig CDC (until_current + default checkpoint): anchor over the empty
+    // table, then capture the typed insert on the second run.
+    let rig = Rig::mysql_cdc(&tbl).dest_path(host_dir.clone());
+    rig.run_ok();
+    c.query_drop(format!(
+        "INSERT INTO {tbl} VALUES (1, 12345.6789, 'off', 18000000000000000000)"
+    ))
+    .unwrap();
+    rig.run_ok();
+
+    // DuckDB re-reads the __changes parquet and compares each value to the SOURCE
+    // literal — independent of any rivet re-decode. A single boolean: true iff the
+    // decimal, the ENUM LABEL (not the index 3), and the unsigned-64 (> i64::MAX)
+    // all survived the change stream exactly.
+    let res = duckdb_run_sql_json(&format!(
+        "SELECT (amount = 12345.6789) AND (en = 'off') AND (big = 18000000000000000000) \
+         FROM read_parquet('{container_dir}/cdc-*.parquet') WHERE id = 1"
+    ));
+    let rows = res["rows"].as_array().expect("duckdb rows");
+    assert_eq!(
+        rows.len(),
+        1,
+        "exactly one captured change for id=1; got: {res}"
+    );
+    assert!(
+        rows[0][0]
+            .as_str()
+            .is_some_and(|s| s.eq_ignore_ascii_case("true")),
+        "CDC-decoded typed values must equal the SOURCE literals read back by DuckDB \
+         (independent of batch): decimal 12345.6789, ENUM LABEL 'off' (not index 3), \
+         unsigned 18000000000000000000 (> i64::MAX). A shared decode bug shows here; got: {res}"
+    );
+}

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -4272,7 +4272,7 @@ fn mysql_cdc_typed_values_match_source_via_duckdb_not_batch() {
     c.query_drop(format!(
         "CREATE TABLE {tbl} (id INT PRIMARY KEY, amount DECIMAL(18,4), \
          en ENUM('active','shipped','off'), big BIGINT UNSIGNED, \
-         note VARCHAR(20), d DATE, vb VARBINARY(4))"
+         note VARCHAR(20), d DATE, vb VARBINARY(4), uid CHAR(36))"
     ))
     .unwrap();
     let _guard = Table(tbl.clone());
@@ -4283,7 +4283,7 @@ fn mysql_cdc_typed_values_match_source_via_duckdb_not_batch() {
     rig.run_ok();
     c.query_drop(format!(
         "INSERT INTO {tbl} VALUES (1, 12345.6789, 'off', 18000000000000000000, \
-         'hello', '2024-03-15', 0xDEADBEEF)"
+         'hello', '2024-03-15', 0xDEADBEEF, '12345678-1234-1234-1234-123456789012')"
     ))
     .unwrap();
     rig.run_ok();
@@ -4295,6 +4295,7 @@ fn mysql_cdc_typed_values_match_source_via_duckdb_not_batch() {
     let res = duckdb_run_sql_json(&format!(
         "SELECT (amount = 12345.6789) AND (en = 'off') AND (big = 18000000000000000000) \
          AND (note = 'hello') AND (d = DATE '2024-03-15') AND (lower(to_hex(vb)) = 'deadbeef') \
+         AND (uid = '12345678-1234-1234-1234-123456789012') \
          FROM read_parquet('{container_dir}/cdc-*.parquet') WHERE id = 1"
     ));
     let rows = res["rows"].as_array().expect("duckdb rows");

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -4309,3 +4309,52 @@ fn mysql_cdc_typed_values_match_source_via_duckdb_not_batch() {
          unsigned 18000000000000000000 (> i64::MAX). A shared decode bug shows here; got: {res}"
     );
 }
+
+/// PG sibling of `mysql_cdc_typed_values_match_source_via_duckdb_not_batch`: the
+/// independent CDC per-type oracle for PostgreSQL. CDC via `Rig::pg_cdc`, the
+/// `__changes` parquet re-read by DuckDB (outside rivet's decode family), each
+/// value asserted vs the SOURCE literal — catching a shared-decode bug (enum
+/// index vs label, a numeric misparse) that the batch-differential misses.
+/// Isolated in its own database (`CdcDb`) so the slot sees only this test's WAL.
+#[test]
+#[ignore = "live: requires docker compose postgres-cdc (wal_level=logical) + duckdb"]
+fn pg_cdc_typed_values_match_source_via_duckdb_not_batch() {
+    let cdc_db = CdcDb::new("cdc_typed_pg");
+    let (host_dir, container_dir) = duckdb_shared_workdir(&unique_name("cdc_typed_pg"));
+    let tbl = unique_name("rivet_cdc_typed").to_lowercase();
+    let slot = unique_name("rivet_typed_slot").to_lowercase();
+    let mut c = cdc_db.connect();
+    c.batch_execute(&format!(
+        "CREATE TYPE {tbl}_status AS ENUM ('active','shipped','off'); \
+         CREATE TABLE {tbl} (id INT PRIMARY KEY, amount NUMERIC(18,4), \
+         status {tbl}_status, note TEXT, big BIGINT, flag BOOLEAN)"
+    ))
+    .unwrap();
+
+    let rig = Rig::pg_cdc(&tbl, &slot)
+        .source_url(cdc_db.url())
+        .dest_path(host_dir.clone());
+    rig.run_ok(); // anchor (creates the slot)
+    c.execute(
+        &format!("INSERT INTO {tbl} VALUES (1, 12345.6789, 'off', 'hello', 9000000000000, true)"),
+        &[],
+    )
+    .unwrap();
+    rig.run_ok(); // capture
+
+    let res = duckdb_run_sql_json(&format!(
+        "SELECT (amount = 12345.6789) AND (status = 'off') AND (note = 'hello') \
+         AND (big = 9000000000000) AND (flag = true) \
+         FROM read_parquet('{container_dir}/cdc-*.parquet') WHERE id = 1"
+    ));
+    let rows = res["rows"].as_array().expect("duckdb rows");
+    assert_eq!(rows.len(), 1, "one captured change for id=1; got: {res}");
+    assert!(
+        rows[0][0]
+            .as_str()
+            .is_some_and(|s| s.eq_ignore_ascii_case("true")),
+        "PG CDC typed values must equal the SOURCE literals via DuckDB (independent of \
+         batch): numeric 12345.6789, enum LABEL 'off' (not an index), text, bigint, bool; \
+         got: {res}"
+    );
+}

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -4272,7 +4272,8 @@ fn mysql_cdc_typed_values_match_source_via_duckdb_not_batch() {
     c.query_drop(format!(
         "CREATE TABLE {tbl} (id INT PRIMARY KEY, amount DECIMAL(18,4), \
          en ENUM('active','shipped','off'), big BIGINT UNSIGNED, \
-         note VARCHAR(20), d DATE, vb VARBINARY(4), uid CHAR(36))"
+         note VARCHAR(20), d DATE, vb VARBINARY(4), uid CHAR(36), \
+         fl DOUBLE, st SET('a','b','c'), flag BOOLEAN, j JSON)"
     ))
     .unwrap();
     let _guard = Table(tbl.clone());
@@ -4283,7 +4284,8 @@ fn mysql_cdc_typed_values_match_source_via_duckdb_not_batch() {
     rig.run_ok();
     c.query_drop(format!(
         "INSERT INTO {tbl} VALUES (1, 12345.6789, 'off', 18000000000000000000, \
-         'hello', '2024-03-15', 0xDEADBEEF, '12345678-1234-1234-1234-123456789012')"
+         'hello', '2024-03-15', 0xDEADBEEF, '12345678-1234-1234-1234-123456789012', \
+         1.5, 'a,b', 1, '{{\"k\": \"v\", \"n\": 42}}')"
     ))
     .unwrap();
     rig.run_ok();
@@ -4296,6 +4298,8 @@ fn mysql_cdc_typed_values_match_source_via_duckdb_not_batch() {
         "SELECT (amount = 12345.6789) AND (en = 'off') AND (big = 18000000000000000000) \
          AND (note = 'hello') AND (d = DATE '2024-03-15') AND (lower(to_hex(vb)) = 'deadbeef') \
          AND (uid = '12345678-1234-1234-1234-123456789012') \
+         AND (fl = 1.5) AND (st = 'a,b') AND (CAST(flag AS INTEGER) = 1) \
+         AND (json_extract_string(j, 'k') = 'v') AND (CAST(json_extract(j, 'n') AS INTEGER) = 42) \
          FROM read_parquet('{container_dir}/cdc-*.parquet') WHERE id = 1"
     ));
     let rows = res["rows"].as_array().expect("duckdb rows");
@@ -4332,7 +4336,7 @@ fn pg_cdc_typed_values_match_source_via_duckdb_not_batch() {
         "CREATE TYPE {tbl}_status AS ENUM ('active','shipped','off'); \
          CREATE TABLE {tbl} (id INT PRIMARY KEY, amount NUMERIC(18,4), \
          status {tbl}_status, note TEXT, big BIGINT, flag BOOLEAN, \
-         fl DOUBLE PRECISION, d DATE, rb BYTEA)"
+         fl DOUBLE PRECISION, d DATE, rb BYTEA, uid UUID, iv INTERVAL, j JSONB)"
     ))
     .unwrap();
 
@@ -4343,7 +4347,9 @@ fn pg_cdc_typed_values_match_source_via_duckdb_not_batch() {
     c.execute(
         &format!(
             "INSERT INTO {tbl} VALUES (1, 12345.6789, 'off', 'hello', 9000000000000, true, \
-             1.5, '2024-03-15', '\\xDEADBEEF')"
+             1.5, '2024-03-15', '\\xDEADBEEF', \
+             '12345678-1234-1234-1234-123456789012', INTERVAL '1 year 2 mons 3 days', \
+             '{{\"k\": \"v\", \"n\": 42}}')"
         ),
         &[],
     )
@@ -4354,6 +4360,8 @@ fn pg_cdc_typed_values_match_source_via_duckdb_not_batch() {
         "SELECT (amount = 12345.6789) AND (status = 'off') AND (note = 'hello') \
          AND (big = 9000000000000) AND (flag = true) AND (fl = 1.5) \
          AND (d = DATE '2024-03-15') AND (lower(to_hex(rb)) = 'deadbeef') \
+         AND (lower(CAST(uid AS VARCHAR)) = '12345678-1234-1234-1234-123456789012') \
+         AND (iv = 'P1Y2M3D') \
          FROM read_parquet('{container_dir}/cdc-*.parquet') WHERE id = 1"
     ));
     let rows = res["rows"].as_array().expect("duckdb rows");

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -4058,3 +4058,68 @@ fn roast_pg_cdc_bounded_on_a_standby_fails_loud() {
          leaked a WAL-pinning slot instead of failing fast"
     );
 }
+
+/// Finding #3: MySQL CDC enriches ENUM/SET labels from information_schema.COLUMNS.
+/// The old query pinned `TABLE_SCHEMA = DATABASE()` and dropped any `db.`
+/// qualifier, so a CROSS-DATABASE capture — a table in a database OTHER than the
+/// connection's default (`rivet`) — enriched NOTHING and every ENUM exported as
+/// its raw integer index (a SET as its bitmask), silently. Capture a qualified
+/// `otherdb.orders` and assert the ENUM lands as its LABEL, from the table's own
+/// schema. RED before the fix: the wire index ('3') leaked through instead of 'off'.
+#[test]
+#[ignore = "live: requires docker compose --profile cdc mysql-cdc"]
+fn cdc_cross_database_enum_enriches_from_the_tables_own_schema() {
+    let d = tempfile::tempdir().unwrap();
+    let dbname = unique_name("rivet_xdb").to_lowercase();
+    let qualified = format!("{dbname}.orders");
+
+    // A SECOND database (NOT the connection's default `rivet`) created via root,
+    // with a SELECT grant so the rivet user can read the table + its catalog.
+    let root_url = MYSQL_CDC_URL.replace("rivet:rivet@", "root:rivet@");
+    let mut admin = mysql::Conn::new(mysql::Opts::from_url(&root_url).unwrap()).unwrap();
+    admin
+        .query_drop(format!("CREATE DATABASE {dbname}"))
+        .expect("create cross db");
+    // Drop guard: tear the whole database down even if the test panics.
+    struct DbGuard(String, String);
+    impl Drop for DbGuard {
+        fn drop(&mut self) {
+            if let Ok(mut c) = mysql::Conn::new(mysql::Opts::from_url(&self.1).unwrap()) {
+                let _ = c.query_drop(format!("DROP DATABASE IF EXISTS {}", self.0));
+            }
+        }
+    }
+    let _guard = DbGuard(dbname.clone(), root_url.clone());
+    admin
+        .query_drop(format!(
+            "CREATE TABLE {dbname}.orders \
+             (id INT PRIMARY KEY, status ENUM('active','shipped','off'))"
+        ))
+        .expect("create cross-db table");
+    admin
+        .query_drop(format!("GRANT SELECT ON {dbname}.* TO 'rivet'@'%'"))
+        .expect("grant select");
+    admin.query_drop("FLUSH PRIVILEGES").unwrap();
+
+    let out = d.path().join("out");
+    let ckpt = d.path().join("cdc.ckpt");
+    std::fs::create_dir_all(&out).unwrap();
+    let cfg = cdc_config(&d, &qualified, &ckpt, &out);
+
+    run_rivet_ok(&cfg); // anchor at the current binlog position
+    admin
+        .query_drop(format!("INSERT INTO {dbname}.orders VALUES (1, 'off')"))
+        .expect("insert enum row");
+    run_rivet_ok(&cfg); // capture the change
+
+    // 'off' is the 3rd ENUM label; the binlog delivers the INDEX (3). Only the
+    // information_schema enrichment — from the table's OWN schema — turns it back
+    // into the label. Pre-fix, cross-db enrichment silently failed and the index
+    // leaked through as text.
+    assert_eq!(
+        parquet_one_string(&out, "status"),
+        "off",
+        "a cross-database ENUM must enrich to its LABEL from the table's own schema, \
+         not the connection's default DATABASE()"
+    );
+}

--- a/tests/live/live_cdc_mongo.rs
+++ b/tests/live/live_cdc_mongo.rs
@@ -541,3 +541,82 @@ fn roast_checkpoint_advances_on_uncaptured_only_traffic() {
         "the checkpoint must advance past uncaptured-only traffic, not stall"
     );
 }
+
+/// Audit blind cell (Mongo CDC per-type value fidelity): the only prior CDC
+/// update/delete test seeds plain STRINGS, so a change-stream relaxed-vs-canonical
+/// extJSON drift, or a Decimal128 rounding, on the OP PATH — distinct from the
+/// batch verbatim rendering that `mongo_batch_type_fidelity_document_is_verbatim_
+/// extjson` pins — was un-oracled. Insert a tricky-typed doc WHILE CDC captures it,
+/// then UPDATE it (the change-stream UpdateLookup post-image goes through the same
+/// rendering), and assert every captured `document` carries the SAME verbatim
+/// extJSON the batch oracle requires: a large Int64 > 2^53, a Decimal128, nested
+/// unicode. This is the independent oracle Mongo has no Form A for (the document
+/// is a verbatim blob).
+#[test]
+#[ignore = "live: requires docker compose up -d mongo-rs"]
+fn mongo_cdc_change_stream_renders_tricky_bson_verbatim_like_batch() {
+    require_alive(LiveService::MongoRs);
+    use mongodb::bson::{Bson, doc};
+    let db = unique_name("cdc_types");
+    let m = MongoTest::connect(PORT, &db);
+    m.drop_collection("t");
+
+    let rig = cdc(&db, "t");
+    rig.run_ok(); // anchor over the empty collection (idle first run)
+
+    // Tricky-typed doc inserted AFTER the anchor, so the change stream carries it.
+    m.insert_many(
+        "t",
+        vec![doc! {
+            "_id": 1_i64,
+            "i64_big": 9_007_199_254_740_993_i64, // 2^53 + 1 — an f64 parser would round it
+            "dec": Bson::Decimal128("123456789.987654321012345".parse().unwrap()),
+            "nested": doc! { "k": "v-\u{00e9}\u{4e2d}", "arr": [1_i32, 2_i32, 3_i32] },
+        }],
+    );
+    // Update it too — the UpdateLookup post-image returns the WHOLE doc, so its
+    // rendering of the tricky types is the specific op-path concern.
+    m.upsert_set("t", 1, "note", "changed");
+    rig.run_ok(); // capture insert + update
+
+    let changes = read_mongo_cdc_changes(&rig.out_dir());
+    let with_doc: Vec<&MongoCdcChange> = changes
+        .iter()
+        .filter(|c| c.document.contains("i64_big"))
+        .collect();
+    assert!(
+        !with_doc.is_empty(),
+        "the change stream must capture at least one post-image carrying the tricky \
+         document; captured {} change(s)",
+        changes.len()
+    );
+    // The independent oracle: the SAME relaxed extended JSON the test renders with
+    // the bson library directly (NOT rivet's document_to_json). The CDC op path
+    // must not DRIFT from this default relaxed rendering (the audit's exact
+    // concern) — so the large Int64 stays a bare, verbatim number, never the
+    // canonical `$numberLong` a drifted op path would emit.
+    for ch in with_doc {
+        assert!(
+            ch.document.contains("9007199254740993") && !ch.document.contains("$numberLong"),
+            "large Int64 must render VERBATIM as the default relaxed bare number in the CDC \
+             document (op '{}') — a canonical/relaxed DRIFT on the op path (or f64 rounding) \
+             corrupts it; got: {}",
+            ch.op,
+            ch.document
+        );
+        assert!(
+            ch.document.contains("123456789.987654321012345")
+                && ch.document.contains("$numberDecimal"),
+            "Decimal128 must be VERBATIM + type-tagged (`$numberDecimal`) in the CDC document \
+             (op '{}'); got: {}",
+            ch.op,
+            ch.document
+        );
+        assert!(
+            ch.document.contains("v-\u{00e9}\u{4e2d}") && ch.document.contains("arr"),
+            "nested unicode + array must be VERBATIM in the CDC document (op '{}'); got: {}",
+            ch.op,
+            ch.document
+        );
+    }
+}

--- a/tests/live/live_cdc_mssql.rs
+++ b/tests/live/live_cdc_mssql.rs
@@ -1279,7 +1279,8 @@ fn mssql_cdc_typed_values_match_source_via_duckdb_not_batch() {
     mssql_cdc_drop_table(&format!("dbo.{table}"));
     mssql_cdc_exec(&format!(
         "CREATE TABLE dbo.{table} (id INT PRIMARY KEY, big BIGINT, amount DECIMAL(18,4), \
-         label VARCHAR(50), d DATE, vb VARBINARY(4), m MONEY)"
+         label VARCHAR(50), d DATE, vb VARBINARY(4), m MONEY, \
+         fl FLOAT, bt BIT, u UNIQUEIDENTIFIER)"
     ));
     enable_cdc(&table, &ci);
     let _guard = MssqlCdcTable {
@@ -1289,7 +1290,8 @@ fn mssql_cdc_typed_values_match_source_via_duckdb_not_batch() {
     let ckpt = d.path().join("cdc.ckpt");
     mssql_cdc_exec(&format!(
         "INSERT INTO dbo.{table} VALUES (1, 9000000000000, 12345.6789, 'hello', \
-         '2026-06-23', 0xDEADBEEF, 123.4567)"
+         '2026-06-23', 0xDEADBEEF, 123.4567, \
+         1.5, 1, '12345678-1234-1234-1234-123456789012')"
     ));
     wait_for_capture(&ci, 1);
     run_rivet_ok(&mssql_cdc_config(&d, &table, &ci, &ckpt, &host_dir));
@@ -1297,6 +1299,8 @@ fn mssql_cdc_typed_values_match_source_via_duckdb_not_batch() {
     let res = duckdb_run_sql_json(&format!(
         "SELECT (big = 9000000000000) AND (amount = 12345.6789) AND (label = 'hello') \
          AND (d = DATE '2026-06-23') AND (lower(to_hex(vb)) = 'deadbeef') AND (m = 123.4567) \
+         AND (fl = 1.5) AND (CAST(bt AS INTEGER) = 1) \
+         AND (lower(CAST(u AS VARCHAR)) = '12345678-1234-1234-1234-123456789012') \
          FROM read_parquet('{container_dir}/cdc-*.parquet') WHERE id = 1"
     ));
     let rows = res["rows"].as_array().expect("duckdb rows");

--- a/tests/live/live_cdc_mssql.rs
+++ b/tests/live/live_cdc_mssql.rs
@@ -1262,3 +1262,50 @@ fn roast_mssql_cdc_large_transaction_is_atomic_across_a_mid_flush_crash() {
         got.len()
     );
 }
+
+/// MSSQL sibling of the independent CDC-type oracle (option 1): the
+/// `mssql_cdc_full_type_matrix_matches_batch` cell is a DIFFERENTIAL self-oracle
+/// (CDC vs batch, shared decode). This reads the `__changes` parquet with DuckDB —
+/// outside rivet's decode family — and asserts each value vs the SOURCE literal,
+/// catching a shared-decode bug matches_batch misses.
+#[test]
+#[ignore = "live: requires docker compose mssql with SQL Server Agent + CDC + duckdb"]
+fn mssql_cdc_typed_values_match_source_via_duckdb_not_batch() {
+    let _serial = CDC_SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    let d = tempfile::tempdir().unwrap();
+    let (host_dir, container_dir) = duckdb_shared_workdir(&unique_name("cdc_typed_ms"));
+    let table = unique_name("rivet_cdc_typed");
+    let ci = format!("dbo_{table}");
+    mssql_cdc_drop_table(&format!("dbo.{table}"));
+    mssql_cdc_exec(&format!(
+        "CREATE TABLE dbo.{table} (id INT PRIMARY KEY, big BIGINT, amount DECIMAL(18,4), \
+         label VARCHAR(50), d DATE, vb VARBINARY(4), m MONEY)"
+    ));
+    enable_cdc(&table, &ci);
+    let _guard = MssqlCdcTable {
+        table: table.clone(),
+        ci: ci.clone(),
+    };
+    let ckpt = d.path().join("cdc.ckpt");
+    mssql_cdc_exec(&format!(
+        "INSERT INTO dbo.{table} VALUES (1, 9000000000000, 12345.6789, 'hello', \
+         '2026-06-23', 0xDEADBEEF, 123.4567)"
+    ));
+    wait_for_capture(&ci, 1);
+    run_rivet_ok(&mssql_cdc_config(&d, &table, &ci, &ckpt, &host_dir));
+
+    let res = duckdb_run_sql_json(&format!(
+        "SELECT (big = 9000000000000) AND (amount = 12345.6789) AND (label = 'hello') \
+         AND (d = DATE '2026-06-23') AND (lower(to_hex(vb)) = 'deadbeef') AND (m = 123.4567) \
+         FROM read_parquet('{container_dir}/cdc-*.parquet') WHERE id = 1"
+    ));
+    let rows = res["rows"].as_array().expect("duckdb rows");
+    assert_eq!(rows.len(), 1, "one captured change for id=1; got: {res}");
+    assert!(
+        rows[0][0]
+            .as_str()
+            .is_some_and(|s| s.eq_ignore_ascii_case("true")),
+        "MSSQL CDC typed values must equal the SOURCE literals via DuckDB (independent of \
+         batch): bigint, decimal 12345.6789, text, date, binary (hex), MONEY 123.4567; got: {res}"
+    );
+}

--- a/tests/live/live_chunked_recovery.rs
+++ b/tests/live/live_chunked_recovery.rs
@@ -114,6 +114,30 @@ fn latest_metric_validated(cfg: &std::path::Path, export: &str) -> Option<bool> 
         .flatten()
 }
 
+/// `total_rows` from the latest `export_metrics` row — the summary's reported row
+/// count (finding #9). On a checkpoint RESUME this must be the CUMULATIVE total
+/// (rehydrated pre-crash base + this run), not just this invocation's rows.
+fn latest_metric_total_rows(cfg: &std::path::Path, export: &str) -> Option<i64> {
+    open_state_db(cfg)
+        .query_row(
+            "SELECT total_rows FROM export_metrics WHERE export_name = ?1 ORDER BY id DESC LIMIT 1",
+            [export],
+            |r| r.get::<_, i64>(0),
+        )
+        .ok()
+}
+
+/// The destination manifest's `column_checksums` (Form B), or `None` when the
+/// key is absent/null (suppressed). Empty array also reads as "no Form B".
+fn manifest_column_checksums(dir: &std::path::Path) -> Option<Vec<serde_json::Value>> {
+    let raw = std::fs::read_to_string(dir.join("manifest.json")).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    match json.get("column_checksums") {
+        Some(serde_json::Value::Array(a)) if !a.is_empty() => Some(a.clone()),
+        _ => None,
+    }
+}
+
 // ─── C1: crash after chunk 0 complete → resume skips chunk 0 ─────────────────
 
 #[test]
@@ -591,6 +615,248 @@ fn parallel_chunked_crash_after_chunk_complete_resume_finishes_with_no_duplicate
         parquet_files.len() >= EXPECTED_CHUNKS as usize,
         "at least {EXPECTED_CHUNKS} parquet files must exist; found {}: {parquet_files:?}",
         parquet_files.len()
+    );
+}
+
+// ─── Finding #9: parallel-checkpoint resume reports the CUMULATIVE row total ──
+
+#[test]
+#[ignore = "live: requires docker compose postgres"]
+fn parallel_chunked_resume_reports_cumulative_total_rows_not_just_this_run() {
+    // A parallel-checkpoint crash before finalize leaves the manifest MISSING, so
+    // resume rehydrates the pre-crash parts from file_log — bumping total_rows,
+    // files, bytes, and manifest_parts together. The parallel runner then landed
+    // its worker rows with `summary.total_rows = agg` (assign), CLOBBERING the
+    // rehydrated base, so the reported total under-counted (only this run's rows,
+    // often 0 when the surviving workers had already drained every chunk). The
+    // manifest's own row_count (sum of parts) stayed correct — this is the SUMMARY
+    // total, recorded to export_metrics. The fix accumulates onto the base.
+    require_alive(LiveService::Postgres);
+
+    const ROW_COUNT: i64 = 400;
+    const CHUNK_SIZE: i64 = 50;
+
+    let table = seed_pg_numeric_table(ROW_COUNT);
+    let export = unique_name("f9_parallel_total_rows");
+    let out = tempfile::tempdir().unwrap();
+    let cfg_dir = tempfile::tempdir().unwrap();
+    let yaml = Rig::pg_batch(&export)
+        .query(&format!("SELECT id, name FROM {}", table.name()))
+        .mode("chunked")
+        .export_line("chunk_column: id")
+        .export_line(&format!("chunk_size: {CHUNK_SIZE}"))
+        .export_line("chunk_checkpoint: true")
+        .export_line("parallel: 4")
+        .dest_path(out.path().to_path_buf())
+        .yaml();
+    let cfg = write_config(&cfg_dir, &yaml);
+
+    let crash = std::process::Command::new(RIVET_BIN)
+        .args([
+            "run",
+            "--config",
+            cfg.to_str().unwrap(),
+            "--export",
+            &export,
+        ])
+        .env("RIVET_TEST_PANIC_AT", "after_chunk_complete:0")
+        .output()
+        .expect("spawn rivet");
+    assert!(
+        !crash.status.success(),
+        "crash run must exit non-zero; stderr:\n{}",
+        String::from_utf8_lossy(&crash.stderr)
+    );
+
+    let resume = std::process::Command::new(RIVET_BIN)
+        .args([
+            "run",
+            "--config",
+            cfg.to_str().unwrap(),
+            "--export",
+            &export,
+            "--resume",
+        ])
+        .output()
+        .expect("spawn rivet resume");
+    assert!(
+        resume.status.success(),
+        "--resume must succeed; stderr:\n{}",
+        String::from_utf8_lossy(&resume.stderr)
+    );
+
+    // The manifest (file_log sum) is correct regardless of the bug — the pin.
+    assert_eq!(
+        manifest_total_rows(&cfg, &export),
+        ROW_COUNT,
+        "manifest row total (file_log sum) must equal the seeded count"
+    );
+    // The SUMMARY's reported total_rows must ALSO be the cumulative total. RED
+    // before the fix: the clobber reported only this invocation's re-exported rows.
+    assert_eq!(
+        latest_metric_total_rows(&cfg, &export),
+        Some(ROW_COUNT),
+        "resume must report the CUMULATIVE row total (rehydrated base + this run), \
+         not just the rows re-exported this invocation"
+    );
+}
+
+// ─── Finding #10: a rehydrating resume SUPPRESSES Form B so validate can't lie ─
+
+#[test]
+#[ignore = "live: requires docker compose postgres"]
+fn chunked_checkpoint_resume_suppresses_form_b_so_validate_does_not_false_fail() {
+    // On a checkpoint resume the manifest is rebuilt to list ALL parts, but the
+    // rehydrated pre-crash parts carry no per-column checksum (file_log stores
+    // none). The run-wide Form B XOR this run harvests would then cover only the
+    // re-exported parts while the manifest lists every part — a partial XOR that
+    // `rivet validate` (Full) re-reads and reports as a FALSE mismatch. The fix
+    // suppresses Form B entirely on such a resume (absent, not partial), so
+    // validate size-verifies the parts and skips only the value re-read.
+    require_alive(LiveService::Postgres);
+
+    const ROW_COUNT: i64 = 400;
+    const CHUNK_SIZE: i64 = 50;
+
+    // Both source tables are created HERE so their drop guards outlive the runs
+    // (a table created inside the closure would drop — and DROP the table — before
+    // the export executes).
+    let base_table = seed_pg_numeric_table(ROW_COUNT);
+    let res_table = seed_pg_numeric_table(ROW_COUNT);
+    // `parallel: 1` for the resume path is deliberate: with 4 workers + a deferred
+    // scope-panic the surviving workers drain EVERY chunk before the abort, so the
+    // resume re-exports nothing and the harvest accumulator is empty — the
+    // suppression path (which only matters when SOME parts re-export while others
+    // rehydrate) never fires. One worker completing only chunk 0 leaves the rest
+    // pending, so resume rehydrates chunk 0 (no checksum) AND re-exports the rest
+    // (with checksums) — the exact mixed case Form B suppression guards.
+    let run_checkpoint = |export: &str,
+                          table_name: &str,
+                          out: &std::path::Path,
+                          cfg_dir: &tempfile::TempDir,
+                          parallel: u32| {
+        let yaml = Rig::pg_batch(export)
+            .query(&format!("SELECT id, name FROM {table_name}"))
+            .mode("chunked")
+            .export_line("chunk_column: id")
+            .export_line(&format!("chunk_size: {CHUNK_SIZE}"))
+            .export_line("chunk_checkpoint: true")
+            .export_line(&format!("parallel: {parallel}"))
+            .dest_path(out.to_path_buf())
+            .yaml();
+        write_config(cfg_dir, &yaml)
+    };
+    let validate = |cfg: &std::path::Path, export: &str| {
+        std::process::Command::new(RIVET_BIN)
+            .args([
+                "validate",
+                "--config",
+                cfg.to_str().unwrap(),
+                "--export",
+                export,
+            ])
+            .output()
+            .expect("spawn rivet validate")
+    };
+
+    // ── Baseline: a CLEAN parallel-checkpoint run RECORDS Form B, and validate
+    //    (Full) re-reads + verifies it → passes. Proves Form B is active on this
+    //    path, so the suppression below is not vacuous.
+    let base_export = unique_name("f10_baseline");
+    let base_out = tempfile::tempdir().unwrap();
+    let base_cfg_dir = tempfile::tempdir().unwrap();
+    let base_cfg = run_checkpoint(
+        &base_export,
+        base_table.name(),
+        base_out.path(),
+        &base_cfg_dir,
+        4,
+    );
+    let base_run = std::process::Command::new(RIVET_BIN)
+        .args([
+            "run",
+            "--config",
+            base_cfg.to_str().unwrap(),
+            "--export",
+            &base_export,
+        ])
+        .output()
+        .expect("spawn rivet");
+    assert!(
+        base_run.status.success(),
+        "baseline run must succeed; stderr:\n{}",
+        String::from_utf8_lossy(&base_run.stderr)
+    );
+    assert!(
+        manifest_column_checksums(base_out.path()).is_some(),
+        "a clean parallel-checkpoint run must record Form B column_checksums"
+    );
+    let base_v = validate(&base_cfg, &base_export);
+    assert!(
+        base_v.status.success(),
+        "clean-run validate (Full) must pass; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&base_v.stdout),
+        String::from_utf8_lossy(&base_v.stderr)
+    );
+
+    // ── Resume: crash before finalize (manifest missing) → resume rehydrates.
+    let res_export = unique_name("f10_resume");
+    let res_out = tempfile::tempdir().unwrap();
+    let res_cfg_dir = tempfile::tempdir().unwrap();
+    let res_cfg = run_checkpoint(
+        &res_export,
+        res_table.name(),
+        res_out.path(),
+        &res_cfg_dir,
+        1,
+    );
+    let crash = std::process::Command::new(RIVET_BIN)
+        .args([
+            "run",
+            "--config",
+            res_cfg.to_str().unwrap(),
+            "--export",
+            &res_export,
+        ])
+        .env("RIVET_TEST_PANIC_AT", "after_chunk_complete:0")
+        .output()
+        .expect("spawn rivet");
+    assert!(
+        !crash.status.success(),
+        "crash run must exit non-zero; stderr:\n{}",
+        String::from_utf8_lossy(&crash.stderr)
+    );
+    let resume = std::process::Command::new(RIVET_BIN)
+        .args([
+            "run",
+            "--config",
+            res_cfg.to_str().unwrap(),
+            "--export",
+            &res_export,
+            "--resume",
+        ])
+        .output()
+        .expect("spawn rivet resume");
+    assert!(
+        resume.status.success(),
+        "--resume must succeed; stderr:\n{}",
+        String::from_utf8_lossy(&resume.stderr)
+    );
+    // Form B suppressed: the manifest lists every part but records NO Form B,
+    // because the rehydrated pre-crash parts have no per-column checksum.
+    assert!(
+        manifest_column_checksums(res_out.path()).is_none(),
+        "a rehydrating resume must SUPPRESS Form B (absent), never record a partial XOR"
+    );
+    // validate (Full): with Form B absent it size-verifies + skips the value
+    // re-read → PASSES. RED before the fix: the partial XOR made validate FALSE-fail.
+    let res_v = validate(&res_cfg, &res_export);
+    assert!(
+        res_v.status.success(),
+        "validate must PASS on a correctly-resumed run — no false Form B mismatch; \
+         stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&res_v.stdout),
+        String::from_utf8_lossy(&res_v.stderr)
     );
 }
 

--- a/tests/live/live_keyset.rs
+++ b/tests/live/live_keyset.rs
@@ -795,6 +795,82 @@ fn keyset_failure_after_data_complete_does_not_resume_and_skip_on_the_next_run()
     );
 }
 
+/// Round-2 hunt HIGH: the INCREMENTAL keyset variant must KEEP its resume anchor
+/// at data-complete (unlike non-incremental, which clears it) so a crash in the
+/// [data-complete → finalize_manifest] window rehydrates the committed pages
+/// instead of orphaning them. The committed parquet SURVIVES on disk either way,
+/// so this asserts on the MANIFEST (dir_manifest_copy_total_rows), not a parquet
+/// re-read — the loss is manifest-level and invisible to a data re-read. RED
+/// against an unconditional data-complete clear_resume_run_id (manifest = 0).
+#[test]
+#[ignore = "live: requires docker compose up -d mysql"]
+fn keyset_incremental_crash_before_finalize_rehydrates_not_orphans_the_manifest() {
+    require_alive(LiveService::Mysql);
+    let table = unique_name("keyset_inc_orphan");
+    let _guard = DropTable(table.clone());
+    let mut conn = mysql_connect();
+    conn.query_drop(format!("DROP TABLE IF EXISTS {table}"))
+        .unwrap();
+    conn.query_drop(format!(
+        "CREATE TABLE {table} (uid VARCHAR(40) NOT NULL PRIMARY KEY, payload INT NOT NULL)"
+    ))
+    .unwrap();
+    conn.query_drop("SET SESSION cte_max_recursion_depth = 20000")
+        .unwrap();
+    conn.query_drop(format!(
+        "INSERT INTO {table} (uid, payload) \
+         WITH RECURSIVE seq AS (SELECT 1 n UNION ALL SELECT n+1 FROM seq WHERE n < 1000) \
+         SELECT CONCAT('id-', LPAD(n, 6, '0')), n FROM seq"
+    ))
+    .unwrap();
+
+    // Incremental keyset (append-only opt-in). chunk_checkpoint implied by the
+    // planner, but set explicitly too for clarity.
+    let export = unique_name("keyset_inc_orphan_exp");
+    let cfg_dir = tempfile::tempdir().unwrap();
+    let out_dir = tempfile::tempdir().unwrap();
+    let yaml = format!(
+        "source:\n  type: mysql\n  url: \"{MYSQL_URL}\"\nexports:\n  - name: {export}\n    \
+         table: {table}\n    mode: chunked\n    chunk_by_key: uid\n    chunk_checkpoint: true\n    \
+         keyset_incremental: true\n    \
+         chunk_size: 300\n    format: parquet\n    destination:\n      type: local\n      path: {out}\n",
+        out = out_dir.path().display(),
+    );
+    let cfg = write_config(&cfg_dir, &yaml);
+
+    // Run 1: commits all 1000 pages under R1, then crashes AFTER data-complete but
+    // BEFORE finalize_manifest — so NO destination manifest for R1 is written.
+    let crash = std::process::Command::new(RIVET_BIN)
+        .args([
+            "run",
+            "--config",
+            cfg.to_str().unwrap(),
+            "--export",
+            &export,
+        ])
+        .env("RIVET_TEST_PANIC_AT", "keyset_after_data_complete")
+        .output()
+        .expect("spawn rivet");
+    assert!(!crash.status.success(), "crash run must exit non-zero");
+
+    // Run 2 (incremental): must REHYDRATE R1's committed pages into a complete
+    // manifest (1000 rows), not orphan them. The parquet survives on disk
+    // regardless, so we assert on the run-unique manifest copies. 0 means R1's
+    // committed pages were orphaned — the manifest-authoritative loader would
+    // silently drop them.
+    let r2 = run_rivet_export(&cfg, &export);
+    assert!(
+        r2.status.success(),
+        "run 2 stderr:\n{}",
+        String::from_utf8_lossy(&r2.stderr)
+    );
+    assert_eq!(
+        dir_manifest_copy_total_rows(out_dir.path()),
+        1000,
+        "an incremental crash before finalize must rehydrate all 1000 committed rows into the manifest; 0 means the pages were orphaned (silent manifest-level row loss)"
+    );
+}
+
 /// PostgreSQL UUID PK is the most common non-integer PK in production
 /// (`id UUID PRIMARY KEY DEFAULT gen_random_uuid()` is the canonical
 /// shape after `gen_random_uuid()` landed in core). The documented path

--- a/tests/live/live_keyset.rs
+++ b/tests/live/live_keyset.rs
@@ -498,14 +498,19 @@ fn keyset_checkpoint_resume_second_run_captures_only_new_keys() {
     };
     seed(&mut conn, 1, 1000);
 
-    // Explicit keyset key + checkpoint. Same cfg dir across runs so the
-    // `.rivet_state.db` (written next to the config) is shared → run 2/3 resume.
+    // Explicit keyset key + checkpoint + keyset_incremental. Same cfg dir across
+    // runs so the `.rivet_state.db` (written next to the config) is shared → run
+    // 2/3 continue. `keyset_incremental: true` is the append-only opt-in: since
+    // the crash-recovery/incremental split, chunk_checkpoint ALONE would re-read
+    // the whole table on a clean re-run; this flag is what makes a clean re-run
+    // pull only new keys (the behaviour this test asserts).
     let export = unique_name("keyset_ckpt_exp");
     let cfg_dir = tempfile::tempdir().unwrap();
     let out_dir = tempfile::tempdir().unwrap();
     let yaml = format!(
         "source:\n  type: mysql\n  url: \"{MYSQL_URL}\"\nexports:\n  - name: {export}\n    \
          table: {table}\n    mode: chunked\n    chunk_by_key: uid\n    chunk_checkpoint: true\n    \
+         keyset_incremental: true\n    \
          chunk_size: 300\n    format: parquet\n    destination:\n      type: local\n      path: {out}\n",
         out = out_dir.path().display(),
     );
@@ -559,6 +564,234 @@ fn keyset_checkpoint_resume_second_run_captures_only_new_keys() {
         dir_manifest_copy_total_rows(out_dir.path()),
         1500,
         "run-unique manifest copies must sum run 1 (1000) + run 3 (500); a clobbered manifest is silent to the parquet re-read"
+    );
+}
+
+/// SAFETY (crash-recovery ⇄ incremental split): keyset `chunk_checkpoint: true`
+/// WITHOUT `keyset_incremental` must FULLY re-read on a CLEAN re-run — never
+/// silently skip already-exported rows. Before the split, chunk_checkpoint
+/// implied incremental-by-key, so a clean re-run of a MUTABLE table skipped every
+/// row whose key had already passed (silent staleness — the production footgun
+/// that kept `init` from defaulting keyset checkpoint on). A crash still resumes
+/// (via the in-progress run_id — see `..._crash_resume_...`); a clean completion
+/// clears that run_id, so a plain re-run starts fresh. This is the RED-proof:
+/// against the old conflated behaviour the second run reads 1000 (skip), not 2000.
+#[test]
+#[ignore = "live: requires docker compose up -d mysql"]
+fn keyset_checkpoint_without_incremental_rereads_on_a_clean_rerun() {
+    require_alive(LiveService::Mysql);
+    let table = unique_name("keyset_safe");
+    let _guard = DropTable(table.clone());
+    let mut conn = mysql_connect();
+    conn.query_drop(format!("DROP TABLE IF EXISTS {table}"))
+        .unwrap();
+    conn.query_drop(format!(
+        "CREATE TABLE {table} (uid VARCHAR(40) NOT NULL PRIMARY KEY, payload INT NOT NULL)"
+    ))
+    .unwrap();
+    conn.query_drop("SET SESSION cte_max_recursion_depth = 20000")
+        .unwrap();
+    conn.query_drop(format!(
+        "INSERT INTO {table} (uid, payload) \
+         WITH RECURSIVE seq AS (SELECT 1 n UNION ALL SELECT n+1 FROM seq WHERE n < 1000) \
+         SELECT CONCAT('id-', LPAD(n, 6, '0')), n FROM seq"
+    ))
+    .unwrap();
+
+    // chunk_checkpoint: true but NO keyset_incremental → crash-recovery ONLY.
+    let export = unique_name("keyset_safe_exp");
+    let cfg_dir = tempfile::tempdir().unwrap();
+    let out_dir = tempfile::tempdir().unwrap();
+    let yaml = format!(
+        "source:\n  type: mysql\n  url: \"{MYSQL_URL}\"\nexports:\n  - name: {export}\n    \
+         table: {table}\n    mode: chunked\n    chunk_by_key: uid\n    chunk_checkpoint: true\n    \
+         chunk_size: 300\n    format: parquet\n    destination:\n      type: local\n      path: {out}\n",
+        out = out_dir.path().display(),
+    );
+    let cfg = write_config(&cfg_dir, &yaml);
+    let run = |label: &str| {
+        let out = run_rivet_export(&cfg, &export);
+        assert!(
+            out.status.success(),
+            "{label} failed; stderr:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    };
+
+    // Run 1 completes cleanly → the in-progress run_id is cleared at finalize.
+    run("run 1");
+    let (count1, _) = read_uid_set(out_dir.path());
+    assert_eq!(count1, 1000, "run 1 must export all seeded rows");
+
+    // Run 2 on the UNCHANGED source: a CLEAN re-run without keyset_incremental
+    // must re-read all 1000 again (full pass) — the parquet re-read total doubles
+    // to 2000. A total of 1000 would mean checkpoint silently implied incremental
+    // (the pre-split staleness bug this test guards).
+    run("run 2 (clean re-run)");
+    let (count2, keys2) = read_uid_set(out_dir.path());
+    assert_eq!(
+        count2, 2000,
+        "clean re-run must FULLY re-read (2000 rows across both runs); {count2} == 1000 would be a silent incremental skip"
+    );
+    let expected: BTreeSet<String> = (1..=1000).map(|n| format!("id-{n:06}")).collect();
+    assert_eq!(
+        keys2, expected,
+        "the key set stays the 1000 source keys (a re-read, not new data)"
+    );
+}
+
+/// #1 (CRITICAL, adversarial-hunt): a FRESH non-incremental keyset run that crashes
+/// AFTER open but BEFORE its first page commit must, on recovery, re-read from the
+/// START — never resume from a PRIOR completed run's stale high-water mark. Before
+/// the cursor-clear fix, Run 2 (fresh) set resume_run_id but left last_cursor_value
+/// at Run 1's final key; a crash before the first commit meant Run 3 loaded that
+/// stale key, issued `WHERE key > <max>`, read 0 rows, and wrote a SUCCESSFUL empty
+/// export — the entire table silently skipped. RED against the pre-fix build.
+#[test]
+#[ignore = "live: requires docker compose up -d mysql"]
+fn keyset_fresh_run_crash_before_first_page_does_not_skip_the_table() {
+    require_alive(LiveService::Mysql);
+    let table = unique_name("keyset_stale");
+    let _guard = DropTable(table.clone());
+    let mut conn = mysql_connect();
+    conn.query_drop(format!("DROP TABLE IF EXISTS {table}"))
+        .unwrap();
+    conn.query_drop(format!(
+        "CREATE TABLE {table} (uid VARCHAR(40) NOT NULL PRIMARY KEY, payload INT NOT NULL)"
+    ))
+    .unwrap();
+    conn.query_drop("SET SESSION cte_max_recursion_depth = 20000")
+        .unwrap();
+    conn.query_drop(format!(
+        "INSERT INTO {table} (uid, payload) \
+         WITH RECURSIVE seq AS (SELECT 1 n UNION ALL SELECT n+1 FROM seq WHERE n < 1000) \
+         SELECT CONCAT('id-', LPAD(n, 6, '0')), n FROM seq"
+    ))
+    .unwrap();
+
+    let export = unique_name("keyset_stale_exp");
+    let cfg_dir = tempfile::tempdir().unwrap();
+    let out_dir = tempfile::tempdir().unwrap();
+    let yaml = format!(
+        "source:\n  type: mysql\n  url: \"{MYSQL_URL}\"\nexports:\n  - name: {export}\n    \
+         table: {table}\n    mode: chunked\n    chunk_by_key: uid\n    chunk_checkpoint: true\n    \
+         chunk_size: 300\n    format: parquet\n    destination:\n      type: local\n      path: {out}\n",
+        out = out_dir.path().display(),
+    );
+    let cfg = write_config(&cfg_dir, &yaml);
+
+    // Run 1: full export of all 1000; on data-completion resume_run_id is cleared
+    // and last_cursor_value = the final key id-001000.
+    let r1 = run_rivet_export(&cfg, &export);
+    assert!(
+        r1.status.success(),
+        "run 1 stderr:\n{}",
+        String::from_utf8_lossy(&r1.stderr)
+    );
+    let (count1, _) = read_uid_set(out_dir.path());
+    assert_eq!(count1, 1000, "run 1 must export all 1000");
+
+    // Run 2: a FRESH run that crashes right after open (no page committed).
+    let crash = std::process::Command::new(RIVET_BIN)
+        .args([
+            "run",
+            "--config",
+            cfg.to_str().unwrap(),
+            "--export",
+            &export,
+        ])
+        .env("RIVET_TEST_PANIC_AT", "keyset_after_open_before_first_page")
+        .output()
+        .expect("spawn rivet");
+    assert!(!crash.status.success(), "crash run must exit non-zero");
+
+    // Run 3: recovery. It MUST re-read all 1000 (total across run1+run3 = 2000).
+    // A total of 1000 means Run 3 resumed from Run 1's stale cursor and skipped the
+    // whole table — the critical silent-loss bug.
+    let r3 = run_rivet_export(&cfg, &export);
+    assert!(
+        r3.status.success(),
+        "run 3 stderr:\n{}",
+        String::from_utf8_lossy(&r3.stderr)
+    );
+    let (count3, keys3) = read_uid_set(out_dir.path());
+    assert_eq!(
+        count3, 2000,
+        "recovery must re-read all 1000 (total 2000); {count3} == 1000 means Run 3 resumed from a STALE cursor and silently skipped the whole table"
+    );
+    let expected: BTreeSet<String> = (1..=1000).map(|n| format!("id-{n:06}")).collect();
+    assert_eq!(keys3, expected, "the full source key set must be present");
+}
+
+/// #3 (MEDIUM, adversarial-hunt): a keyset run that commits ALL its data then fails
+/// (a post-data gate, or any late failure) must NOT leave a resume anchor — the next
+/// run is a fresh full pass, never a crash-recovery that skips rows updated since.
+/// Data-completion clears resume_run_id, so a subsequent failure cannot strand it.
+/// RED against a build that only cleared at finalize (skipped on failure).
+#[test]
+#[ignore = "live: requires docker compose up -d mysql"]
+fn keyset_failure_after_data_complete_does_not_resume_and_skip_on_the_next_run() {
+    require_alive(LiveService::Mysql);
+    let table = unique_name("keyset_gate");
+    let _guard = DropTable(table.clone());
+    let mut conn = mysql_connect();
+    conn.query_drop(format!("DROP TABLE IF EXISTS {table}"))
+        .unwrap();
+    conn.query_drop(format!(
+        "CREATE TABLE {table} (uid VARCHAR(40) NOT NULL PRIMARY KEY, payload INT NOT NULL)"
+    ))
+    .unwrap();
+    conn.query_drop("SET SESSION cte_max_recursion_depth = 20000")
+        .unwrap();
+    conn.query_drop(format!(
+        "INSERT INTO {table} (uid, payload) \
+         WITH RECURSIVE seq AS (SELECT 1 n UNION ALL SELECT n+1 FROM seq WHERE n < 1000) \
+         SELECT CONCAT('id-', LPAD(n, 6, '0')), n FROM seq"
+    ))
+    .unwrap();
+
+    let export = unique_name("keyset_gate_exp");
+    let cfg_dir = tempfile::tempdir().unwrap();
+    let out_dir = tempfile::tempdir().unwrap();
+    let yaml = format!(
+        "source:\n  type: mysql\n  url: \"{MYSQL_URL}\"\nexports:\n  - name: {export}\n    \
+         table: {table}\n    mode: chunked\n    chunk_by_key: uid\n    chunk_checkpoint: true\n    \
+         chunk_size: 300\n    format: parquet\n    destination:\n      type: local\n      path: {out}\n",
+        out = out_dir.path().display(),
+    );
+    let cfg = write_config(&cfg_dir, &yaml);
+
+    // Run 1: commits ALL 1000, then fails AFTER data-completion (a stand-in for a
+    // post-data gate rejection). Data-completion has already cleared resume_run_id.
+    let fail = std::process::Command::new(RIVET_BIN)
+        .args([
+            "run",
+            "--config",
+            cfg.to_str().unwrap(),
+            "--export",
+            &export,
+        ])
+        .env("RIVET_TEST_PANIC_AT", "keyset_after_data_complete")
+        .output()
+        .expect("spawn rivet");
+    assert!(
+        !fail.status.success(),
+        "the post-data failure must exit non-zero"
+    );
+
+    // Run 2: a deliberate full re-run. It MUST re-read all 1000 (total 2000), NOT
+    // resume from the high-water mark. A total of 1000 means Run 1's stale
+    // resume_run_id made Run 2 a crash-recovery that skipped the whole table.
+    let r2 = run_rivet_export(&cfg, &export);
+    assert!(
+        r2.status.success(),
+        "run 2 stderr:\n{}",
+        String::from_utf8_lossy(&r2.stderr)
+    );
+    let (count2, _) = read_uid_set(out_dir.path());
+    assert_eq!(
+        count2, 2000,
+        "the re-run after a post-data failure must FULLY re-read (total 2000); {count2} == 1000 means a stale resume anchor silently skipped the table"
     );
 }
 
@@ -767,6 +1000,7 @@ fn keyset_checkpoint_resume_pg_second_run_captures_only_new_keys() {
     let yaml = format!(
         "source:\n  type: postgres\n  url: \"{POSTGRES_URL}\"\nexports:\n  - name: {export}\n    \
          table: public.{table}\n    mode: chunked\n    chunk_by_key: uid\n    chunk_checkpoint: true\n    \
+         keyset_incremental: true\n    \
          chunk_size: 300\n    format: parquet\n    destination:\n      type: local\n      path: {out}\n",
         out = out_dir.path().display(),
     );
@@ -855,7 +1089,8 @@ fn keyset_checkpoint_resume_mssql_second_run_captures_only_new_keys() {
     let yaml = format!(
         "source:\n  type: mssql\n  url: \"{MSSQL_URL}\"\n  tls:\n    accept_invalid_certs: true\n\
          exports:\n  - name: {export}\n    table: dbo.{table}\n    mode: chunked\n    \
-         chunk_by_key: uid\n    chunk_checkpoint: true\n    chunk_size: 300\n    format: parquet\n    \
+         chunk_by_key: uid\n    chunk_checkpoint: true\n    keyset_incremental: true\n    \
+         chunk_size: 300\n    format: parquet\n    \
          destination:\n      type: local\n      path: {out}\n",
         out = out_dir.path().display(),
     );

--- a/tests/live/live_plan_apply.rs
+++ b/tests/live/live_plan_apply.rs
@@ -627,3 +627,91 @@ fn apply_missing_plan_file_exits_nonzero() {
         "stderr must not be empty when plan file is missing"
     );
 }
+
+/// Round-3/4: an INCREMENTAL keyset export through the `rivet apply` wrapper must
+/// clear its resume anchor at finalize — the SAME post-finalize clear `rivet run`
+/// does (`finalize_keyset_anchor`) — so the run_id ROTATES across repeated applies.
+/// Before the two-adapter seam, the apply wrapper forgot the clear: the run_id
+/// froze, both applies wrote the SAME `manifest-<run_id>.json` copy (collision),
+/// and a run_id-deduping loader silently skips the second delta. This is the
+/// apply-wrapper half of the seam, RED-proven on the run-unique manifest COPIES —
+/// a parquet glob cannot see a run_id collision. Applies share `.rivet_state.db`
+/// next to the plan (apply_cmd.rs), so the resume anchor persists across them.
+#[test]
+#[ignore = "live: requires docker compose up -d postgres"]
+fn incremental_keyset_apply_rotates_run_id_across_repeated_applies() {
+    require_alive(LiveService::Postgres);
+    let table = unique_name("ks_apply_incr");
+    let mut c = pg_connect();
+    c.batch_execute(&format!(
+        "CREATE TABLE {table} (k TEXT PRIMARY KEY, name TEXT NOT NULL); \
+         INSERT INTO {table} SELECT 'k' || lpad(g::text, 6, '0'), 'n' || g \
+         FROM generate_series(1, 100) g;"
+    ))
+    .unwrap();
+    let _guard = PgTable::adopt(table.clone());
+
+    let out_dir = tempfile::tempdir().unwrap();
+    let cfg_dir = tempfile::tempdir().unwrap();
+    let yaml = format!(
+        "source:\n  type: postgres\n  url_env: DATABASE_URL\nexports:\n  - name: {table}\n    \
+         table: {table}\n    mode: chunked\n    chunk_by_key: k\n    chunk_checkpoint: true\n    \
+         keyset_incremental: true\n    chunk_size: 40\n    format: parquet\n    \
+         destination:\n      type: local\n      path: {out}\n",
+        out = out_dir.path().display(),
+    );
+    let cfg = write_config(&cfg_dir, &yaml);
+    let plan_path = cfg_dir.path().join("plan.json");
+
+    let plan = std::process::Command::new(RIVET_BIN)
+        .args([
+            "plan",
+            "--config",
+            cfg.to_str().unwrap(),
+            "--export",
+            &table,
+            "--format",
+            "json",
+            "--output",
+            plan_path.to_str().unwrap(),
+        ])
+        .env("DATABASE_URL", POSTGRES_URL)
+        .output()
+        .expect("spawn plan");
+    assert!(
+        plan.status.success(),
+        "plan stderr:\n{}",
+        String::from_utf8_lossy(&plan.stderr)
+    );
+
+    let apply = |label: &str| {
+        let out = std::process::Command::new(RIVET_BIN)
+            .args(["apply", plan_path.to_str().unwrap()])
+            .env("DATABASE_URL", POSTGRES_URL)
+            .output()
+            .expect("spawn apply");
+        assert!(
+            out.status.success(),
+            "{label} stderr:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    };
+
+    // Apply 1: exports all 100 under run_id R1; finalize must clear the anchor.
+    apply("apply 1");
+    // An append-only batch so apply 2 has data and writes its own manifest.
+    c.batch_execute(&format!(
+        "INSERT INTO {table} SELECT 'k' || lpad(g::text, 6, '0'), 'n' || g \
+         FROM generate_series(101, 150) g;"
+    ))
+    .unwrap();
+    // Apply 2: with the anchor cleared it is a FRESH run (new run_id R2) pulling
+    // only the new keys. With the bug the anchor is frozen → R1 reused → one copy.
+    apply("apply 2");
+
+    assert_eq!(
+        dir_manifest_copy_count(out_dir.path()),
+        2,
+        "each apply must rotate the run_id → two distinct manifest-<run_id>.json copies; 1 means the apply wrapper left the resume anchor frozen (the run_id-collision silent-delta-skip class)"
+    );
+}

--- a/tests/offline/chunking_matrix_guard.rs
+++ b/tests/offline/chunking_matrix_guard.rs
@@ -204,7 +204,7 @@ const ORACLE_TRACKED: &[(&str, usize)] = &[
     // *_cdc_full_type_matrix_matches_batch self-oracle). PG + MySQL + tz/enum/
     // money/mongo cells upgraded to independent so far; MSSQL + the PG float/date/
     // binary/uuid cells are the remaining debt.
-    ("docs/cdc-type-fidelity-matrix.yaml", 12),
+    ("docs/cdc-type-fidelity-matrix.yaml", 11),
     // Batch type fidelity is already oracle-STRONG (24 independent cells: golden
     // hard-coded values + DuckDB/pyarrow foreign readers). The 6 weak are cells
     // whose CITED test is schema-coverage only (no independent VALUE re-read) —

--- a/tests/offline/chunking_matrix_guard.rs
+++ b/tests/offline/chunking_matrix_guard.rs
@@ -204,7 +204,7 @@ const ORACLE_TRACKED: &[(&str, usize)] = &[
     // *_cdc_full_type_matrix_matches_batch self-oracle). PG + MySQL + tz/enum/
     // money/mongo cells upgraded to independent so far; MSSQL + the PG float/date/
     // binary/uuid cells are the remaining debt.
-    ("docs/cdc-type-fidelity-matrix.yaml", 16),
+    ("docs/cdc-type-fidelity-matrix.yaml", 12),
     // Batch type fidelity is already oracle-STRONG (24 independent cells: golden
     // hard-coded values + DuckDB/pyarrow foreign readers). The 6 weak are cells
     // whose CITED test is schema-coverage only (no independent VALUE re-read) —

--- a/tests/offline/chunking_matrix_guard.rs
+++ b/tests/offline/chunking_matrix_guard.rs
@@ -14,6 +14,14 @@
 //! 4. The number of `gap:` cells MUST NOT exceed the ratchet baseline — you
 //!    cannot ADD a gap. Filling a gap (gap → test) lets you lower the baseline;
 //!    the ratchet only ever tightens.
+//! 5. GENERATIVE column-completeness: a matrix keyed on source engines must
+//!    declare EVERY `SourceType`, one keyed on warehouse targets must declare
+//!    EVERY `ExportTarget` — the required set is derived from the enums THEMSELVES
+//!    (parsed from product source), so a new engine/target, or a silently-dropped
+//!    column, forces a `test`/`gap`/`na` cell instead of an invisible hole. Guards
+//!    1-4 are DESCRIPTIVE (they only check what an author wrote down); this one is
+//!    GENERATIVE (product code enumerates what MUST be there) — the coverage-audit
+//!    meta-fix that stops the un-enumerated-sibling class at CI.
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -289,5 +297,107 @@ fn matrix_gaps_do_not_exceed_ratchet() {
              If {gaps} > {ceiling}: you ADDED a gap — fill it with a test (gaps cannot grow). \
              If {gaps} < {ceiling}: you FILLED one — lower the ceiling in MATRICES to {gaps}."
         );
+    }
+}
+
+/// The lowercased variant idents of a UNIT enum, parsed from product source — the
+/// same "derive from authoritative product code" trick [`all_fn_names`] uses.
+/// `SourceType::Postgres` → `"postgres"`, `ExportTarget::DuckDb` → `"duckdb"`: the
+/// lowercase of every variant matches the matrix column labels exactly, so adding
+/// a variant grows the required-column set automatically — no hand-kept list.
+fn enum_variants_lowercased(rel: &str, enum_name: &str) -> HashSet<String> {
+    let text = std::fs::read_to_string(repo_root().join(rel))
+        .unwrap_or_else(|e| panic!("read {rel}: {e}"));
+    let needle = format!("enum {enum_name} {{");
+    let start = text
+        .find(&needle)
+        .unwrap_or_else(|| panic!("`{needle}` not found in {rel}"));
+    let body = &text[start + needle.len()..];
+    // Matching close brace (depth-tracked; these are unit enums, so it stays flat).
+    let mut depth = 1usize;
+    let mut end = body.len();
+    for (i, ch) in body.char_indices() {
+        match ch {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    end = i;
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    let mut out = HashSet::new();
+    for line in body[..end].lines() {
+        let t = line.trim_start();
+        // Skip doc/line comments (`///`, `//`), attributes (`#[…]`), blanks.
+        if t.is_empty() || t.starts_with("//") || t.starts_with('#') {
+            continue;
+        }
+        // A variant line begins with an UpperCamel ident (a unit enum has no other
+        // Upper-leading top-level line once comments/attrs are stripped).
+        let ident: String = t
+            .chars()
+            .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+            .collect();
+        if ident.chars().next().is_some_and(|c| c.is_ascii_uppercase()) {
+            out.insert(ident.to_ascii_lowercase());
+        }
+    }
+    out
+}
+
+/// GENERATIVE column-completeness — the coverage-audit meta-fix. The other three
+/// guards are DESCRIPTIVE: they only check the columns an author already wrote
+/// down, so a matrix that silently DROPS an engine/target — or never adds one for
+/// a new enum variant — stays green (the un-enumerated-sibling hole the audit
+/// found). This derives the required column set from the `SourceType` and
+/// `ExportTarget` enums THEMSELVES: a matrix keyed on source engines must declare
+/// EVERY `SourceType`, one keyed on warehouse targets must declare EVERY
+/// `ExportTarget`. Adding a variant to either enum forces a column into every
+/// relevant matrix — a `test`/`gap`/`na` cell, never a silent omission. Composes
+/// with the gaps==0 ratchet: a forced column can be a justified `na`, but can't be
+/// papered over as a growable gap.
+#[test]
+fn matrix_columns_cover_every_source_and_target_enum_variant() {
+    let sources = enum_variants_lowercased("src/config/source.rs", "SourceType");
+    let targets = enum_variants_lowercased("src/types/target.rs", "ExportTarget");
+    // Parse sanity: a drift here would silently UNDER-require, defeating the guard.
+    assert!(
+        sources.len() == 4 && sources.contains("postgres") && sources.contains("mongo"),
+        "SourceType parse produced {sources:?} (expected the 4 source engines)"
+    );
+    assert!(
+        targets.len() == 4 && targets.contains("duckdb") && targets.contains("clickhouse"),
+        "ExportTarget parse produced {targets:?} (expected the 4 warehouse targets)"
+    );
+
+    for (path, _) in MATRICES {
+        let matrix = load_matrix(path);
+        let declared: HashSet<&str> = matrix.engines.iter().map(String::as_str).collect();
+        let keyed_on_sources = matrix.engines.iter().any(|e| sources.contains(e.as_str()));
+        let keyed_on_targets = matrix.engines.iter().any(|e| targets.contains(e.as_str()));
+        if keyed_on_sources {
+            for s in &sources {
+                assert!(
+                    declared.contains(s.as_str()),
+                    "{path} is keyed on source engines but is MISSING the '{s}' column. Every \
+                     SourceType must be a column (a test/gap/na cell per scenario) — a \
+                     silently-absent engine is the un-enumerated-sibling hole the audit found. \
+                     Add it, or n/a it with a reason."
+                );
+            }
+        }
+        if keyed_on_targets {
+            for t in &targets {
+                assert!(
+                    declared.contains(t.as_str()),
+                    "{path} is keyed on warehouse targets but is MISSING the '{t}' column. Every \
+                     ExportTarget must be a column — add it (test/gap/na per scenario)."
+                );
+            }
+        }
     }
 }

--- a/tests/offline/chunking_matrix_guard.rs
+++ b/tests/offline/chunking_matrix_guard.rs
@@ -22,6 +22,12 @@
 //!    1-4 are DESCRIPTIVE (they only check what an author wrote down); this one is
 //!    GENERATIVE (product code enumerates what MUST be there) — the coverage-audit
 //!    meta-fix that stops the un-enumerated-sibling class at CI.
+//! 6. GENERATIVE row-completeness (the sibling of #5 on the OTHER axis): every
+//!    `RivetType` variant must map to a `type_*` scenario row in the CDC
+//!    type-fidelity matrix — derived from the `RivetType` enum itself. #5 stops a
+//!    dropped/missing COLUMN (engine/target); #6 stops a dropped/missing ROW
+//!    (type). Together the column AND row axes are product-code-enumerated, so the
+//!    per-type-CDC quadrant (findings #2/#3/#4) can no longer grow a silent hole.
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -113,6 +119,14 @@ const MATRICES: &[(&str, usize)] = &[
     // document column cannot structurally drift). 0 gaps — every runner × feature cell
     // is a test or a justified n/a.
     ("docs/runner-coverage-matrix.yaml", 0),
+    // CDC per-type value fidelity — the change-stream sibling of type-fidelity, the
+    // axis where findings #2 (MSSQL MONEY>2^53), #3 (MySQL ENUM cross-db) and #4
+    // (BIT(64) bit 63) lived: batch correct, CDC/edge sibling not. Workhorse cells
+    // cite each engine's *_cdc_full_type_matrix_matches_batch (ArrayData equality
+    // CDC==batch); edge scenarios cite the range-specific tests. Row axis is
+    // GENERATIVELY complete over RivetType (matrix_cdc_type_rows_cover_every_rivet_type).
+    // 0 gaps: every (type × engine) cell is a test or a justified n/a.
+    ("docs/cdc-type-fidelity-matrix.yaml", 0),
 ];
 
 #[derive(Deserialize)]
@@ -300,12 +314,14 @@ fn matrix_gaps_do_not_exceed_ratchet() {
     }
 }
 
-/// The lowercased variant idents of a UNIT enum, parsed from product source — the
-/// same "derive from authoritative product code" trick [`all_fn_names`] uses.
-/// `SourceType::Postgres` → `"postgres"`, `ExportTarget::DuckDb` → `"duckdb"`: the
-/// lowercase of every variant matches the matrix column labels exactly, so adding
-/// a variant grows the required-column set automatically — no hand-kept list.
-fn enum_variants_lowercased(rel: &str, enum_name: &str) -> HashSet<String> {
+/// The CamelCase variant idents of an enum, parsed from product source — the same
+/// "derive from authoritative product code" trick [`all_fn_names`] uses. Handles
+/// unit variants (`Postgres,`) AND struct/tuple variants (`Decimal {`, taking the
+/// leading ident), skipping doc/line comments and attributes. Brace depth is
+/// tracked so a struct variant's OWN field lines (depth 2) aren't mistaken for
+/// variants, and its `{…}` doesn't end the scan early. Adding a variant grows the
+/// derived set automatically — no hand-kept list.
+fn enum_variants(rel: &str, enum_name: &str) -> HashSet<String> {
     let text = std::fs::read_to_string(repo_root().join(rel))
         .unwrap_or_else(|e| panic!("read {rel}: {e}"));
     let needle = format!("enum {enum_name} {{");
@@ -313,40 +329,39 @@ fn enum_variants_lowercased(rel: &str, enum_name: &str) -> HashSet<String> {
         .find(&needle)
         .unwrap_or_else(|| panic!("`{needle}` not found in {rel}"));
     let body = &text[start + needle.len()..];
-    // Matching close brace (depth-tracked; these are unit enums, so it stays flat).
-    let mut depth = 1usize;
-    let mut end = body.len();
-    for (i, ch) in body.char_indices() {
-        match ch {
-            '{' => depth += 1,
-            '}' => {
-                depth -= 1;
-                if depth == 0 {
-                    end = i;
-                    break;
-                }
-            }
-            _ => {}
-        }
-    }
     let mut out = HashSet::new();
-    for line in body[..end].lines() {
+    let mut depth = 1usize; // already inside the enum's `{`
+    for line in body.lines() {
         let t = line.trim_start();
-        // Skip doc/line comments (`///`, `//`), attributes (`#[…]`), blanks.
-        if t.is_empty() || t.starts_with("//") || t.starts_with('#') {
-            continue;
+        let at_variant_depth = depth == 1;
+        // Update depth AFTER classifying this line (an opening `{` affects the NEXT
+        // lines, not this variant's own line). Stop at the enum's closing brace.
+        let opens = t.matches('{').count();
+        let closes = t.matches('}').count();
+        if at_variant_depth && !t.is_empty() && !t.starts_with("//") && !t.starts_with('#') {
+            let ident: String = t
+                .chars()
+                .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+                .collect();
+            if ident.chars().next().is_some_and(|c| c.is_ascii_uppercase()) {
+                out.insert(ident);
+            }
         }
-        // A variant line begins with an UpperCamel ident (a unit enum has no other
-        // Upper-leading top-level line once comments/attrs are stripped).
-        let ident: String = t
-            .chars()
-            .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
-            .collect();
-        if ident.chars().next().is_some_and(|c| c.is_ascii_uppercase()) {
-            out.insert(ident.to_ascii_lowercase());
+        depth = depth + opens - closes.min(depth);
+        if depth == 0 {
+            break; // enum's closing brace
         }
     }
     out
+}
+
+/// [`enum_variants`] lowercased — `SourceType::Postgres` → `"postgres"`,
+/// `ExportTarget::DuckDb` → `"duckdb"`, matching the matrix column labels exactly.
+fn enum_variants_lowercased(rel: &str, enum_name: &str) -> HashSet<String> {
+    enum_variants(rel, enum_name)
+        .into_iter()
+        .map(|v| v.to_ascii_lowercase())
+        .collect()
 }
 
 /// GENERATIVE column-completeness — the coverage-audit meta-fix. The other three
@@ -399,5 +414,68 @@ fn matrix_columns_cover_every_source_and_target_enum_variant() {
                 );
             }
         }
+    }
+}
+
+/// The RivetType FAMILY → cdc-type scenario id each variant must map to: the
+/// authoritative type enumeration paired with the required matrix row. Parametric
+/// variants (`Decimal{}`, `Time{}`, `Timestamp{}`, `List{}`) map by family;
+/// `Unsupported` is not a real column type (n/a by nature) and is excluded below.
+const RIVET_TYPE_ROWS: &[(&str, &str)] = &[
+    ("Bool", "type_boolean"),
+    ("Int16", "type_integer_families"),
+    ("Int32", "type_integer_families"),
+    ("Int64", "type_integer_families"),
+    ("UInt64", "type_integer_families"),
+    ("Float32", "type_float"),
+    ("Float64", "type_float"),
+    ("Decimal", "type_decimal"),
+    ("Date", "type_date_time"),
+    ("Time", "type_date_time"),
+    ("Timestamp", "type_timestamp_tz"),
+    ("String", "type_text"),
+    ("Text", "type_text"),
+    ("Binary", "type_binary"),
+    ("Json", "type_json"),
+    ("Uuid", "type_uuid"),
+    ("Enum", "type_enum"),
+    ("Interval", "type_interval"),
+    ("List", "type_list"),
+];
+
+/// GENERATIVE row-completeness (the audit's row-axis sibling of the column-axis
+/// guard #5). Guard #5 forces every ENGINE column; this forces every TYPE row. The
+/// required rows are derived from the `RivetType` enum itself: every variant
+/// (except `Unsupported`) must map to a cdc-type scenario in `RIVET_TYPE_ROWS`, and
+/// every mapped scenario must EXIST in the CDC type-fidelity matrix. So a new
+/// `RivetType` cannot ship without a CDC-fidelity row — the per-type-CDC axis where
+/// findings #2/#3/#4 lived can no longer grow a silent hole.
+#[test]
+fn matrix_cdc_type_rows_cover_every_rivet_type() {
+    let variants = enum_variants("src/types/rivet_type.rs", "RivetType");
+    assert!(
+        variants.contains("Decimal") && variants.contains("List") && variants.len() >= 19,
+        "RivetType parse produced {variants:?} (expected the full type universe)"
+    );
+    let mapped: HashSet<&str> = RIVET_TYPE_ROWS.iter().map(|(v, _)| *v).collect();
+    for v in &variants {
+        if v == "Unsupported" {
+            continue; // not a real column type — n/a by nature
+        }
+        assert!(
+            mapped.contains(v.as_str()),
+            "RivetType::{v} has no row mapping in RIVET_TYPE_ROWS. A NEW type must not ship \
+             without a CDC-fidelity row — map it to a `type_*` scenario (add the row to \
+             docs/cdc-type-fidelity-matrix.yaml if it is a new family)."
+        );
+    }
+    let matrix = load_matrix("docs/cdc-type-fidelity-matrix.yaml");
+    let ids: HashSet<&str> = matrix.scenarios.iter().map(|s| s.id.as_str()).collect();
+    for (variant, scenario) in RIVET_TYPE_ROWS {
+        assert!(
+            ids.contains(scenario),
+            "RivetType::{variant} maps to cdc-type row '{scenario}', MISSING from \
+             docs/cdc-type-fidelity-matrix.yaml — add the scenario (a test/gap/na cell per engine)."
+        );
     }
 }

--- a/tests/offline/chunking_matrix_guard.rs
+++ b/tests/offline/chunking_matrix_guard.rs
@@ -200,16 +200,16 @@ const ORACLE_STRENGTHS: &[&str] = &["independent", "differential", "self", "fail
 /// batch-differential to an INDEPENDENT oracle (a DuckDB/source re-read); never
 /// raise it — the ratchet drives the shared-decode-blind self-oracle debt to 0.
 const ORACLE_TRACKED: &[(&str, usize)] = &[
-    // CDC value-decode is the youngest, most differential-heavy surface (the
-    // *_cdc_full_type_matrix_matches_batch self-oracle). PG + MySQL + tz/enum/
-    // money/mongo cells upgraded to independent so far; MSSQL + the PG float/date/
-    // binary/uuid cells are the remaining debt.
+    // CDC value-decode — the differential debt was ground to 0: every (type × SQL
+    // engine) cell is now an INDEPENDENT DuckDB-vs-source oracle (via the three
+    // *_cdc_typed_values_match_source_via_duckdb_not_batch tests) or a fail_loud/na,
+    // never the shared-decode *_matches_batch self-oracle. Ceiling 0: any new
+    // differential CDC-type cell fails CI.
     ("docs/cdc-type-fidelity-matrix.yaml", 0),
-    // Batch type fidelity is already oracle-STRONG (24 independent cells: golden
-    // hard-coded values + DuckDB/pyarrow foreign readers). The 6 weak are cells
-    // whose CITED test is schema-coverage only (no independent VALUE re-read) —
-    // upgrade by pointing them at the duckdb_validates_* value test.
-    ("docs/type-fidelity-matrix.yaml", 6),
+    // Batch type fidelity — 24 independent value cells (golden hard-coded + DuckDB/
+    // pyarrow foreign readers); the last 6 schema-only cells were repointed to the
+    // per-column null-profile source-vs-dest oracle. Ceiling 0.
+    ("docs/type-fidelity-matrix.yaml", 0),
 ];
 
 impl Scenario {

--- a/tests/offline/chunking_matrix_guard.rs
+++ b/tests/offline/chunking_matrix_guard.rs
@@ -204,7 +204,7 @@ const ORACLE_TRACKED: &[(&str, usize)] = &[
     // *_cdc_full_type_matrix_matches_batch self-oracle). PG + MySQL + tz/enum/
     // money/mongo cells upgraded to independent so far; MSSQL + the PG float/date/
     // binary/uuid cells are the remaining debt.
-    ("docs/cdc-type-fidelity-matrix.yaml", 11),
+    ("docs/cdc-type-fidelity-matrix.yaml", 0),
     // Batch type fidelity is already oracle-STRONG (24 independent cells: golden
     // hard-coded values + DuckDB/pyarrow foreign readers). The 6 weak are cells
     // whose CITED test is schema-coverage only (no independent VALUE re-read) —

--- a/tests/offline/chunking_matrix_guard.rs
+++ b/tests/offline/chunking_matrix_guard.rs
@@ -199,7 +199,18 @@ const ORACLE_STRENGTHS: &[&str] = &["independent", "differential", "self", "fail
 /// ratchet ceiling. LOWER the ceiling each time a cell is upgraded from a
 /// batch-differential to an INDEPENDENT oracle (a DuckDB/source re-read); never
 /// raise it — the ratchet drives the shared-decode-blind self-oracle debt to 0.
-const ORACLE_TRACKED: &[(&str, usize)] = &[("docs/cdc-type-fidelity-matrix.yaml", 22)];
+const ORACLE_TRACKED: &[(&str, usize)] = &[
+    // CDC value-decode is the youngest, most differential-heavy surface (the
+    // *_cdc_full_type_matrix_matches_batch self-oracle). PG + MySQL + tz/enum/
+    // money/mongo cells upgraded to independent so far; MSSQL + the PG float/date/
+    // binary/uuid cells are the remaining debt.
+    ("docs/cdc-type-fidelity-matrix.yaml", 22),
+    // Batch type fidelity is already oracle-STRONG (24 independent cells: golden
+    // hard-coded values + DuckDB/pyarrow foreign readers). The 6 weak are cells
+    // whose CITED test is schema-coverage only (no independent VALUE re-read) —
+    // upgrade by pointing them at the duckdb_validates_* value test.
+    ("docs/type-fidelity-matrix.yaml", 6),
+];
 
 impl Scenario {
     /// `(column, cell)` for every column the matrix declares; panics if a

--- a/tests/offline/chunking_matrix_guard.rs
+++ b/tests/offline/chunking_matrix_guard.rs
@@ -199,7 +199,7 @@ const ORACLE_STRENGTHS: &[&str] = &["independent", "differential", "self", "fail
 /// ratchet ceiling. LOWER the ceiling each time a cell is upgraded from a
 /// batch-differential to an INDEPENDENT oracle (a DuckDB/source re-read); never
 /// raise it — the ratchet drives the shared-decode-blind self-oracle debt to 0.
-const ORACLE_TRACKED: &[(&str, usize)] = &[("docs/cdc-type-fidelity-matrix.yaml", 27)];
+const ORACLE_TRACKED: &[(&str, usize)] = &[("docs/cdc-type-fidelity-matrix.yaml", 22)];
 
 impl Scenario {
     /// `(column, cell)` for every column the matrix declares; panics if a

--- a/tests/offline/chunking_matrix_guard.rs
+++ b/tests/offline/chunking_matrix_guard.rs
@@ -28,6 +28,15 @@
 //!    dropped/missing COLUMN (engine/target); #6 stops a dropped/missing ROW
 //!    (type). Together the column AND row axes are product-code-enumerated, so the
 //!    per-type-CDC quadrant (findings #2/#3/#4) can no longer grow a silent hole.
+//! 7. ORACLE-STRENGTH ratchet: #1-#6 ensure a cell EXISTS and names a real test;
+//!    this grades HOW STRONG the oracle is. A `differential` cell (CDC==batch) is a
+//!    self-oracle over the SHARED decode — it passes a bug both siblings share (the
+//!    class that hid #5/#6/#8, and that the value-checksum Form A also misses). The
+//!    ratchet counts the weak (differential/self/un-annotated) `test:` cells per
+//!    oracle-tracked matrix and forbids the count from GROWING; upgrading a cell to
+//!    an INDEPENDENT oracle (a DuckDB/source-vs-dest re-read, outside rivet's decode
+//!    family) lowers the ceiling. So the shared-decode self-oracle debt is visible
+//!    and monotonically shrinks toward 0.
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -155,6 +164,14 @@ struct Cell {
     test: Option<String>,
     gap: Option<String>,
     na: Option<String>,
+    /// Oracle STRENGTH of a `test:` cell (guard #7, on oracle-tracked matrices):
+    /// `independent` (a reader OUTSIDE rivet's decode family — foreign reader /
+    /// source-vs-dest / hard-coded literal — catches a SHARED-decode value bug),
+    /// `fail_loud` (asserts the error path, not a value compare), `differential`
+    /// (sibling-vs-sibling, e.g. CDC==batch — the self-oracle that MISSES a shared
+    /// bug), `self`. ABSENT on a `test:` cell defaults to `differential` (weak),
+    /// so a new cell is assumed weak until proven independent.
+    oracle: Option<String>,
 }
 
 impl Cell {
@@ -162,7 +179,27 @@ impl Cell {
     fn kind_count(&self) -> usize {
         self.test.is_some() as usize + self.gap.is_some() as usize + self.na.is_some() as usize
     }
+
+    /// Is this a `test:` cell whose oracle could HIDE a shared-decode value bug?
+    /// (`differential`/`self`, or an un-annotated test — weak by default.) The
+    /// ratchet target: drive these to `independent`/`fail_loud`, never grow them.
+    fn is_weak_oracle(&self) -> bool {
+        self.test.is_some()
+            && !matches!(
+                self.oracle.as_deref(),
+                Some("independent") | Some("fail_loud")
+            )
+    }
 }
+
+/// The valid `oracle:` strengths (typo-guarded).
+const ORACLE_STRENGTHS: &[&str] = &["independent", "differential", "self", "fail_loud"];
+
+/// Oracle-tracked matrices + their weak-oracle (differential/self/un-annotated)
+/// ratchet ceiling. LOWER the ceiling each time a cell is upgraded from a
+/// batch-differential to an INDEPENDENT oracle (a DuckDB/source re-read); never
+/// raise it — the ratchet drives the shared-decode-blind self-oracle debt to 0.
+const ORACLE_TRACKED: &[(&str, usize)] = &[("docs/cdc-type-fidelity-matrix.yaml", 27)];
 
 impl Scenario {
     /// `(column, cell)` for every column the matrix declares; panics if a
@@ -476,6 +513,52 @@ fn matrix_cdc_type_rows_cover_every_rivet_type() {
             ids.contains(scenario),
             "RivetType::{variant} maps to cdc-type row '{scenario}', MISSING from \
              docs/cdc-type-fidelity-matrix.yaml — add the scenario (a test/gap/na cell per engine)."
+        );
+    }
+}
+
+/// Guard #7 — GENERATIVE oracle-strength ratchet. Guards #1-#6 ensure a cell
+/// EXISTS and names a real test; this one grades HOW STRONG that test's oracle is.
+/// A `differential` cell (CDC==batch) is a self-oracle over the SHARED decode — it
+/// passes a bug both siblings share (the class the value-checksum Form A also
+/// misses, and that the audit found hiding #5/#6/#8). The ratchet counts the weak
+/// (differential / self / un-annotated) cells per tracked matrix and forbids the
+/// count from GROWING; upgrading a cell to an INDEPENDENT oracle (a DuckDB /
+/// source-vs-dest re-read, outside rivet's decode family) lowers the ceiling. So
+/// the shared-decode self-oracle debt is visible and can only shrink.
+#[test]
+fn matrix_oracle_strength_ratchet() {
+    for (path, ceiling) in ORACLE_TRACKED {
+        let matrix = load_matrix(path);
+        let mut weak = 0usize;
+        for sc in &matrix.scenarios {
+            for (eng, cell) in sc.resolved_cells(&matrix.engines, path) {
+                // Typo-guard any declared strength.
+                if let Some(o) = cell.oracle.as_deref() {
+                    assert!(
+                        ORACLE_STRENGTHS.contains(&o),
+                        "{path} scenario '{}' column '{}' has oracle: '{o}' — must be one of {ORACLE_STRENGTHS:?}",
+                        sc.id,
+                        eng
+                    );
+                    // `oracle:` only means something on a `test:` cell.
+                    assert!(
+                        cell.test.is_some(),
+                        "{path} scenario '{}' column '{}' declares oracle: '{o}' but is not a `test` cell",
+                        sc.id,
+                        eng
+                    );
+                }
+                weak += cell.is_weak_oracle() as usize;
+            }
+        }
+        assert_eq!(
+            weak, *ceiling,
+            "{path} has {weak} WEAK-oracle cells (differential / self / un-annotated); the \
+             ratchet expects exactly {ceiling}. If {weak} > {ceiling}: you added a weak cell — \
+             give it an INDEPENDENT oracle (DuckDB/source re-read) or fail_loud, not a \
+             batch-differential. If {weak} < {ceiling}: you UPGRADED one — lower the ceiling in \
+             ORACLE_TRACKED to {weak} to lock the win."
         );
     }
 }

--- a/tests/offline/chunking_matrix_guard.rs
+++ b/tests/offline/chunking_matrix_guard.rs
@@ -204,7 +204,7 @@ const ORACLE_TRACKED: &[(&str, usize)] = &[
     // *_cdc_full_type_matrix_matches_batch self-oracle). PG + MySQL + tz/enum/
     // money/mongo cells upgraded to independent so far; MSSQL + the PG float/date/
     // binary/uuid cells are the remaining debt.
-    ("docs/cdc-type-fidelity-matrix.yaml", 22),
+    ("docs/cdc-type-fidelity-matrix.yaml", 16),
     // Batch type fidelity is already oracle-STRONG (24 independent cells: golden
     // hard-coded values + DuckDB/pyarrow foreign readers). The 6 weak are cells
     // whose CITED test is schema-coverage only (no independent VALUE re-read) —

--- a/tests/type_roundtrip/duckdb_load.rs
+++ b/tests/type_roundtrip/duckdb_load.rs
@@ -488,3 +488,116 @@ fn duckdb_pg_matrix_per_column_null_profile_matches_source() {
         );
     }
 }
+
+/// Assert the destination parquet's per-column NULL-count (and distinct-count for
+/// the `Some` entries) matches the pre-computed SOURCE profile — the shared core
+/// of the null-profile oracle. Each engine test computes the source side with its
+/// own connection (the PG sibling above inlines the same comparison; see it for
+/// the full rationale: this is what count/sum checks on OTHER columns miss).
+fn assert_dest_matches_null_profile(glob: &str, profile: &[(String, i64, Option<i64>)]) {
+    for (col, src_nulls, src_distinct) in profile {
+        let dst_nulls = dd_scalar_i64(&duckdb_run_sql_json(&format!(
+            "SELECT count(*) - count(\"{col}\") FROM read_parquet('{glob}')"
+        )));
+        assert_eq!(
+            *src_nulls, dst_nulls,
+            "column '{col}': null-count parity — source {src_nulls} vs dest {dst_nulls} \
+             (a silent per-column degradation to 100% NULL / nulled values)"
+        );
+        if let Some(d) = src_distinct {
+            let dst_d = dd_scalar_i64(&duckdb_run_sql_json(&format!(
+                "SELECT count(DISTINCT \"{col}\") FROM read_parquet('{glob}')"
+            )));
+            assert_eq!(
+                *d, dst_d,
+                "column '{col}': distinct-count parity — source {d} vs dest {dst_d} \
+                 (value corruption / a lost value-bracket the NULL-count would not reveal)"
+            );
+        }
+    }
+}
+
+/// MySQL sibling of `duckdb_pg_matrix_per_column_null_profile_matches_source`.
+#[test]
+#[ignore = "live: requires docker compose mysql + duckdb"]
+fn duckdb_mysql_matrix_per_column_null_profile_matches_source() {
+    use mysql::prelude::Queryable;
+    require_alive(LiveService::Mysql);
+    require_alive(LiveService::DuckDb);
+
+    let table_name = unique_name("dd_my_np");
+    setup_mysql_matrix_table(&table_name);
+    let _guard = MysqlCleanup(table_name.clone());
+
+    let (host_dir, container_dir) = duckdb_shared_workdir(&unique_name("dd_my_np_out"));
+    run_mysql_matrix_export(&table_name, "parquet", &host_dir);
+    let glob = format!("{container_dir}/*.parquet");
+
+    let mut c = mysql_connect();
+    let distinct: std::collections::HashSet<&str> = ["id", "c_int", "amount", "label", "uid"]
+        .into_iter()
+        .collect();
+    let profile: Vec<(String, i64, Option<i64>)> = super::helpers::MYSQL_MATRIX_COLUMNS
+        .split(',')
+        .map(|s| s.trim())
+        .map(|col| {
+            let nulls: i64 = c
+                .query_first(format!(
+                    "SELECT count(*) - count(`{col}`) FROM {table_name}"
+                ))
+                .unwrap()
+                .unwrap();
+            let dist = distinct.contains(col).then(|| {
+                c.query_first::<i64, _>(format!("SELECT count(DISTINCT `{col}`) FROM {table_name}"))
+                    .unwrap()
+                    .unwrap()
+            });
+            (col.to_string(), nulls, dist)
+        })
+        .collect();
+    assert!(
+        profile.len() >= 30,
+        "MySQL matrix must be rich; got {}",
+        profile.len()
+    );
+    assert_dest_matches_null_profile(&glob, &profile);
+}
+
+/// MSSQL sibling of `duckdb_pg_matrix_per_column_null_profile_matches_source`.
+#[test]
+#[ignore = "live: requires docker compose mssql + duckdb"]
+fn duckdb_mssql_matrix_per_column_null_profile_matches_source() {
+    require_alive(LiveService::Mssql);
+    require_alive(LiveService::DuckDb);
+
+    let table_name = unique_name("dd_ms_np");
+    setup_mssql_matrix_table(&table_name);
+    let _guard = MssqlCleanup(table_name.clone());
+
+    let (host_dir, container_dir) = duckdb_shared_workdir(&unique_name("dd_ms_np_out"));
+    run_mssql_matrix_export(&table_name, "parquet", &host_dir);
+    let glob = format!("{container_dir}/*.parquet");
+
+    let distinct: std::collections::HashSet<&str> = ["id", "c_int", "amount", "label", "uid"]
+        .into_iter()
+        .collect();
+    let profile: Vec<(String, i64, Option<i64>)> = super::helpers::MSSQL_MATRIX_COLUMNS
+        .split(',')
+        .map(|s| s.trim())
+        .map(|col| {
+            let nulls = mssql_query_i64(&format!(
+                "SELECT count(*) - count([{col}]) FROM {table_name}"
+            ));
+            let dist = distinct.contains(col).then(|| {
+                mssql_query_i64(&format!("SELECT count(DISTINCT [{col}]) FROM {table_name}"))
+            });
+            (col.to_string(), nulls, dist)
+        })
+        .collect();
+    assert!(
+        profile.len() >= 20,
+        "MSSQL matrix must be rich; got {}",
+        profile.len()
+    );
+    assert_dest_matches_null_profile(&glob, &profile);
+}

--- a/tests/type_roundtrip/duckdb_load.rs
+++ b/tests/type_roundtrip/duckdb_load.rs
@@ -376,3 +376,115 @@ fn duckdb_validates_mssql_type_matrix_parquet() {
         "datetimeoffset NULL must stay NULL"
     );
 }
+
+/// Scalar `i64` out of a one-cell DuckDB JSON result (every value is stringified
+/// by [`duckdb_run_sql_json`]).
+fn dd_scalar_i64(res: &serde_json::Value) -> i64 {
+    res["rows"][0][0]
+        .as_str()
+        .unwrap_or_else(|| panic!("duckdb scalar not a string: {res}"))
+        .parse()
+        .unwrap_or_else(|e| panic!("duckdb scalar not an int: {e} ({res})"))
+}
+
+/// The silent-loss oracle CLAUDE.md prescribes but the cross-product coverage
+/// audit found NOWHERE for pg/mysql/mssql/mongo: a per-column NULL-profile (+
+/// distinct-count on scalars) of the DESTINATION parquet vs the SOURCE table.
+/// Counts/sums of hand-picked columns pass while a column silently degrades to
+/// 100% NULL (the `uuid`→NULL `FixedSizeBinary(16)` class, a dropped Mongo `_id`
+/// bracket, a coarsened list) — the destination still has the right ROW count, so
+/// only a PER-COLUMN null-count vs the source catches it. Two independent readers:
+/// DuckDB re-reads the parquet, Postgres reads the source. This is the batch
+/// SNAPSHOT path — the headline, most-used export — whose only prior oracle was
+/// count/manifest parity.
+#[test]
+#[ignore = "live: requires docker compose postgres + duckdb"]
+fn duckdb_pg_matrix_per_column_null_profile_matches_source() {
+    require_alive(LiveService::Postgres);
+    require_alive(LiveService::DuckDb);
+
+    let table_name = unique_name("dd_pg_np");
+    let enum_type = setup_pg_matrix_table(&table_name);
+    let _guard = PgCleanup {
+        table: table_name.clone(),
+        enum_type,
+    };
+
+    let (host_dir, container_dir) = duckdb_shared_workdir(&unique_name("dd_pg_np_out"));
+    run_pg_matrix_export(&table_name, "parquet", &host_dir);
+    let glob = format!("{container_dir}/*.parquet");
+
+    let mut pg = pg_connect();
+    // Every source column, in physical order.
+    let cols: Vec<String> = pg
+        .query(
+            "SELECT column_name FROM information_schema.columns \
+             WHERE table_name = $1 ORDER BY ordinal_position",
+            &[&table_name],
+        )
+        .unwrap()
+        .iter()
+        .map(|r| r.get::<_, String>(0))
+        .collect();
+    assert!(
+        cols.len() >= 25,
+        "the matrix must present a rich column set to profile; got {} columns",
+        cols.len()
+    );
+
+    // Row-count parity baseline (a wholesale row loss would show here first).
+    let src_rows: i64 = pg
+        .query_one(&format!("SELECT count(*) FROM {table_name}"), &[])
+        .unwrap()
+        .get(0);
+    let dst_rows = dd_scalar_i64(&duckdb_run_sql_json(&format!(
+        "SELECT count(*) FROM read_parquet('{glob}')"
+    )));
+    assert_eq!(
+        src_rows, dst_rows,
+        "row-count parity source vs dest parquet"
+    );
+
+    // Per-column NULL-count parity — the primary silent-loss signal. Works for
+    // EVERY type (count ignores NULLs on both readers), so no column is exempt.
+    for col in &cols {
+        let src_nulls: i64 = pg
+            .query_one(
+                &format!("SELECT count(*) - count(\"{col}\") FROM {table_name}"),
+                &[],
+            )
+            .unwrap()
+            .get(0);
+        let dst_nulls = dd_scalar_i64(&duckdb_run_sql_json(&format!(
+            "SELECT count(*) - count(\"{col}\") FROM read_parquet('{glob}')"
+        )));
+        assert_eq!(
+            src_nulls, dst_nulls,
+            "column '{col}': source has {src_nulls} NULLs, dest parquet has {dst_nulls} — a \
+             silent per-column degradation (column dropped to 100% NULL / values nulled) that \
+             count/sum checks on other columns cannot see"
+        );
+    }
+
+    // Distinct-count parity on a curated scalar set — catches VALUE corruption or
+    // a dropped value-bracket that a matching NULL-count would miss (values wrong
+    // but not null). Compares COUNTS, so the differing physical representation
+    // (uuid text vs 16-byte blob, decimal) does not matter.
+    for col in ["id", "c_integer", "amount", "label", "uid"] {
+        let src_d: i64 = pg
+            .query_one(
+                &format!("SELECT count(DISTINCT \"{col}\") FROM {table_name}"),
+                &[],
+            )
+            .unwrap()
+            .get(0);
+        let dst_d = dd_scalar_i64(&duckdb_run_sql_json(&format!(
+            "SELECT count(DISTINCT \"{col}\") FROM read_parquet('{glob}')"
+        )));
+        assert_eq!(
+            src_d, dst_d,
+            "column '{col}': distinct-count parity — {src_d} in source vs {dst_d} in dest \
+             (value corruption / a lost value-bracket the NULL-count would not reveal)"
+        );
+    }
+}

--- a/tests/type_roundtrip/pg_edge_cases.rs
+++ b/tests/type_roundtrip/pg_edge_cases.rs
@@ -333,6 +333,36 @@ fn pg_edge_array_edge_shapes_round_trip() {
     );
 }
 
+// A MULTI-dimensional array in an `int[]` column has no flat Arrow List mapping
+// (the OID doesn't encode dimensionality, so a 2-D value routes to the 1-D list
+// builder). The old `.ok().flatten()` swallowed the postgres decode Err and wrote
+// a silent whole-cell NULL — silent data loss the value-checksum can't catch. It
+// must now FAIL LOUD, naming the column and the cast-to-text remediation.
+#[test]
+#[ignore = "live: requires docker compose postgres"]
+fn pg_edge_multidim_array_fails_loud_not_silent_null() {
+    let (_glob, out) = pg_edge_export(
+        "CREATE TABLE {table_name} (id INT PRIMARY KEY, grid INT[]);
+         INSERT INTO {table_name} VALUES (1, ARRAY[ARRAY[1,2],ARRAY[3,4]])",
+        "SELECT id, grid FROM {table_name}",
+        "pg_edge_md_arr",
+        "",
+    );
+    assert!(
+        !out.status.success(),
+        "a 2-D array export must FAIL, not silently NULL the cell"
+    );
+    let err = String::from_utf8_lossy(&out.stderr).to_lowercase();
+    assert!(
+        err.contains("multi-dimensional") && err.contains("grid"),
+        "the failure must name the column + the multi-dim cause; got:\n{err}"
+    );
+    assert!(
+        err.contains("::text") || err.contains("flatten"),
+        "the failure must name the cast-to-text remediation; got:\n{err}"
+    );
+}
+
 // ─── String edge cases: empty, whitespace, large single cell ───────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Post-0.21.1 durability + correctness hardening. The tip commit is this session's
work; the branch also carries ~30 prior audit commits (silent-loss / silent-
corruption fixes across PG/MySQL/MSSQL/Mongo CDC + warehouse load, plus a
generative coverage-matrix + oracle-strength ratchet that drove the shared-decode
self-oracle debt to 0).

### This session — three correctness fixes (each RED-proven + live-validated)

**1. Keyset `chunk_checkpoint` / `keyset_incremental` split — production data-safety.**
`chunk_checkpoint: true` on a keyset export used to mean crash-recovery AND
incremental-by-key, so a clean re-run silently skipped UPDATEd rows on a mutable
table — which is why `rivet init` could not default it on and a crashed run
stranded durable rows behind a checkpoint most configs left off. Now
`chunk_checkpoint` is crash-recovery ONLY (a clean re-run does a full pass, never
skipping; crash detected via the in-progress run_id), and the append-only
continue-from-key behaviour is the new off-by-default `keyset_incremental`. `init`
defaults `chunk_checkpoint` on for keyset. **Breaking:** a keyset config relying on
`chunk_checkpoint` for incremental must add `keyset_incremental: true` (see CHANGELOG).

**2. `rivet check` was blind to keyset (`chunk_by_key`).** It probed the wrong
column for an index, so every keyset table read as `chunked(?, …)` / false `UNSAFE`
even though the planner guarantees a keyset key is a unique index. Preflight now
understands `chunk_by_key` on all engines; adds a missing-checkpoint nudge.

**3. CDC unchanged-TOAST poison defer.** PG `test_decoding` decodes every table in
the DB, so `parse_test_decoding` bailing on an unrecoverable unchanged-TOAST datum
poisoned capture of unrelated tables sharing the slot (RED against two live PG CDC
tests). The refusal is now deferred via `ChangeEvent.poison` and raised only for
CAPTURED tables (both the file sink and the NDJSON driver check it).

### Adversarial multi-agent bug hunt → 5 follow-up fixes

A multi-agent hunt over the diff found five real bugs in the three fixes above,
all now fixed + RED-proven:

| Severity | Bug | RED-proof |
|---|---|---|
| CRITICAL | stale-cursor crash-recovery could skip a whole table | live crash-hook test (count 1000 vs 2000) |
| HIGH | NDJSON `cdc` driver ignored `poison` | offline mutation |
| MEDIUM | gate-failed run left a stale resume anchor | live crash-hook test |
| MEDIUM | `keyset_incremental` was a silent no-op without `chunk_checkpoint` | offline mutation |
| MEDIUM | checkpoint-nudge advised the removed semantics | assertion |

A graph review confirmed both new shared contracts (`ChangeEvent.poison`,
`KeysetPlan.incremental`) have no bypassing consumer.

## Testing

- Offline: lib 2114 / offline_suite 206 / bins 2213, clippy clean, fmt clean.
- Live: keyset (5 tests incl. two crash-hook RED-proofs) + PG CDC in parallel + Mongo resume — all green on the local MySQL/PostgreSQL/SQL Server/Mongo stack.
- Docs + JSON schema + config-reference regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1XP8eQFHpCpPtxva72ijx
