### PR TITLE
ci: host-side mongo readiness in release gate + pin fuzz nightly

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -18,6 +18,14 @@ on:
 permissions:
   contents: read
 
+# Pinned nightly. The rolling `nightly` hit a rustc ICE (~2026-07-24) compiling
+# tokio under `-Zsanitizer=address`, which `cargo fuzz` enables — every target
+# failed to BUILD (not a Rivet bug). This date is the last nightly proven to build
+# the fuzz targets. Bump it once upstream fixes the ICE: run `cargo +<date> fuzz
+# build` locally first, and only forward to a nightly that compiles clean.
+env:
+  FUZZ_NIGHTLY: nightly-2026-07-22
+
 concurrency:
   group: fuzz-${{ github.ref }}
   cancel-in-progress: true
@@ -33,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install nightly + cargo-fuzz
         run: |
-          rustup toolchain install nightly --profile minimal
+          rustup toolchain install "$FUZZ_NIGHTLY" --profile minimal
           cargo install cargo-fuzz --locked
       - name: Seed the corpus
         run: |
@@ -41,7 +49,7 @@ jobs:
           cp -n "fuzz/seeds/${{ matrix.target }}"/* "fuzz/corpus/${{ matrix.target }}/" || true
       - name: Fuzz ${{ matrix.target }}
         run: |
-          cargo +nightly fuzz run "${{ matrix.target }}" -- \
+          cargo "+$FUZZ_NIGHTLY" fuzz run "${{ matrix.target }}" -- \
             -max_total_time="${{ github.event.inputs.max_total_time || '300' }}" \
             -rss_limit_mb=4096
       - name: Upload crash reproducer on failure

--- a/dev/release-oracle/run.sh
+++ b/dev/release-oracle/run.sh
@@ -56,6 +56,17 @@ export BLESS_VERDICTS BLESS_DUCKDB
 
 [ -x "$RIVET" ] || { echo "rivet binary not found at $RIVET (build --release or set RIVET_BIN)"; exit 2; }
 command -v duckdb >/dev/null || { echo "duckdb not on PATH (needed for the integrity oracle)"; exit 2; }
+# Mongo is the ONLY engine seeded FROM THE HOST (`python3 seeds/mongo_seed.py` → pymongo);
+# pg/mysql/mssql seed INSIDE the container via `docker exec`. So a `python3` that can't import
+# pymongo makes every mongo version emit a cryptic "seed had errors" and the gate read
+# NOT-RELEASABLE — with no hint that the cause is the environment, not rivet. (Real bite: a
+# login shell whose PATH prefers /usr/local/bin/python3 over a pyenv shim that has pymongo.)
+# Fail LOUD here, only when mongo is actually in scope, naming the interpreter.
+if { [ -z "$ENGINES_FILTER" ] || grep -qw mongo <<<"${ENGINES_FILTER//,/ }"; } \
+   && ! python3 -c "import pymongo" >/dev/null 2>&1; then
+  echo "mongo seed needs pymongo but \`$(command -v python3 || echo python3)\` can't import it — \`pip install pymongo\`, or fix PATH (a login shell may shadow a pyenv shim with /usr/local/bin/python3)."
+  exit 2
+fi
 
 # ── local object stores (reuse the repo compose) ──
 AZURITE_CONN="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"


### PR DESCRIPTION
Two dev-infra fixes from dogfooding the 0.23.0 release gate. **No product code changes.**

### 1. release-oracle mongo `seed had errors` → fail-loud pymongo preflight
Mongo is the ONLY engine seeded **from the host** (`python3 seeds/mongo_seed.py` → pymongo); pg/mysql/mssql seed **inside** the container via `docker exec`. So a `python3` that can't import pymongo makes every mongo version fail with a cryptic `seed had errors` and the gate reads `NOT-RELEASABLE` — with **no hint the cause is the environment, not rivet**.

Real bite (this session): a login shell whose PATH prefers `/usr/local/bin/python3` over a pyenv shim that has pymongo. It sent the debug down two wrong diagnoses (colima port-forward, then a readiness race) before the actual cause — a `python3` interpreter mismatch — showed up. **The gate itself is correct.**

Fix: a fail-loud preflight (same `exit 2` pattern as the existing rivet-bin / duckdb checks) that names the offending interpreter when mongo is in scope and pymongo is missing.

**Verified on devbox (OrbStack):**
- normal shell (pyenv python3, has pymongo): mongo gate green across 4.4/5/6/7/8 (verdicts, integrity+types, load s3/gcs/azure ×150000).
- broken PATH (`bash -lc` → /usr/local/bin/python3): preflight exits 2 with `mongo seed needs pymongo but \`/usr/local/bin/python3\` can't import it …` — instead of 5 cryptic seed errors.

### 2. Fuzz CI nightly pin
The rolling `nightly` hit a rustc **ICE** (~2026-07-24) compiling tokio under `-Zsanitizer=address` (cargo-fuzz enables it) → every target failed to **build** (not a rivet bug). Pin `FUZZ_NIGHTLY=nightly-2026-07-22`. The one real crash the fuzzer had found (pg_test_decoding time-overflow panic) was already fixed on main in `6e0a209` with a RED-proven regression test.

**Verified:** a `workflow_dispatch` Fuzz run on this branch — all 3 targets (config_from_yaml, pg_test_decoding, mongo_resume_token) **completed success** (past the ICE, 60s fuzz each, no panic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CStm5SRuTx8s7uyGvD8vJ