### PR TITLE
fix: nine silent-loss defects, an independent read-back oracle, and the whole journey as one gate matrix

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -44,5 +44,18 @@ exclude_re = [
     # RED-proven against `delete !`), and the read itself is live-guarded by
     # mysql_cdc_refuses_a_compressed_binlog_instead_of_capturing_nothing, which
     # flips the server global and asserts the run fails.
+    # `hash_value`'s per-DataType arms are a typed FAST PATH, not a behaviour:
+    # deleting one falls through to the `_` arm, which hashes the value's
+    # rendered TEXT instead of its bytes. The digest is a `HashSet<u64>` key
+    # inside one uniqueness check and is never persisted, compared across runs,
+    # or shown — so a different-but-injective digest satisfies the same
+    # contract. Demonstrated rather than argued: with the `Int64` arm deleted,
+    # `uniqueness_fails` (an Int64 column carrying a duplicate) still reports
+    # the duplicate, and all 25 quality unit tests plus 12 live uniqueness
+    # tests stay green. What WOULD be a real bug — a present value that cannot
+    # be hashed at all being silently skipped — is guarded by
+    # `uniqueness_refuses_when_a_present_value_cannot_be_hashed`, which does
+    # not depend on which arm renders it.
+    "delete match arm .* in hash_value",
     "replace refuse_compressed_binlog -> Result<\\(\\)> with Ok\\(\\(\\)\\)",
 ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -939,3 +939,52 @@ from the run's own metrics row. RED against the pre-fix order (`left: Some(0)`,
 `right: Some(4)`) while the pre-existing worker-error test stays GREEN against
 the same mutant. When a new test and an old one disagree about a mutant, the
 disagreement is the finding: the old test's blind spot has a name and a boundary.
+
+## A coverage ledger must grade the CALL SITE, not the definition
+
+A matrix row saying `test` means "the gate runs this". The guard that protects
+it asked a weaker question — does every `def verify_*` have a ROW — and the gap
+between the two was live: `blessed_path.verify_blessed_path` was registered
+`test` for all four engines and had **no caller anywhere in the tree**. Dead
+code behind four green cells, and every signal a reader has (the matrix, the
+definition, the guard, the docstring) agreed it was covered. Nothing in the
+suite asks "is this reachable from an entry point".
+
+Process rule: **a drift guard over a coverage ledger must assert the check is
+INVOKED, not merely defined** — an occurrence of `name(` that is not the `def`,
+in any module the runner can reach. `every_gate_function_has_a_call_site`
+(`tests/offline/release_gate_matrix_guard.rs`), RED-proven by deleting one call.
+The same shape applies to any registry-of-checks: a lint rule list, a scenario
+table, a hook map. Registration is a claim about behaviour; only the call site
+is evidence.
+
+Two siblings from the same build, both recurrences of rules already in this file:
+
+1. **An unscoped count is satisfied by history.** Three separate assertions in
+   ONE module counted `WHERE export_name='flow'` (37 rows on a cell that wrote
+   one) and `SELECT count(*) FROM load_run` (the same 21 in all twelve load
+   cells). Scope by whatever key the table actually has — a watermark on
+   `max(id)` where there is no `run_id` (clock-free; comparing the host's clock
+   to the database's is two clocks), the run ids from `.rivet/runs/*/summary.json`
+   (which rivet writes beside the CONFIG whatever the destination is, so it has
+   no local-vs-cloud asymmetry the way the destination manifest does), a PREFIX
+   match on `load_id` (the stored id is `<--run-id>:<export>` — one load over N
+   exports records N rows). A count twelve cells agree on is measuring none of
+   them.
+
+2. **One oracle across backends, or two that disagree about the bug.** The local
+   readback was fixed to count only manifest-DECLARED parts (a crash leaves
+   orphans no manifest names); the cloud readback kept counting everything under
+   the prefix, so every resume cell on s3/gcs read 2000 rows from a 1000-row
+   table. The fix is not to patch the second one — it is to PULL the cloud prefix
+   whole and run the identical local oracle over it. A store-specific "what was
+   delivered" is a second definition, and it drifts on the first fix.
+
+And a fixture rule the same run paid for: **`DROP TABLE` before a CDC disable
+orphans the change table**, so a guard joining `cdc.change_tables` to
+`sys.tables` stops seeing it, the disable is skipped, and the next
+`sp_cdc_enable_table` fails with 22926 "capture instance already exists". It
+alternates pass/fail and reads as a race; it is order-dependent state the guard
+went blind to. Disable first, guard on `capture_instance` (which survives the
+drop), and wait on `fn_cdc_get_min_lsn` rather than the enable call's exit code —
+rivet's preflight reads that function, so "enabled" is not "ready".

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "chrono",
+ "chrono-tz",
  "half",
  "hashbrown 0.17.1",
  "num-complex",
@@ -646,6 +647,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
 ]
 
 [[package]]
@@ -2903,12 +2914,30 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.13.1",
  "serde",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -4436,7 +4465,7 @@ dependencies = [
  "log",
  "parking_lot",
  "percent-encoding",
- "phf",
+ "phf 0.13.1",
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,13 @@ md-5 = "0.11"
 # `canonical_extension_types` enables Arrow's canonical extension wrappers
 # (`arrow_schema::extension::{Uuid, Json}`) — see Cargo dep on `parquet`
 # below for the writer-side pairing.
-arrow = { version = "59", features = ["canonical_extension_types"] }
+# `chrono-tz`: Arrow's ArrayFormatter REFUSES a timestamp whose timezone is a
+# NAME rather than an offset without it — "only offset based timezones supported
+# without chrono-tz feature". rivet maps every timestamp to Some("UTC")
+# (types/mapping.rs), so `meta_columns.row_hash` failed on EVERY temporal column:
+# a real MySQL config lost 63 of 65 exports to it. Offsets and naive timestamps
+# rendered fine, which is why nothing else caught it.
+arrow = { version = "59", features = ["canonical_extension_types", "chrono-tz"] }
 # Direct dep on `arrow-schema` so we can use the `extension` module — the
 # `arrow` facade re-exports `DataType` / `Field` but not the `extension`
 # submodule. Version is pinned to match `arrow`'s transitive choice.

--- a/Makefile
+++ b/Makefile
@@ -169,5 +169,94 @@ seed-garbage-mysql:
 seed-garbage-mssql:
 	docker compose exec -T mssql /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'Rivet_Passw0rd!' -C -d rivet -b -i /dev/stdin < dev/garbage/mssql.sql
 
-release-oracle:  ## Release gate: every engine×version × scenario against local MinIO/fake-gcs/Azurite + a BigQuery golden. Green everywhere ⇒ releasable.
+release-oracle:  ## Release gate, BARE: only what is already in your shell. Read the SKIP count — with nothing set it is ~95 PASS / 60 SKIP and still prints RELEASE-READY.
 	python3 -m dev.release_oracle
+
+# ─── the gate's environment, assembled ────────────────────────────────────────
+#
+# Every URL below points at the CANONICAL dev stand in docker-compose.yaml, and
+# every one is `?=` so a caller can override a single service without editing
+# this file.
+#
+# WHY THIS EXISTS. The gate is env-driven and SKIPs — never silently passes —
+# when a URL is absent. That is the honest behaviour and it has a trap: a run
+# with none of these set is ~95 PASS / 60 SKIP and prints RELEASE-READY, which
+# is literally true ("every non-skipped cell is green") and nearly meaningless.
+# Assembling twenty variables by hand before every release means the verdict
+# depends on someone remembering them. It did: the first end-to-end pass with
+# the full environment surfaced SIX latent defects in the gate's own scaffolding
+# that no partial run could reach.
+#
+# The CDC ports are NOT the batch ports. `mysql-cdc` is 3307 and `mssql-cdc` is
+# 1434 — separate services with binlog / CDC + Agent enabled. Pointing the CDC
+# legs at 3306/1433 makes them fail in a way that reads like a product defect.
+RIVET_ORACLE_POSTGRES_URL ?= postgresql://rivet:rivet@127.0.0.1:5432/rivet
+RIVET_ORACLE_MYSQL_URL    ?= mysql://rivet:rivet@127.0.0.1:3306/rivet
+RIVET_ORACLE_MSSQL_URL    ?= mssql://sa:Rivet_Passw0rd!@127.0.0.1:1433/rivet
+RIVET_ORACLE_MONGO_URL    ?= mongodb://127.0.0.1:27017/rivet
+RIVET_CDC_POSTGRES_URL    ?= postgresql://rivet:rivet@127.0.0.1:5434/rivet
+RIVET_CDC_MYSQL_URL       ?= mysql://rivet:rivet@127.0.0.1:3307/rivet
+RIVET_CDC_MSSQL_URL       ?= mssql://sa:Rivet_Passw0rd!@127.0.0.1:1434/rivet
+# `directConnection=true`, not `replicaSet=rs0`: the set advertises a member
+# address the host cannot resolve, so the driver reports ReplicaSetNoPrimary and
+# every mongo CDC cell dies at init.
+RIVET_CDC_MONGO_URL       ?= mongodb://127.0.0.1:27018/rivet?directConnection=true
+# One Postgres state DB serves every "grade the other backend" leg.
+RIVET_GATE_STATE_URL      ?= postgresql://rivet:rivet@127.0.0.1:5433/rivet_state
+RIVET_SWEEP_STATE_CONTAINER ?= rivet-postgres-state-1
+RIVET_CONC_SRC_CONTAINER  ?= rivet-postgres-1
+# Not hard-coded to anyone's project: whatever `gcloud` is pointed at. Empty ⇒
+# the BigQuery legs SKIP with that reason, which is correct on a machine with no
+# warehouse.
+BQ_ORACLE_PROJECT         ?= $(shell gcloud config get-value project 2>/dev/null)
+BQ_ORACLE_DATASET         ?= rivet_blessed
+BQ_ORACLE_BUCKET          ?= rivet_data_test
+PREV_RELEASE_DIR          ?= target/prev-release
+
+GATE_ENV = \
+  RIVET_ORACLE_POSTGRES_URL='$(RIVET_ORACLE_POSTGRES_URL)' \
+  RIVET_ORACLE_MYSQL_URL='$(RIVET_ORACLE_MYSQL_URL)' \
+  RIVET_ORACLE_MSSQL_URL='$(RIVET_ORACLE_MSSQL_URL)' \
+  RIVET_ORACLE_MONGO_URL='$(RIVET_ORACLE_MONGO_URL)' \
+  RIVET_REGRESSION_SOURCE_URL='$(RIVET_ORACLE_POSTGRES_URL)' \
+  RIVET_CDC_POSTGRES_URL='$(RIVET_CDC_POSTGRES_URL)' \
+  RIVET_CDC_MYSQL_URL='$(RIVET_CDC_MYSQL_URL)' \
+  RIVET_CDC_MSSQL_URL='$(RIVET_CDC_MSSQL_URL)' \
+  RIVET_CDC_MONGO_URL='$(RIVET_CDC_MONGO_URL)' \
+  RIVET_CDC_STATE_URL='$(RIVET_GATE_STATE_URL)' \
+  RIVET_CONC_STATE_URL='$(RIVET_GATE_STATE_URL)' \
+  RIVET_GATE_STATE_URL='$(RIVET_GATE_STATE_URL)' \
+  RIVET_TEST_STATE_URL='$(RIVET_GATE_STATE_URL)' \
+  RIVET_SWEEP_STATE_CONTAINER='$(RIVET_SWEEP_STATE_CONTAINER)' \
+  RIVET_CONC_SRC_CONTAINER='$(RIVET_CONC_SRC_CONTAINER)' \
+  RIVET_CONC_SRC_URL='$(RIVET_ORACLE_POSTGRES_URL)' \
+  BQ_ORACLE_PROJECT='$(BQ_ORACLE_PROJECT)' \
+  BQ_ORACLE_DATASET='$(BQ_ORACLE_DATASET)' \
+  BQ_ORACLE_BUCKET='$(BQ_ORACLE_BUCKET)'
+
+release-oracle-prev-bin:  ## Download the PREVIOUS release binary (the regression + scale baseline). A downloaded asset, never a locally rebuilt parent.
+	@mkdir -p $(PREV_RELEASE_DIR)
+	@tag=$$(gh release list --limit 1 --json tagName -q '.[0].tagName'); \
+	 arch=$$(uname -m); os=$$(uname -s | tr 'A-Z' 'a-z'); \
+	 [ "$$arch" = "arm64" ] && arch=aarch64; \
+	 case "$$os" in darwin) triple="$$arch-apple-darwin";; *) triple="$$arch-unknown-linux-gnu";; esac; \
+	 echo "  downloading $$tag ($$triple) — the artifact users actually run"; \
+	 gh release download "$$tag" --pattern "rivet-$$tag-$$triple.tar.gz" --dir $(PREV_RELEASE_DIR) --clobber; \
+	 tar -xzf "$(PREV_RELEASE_DIR)/rivet-$$tag-$$triple.tar.gz" -C $(PREV_RELEASE_DIR); \
+	 chmod +x "$(PREV_RELEASE_DIR)/rivet-$$tag-$$triple/rivet"; \
+	 echo "  $$($(PREV_RELEASE_DIR)/rivet-$$tag-$$triple/rivet --version) → $(PREV_RELEASE_DIR)/rivet-$$tag-$$triple/rivet"
+
+release-oracle-full: release-oracle-prev-bin  ## Release gate with the WHOLE environment against the local dev stand. This is the one a release is judged by.
+	@# The gate grades `target/release/rivet`. A stale one grades yesterday's
+	@# code, and `cargo package` poisons the fingerprints so cargo reports
+	@# `Fresh` on a binary that predates your edits — drop the snapshot first.
+	@rm -rf target/package
+	cargo build --release
+	@prev=$$(ls -d $(PREV_RELEASE_DIR)/rivet-v*/rivet 2>/dev/null | tail -1); \
+	 echo "  previous release: $${prev:-<none — the regression + scale legs will SKIP>}"; \
+	 env $(GATE_ENV) RIVET_PREV_RELEASE_BIN="$$prev" python3 -m dev.release_oracle $(ARGS)
+
+release-oracle-bless: release-oracle-prev-bin  ## Re-capture the verdict + duckdb-type goldens. Deliberate: a golden must be written by rivet's own code, never edited by hand.
+	@rm -rf target/package
+	cargo build --release
+	env $(GATE_ENV) python3 -m dev.release_oracle --bless-local $(ARGS)

--- a/dev/fixtures/aa_imports_probe.py
+++ b/dev/fixtures/aa_imports_probe.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Run each hypothesis about the field's slow cohort against the local fixture.
+
+WHY: a production run took 5.2 minutes to export 40,791 rows. Four explanations
+were plausible from the artifacts alone; three of them were wrong, and reading
+the code could not tell them apart. Each is reduced here to a timed export on a
+stand with no tunnel, where the answer is a number.
+
+Every hypothesis states what it would mean if TRUE and if FALSE, before it runs —
+otherwise a measurement becomes whatever the reader already believed.
+"""
+
+import argparse
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+RIVET = ROOT / "target" / "release" / "rivet"
+URL = "mysql://rivet:rivet@127.0.0.1:3306/rivet"
+FIELD_SECONDS = 312.0  # aa_import_ikea_es: 40,791 rows, 5.2 min
+
+
+def mysql(sql, container="rivet-mysql-1"):
+    return subprocess.run(
+        ["docker", "exec", "-i", container, "mysql", "-urivet", "-privet", "-N", "rivet"],
+        input=sql, capture_output=True, text=True).stdout.strip()
+
+
+def columns(table):
+    return mysql(f"SELECT group_concat(column_name) FROM information_schema.columns "
+                 f"WHERE table_schema='rivet' AND table_name='{table}'")
+
+
+def config(work, table, dest, mode="full", extra=""):
+    cfg = work / f"{table}.yaml"
+    cfg.write_text(
+        f"source: {{type: mysql, url_env: ORACLE_URL}}\n"
+        f"exports:\n  - name: {table}\n"
+        f"    query: >\n      SELECT {columns(table)} FROM {table}\n"
+        f"    mode: {mode}\n{extra}"
+        f"    format: parquet\n"
+        f"    meta_columns: {{exported_at: true, row_hash: true}}\n"
+        f"    destination: {dest}\n")
+    return cfg
+
+
+def timed(cfg, out):
+    shutil.rmtree(out, ignore_errors=True)
+    t = time.monotonic()
+    p = subprocess.run([str(RIVET), "run", "-c", str(cfg)],
+                       capture_output=True, text=True,
+                       env={**__import__("os").environ, "ORACLE_URL": URL})
+    return time.monotonic() - t, p.returncode == 0
+
+
+def raw_mb(table):
+    mysql(f"ANALYZE TABLE {table};")
+    v = mysql(f"SELECT data_length FROM information_schema.tables "
+              f"WHERE table_schema='rivet' AND table_name='{table}'")
+    return int(v) / 1e6 if v.isdigit() else 0.0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--work", default="/tmp/aa_probe")
+    ns = ap.parse_args()
+    work = Path(ns.work); work.mkdir(parents=True, exist_ok=True)
+    out = work / "out"
+    dest = f"{{type: local, path: {out}/}}"
+
+    print(f"field baseline: aa_import_ikea_es — 40,791 rows, {FIELD_SECONDS:.0f}s\n")
+    verdicts = []
+
+    # H1 — is the cost rivet's own?  TRUE  → the cohort's shape is slow in rivet.
+    #                                FALSE → the cost is environmental; stop tuning the config.
+    t, ok = timed(config(work, "f_ikea_es", dest), out)
+    verdicts.append(("H1 rivet's own per-export cost", t, FIELD_SECONDS / max(t, 1e-9),
+                     "REFUTED — rivet is not the cost" if t < 5 else "SUPPORTED"))
+
+    # H2 — is it the object-store destination?  (the field writes to real GCS)
+    import os
+    os.environ["STORAGE_EMULATOR_HOST"] = "http://127.0.0.1:4443"
+    gdest = ("\n      type: gcs\n      bucket: rivet-oracle\n"
+             "      prefix: aa_probe/ikea/\n      endpoint: http://127.0.0.1:4443")
+    t2, ok2 = timed(config(work, "f_ikea_es", gdest), out)
+    verdicts.append(("H2 object-store destination", t2, FIELD_SECONDS / max(t2, 1e-9),
+                     "REFUTED — destination is not the cost" if t2 < 10 else "SUPPORTED"))
+
+    # H3 — table BLOAT: a full scan reads PAGES, so 40k live rows in a table with
+    #      massive dead space might scan like a big table.
+    #      TRUE → tell them to OPTIMIZE TABLE. FALSE → dead space is nearly free.
+    if mysql("SHOW TABLES LIKE 'f_ikea_bloat'"):
+        t3, _ = timed(config(work, "f_ikea_bloat", dest), out)
+        ratio = raw_mb("f_ikea_bloat") / max(raw_mb("f_ikea_es"), 1e-9)
+        verdicts.append((f"H3 table bloat ({ratio:.0f}x on-disk, same live rows)", t3,
+                         FIELD_SECONDS / max(t3, 1e-9),
+                         "REFUTED — InnoDB does not pay for dead space here"
+                         if t3 < 5 else "SUPPORTED"))
+
+    # H4 — does parquet size predict WIRE volume?  This is the one that matters:
+    #      every MB/min figure computed from `file_log` measures COMPRESSED bytes,
+    #      while a tunnel carries the server's RAW rows.
+    if mysql("SHOW TABLES LIKE 'f_ikea_real'"):
+        for t_name in ("f_ikea_es", "f_ikea_real"):
+            timed(config(work, t_name, dest), out)
+            pq = sum(f.stat().st_size for f in out.rglob("*.parquet")) / 1e6
+            print(f"  {t_name:<14} raw {raw_mb(t_name):6.1f} MB → parquet {pq:5.2f} MB"
+                  f"  = {raw_mb(t_name)/max(pq,1e-9):5.1f}:1")
+        print("  → identical raw bytes, parquet differs by compressibility alone.\n"
+              "    Any MB/min computed from parquet UNDERSTATES the wire by that ratio.\n")
+
+    print(f"{'hypothesis':<48} {'seconds':>8} {'vs field':>9}  verdict")
+    for name, t, r, v in verdicts:
+        print(f"{name:<48} {t:8.2f} {r:8.0f}x  {v}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dev/fixtures/aa_imports_seed.py
+++ b/dev/fixtures/aa_imports_seed.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Recreate the field's `aa_import_*` cohort locally, by MEASURED shape.
+
+WHY THIS EXISTS
+
+A production run took 3h51m to move 1.48 GB, and twelve exports of 2.4–8.0 MB
+each took 4.8–5.5 minutes — time nearly constant while the data varied 3x. The
+harm counters that looked like they explained it (`Innodb_rows_read`) turned out
+to be deltas of a GLOBAL server counter taken around CONCURRENT exports, so they
+attributed every other export's work to whichever one was being measured. rivet's
+own doc comment says so: "accurate on a quiet pilot box". They were read as
+per-export truth and produced a confident, wrong diagnosis.
+
+So the shapes are reproduced here instead, on a stand with no tunnel and no
+concurrent load, where the same question can be asked of something measurable.
+
+WHAT IS REPRODUCED, AND FROM WHERE
+
+Every number below is measured from the field artifacts, not invented:
+  rows        `export_metrics.total_rows` (what the run actually delivered)
+  columns     the curated SELECT in the config `rivet init` generated
+  bytes/row   `file_log.bytes / file_log.row_count` — real compressed width
+  key shape   `rivet check`'s "Cursor range" vs the row estimate, which is what
+              proves `ref_id` is NOT unique (15.9M rows over a span of 7.36M =
+              2.16 rows per key, so keyset is impossible on it)
+  index       `rivet check`'s "Access:" line
+
+The big tables are scaled DOWN by row count but keep their key DENSITY and
+uniqueness, because those are what decide the strategy. The small ones are exact
+— they are the unexplained cohort, and they are cheap.
+"""
+
+import argparse
+import random
+import subprocess
+import sys
+
+# (table, rows, ncols, bytes_per_row_compressed, key, key_density, indexed)
+#
+# `key_density` is rows per distinct key value: 1.0 means the key is unique and
+# keyset works; >1 means it is not, and the planner will refuse `chunk_by_key`.
+COHORT = [
+    # the unexplained cohort — exact sizes, no index on the read path
+    ("f_ikea_es",        40_791, 16,  78, None, 0,    False),
+    ("f_iherbs",         37_265, 17,  84, None, 0,    False),
+    ("f_shopee_in",      44_815, 20,  88, None, 0,    False),
+    ("f_actionpays",     73_023, 16,  94, None, 0,    False),
+    ("f_amazon_pt",      84_693, 20,  94, None, 0,    False),
+    # the one that CROSSED the 300s ceiling: biggest of the family
+    ("f_partnerize",     94_000, 17,  90, None, 0,    False),
+    # controls that WORK in the field: unique id, index scan, ~870k rows/min
+    ("f_bonus_conv_eur", 500_000, 12, 19, "id",  1.0,  True),
+    # the range victims, scaled 30x down, DENSITY preserved (non-unique key)
+    ("f_bonuses_version", 500_000, 16, 22, "ref_id", 2.16, True),
+    ("f_amazon_in_ver",   200_000, 11, 24, "ref_id", 5.24, True),
+]
+
+
+def ddl(name, ncols, brow, key, indexed):
+    """A table whose ROW WIDTH matches the field's, in the field's column count.
+
+    Width matters more than the exact types: the question is how long rivet takes
+    per byte and per export, and a 16-column table of the right width answers it.
+    The parquet figure is COMPRESSED, so the raw column is sized generously —
+    text compresses roughly 3-5x at zstd, and under-sizing here would make the
+    fixture easier than the thing it reproduces.
+    """
+    raw = max(brow * 4, 40)
+    cols = []
+    if key:
+        cols.append(f"`{key}` bigint unsigned NOT NULL")
+    cols.append("`status` varchar(32) NULL")
+    cols.append("`amount` decimal(18,4) NULL")
+    cols.append("`created_at` datetime NULL")
+    cols.append("`updated_at` datetime NULL")
+    # spread the remaining width across text columns, like the import payloads
+    rest = ncols - len(cols)
+    per = max(raw // max(rest, 1), 16)
+    for i in range(rest):
+        cols.append(f"`c{i}` varchar({min(per, 512)}) NULL")
+    idx = f", KEY `k_{key}` (`{key}`)" if (key and indexed) else ""
+    return f"CREATE TABLE `{name}` (\n  " + ",\n  ".join(cols) + idx + "\n) ENGINE=InnoDB"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--container", default="rivet-mysql-1")
+    ap.add_argument("--db", default="rivet")
+    ap.add_argument("--only", default="", help="comma-separated subset")
+    ns = ap.parse_args()
+
+    want = set(x for x in ns.only.split(",") if x)
+    sql = []
+    for name, rows, ncols, brow, key, dens, indexed in COHORT:
+        if want and name not in want:
+            continue
+        sql.append(f"DROP TABLE IF EXISTS `{name}`;")
+        sql.append(ddl(name, ncols, brow, key, indexed) + ";")
+
+    run(ns, "\n".join(sql))
+    print("tables created", file=sys.stderr)
+
+    for name, rows, ncols, brow, key, dens, indexed in COHORT:
+        if want and name not in want:
+            continue
+        fill(ns, name, rows, ncols, brow, key, dens)
+        print(f"  {name}: {rows:,} rows", file=sys.stderr)
+
+
+def fill(ns, name, rows, ncols, brow, key, dens):
+    """Generate rows server-side from a recursive CTE — no round-trips.
+
+    A client-side INSERT loop over 500k rows spends its time in the driver, which
+    is exactly the confound this fixture exists to remove.
+    """
+    raw = max(brow * 4, 40)
+    ncols_text = ncols - (5 if key else 4)
+    per = max(raw // max(ncols_text, 1), 16)
+    # `dens` rows per key value: FLOOR((n-1)/dens)+1 repeats each key `dens` times
+    keyexpr = f"FLOOR((n - 1) / {dens}) + 1" if key and dens > 1 else "n"
+    sel = []
+    if key:
+        sel.append(f"{keyexpr}")
+    sel += ["ELT(1 + (n % 4), 'new', 'done', 'hold', 'void')",
+            "ROUND((n % 100000) + 0.99, 2)",
+            "DATE_SUB(NOW(), INTERVAL (n % 900) DAY)",
+            "DATE_SUB(NOW(), INTERVAL (n % 400) DAY)"]
+    for i in range(ncols_text):
+        sel.append(f"RPAD(CONCAT('c{i}_', n), {min(per,512)}, 'x')")
+    body = ", ".join(sel)
+    # chunked so one statement never builds a 500k-row temp result
+    step = 900  # under the default cte_max_recursion_depth (1000)
+    for lo in range(0, rows, step):
+        hi = min(lo + step, rows)
+        run(ns, f"""
+INSERT INTO `{name}`
+WITH RECURSIVE s(n) AS (  /* depth is bounded by `step` below, so the
+     server default (1000) is raised per statement instead of per session:
+     the seed user has no SESSION_VARIABLES_ADMIN on a least-privilege stand */
+  SELECT {lo + 1} UNION ALL SELECT n + 1 FROM s WHERE n < {hi}
+)
+SELECT {body} FROM s;""")
+
+
+def run(ns, sql):
+    p = subprocess.run(
+        ["docker", "exec", "-i", ns.container, "mysql", "-urivet", "-privet", ns.db],
+        input=sql, capture_output=True, text=True,
+    )
+    if p.returncode != 0:
+        print(p.stderr[-800:], file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/mssql/init.sql
+++ b/dev/mssql/init.sql
@@ -66,3 +66,49 @@ SELECT TOP (500)
     CAST(ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS DECIMAL(12,2)) * 1.5
 FROM sys.all_objects a CROSS JOIN sys.all_objects b;
 GO
+
+-- ─── Type-matrix demo, the SQL Server twin of the PG/MySQL fixture ──────────
+--
+-- `dev/postgres/init.sql` and `dev/mysql/init.sql` have declared
+-- `rivet_type_matrix` for a long time; this file did not, and the cross-engine
+-- stand tests that read it (`chunking_stand::stand_meta_columns_mssql`,
+-- `stand_type_matrix_every_consumer_mssql`) passed locally only because a
+-- hand-created table happened to sit in a long-lived container. On a fresh CI
+-- stand they failed with `Invalid object name 'dbo.rivet_type_matrix'`. The
+-- fixture belongs to the stand, so it is declared here — same four rows and the
+-- same semantic columns as PostgreSQL, in the T-SQL types rivet maps them to.
+--
+-- `created_at` (datetime2) and `created_at_tz` (datetimeoffset) are the pair
+-- that matters: naive and zone-carrying in one export, which is what makes the
+-- row-hash / checksum / uniqueness consumers face a real timestamp instead of
+-- two integers.
+IF OBJECT_ID('dbo.rivet_type_matrix', 'U') IS NOT NULL DROP TABLE dbo.rivet_type_matrix;
+GO
+CREATE TABLE dbo.rivet_type_matrix (
+    id            BIGINT           NOT NULL PRIMARY KEY,
+    label         NVARCHAR(100)    NOT NULL,
+    amount        DECIMAL(18,2)    NULL,
+    fee           DECIMAL(18,6)    NULL,
+    created_at    DATETIME2(6)     NOT NULL,
+    created_at_tz DATETIMEOFFSET(6) NOT NULL,
+    raw_bytes     VARBINARY(64)    NOT NULL,
+    uid           UNIQUEIDENTIFIER NOT NULL,
+    attrs         NVARCHAR(MAX)    NULL
+);
+GO
+INSERT INTO dbo.rivet_type_matrix
+    (id, label, amount, fee, created_at, created_at_tz, raw_bytes, uid, attrs)
+VALUES
+  (1, N'payments-like', 0.10, 0.000001,
+      '2035-08-07T09:08:07.987654', '2035-08-07T09:08:07.987654+00:00',
+      0x00FF012345, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380011', N'{"tier":"gold","n":1}'),
+  (2, N'payments-like', 0.20, 0.000002,
+      '2019-02-03T03:07:06.554433', '2019-02-03T08:07:06.554433+05:00',
+      0xDEADBEEF, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380022', N'["a","b"]'),
+  (3, N'payments-like', 999999999999.99, 10.123456,
+      '2020-01-15T00:00:00.000001', '2020-01-15T00:00:00.000001+00:00',
+      0xCAFE, 'C0EEBC99-9C0B-4EF8-BB6D-6BB9BD380033', N'{"big":true}'),
+  (4, N'payments-like', -100.05, -0.123456,
+      '2021-06-30T12:59:59.999999', '2021-06-30T12:59:59.999999+00:00',
+      0x00, 'D0EEBC99-9C0B-4EF8-BB6D-6BB9BD380044', N'{}');
+GO

--- a/dev/release-oracle/golden/verdicts.json
+++ b/dev/release-oracle/golden/verdicts.json
@@ -1,5 +1,9 @@
 {
   "mongo": {
+    "content_items": {
+      "strategy": "full",
+      "verdict": "ACCEPTABLE"
+    },
     "orders": {
       "strategy": "full",
       "verdict": "DEGRADED"

--- a/dev/release-oracle/lib/gcs_pull.py
+++ b/dev/release-oracle/lib/gcs_pull.py
@@ -5,8 +5,14 @@ dir — an INDEPENDENT readback for the load gate when `gsutil` is not installed
 Uses only the fake-gcs JSON API (list) + its media download endpoint, so it never
 routes through rivet: a rivet write bug cannot rubber-stamp its own output.
 
-Usage: gcs_pull.py <endpoint> <bucket> <prefix> <dest_dir>
-Prints the number of parquet objects downloaded.
+Usage: gcs_pull.py <endpoint> <bucket> <prefix> <dest_dir> [--all]
+Prints the number of objects downloaded.
+
+`--all` pulls EVERY object and preserves its path under the prefix, rather than
+only `.parquet` flattened to `part_N.parquet`. A caller that needs to know what
+the run DECLARED — the manifests — cannot answer that from the parquet alone,
+and the flattened names break any manifest that names its parts. Opt-in so the
+default shape and printed count stay exactly what the load gate already reads.
 """
 import os
 import sys
@@ -14,6 +20,7 @@ import urllib.parse
 import urllib.request
 
 endpoint, bucket, prefix, dest = sys.argv[1:5]
+pull_all = "--all" in sys.argv[5:]
 os.makedirs(dest, exist_ok=True)
 
 list_url = f"{endpoint}/storage/v1/b/{bucket}/o?prefix={urllib.parse.quote(prefix, safe='')}"
@@ -28,11 +35,17 @@ except Exception:
 n = 0
 for it in items:
     name = it.get("name", "")
-    if not name.endswith(".parquet"):
+    if not pull_all and not name.endswith(".parquet"):
         continue
     media = f"{endpoint}/download/storage/v1/b/{bucket}/o/{urllib.parse.quote(name, safe='')}?alt=media"
+    if pull_all:
+        rel = name[len(prefix):].lstrip("/") or os.path.basename(name)
+        out = os.path.join(dest, rel)
+        os.makedirs(os.path.dirname(out) or dest, exist_ok=True)
+    else:
+        out = os.path.join(dest, f"part_{n}.parquet")
     try:
-        urllib.request.urlretrieve(media, os.path.join(dest, f"part_{n}.parquet"))
+        urllib.request.urlretrieve(media, out)
         n += 1
     except Exception:
         pass

--- a/dev/release_oracle/__main__.py
+++ b/dev/release_oracle/__main__.py
@@ -44,7 +44,17 @@ import time
 from pathlib import Path
 
 from .core import Ledger, Status, engine_container, docker, have, remove_engine_containers, rivet, rivet_bin, run, HERE, ROOT
-from . import bigquery, cdc, concurrency, gifs, regression, release_path, scenarios, state_parity
+from . import (
+    bigquery,
+    blessed_flow,
+    cdc,
+    concurrency,
+    gifs,
+    regression,
+    release_path,
+    scenarios,
+    state_parity,
+)
 
 
 def matrix_cfg(*args: str) -> str:
@@ -182,6 +192,10 @@ def preflight(led: Ledger, *, bless_gifs: bool = False) -> None:
     scenarios.verify_state_migrations(led)
     scenarios.verify_inflight_run_stays_loadable(led)
     scenarios.verify_coverage_matrices(led)
+    # Cheap and container-free: the flag surface is read from `rivet --help`,
+    # so it belongs with the file-level guards rather than after twenty
+    # minutes of bring-up.
+    blessed_flow.verify_flag_surface(led)
     # The instructional GIFs are documentation that can go stale silently — they
     # are binary assets, so no test reads them and no diff flags them. Placed
     # among the cheap file-level guards, before anything spends twenty minutes on

--- a/dev/release_oracle/blessed_flow.py
+++ b/dev/release_oracle/blessed_flow.py
@@ -566,7 +566,11 @@ def run_cell(led: Ledger, cell: Cell, url: str, state_url: str, tag: str = "live
     them at once. A teardown that only runs on the happy path is a leak with
     extra steps.
     """
-    tag = "flow"
+    # `tag` is the engine VERSION and arrives from the caller. It used to be
+    # hard-coded to the literal "flow" here, which put "flow" in the ledger's
+    # VERSION column for all four gridded postgres versions — and, once the
+    # prefix started using it, silently undid that fix by shadowing the
+    # parameter. The gate caught the inert fix on the very next run.
     slug = f"{cell.pipeline}_{cell.lifecycle}_{cell.store}_{cell.state}"
     work = scenarios.work_dir() / f"flow_{cell.engine}{tag}_{slug}_{cell.table}"
     shutil.rmtree(work, ignore_errors=True)
@@ -627,7 +631,10 @@ def run_cell(led: Ledger, cell: Cell, url: str, state_url: str, tag: str = "live
 def _run_chain(led: Ledger, cell: Cell, url: str, state_url: str, work: Path,
                cdc_block: str, tag: str = "live") -> None:
     """Walk one cell's whole chain, recording a row per stage."""
-    tag = "flow"
+    # NOT re-bound here. `tag` is the engine version, passed in — a literal
+    # "flow" at this line shadowed the parameter and made the version-scoped
+    # prefix inert while looking correct at its definition. Twice, in two
+    # functions, before the gate's readback said so out loud.
     slug = f"{cell.pipeline}_{cell.lifecycle}_{cell.store}_{cell.state}"
     dest_dir = work / "out"
     # The work root's name makes the prefix unique PER GATE INVOCATION. Without

--- a/dev/release_oracle/blessed_flow.py
+++ b/dev/release_oracle/blessed_flow.py
@@ -1,0 +1,1495 @@
+"""The WHOLE user journey, end to end, as one executable matrix.
+
+`blessed_path` walks the batch command chain once per read-strategy. This module
+is the complete thing: the full chain including `load`, both pipeline kinds, the
+lifecycles a real deployment goes through (clean → repeat → crash+resume), every
+store, both state backends, and the flags each command actually has.
+
+WHY ONE MODULE AND NOT MORE CELLS ELSEWHERE
+
+Because the alternative was tried and it is how the gaps happened. Coverage grew
+by adding a cell wherever a defect appeared, so twenty-four matrices exist and
+the axis that mattered — type × value-consumer — was in none of them. Adding
+`cdc` here, `s3` there and `resume` somewhere else repeats that: each addition
+is locally sensible and the whole stays un-designed.
+
+So the axes are declared up front, the cross-product is generated, and a cell is
+either RUN or explicitly `na` with a reason. What is not covered is visible as a
+hole in a grid rather than as an absence nobody enumerated.
+
+THE AXES
+
+  pipeline    batch | cdc — different chains, not a flag on one chain. `plan`
+              and `apply` REFUSE a cdc export ("cdc mode has no batch plan"),
+              which is correct: a plan fixes the bounds of finite work and a
+              change stream has none. So `cdc` runs `run` where `batch` runs
+              `plan → apply`.
+  lifecycle   clean | repeat | resume. `repeat` is the scheduler's real shape
+              (two runs into one prefix, union must survive); `resume` is the
+              crash path. Both have cost real data: parts clobbered by a second
+              run's identical names, and a resumed run declaring a zero-part
+              manifest over parquet already on disk.
+  store       local | s3 | gcs. The object stores are not a formality — they
+              have no rename, so a concurrent writer's staging collides where
+              a filesystem's would not (found live, 3 of 6 rounds losing a
+              manifest copy).
+  state       sqlite | postgres. Two hand-written SQL implementations of one
+              contract. Shape tracking never once worked on Postgres while
+              every run reported success.
+  engine      postgres | mysql | mssql | mongo.
+
+WHAT EVERY CELL ASSERTS
+
+Each stage is its own ledger row, so a chain that dies at `plan` does not leave
+`apply` silently absent — it leaves it SKIP "not reached". Artifacts are checked
+per stage: config, plan.json, parquet parts, manifest.json, `_SUCCESS`, the CDC
+checkpoint, and the meta-DB rows on WHICHEVER backend the cell runs
+(export_metrics, file_log, run_status, and for load: load_run,
+loaded_source_run).
+
+Values are read by DuckDB — a decoder rivet does not share. `validate` re-reads
+with rivet's own code and `reconcile` asks the source; three different questions,
+and a chain that answers one of them is not a verified chain.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from . import blessed_path, cdc, scenarios
+from .core import (
+    run,
+    Ledger,
+    container_for_port,
+    docker_exec,
+    have,
+    port_of,
+    rivet,
+    rivet_bin,
+)
+
+#: The gate's own bucket, read from its config rather than named here. A private
+#: name (`rivet-blessed`) is a bucket the bring-up never creates: every s3 cell
+#: failed at `doctor` with an auth/reachability error that looked like a
+#: credentials problem and was a missing bucket.
+def _bucket(store: str) -> str:
+    return scenarios.cfg("store", store, "bucket") or "rivet-oracle"
+
+#: The golden seed's tables, smallest first so a failure surfaces cheaply.
+TABLES = ("users", "orders")
+
+#: Per-engine URL templates come from the gate's own matrix; only the stand's
+#: ports live here.
+STAND_PORT = {"postgres": 5432, "mysql": 3306, "mssql": 1433, "mongo": 27017}
+
+
+@dataclass
+class Cell:
+    """One point of the cross-product, and the flags its chain will carry."""
+
+    engine: str
+    pipeline: str  # batch | cdc
+    lifecycle: str  # clean | repeat | resume
+    store: str  # local | s3 | gcs
+    state: str  # sqlite | postgres
+    table: str = "users"
+    #: Flags exercised on this cell, per command. Declared rather than implied so
+    #: the matrix can be read for flag coverage without running it.
+    flags: dict[str, list[str]] = field(default_factory=dict)
+
+    @property
+    def label(self) -> str:
+        return f"{self.pipeline}/{self.lifecycle}/{self.store}/{self.state}/{self.table}"
+
+    def na_reason(self) -> str | None:
+        """Why this cell cannot run, or None if it should.
+
+        Stated per combination rather than filtered silently: a cross-product
+        with invisible holes is the thing this module exists to replace.
+        """
+        if self.pipeline == "cdc" and self.engine == "mongo" and self.store != "local":
+            return "mongo CDC to an object store is covered by the cdc_e2e cells; not duplicated here"
+        if self.lifecycle == "resume" and self.pipeline == "cdc":
+            return "CDC resume is checkpoint-driven and has its own two-run tests per engine (roast_*_resume)"
+        if self.store != "local" and self.state == "sqlite":
+            # One backend per store keeps the product honest without squaring it:
+            # the store axis tests the WRITER, the state axis tests the LEDGER.
+            return "store × state is not squared — object stores run on the postgres ledger only"
+        return None
+
+
+def cross_product(engines: list[str]) -> list[Cell]:
+    """Every combination, `na` ones included — they are recorded, not dropped."""
+    out: list[Cell] = []
+    for eng in engines:
+        for pipeline in ("batch", "cdc"):
+            for lifecycle in ("clean", "repeat", "resume"):
+                for store in ("local", "s3", "gcs"):
+                    for state in ("sqlite", "postgres"):
+                        out.append(
+                            Cell(
+                                engine=eng,
+                                pipeline=pipeline,
+                                lifecycle=lifecycle,
+                                store=store,
+                                state=state,
+                                flags=_flags_for(len(out), pipeline, lifecycle, store),
+                            )
+                        )
+    return out
+
+
+def _rot(seed: str, n: int) -> int:
+    """A stable rotation index from a cell's coordinates.
+
+    NOT the enumeration index: `cell_ix % 3` over a nested cross-product
+    aliases with the inner loops — the first probe run drew `--discover` for
+    every postgres-backend cell and `--table` for every sqlite one, so two
+    axes silently became one. A digest of the coordinates has no such period.
+    """
+    return int(hashlib.sha1(seed.encode()).hexdigest(), 16) % n
+
+
+def _flags_for(cell_ix: int, pipeline: str, lifecycle: str, store: str) -> dict[str, list[str]]:
+    """The flags a cell's chain carries.
+
+    Distributed across cells rather than piled onto each, so the UNION covers
+    every flag of every command in the chain while no single cell tests one
+    combination over and over. `flag_coverage()` reports the union, and a flag
+    that reaches no cell shows up there as absent — the same "hole in a grid
+    rather than an unenumerated absence" the module is built on.
+
+    Excluded deliberately, with reasons rather than by omission:
+      --help / --json-errors   surface, not behaviour; `--json-errors` shapes
+                               stderr on a path this chain does not take (it
+                               asserts success, so there is no error to shape).
+      --export                 the configs here declare ONE export, so a
+                               selector cannot select anything different.
+      --param                  belongs to the curated-query matrix, which owns
+                               the substitution semantics.
+    """
+    f: dict[str, list[str]] = {"check": ["--strict"], "validate": ["--depth", "full"]}
+
+    # init is the first stage of every chain and was being run with ONE of its
+    # thirteen flags — the `verify_flag_surface` guard's first real finding.
+    # `--source-env` is fixed (a URL on argv is visible in `ps`); the rest rotate.
+    seed = f"{pipeline}/{lifecycle}/{store}/{cell_ix}"
+    f["init"] = ["--source-env", "ORACLE_URL", "--mode", "cdc" if pipeline == "cdc" else "full"]
+    if store == "s3":
+        f["init"] += ["--s3-bucket", "BUCKET", "--s3-region", "us-east-1"]
+    elif store == "gcs":
+        f["init"] += ["--gcs-bucket", "BUCKET"]
+    # `--discover` is incompatible with the bucket scaffolds, and --include /
+    # --exclude are whole-schema only (they conflict with --table). So the
+    # shapes rotate rather than stack — three ways to ask init for a config,
+    # each of which a real user types.
+    if store == "local" and _rot(seed + "init", 3) == 1:
+        f["init"] += ["--discover"]
+    elif _rot(seed + "init", 3) == 2:
+        # --schema rides with the whole-schema shape: it is what makes
+        # --include/--exclude address a schema at all, and on MySQL it names
+        # the database.
+        f["init"] += ["--schema", "SCHEMA", "--include", "GLOB",
+                      "--exclude", "nothing_matches_this"]
+    else:
+        f["init"] += ["--table", "TABLE"]  # resolved per engine by the executor
+
+    # check: --type-report / --json / --target rotate, so all three are carried
+    # somewhere without three runs of `check` per cell.
+    rot = _rot(seed + "check", 3)
+    if rot == 0:
+        f["check"] += ["--type-report"]
+    elif rot == 1:
+        f["check"] += ["--json"]
+    else:
+        f["check"] += ["--target", "bigquery"]
+
+    # validate: --format json on half, and the addressing flags (--prefix,
+    # --run-id, --date) are filled in by the caller once the run exists — a
+    # run id typed before the run is a run id that matches nothing.
+    if _rot(seed + "vfmt", 2) == 0:
+        f["validate"] += ["--format", "json"]
+
+    # validate's ADDRESSING flags (--prefix / --run-id / --date) name a run that
+    # does not exist until the run happens, so they are declared here and filled
+    # in by the executor from the artifacts. Declaring them as literals would be
+    # a test of this module's guess at a run id.
+    f["validate:addr"] = [["--prefix"], ["--run-id"], ["--date"]][_rot(seed + "addr", 3)]
+
+    if pipeline == "batch":
+        f["plan"] = ["--format", "json"]
+        f["apply"] = []
+        if lifecycle == "resume":
+            # `--resume` on a tree that never crashed resumes nothing — the flag
+            # is carried, the path is not. The executor crashes the first apply
+            # with a fault hook and this second one is the real resume.
+            f["apply"] = ["--resume"]
+            f["apply:crash"] = ["after_file_write"]
+        elif lifecycle == "repeat":
+            # The second apply of a repeat cell carries --force; the first must
+            # not, or the cell would stop being a repeat and become two clean
+            # runs that happen to share a prefix.
+            f["apply:second"] = ["--force"]
+        if store == "local" and _rot(seed + "pep", 4) == 0:
+            f["apply"] = f["apply"] + ["--parallel-export-processes"]
+        # The reconcile leg is a `rivet run`, so it is where the batch chain
+        # carries the rest of run's surface. `--force` and `--resume` are
+        # mutually exclusive in meaning (redo everything vs continue), so they
+        # rotate rather than stack.
+        # The reconcile leg is a second `rivet run` over a prefix that already
+        # has `_SUCCESS`, so `--force` is REQUIRED — rivet refuses otherwise,
+        # by design and with a clear message ("re-running would overwrite a
+        # verified dataset"). The first draft rotated `--resume` in here and
+        # the refusal is what taught it: `--resume` belongs to the lifecycle
+        # that actually crashed, not to a rotation over completed runs.
+        f["reconcile"] = ["--reconcile", "--force"]
+        f["reconcile"] += [
+            [],
+            ["--parallel-export-processes"],
+            ["--parallel-exports"],
+        ][_rot(seed + "rec", 3)]
+    else:
+        f["run"] = ["--validate", "--summary-output", "SUMMARY"]
+        if lifecycle == "repeat":
+            f["run"] += ["--reconcile"]
+        if _rot(seed + "rjson", 3) == 0:
+            f["run"] += ["--json"]
+        if _rot(seed + "pexp", 5) == 0:
+            f["run"] += ["--parallel-exports"]
+    return f
+
+
+# ── the chain ────────────────────────────────────────────────────────────────
+#
+# Declared as data so `batch` and `cdc` share ONE executor. The two differ in
+# exactly one place — where batch does `plan → apply`, cdc does `run` — and a
+# second executor would let them drift the way `dbo.orders` drifted when two
+# files owned one table.
+CHAIN = {
+    "batch": ["init", "doctor", "check", "plan", "apply", "artifacts", "state", "oracle",
+              "validate", "reconcile", "load", "load:cleanup"],
+    "cdc":   ["init", "doctor", "check", "run", "artifacts", "state", "oracle",
+              "validate", "load"],
+}
+
+
+def _why(p) -> str:
+    """The line that explains a non-zero exit.
+
+    `exit=1` in a 200-row report tells a reader to go re-run the cell by hand.
+    rivet already prints the reason; carrying it into the ledger is the
+    difference between a report and a to-do list.
+    """
+    for src in (p.stderr or "", p.stdout or ""):
+        lines = [ln.strip() for ln in src.splitlines() if ln.strip()]
+        for ln in reversed(lines):
+            if ln.lower().startswith(("error", "caused by", "rivet: error")):
+                return ln[:220]
+        if lines:
+            return lines[-1][:220]
+    return ""
+
+
+def _stage(led: Ledger, cell: Cell, tag: str, stage: str, ok: bool, detail: str) -> bool:
+    """Record one stage. Every stage is its own row — a chain that dies at `plan`
+    must leave `apply` as SKIP "not reached", never absent: in a 200-row report an
+    absent cell reads as not-applicable."""
+    name = f"flow:{stage}"
+    msg = f"{cell.engine} {cell.label} · {stage}"
+    if ok:
+        led.passed(cell.engine, tag, name, cell.store, msg, detail)
+    else:
+        led.failed(cell.engine, tag, name, cell.store, f"{msg} — {detail}", detail)
+    return ok
+
+
+def _unreached(led: Ledger, cell: Cell, tag: str, after: str) -> None:
+    steps = CHAIN[cell.pipeline]
+    if after not in steps:
+        return
+    for s in steps[steps.index(after) + 1:]:
+        led.skipped(cell.engine, tag, f"flow:{s}", cell.store,
+                    f"{cell.engine} {cell.label} · {s} — not reached ({after} failed)",
+                    f"unreached after {after}")
+
+
+def _config(cell: Cell, work: Path, src_block: str, dest_block: str,
+            cdc_block: str = "") -> Path:
+    cfg = work / "rivet.yaml"
+    if cell.pipeline == "cdc":
+        body = (
+            f"  - name: flow\n"
+            f"    table: {cell.table}\n"
+            f"    mode: cdc\n"
+            f"    format: parquet\n"
+            f"    {cdc_block}\n"
+            f"{dest_block}\n"
+        )
+    else:
+        body = (
+            f"  - name: flow\n"
+            f"    table: {cell.table}\n"
+            f"    mode: full\n"
+            f"    format: parquet\n"
+            f"{dest_block}\n"
+        )
+    cfg.write_text(f"{src_block}\nexports:\n{body}")
+    return cfg
+
+
+def _state_sql(cell: Cell, work: Path, state_url: str, sql: str) -> int:
+    """One scalar from whichever state backend this cell writes to, or -1."""
+    if cell.state == "sqlite":
+        import sqlite3
+        db = work / ".rivet_state.db"
+        if not db.is_file():
+            return -1
+        tmp = db.with_name(".read_state.db")
+        # Read a COPY: `mode=ro` on a live WAL database fails to open, which
+        # reads as "no state DB" when the file is right there.
+        shutil.copy2(db, tmp)
+        for side in ("-wal", "-shm"):
+            sc = db.with_name(db.name + side)
+            if sc.is_file():
+                shutil.copy2(sc, tmp.with_name(tmp.name + side))
+        try:
+            row = sqlite3.connect(str(tmp)).execute(sql).fetchone()
+            return int(row[0]) if row and row[0] is not None else 0
+        except sqlite3.Error:
+            return -1
+    port = port_of(state_url)
+    c = container_for_port(port) if port else None
+    if not c:
+        return -1
+    db = state_url.rsplit("/", 1)[-1]
+    out = docker_exec(c, "psql", "-U", "rivet", "-d", db, "-tA", "-c", sql).stdout.strip()
+    head = out.splitlines()[0].strip() if out else ""
+    return int(head) if head.lstrip("-").isdigit() else -1
+
+
+def _state_watermark(cell: Cell, work: Path, state_url: str) -> int:
+    """`max(id)` in `export_metrics` BEFORE the chain runs.
+
+    The scoping problem, and why a name is not enough: every cell names its
+    export `flow`, and the Postgres ledger is SHARED across cells and across
+    days. `WHERE export_name='flow'` therefore counted 37 rows on a cell that
+    wrote 3 — and would have counted 37 on a cell that wrote NONE. That is the
+    unscoped-count defect this repo has paid for more than once, and it was
+    sitting inside a function whose own docstring warned about it.
+
+    A watermark is the fix rather than a timestamp because `export_metrics` has
+    no `run_id` and comparing the host's clock to the database's is two clocks.
+    `id > watermark` is neither.
+    """
+    if cell.state == "sqlite":
+        return 0  # a fresh per-cell file; there is no prior history to exclude
+    return max(0, _state_sql(cell, work, state_url,
+                             "SELECT coalesce(max(id), 0) FROM export_metrics"))
+
+
+def _meta_rows(cell: Cell, work: Path, state_url: str, mark: int,
+               run_ids: list[str]) -> tuple[bool, str]:
+    """Did THIS run record itself, on whichever backend this cell uses?
+
+    Scoped three ways, one per table's own key: `export_metrics` by the
+    watermark (it has no run_id), `file_log` and `run_status` by the run ids the
+    manifests actually name. A count that a previous cell could satisfy is not
+    evidence about this one.
+    """
+    ids = ", ".join(f"'{r}'" for r in run_ids) if run_ids else "''"
+    got = {
+        "export_metrics": _state_sql(cell, work, state_url,
+                                     f"SELECT count(*) FROM export_metrics "
+                                     f"WHERE id > {mark} AND export_name = 'flow'"),
+        "file_log": _state_sql(cell, work, state_url,
+                               f"SELECT count(*) FROM file_log WHERE run_id IN ({ids})"),
+        "run_status": _state_sql(cell, work, state_url,
+                                 f"SELECT count(*) FROM run_status WHERE run_id IN ({ids})"),
+    }
+    missing = [t for t, n in got.items() if n < 1]
+    return (not missing), (", ".join(f"{t}={n}" for t, n in got.items())
+                           + f" (scoped: id>{mark}, {len(run_ids)} run id(s))")
+
+
+def _run_ids(work: Path) -> list[str]:
+    """The run ids of every run this cell performed.
+
+    Read from `.rivet/runs/*/summary.json`, which rivet writes beside the CONFIG
+    for every run regardless of where the data went. The first version read the
+    destination manifest instead, which is correct for a local prefix and empty
+    for every cloud one — so each s3/gcs cell scoped its ledger check to zero ids
+    and reported `file_log=0` about a run that had just written files. A
+    per-run record that lives with the config has no such asymmetry.
+    """
+    out = set()
+    for f in sorted((work / ".rivet" / "runs").glob("*/summary.json")):
+        try:
+            rid = json.loads(f.read_text()).get("run_id")
+        except (OSError, json.JSONDecodeError):
+            continue
+        if rid:
+            out.add(str(rid))
+    return sorted(out)
+
+
+def _dest_block(cell: Cell, dest_dir: Path, prefix: str) -> str | None:
+    if cell.store == "local":
+        return f"    destination: {{type: local, path: {dest_dir}/}}"
+    raw = scenarios.store_dest(cell.store, _bucket(cell.store), prefix)
+    if not raw:
+        return None
+    # `store_dest` returns the CONTENT under `destination:`, already indented —
+    # the key itself is the caller's to write.
+    return "    destination:\n" + raw.rstrip("\n")
+
+
+def _readback(cell: Cell, dest_dir: Path, prefix: str, work: Path) -> int:
+    """Rows the destination DELIVERED, read by DuckDB and nothing else.
+
+    Cloud prefixes are PULLED to a local directory first so that all three
+    stores go through the SAME oracle — `_flow_rows`, which counts only parts a
+    manifest declares committed. The alternative (a cloud-specific readback that
+    counts everything under the prefix) is a second definition of "what was
+    delivered", and it drifted immediately: the local path was fixed to ignore a
+    crashed run's orphans and the cloud path went on counting them, so every
+    resume cell on s3/gcs read 2000 rows from a 1000-row table. One oracle, or
+    two that disagree about the crash you are trying to measure.
+    """
+    if cell.store == "local":
+        return _flow_rows(dest_dir)
+    pulled = _pull(cell.store, _bucket(cell.store), prefix, work)
+    return _flow_rows(pulled) if pulled else -1
+
+
+def _pull(store: str, bucket: str, prefix: str, work: Path) -> Path | None:
+    """Bring a cloud prefix down whole — manifests included, not just parquet."""
+    dl = work / f"pull_{store}"
+    shutil.rmtree(dl, ignore_errors=True)
+    dl.mkdir(parents=True, exist_ok=True)
+    if store == "s3":
+        if not have("mc"):
+            return None
+        alias = "rivetgate"
+        run(["mc", "alias", "set", alias, "http://127.0.0.1:9000",
+             scenarios.MINIO_ACCESS_KEY, scenarios.MINIO_SECRET_KEY])
+        p = run(["mc", "cp", "--recursive", f"{alias}/{bucket}/{prefix}/", str(dl)])
+        return dl if p.ok else None
+    if store == "gcs":
+        # The emulator's JSON API is enough, and it keeps the pull independent
+        # of rivet — the same helper `store_readback` uses.
+        # `--all`: the manifests are the point. The default mode pulls only
+        # parquet and renames it `part_N.parquet`, which cannot answer "what did
+        # this run declare".
+        got = run([scenarios.PY, str(scenarios._asset("lib/gcs_pull.py")),
+                   "http://127.0.0.1:4443", bucket, prefix, str(dl), "--all"]).stdout.strip()
+        try:
+            return dl if int(got) > 0 else None
+        except ValueError:
+            return None
+    return None
+
+
+def _flow_rows(path: Path) -> int:
+    """Rows in the MANIFESTED dataset — not every parquet under the prefix.
+
+    The difference is the whole point on a `resume` cell. A crash leaves parts
+    on disk that no manifest declares; the resumed run then re-exports the
+    range, so a blind `**/*.parquet` reads the table twice and calls it a
+    doubling. It is not: those orphans are the `gc_orphans` case, and a run's
+    delivery is what its manifest declares. Reading them as delivered was this
+    module's own bug, and the repo has the rule in writing — raw artifacts under
+    a failed prefix are not evidence about what the run delivered.
+    """
+    files = _manifest_files(path)
+    if files is None:
+        # No manifest: nothing was declared, so nothing was delivered. Counting
+        # the parquet anyway would report a failed run's leftovers as output.
+        return -1
+    if not files:
+        return 0
+    lst = ", ".join(f"'{f}'" for f in files)
+    got = scenarios._duckdb_list(f"SELECT count(*) FROM read_parquet([{lst}])")
+    head = got.splitlines()[0].strip() if got else ""
+    head = head.split("|")[0].split(",")[0].strip()
+    return int(head) if head.lstrip("-").isdigit() else -1
+
+
+def _manifest_files(prefix: Path) -> list[str] | None:
+    """Absolute paths of the parts the manifest DECLARES, or None if unmanifested.
+
+    On a `repeat` cell there are several manifest copies (one per run, immutable)
+    plus the canonical last-writer-wins pointer. The union across the COPIES is
+    the readable dataset — reading only `manifest.json` would report the last
+    run's parts as the whole, which is exactly how a sidecar clobber stays
+    invisible.
+    """
+    copies = sorted(prefix.rglob("manifest-*.json"))
+    docs = copies or ([prefix / "manifest.json"] if (prefix / "manifest.json").is_file() else [])
+    if not docs:
+        return None
+    out: list[str] = []
+    for d in docs:
+        try:
+            art = json.loads(d.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        for f in art.get("parts", []) or []:
+            # A part the manifest lists but marks non-committed is not delivered
+            # data; counting it would report an in-flight row as an outcome.
+            if isinstance(f, dict) and f.get("status") not in (None, "committed"):
+                continue
+            name = f.get("path") or f.get("name") if isinstance(f, dict) else f
+            if not name:
+                continue
+            cand = Path(name)
+            if not cand.is_absolute():
+                cand = d.parent / cand
+            if cand.is_file():
+                out.append(str(cand))
+    return sorted(set(out))
+
+
+def run_cell(led: Ledger, cell: Cell, url: str, state_url: str) -> None:
+    """Walk one cell's chain, with the CDC fixture raised and torn down around it.
+
+    The teardown is a `finally` because on PostgreSQL it drops a replication
+    slot, and a leaked inactive slot pins WAL and consumes one of the stand's
+    32. A morning's tests once leaked 25 of them and the resulting failures
+    looked like three different bugs before the slot count explained all of
+    them at once. A teardown that only runs on the happy path is a leak with
+    extra steps.
+    """
+    tag = "flow"
+    slug = f"{cell.pipeline}_{cell.lifecycle}_{cell.store}_{cell.state}"
+    work = scenarios.work_dir() / f"flow_{cell.engine}_{slug}_{cell.table}"
+    shutil.rmtree(work, ignore_errors=True)
+    work.mkdir(parents=True, exist_ok=True)
+
+    cdc_block = ""
+    if cell.pipeline == "cdc":
+        # The CDC stands carry no golden seed — they are per-test fixtures. So
+        # the cell seeds its own, through the SAME per-engine setup the cdc_e2e
+        # matrix uses. A second seeder here is exactly the parallel harness the
+        # rig rule exists to prevent: two definitions of "the CDC probe table"
+        # drift, and the one that drifts is never the one you are reading.
+        #
+        # It happens BEFORE init, not after: init discovers the source, and a
+        # table that does not exist yet is a table init cannot scaffold.
+        spec = cdc._ENGINES.get(cell.engine)
+        if spec is None:
+            led.skipped(cell.engine, tag, "flow:chain", cell.store,
+                        f"{cell.engine} {cell.label} — no cdc engine spec")
+            return
+        # Retried: SQL Server's fixture disables and re-enables CDC on the table,
+        # and `sp_cdc_enable_table` can fail while the previous capture job is
+        # still shutting down. Six of eight mssql cells failed that way — a race
+        # in the fixture, reported as a source failure.
+        blk = spec.setup(url, work)
+        for _ in range(2):
+            if blk is not None:
+                break
+            time.sleep(3.0)
+            blk = spec.setup(url, work)
+        if blk is None:
+            _stage(led, cell, tag, "init", False, "cdc fixture setup failed on the source")
+            _unreached(led, cell, tag, "init")
+            return
+        # A checkpoint is what makes the SECOND run resume rather than
+        # re-anchor; the shared block omits it because cdc_e2e drives resume by
+        # other means. Spliced into the inline table rather than appended, so
+        # the engine's own slot/stream params stay exactly as that module set
+        # them.
+        ck = work / "cdc.ckpt"
+        # Splice a checkpoint ONLY if the engine's own block has none. MySQL's
+        # already carries one (it needs the anchor for its no-server-side-anchor
+        # resume model); appending a second produced a duplicate key, the config
+        # stopped parsing, and all eight mysql CDC cells died at `doctor` with
+        # "config check failed" — a harness bug that reads exactly like a
+        # product one.
+        cdc_block = (blk.rstrip() if "checkpoint:" in blk
+                     else blk.rstrip().rstrip("}").rstrip().rstrip(",") + f", checkpoint: {ck} }}")
+        cell.table = _CDC_TABLE.get(cell.engine, cell.table)
+
+    try:
+        _run_chain(led, cell, url, state_url, work, cdc_block)
+    finally:
+        if cell.pipeline == "cdc":
+            cdc._ENGINES[cell.engine].cleanup(url, work)
+
+
+def _run_chain(led: Ledger, cell: Cell, url: str, state_url: str, work: Path,
+               cdc_block: str) -> None:
+    """Walk one cell's whole chain, recording a row per stage."""
+    tag = "flow"
+    slug = f"{cell.pipeline}_{cell.lifecycle}_{cell.store}_{cell.state}"
+    dest_dir = work / "out"
+    # The work root's name makes the prefix unique PER GATE INVOCATION. Without
+    # it, an object-store prefix accumulates every previous run's parts and the
+    # readback — which counts what is under the prefix — reads 3000 rows from a
+    # 1000-row table across three invocations. The local path is immune because
+    # it counts only manifested parts in a fresh tempdir; the cloud path had no
+    # such filter, and the same defect came back one store over. Same shape as
+    # the CDC leg's `oracle-cdc/<work-root>/…`.
+    prefix = (f"flow/{scenarios.work_dir().name}/{cell.engine}/{slug}/"
+              f"{cell.table.replace('.', '_')}")
+    mark = 0
+
+    cdc._export_store_creds()  # MINIO_/AZURITE_ keys the dest blocks name by *_env
+    env = dict(scenarios._store_env(url))
+    if cell.state == "postgres":
+        if not state_url:
+            led.skipped(cell.engine, tag, "flow:chain", cell.store,
+                        f"{cell.engine} {cell.label} — postgres backend needs --state-url")
+            return
+        env["RIVET_STATE_URL"] = state_url
+        mark = _state_watermark(cell, work, state_url)
+    else:
+        # An inherited RIVET_STATE_URL would silently make every "sqlite" cell a
+        # second Postgres cell — the axis would read as covered and test one
+        # backend twice.
+        env["RIVET_STATE_URL"] = ""
+
+    # ── init ─────────────────────────────────────────────────────────────────
+    gen = work / "init.yaml"
+    args = _resolve_init(cell)
+    disco = ""
+    if "--discover" in args:
+        # `--discover` writes a SURVEY (JSON: per-table row estimates, cursor
+        # candidates, a suggested_mode) — not a config, and it says so, noting
+        # that `--mode` is ignored. So this cell does what an operator does:
+        # survey first, then scaffold. Grading the survey as if it were a config
+        # was this module's own bug, found by running it.
+        rep = work / "discover.json"
+        d = rivet("init", *args, "-o", str(rep), env=env, timeout=scenarios.NO_TIMEOUT)
+        try:
+            art = json.loads(rep.read_text()) if rep.is_file() else {}
+        except json.JSONDecodeError:
+            art = {}
+        tables = art.get("tables") or []
+        okd = d.ok and bool(tables) and all("suggested_mode" in t for t in tables)
+        disco = f"discover: {len(tables)} tables surveyed · "
+        if not _stage(led, cell, tag, "init:discover", okd,
+                      f"exit={d.returncode} tables={len(tables)} "
+                      f"keys={sorted(art)[:5]}"):
+            _unreached(led, cell, tag, "init")
+            return
+        args = [a for a in args if a != "--discover"]
+        args += ["--table", _qualified(cell)]
+    p = rivet("init", *args, "-o", str(gen), env=env, timeout=scenarios.NO_TIMEOUT)
+    body = gen.read_text() if gen.is_file() else ""
+    # What init's flags PRODUCED, not just that it exited 0. `--mode cdc` must
+    # yield a cdc block, `--s3-bucket` an s3 destination, `--exclude` must not
+    # have swallowed the table. A chain that only checks the exit code is
+    # running init with thirteen flags and grading one.
+    want_mode = "mode: cdc" if cell.pipeline == "cdc" else "mode:"
+    shape = [
+        ("exports", "exports:" in body),
+        ("mode", want_mode in body),
+        ("table", cell.table in body),
+    ]
+    if cell.store in ("s3", "gcs"):
+        shape.append((f"{cell.store} dest", f"type: {cell.store}" in body))
+    bad = [n for n, okk in shape if not okk]
+    ok = p.ok and not bad
+    detail = (f"{disco}{' '.join(args)} → {len(body.splitlines())} lines"
+              if ok else f"exit={p.returncode} missing={bad or 'file'} {_why(p)}")
+    if not _stage(led, cell, tag, "init", ok, detail):
+        _unreached(led, cell, tag, "init")
+        return
+
+    db = _dest_block(cell, dest_dir, prefix)
+    if db is None:
+        led.skipped(cell.engine, tag, "flow:chain", cell.store,
+                    f"{cell.engine} {cell.label} — no destination block for {cell.store}")
+        return
+    tls = "\n  tls: {accept_invalid_certs: true}" if cell.engine == "mssql" else ""
+    src = f"source:\n  type: {cell.engine}\n  url_env: ORACLE_URL{tls}"
+    cfg = _config(cell, work, src, db, cdc_block)
+
+    # ── doctor / check ───────────────────────────────────────────────────────
+    for st in ("doctor", "check"):
+        args = [st, "-c", str(cfg), *cell.flags.get(st, [])]
+        p = rivet(*args, env=env, timeout=scenarios.NO_TIMEOUT)
+        if not _stage(led, cell, tag, st, p.ok, f"exit={p.returncode} " + (p.out.strip().splitlines()[-1][:120] if p.ok and p.out.strip() else _why(p))):
+            _unreached(led, cell, tag, st)
+            return
+
+    # ── the work: plan → apply (batch) or run (cdc) ──────────────────────────
+    if cell.pipeline == "batch":
+        plan = work / "plan.json"
+        p = rivet("plan", "-c", str(cfg), "-o", str(plan), *cell.flags.get("plan", []),
+                  env=env, timeout=scenarios.NO_TIMEOUT)
+        # A plan artifact is a CONTRACT `apply` must still accept — the 0.7.5
+        # fixtures asserted its JSON had certain keys for two months while
+        # `apply` rejected every one of them. So the assertion here is that the
+        # file parses AND names the export; `apply`, next stage, is the real
+        # reader.
+        art = json.loads(plan.read_text()) if plan.is_file() else {}
+        ok = p.ok and bool(art) and "flow" in json.dumps(art)
+        if not _stage(led, cell, tag, "plan", ok,
+                      f"exit={p.returncode} plan.json={plan.is_file()} keys={sorted(art)[:6]}"):
+            _unreached(led, cell, tag, "plan")
+            return
+
+        crash_note = ""
+        if cell.lifecycle == "resume":
+            # A resume test whose first run SUCCEEDED is testing a clean re-run
+            # wearing a `--resume` flag. The fault hook is what makes the second
+            # apply resume something: it kills the process after a part is
+            # durable but before the manifest records it.
+            hook = cell.flags.get("apply:crash", ["after_file_write"])[0]
+            c = rivet("apply", str(plan), env={**env, "RIVET_TEST_PANIC_AT": hook},
+                      timeout=scenarios.NO_TIMEOUT)
+            left = sorted(dest_dir.rglob("*.parquet")) if cell.store == "local" else []
+            # A crash that changed nothing leaves the resume with nothing to
+            # resume — the fixture would be inert, which is the defect class
+            # this whole gate exists to catch. So it is asserted, not assumed.
+            if c.ok:
+                _stage(led, cell, tag, "apply:crash", False,
+                       f"fault hook {hook} did not stop the run (exit=0) — "
+                       "the resume below would be a clean re-run, not a resume")
+                _unreached(led, cell, tag, "apply")
+                return
+            crash_note = f"crashed at {hook} (exit={c.returncode}, {len(left)} part(s) left) → "
+
+        p = rivet("apply", str(plan), *cell.flags.get("apply", []),
+                  env=env, timeout=scenarios.NO_TIMEOUT)
+        applied = p.ok
+        if cell.lifecycle == "repeat" and applied:
+            # The scheduler's real shape: a second run into the SAME prefix. The
+            # union of both runs must be readable — a part name that carries only
+            # a per-run sequence silently overwrites the first run's output, and
+            # the data is gone from the destination while both runs report
+            # success.
+            p2 = rivet("apply", str(plan), *cell.flags.get("apply:second", []),
+                       env=env, timeout=scenarios.NO_TIMEOUT)
+            applied = p2.ok
+        if not _stage(led, cell, tag, "apply", applied, f"{crash_note}exit={p.returncode} {_why(p) if not applied else ''}"):
+            _unreached(led, cell, tag, "apply")
+            return
+    else:
+        # Anchor first (an empty run that pins the position), THEN write the
+        # changes, THEN capture. A capture run with no prior anchor tests the
+        # first-open path only; the idle-first-run variant is where MySQL once
+        # lost a change outright.
+        rivet("run", "-c", str(cfg), env=env, timeout=scenarios.NO_TIMEOUT)
+        cdc._ENGINES[cell.engine].changes(url)
+        # `--summary-output` is resolved against the CWD, so a bare filename
+        # writes into whatever directory the gate happens to run from — it left
+        # a `summary.json` in the repo root. The placeholder is filled here,
+        # where the cell's work dir is known.
+        args = ["run", "-c", str(cfg),
+                *[str(work / "run-summary.json") if a == "SUMMARY" else a
+                  for a in cell.flags.get("run", [])]]
+        p = rivet(*args, env=env, timeout=scenarios.NO_TIMEOUT)
+        ran = p.ok
+        if cell.lifecycle == "repeat" and ran:
+            p2 = rivet(*args, env=env, timeout=scenarios.NO_TIMEOUT)
+            ran = p2.ok
+        if not _stage(led, cell, tag, "run", ran, f"exit={p.returncode} {_why(p)}"):
+            _unreached(led, cell, tag, "run")
+            return
+
+    # ── artifacts ────────────────────────────────────────────────────────────
+    #
+    # What a consumer finds on disk, not what the run said it did. The manifest
+    # is read for its declared totals; the parquet is counted by DuckDB two
+    # stages down. A run reporting success over a zero-part manifest is exactly
+    # the shape this separation catches.
+    if cell.store == "local":
+        man = dest_dir / "manifest.json"
+        parts = sorted(dest_dir.rglob("*.parquet"))
+        copies = sorted(dest_dir.rglob("manifest-*.json"))
+        succ = list(dest_dir.rglob("_SUCCESS"))
+        art = json.loads(man.read_text()) if man.is_file() else {}
+        ok = bool(parts) and bool(art)
+        detail = (f"parts={len(parts)} manifest={man.is_file()} "
+                  f"copies={len(copies)} _SUCCESS={len(succ)}")
+        if cell.lifecycle == "repeat":
+            # Two runs into one prefix must leave TWO immutable manifest copies.
+            # Asserting on the parquet instead is what hid the sidecar clobber:
+            # the data survives a clobbered manifest, which is precisely what
+            # makes the clobber invisible.
+            ok = ok and len(copies) >= 2
+            detail += " (repeat wants >=2 manifest copies)"
+    else:
+        # No local mirror to walk; the store's own client answers at `oracle`.
+        ok, detail = True, f"{cell.store} — artifacts asserted at the store by the oracle stage"
+    if not _stage(led, cell, tag, "artifacts", ok, detail):
+        _unreached(led, cell, tag, "artifacts")
+        return
+
+    if cell.pipeline == "cdc":
+        ck = work / "cdc.ckpt"
+        # A CDC run that captured but wrote no checkpoint resumes from a NEWER
+        # position next cycle and silently skips everything between — the
+        # anchor, not the capture, is what makes the second run correct.
+        if not _stage(led, cell, tag, "artifacts:checkpoint", ck.is_file(),
+                      f"checkpoint={ck.is_file()} bytes={ck.stat().st_size if ck.is_file() else 0}"):
+            _unreached(led, cell, tag, "artifacts")
+            return
+
+    # ── state (meta DB) ──────────────────────────────────────────────────────
+    ids = _run_ids(work)
+    ok, detail = _meta_rows(cell, work, state_url, mark, ids)
+    if not _stage(led, cell, tag, "state", ok, f"[{cell.state}] {detail}"):
+        _unreached(led, cell, tag, "state")
+        return
+
+    # ── oracle: DuckDB, and only DuckDB ──────────────────────────────────────
+    if not have("duckdb"):
+        led.skipped(cell.engine, tag, "flow:oracle", cell.store,
+                    f"{cell.engine} {cell.label} · oracle — no duckdb")
+    else:
+        duck = _readback(cell, dest_dir, prefix, work)
+        if cell.pipeline == "batch":
+            want = blessed_path._source_rows(cell.engine, url, cell.table)
+            if want < 0:
+                led.skipped(cell.engine, tag, "flow:oracle", cell.store,
+                            f"{cell.engine} {cell.label} · oracle — source unreachable for a count")
+            else:
+                # `repeat` writes the same table twice into one prefix, so the
+                # readable dataset is the UNION: 2x. That is the assertion — a
+                # clobbered second run reads back 1x and looks like a clean run.
+                mult = 2 if cell.lifecycle == "repeat" else 1
+                _stage(led, cell, tag, "oracle", duck == want * mult,
+                       f"duckdb={duck} source={want}x{mult}")
+        else:
+            # A change stream is not the table: the count is of CHANGES, which
+            # only the source's own write history predicts. What DuckDB can say
+            # independently is that the parts decode and are non-empty — a
+            # capture that wrote unreadable or zero rows fails here.
+            _stage(led, cell, tag, "oracle", duck > 0,
+                   f"duckdb={duck} changes decoded by an independent reader")
+
+    # ── validate ─────────────────────────────────────────────────────────────
+    p = rivet("validate", "-c", str(cfg), *cell.flags.get("validate", []),
+              env=env, timeout=scenarios.NO_TIMEOUT)
+    ok, detail = p.ok, f"exit={p.returncode}" + ("" if p.ok else f" {_why(p)}")
+    # Second pass, ADDRESSED. `validate` with no selector validates the latest
+    # run; the addressing flags are how an operator checks yesterday's output,
+    # and a flag that resolves nothing exits 0 on some paths — so the value
+    # comes from the artifact, never from a guess.
+    addr = cell.flags.get("validate:addr", [])
+    extra = _addressing(cell, addr, dest_dir, prefix, work)
+    if ok and extra:
+        p2 = rivet("validate", "-c", str(cfg), *extra, env=env, timeout=scenarios.NO_TIMEOUT)
+        ok = p2.ok
+        detail += f" · addressed {' '.join(extra)} exit={p2.returncode}"
+    elif ok:
+        detail += f" · addressed {addr[0] if addr else '-'} SKIPPED (no value in artifacts)"
+    if not _stage(led, cell, tag, "validate", ok, detail):
+        _unreached(led, cell, tag, "validate")
+        return
+
+    # ── reconcile (batch only — a change stream has no row-count identity) ───
+    if cell.pipeline == "batch":
+        p = rivet("run", "-c", str(cfg), *cell.flags.get("reconcile", ["--reconcile"]),
+                  env=env, timeout=scenarios.NO_TIMEOUT)
+        if not _stage(led, cell, tag, "reconcile", p.ok, f"exit={p.returncode} {_why(p)}"):
+            _unreached(led, cell, tag, "reconcile")
+            return
+
+    # ── load ─────────────────────────────────────────────────────────────────
+    _load_leg(led, cell, tag, work, env, url, state_url, mark)
+
+
+def _load_leg(led: Ledger, cell: Cell, tag: str, work: Path, env: dict, url: str,
+              state_url: str, mark: int) -> None:
+    """Export to REAL GCS, load into BigQuery, verify, clean up — then assert the
+    LEDGER recorded it.
+
+    Not run against fake-gcs, and the reason is not fastidiousness: a warehouse
+    cannot read an emulator's bucket, so a `load` cell pointed there would be
+    asserting on an error. The store axis proves rivet SPEAKS the protocol; this
+    proves a reader that shares no code with rivet can decode the result.
+
+    What this adds over the sibling bq cycle is the ledger half: `load_run` and
+    `loaded_source_run`. The second is what makes a re-load idempotent — it is
+    the link back to the extract run whose parts were consumed — and nothing
+    asserted it existed.
+    """
+    proj = os.environ.get("BQ_ORACLE_PROJECT") or run(
+        ["gcloud", "config", "get-value", "project"]).stdout.strip()
+    bucket = os.environ.get("BQ_ORACLE_BUCKET", "rivet_data_test")
+    # Per ENGINE, because `rivet load` derives the warehouse table from `table:`
+    # — so all four engines' `users` land on ONE table. rivet caught this itself
+    # and refused ("last loaded from `postgres:users`"), which is the guard doing
+    # its job; nine cells failed on a collision the matrix created.
+    dset = os.environ.get("BQ_ORACLE_DATASET", "rivet_blessed") + "_" + cell.engine
+    if cell.store != "gcs" or cell.pipeline != "batch":
+        led.skipped(cell.engine, tag, "flow:load", cell.store,
+                    f"{cell.engine} {cell.label} · load — the warehouse leg runs on the "
+                    "batch/gcs cells; a change stream has no batch load and the other "
+                    "stores are covered by their own readback")
+        return
+    if not have("bq") or not proj:
+        led.skipped(cell.engine, tag, "flow:load", cell.store,
+                    f"{cell.engine} {cell.label} · load — no `bq` CLI or no project "
+                    "(set BQ_ORACLE_PROJECT); the emulator cannot stand in, a warehouse "
+                    "must read the real bucket")
+        return
+
+    tbl = cell.table.split(".")[-1]
+    pfx = f"flow/{cell.engine}/{cell.pipeline}/{tbl}"
+    lcfg = work / "load.yaml"
+    tls = "\n  tls: {accept_invalid_certs: true}" if cell.engine == "mssql" else ""
+    lcfg.write_text(
+        f"source:\n  type: {cell.engine}\n  url_env: ORACLE_URL{tls}\n"
+        # The warehouse table is derived from `table:`, not from the export name.
+        f"exports:\n  - name: {tbl}\n    table: {cell.table}\n"
+        f"    mode: full\n    format: parquet\n"
+        f"    destination: {{type: gcs, bucket: {bucket}, prefix: {pfx}/}}\n"
+        f"load:\n  target: bigquery\n  project: {proj}\n  dataset: {dset}\n"
+    )
+    # Clear both sides first. A leftover table makes the next count a union of
+    # two loads, and a gate that accumulates state stops measuring the run in
+    # front of it.
+    run(["bq", "--project_id", proj, "mk", "-f", "--dataset", f"{proj}:{dset}"])
+    run(["bq", "--project_id", proj, "rm", "-f", "-t", f"{proj}:{dset}.{tbl}"])
+    run(["gcloud", "storage", "rm", "-r", f"gs://{bucket}/{pfx}"])
+
+    e = rivet("run", "-c", str(lcfg), env=env, timeout=scenarios.NO_TIMEOUT)
+    if not e.ok:
+        _stage(led, cell, tag, "load", False, f"export to real gcs failed: {_why(e)}")
+        return
+    # Unique per cell: the id is what the ledger check scopes on, and a shared
+    # one would let one cell's rows satisfy another's assertion.
+    load_id = f"flow-{cell.engine}-{cell.lifecycle}-{cell.state}-{scenarios.work_dir().name}"
+    p = rivet("load", "-c", str(lcfg), "--rivet-bin", str(rivet_bin()),
+              "--run-id", load_id, env=env, timeout=scenarios.NO_TIMEOUT)
+    if not p.ok:
+        _stage(led, cell, tag, "load", False, f"exit={p.returncode} {_why(p)}")
+        run(["gcloud", "storage", "rm", "-r", f"gs://{bucket}/{pfx}"])
+        return
+
+    # BigQuery's own count, decoded by Google's parquet reader.
+    q = run(["bq", "--project_id", proj, "query", "--nouse_legacy_sql", "--format", "csv",
+             f"SELECT count(*) FROM `{proj}.{dset}.{tbl}`"]).stdout.strip().splitlines()
+    got = int(q[-1]) if q and q[-1].strip().isdigit() else -1
+    want = blessed_path._source_rows(cell.engine, url, cell.table)
+    lok, ldetail = _load_rows(cell, work, state_url, load_id, tbl)
+    _stage(led, cell, tag, "load", got == want and got > 0 and lok,
+           f"bigquery={got} source={want} · ledger {ldetail}")
+
+    # Cleanup is part of the cycle. `bq rm -f` exits 0 whether or not the table
+    # existed, so its exit code is not evidence — the drop is verified by asking
+    # for the table afterwards.
+    run(["bq", "--project_id", proj, "rm", "-f", "-t", f"{proj}:{dset}.{tbl}"])
+    gone = run(["bq", "--project_id", proj, "show", "-t", f"{proj}:{dset}.{tbl}"])
+    run(["gcloud", "storage", "rm", "-r", f"gs://{bucket}/{pfx}"])
+    _stage(led, cell, tag, "load:cleanup", not gone.ok,
+           "warehouse table dropped (verified by a show that fails)"
+           if not gone.ok else "the table is STILL THERE after rm — the next run's count "
+           "would be a union of two loads")
+
+
+def _load_rows(cell: Cell, work: Path, state_url: str, load_id: str,
+               tbl: str) -> tuple[bool, str]:
+    """Did THIS load record itself, and does the link back to the extract exist?
+
+    Scoped by the `--run-id` the load was given, which becomes its `load_id`.
+    The first version counted the tables whole and reported `load_run=21` in
+    every one of twelve cells — the same unscoped-history defect already fixed
+    for `export_metrics`/`file_log`/`run_status`, left standing one function
+    over. A count that twelve different cells agree on is not measuring any of
+    them.
+
+    `loaded_source_run` is the half that matters most: it is the link back to
+    the extract run whose parts were consumed, and without it a re-load
+    double-counts.
+    """
+    # PREFIX match, not equality: the stored id is `<--run-id>:<export_name>`.
+    # One `rivet load` over N exports records N rows, and the suffix is what
+    # tells them apart — so the correlation id on the CLI is a prefix of every
+    # row it produced, never equal to one. An exact match found zero rows on a
+    # load that had recorded four correct ones.
+    like = f"{load_id}:%"
+    got = {
+        "load_run": _state_sql(cell, work, state_url,
+                               f"SELECT count(*) FROM load_run WHERE load_id LIKE '{like}'"),
+        "loaded_source_run": _state_sql(
+            cell, work, state_url,
+            f"SELECT count(*) FROM loaded_source_run WHERE load_id LIKE '{like}'"),
+    }
+    missing = [t for t, n in got.items() if n < 1]
+    return (not missing), ", ".join(f"{t}={n}" for t, n in got.items()) + f" (load_id={load_id})"
+
+
+#: Where a run leaves its per-CELL verdicts. The stage rows go to the gate's
+#: ledger; this is the coarser record a re-run needs — which CELLS to redo.
+VERDICTS = "blessed-flow-verdicts.json"
+
+
+def _verdict_path() -> Path:
+    return Path(os.environ.get("RIVET_FLOW_VERDICTS", scenarios.work_dir() / VERDICTS))
+
+
+def failed_cells(path: Path | None = None) -> set[str]:
+    """The cell keys a previous run failed, for `only=`.
+
+    The matrix is ~15 minutes; re-running all 76 cells to re-check four is how a
+    feedback loop gets long enough that people stop closing it.
+    """
+    p = path or _verdict_path()
+    try:
+        return {k for k, v in json.loads(p.read_text()).items() if v == "fail"}
+    except (OSError, json.JSONDecodeError):
+        return set()
+
+
+def sc_blessed_flow(led: Ledger, engine: str, tag: str, url: str,
+                    state_url: str = "", cdc_url: str = "",
+                    only: set[str] | None = None) -> None:
+    """Run this engine's column of the matrix, recording every cell.
+
+    Per engine×version rather than once for all engines, because that is the
+    shape the gate already has: `engine_loop` brings ONE engine up at a time and
+    tears it down, so a signature taking a list of engines could only ever be
+    called from a place where three of the four are down. An `na` cell is a
+    ledger SKIP carrying its reason, so the report shows the grid's holes rather
+    than leaving them to be inferred from what is absent.
+
+    `only` restricts the run to the named cell keys (see `failed_cells`). A cell
+    outside the set is recorded SKIP with that reason, not omitted — a partial
+    re-run that silently prints fewer rows is a report that looks like a smaller
+    matrix.
+    """
+    led.phase(f"blessed flow · {engine} {tag} — whole journey × pipeline × lifecycle × store × state"
+              + (f" (rerunning {len(only)} cell(s))" if only else ""))
+    cells = cross_product([engine])
+    runnable = [c for c in cells if c.na_reason() is None]
+    led.ok(f"blessed flow[{engine}]: {len(cells)} cells declared, {len(runnable)} runnable, "
+           f"{len(cells) - len(runnable)} na")
+
+    verdicts: dict[str, str] = {}
+    vp = _verdict_path()
+    try:
+        verdicts = json.loads(vp.read_text())
+    except (OSError, json.JSONDecodeError):
+        verdicts = {}
+
+    cdc_url = cdc_url or os.environ.get(f"RIVET_CDC_{engine.upper()}_URL", "")
+    for cell in cells:
+        key = f"{engine}/{cell.pipeline}/{cell.lifecycle}/{cell.store}/{cell.state}"
+        why = cell.na_reason()
+        if why:
+            led.skipped(cell.engine, tag, f"flow:{cell.pipeline}/{cell.lifecycle}",
+                        cell.store, f"{cell.engine} {cell.label} — na: {why}", "na")
+            continue
+        if only is not None and key not in only:
+            led.skipped(cell.engine, tag, "flow:chain", cell.store,
+                        f"{cell.engine} {cell.label} — not in this re-run's cell set")
+            continue
+        u = cdc_url if cell.pipeline == "cdc" else url
+        if not u:
+            led.skipped(cell.engine, tag, "flow:chain", cell.store,
+                        f"{cell.engine} {cell.label} — no RIVET_CDC_{engine.upper()}_URL "
+                        "(the batch stand has no logical-decoding/CDC setup)")
+            continue
+        if cell.state == "postgres" and not state_url:
+            led.skipped(cell.engine, tag, "flow:chain", cell.store,
+                        f"{cell.engine} {cell.label} — postgres ledger needs --state-url")
+            continue
+        if cell.store != "local" and not scenarios.store_up(cell.store):
+            led.skipped(cell.engine, tag, "flow:chain", cell.store,
+                        f"{cell.engine} {cell.label} — {cell.store} store not up")
+            continue
+        before = sum(1 for c in led.cells if c.status.value == "FAIL")
+        run_cell(led, cell, u, state_url)
+        after = sum(1 for c in led.cells if c.status.value == "FAIL")
+        verdicts[key] = "fail" if after > before else "pass"
+        # Written after EVERY cell, not at the end: a matrix killed at minute ten
+        # would otherwise leave nothing to resume from, which is the same defect
+        # the CDC checkpoint exists to prevent one layer down.
+        try:
+            vp.write_text(json.dumps(verdicts, indent=1, sort_keys=True))
+        except OSError:
+            pass
+
+
+def flag_coverage(cells: list[Cell]) -> dict[str, set[str]]:
+    """Which flags the matrix actually exercises, per command.
+
+    Reported alongside the run so a flag nobody carries is visible as an empty
+    set rather than as an assumption.
+    """
+    out: dict[str, set[str]] = {}
+    for c in cells:
+        if c.na_reason():
+            continue
+        for cmd, fl in c.flags.items():
+            out.setdefault(cmd, set()).update(f for f in fl if f.startswith("--"))
+    return out
+
+
+def _addressing(cell: Cell, addr: list[str], dest_dir: Path, prefix: str,
+                work: Path) -> list[str]:
+    """Turn a declared addressing flag into one carrying a REAL value.
+
+    Returns [] when the artifacts do not supply one — the caller then records
+    the skip in the stage detail rather than validating the latest run twice
+    and calling it addressed coverage.
+    """
+    if not addr:
+        return []
+    flag = addr[0]
+    man = (dest_dir / "manifest.json") if cell.store == "local" else None
+    art = {}
+    if man and man.is_file():
+        try:
+            art = json.loads(man.read_text())
+        except json.JSONDecodeError:
+            art = {}
+    if flag == "--prefix":
+        return ["--prefix", str(dest_dir)] if cell.store == "local" else []
+    if flag == "--run-id":
+        rid = art.get("run_id") or art.get("runId")
+        return ["--run-id", str(rid)] if rid else []
+    if flag == "--date":
+        stamp = art.get("started_at") or art.get("completed_at") or ""
+        day = str(stamp)[:10]
+        return ["--date", day] if len(day) == 10 and day[4] == "-" else []
+    return []
+
+
+#: Flags the matrix deliberately does not carry, each with the reason. A flag
+#: absent from BOTH this map and `flag_coverage()` fails `verify_flag_surface` —
+#: which is the point: a new flag lands with no cell carrying it and the gate
+#: says so, rather than the matrix quietly grading what its author remembered.
+FLAG_EXCUSED = {
+    "--help": "surface, not behaviour",
+    "--json-errors": "shapes stderr on a failing path; this chain asserts success",
+    "--config": "carried by every stage as -c",
+    "--export": "the configs here declare ONE export — a selector cannot select differently",
+    "--param": "owned by the curated-query matrix, which defines substitution",
+    "--output": "carried positionally as -o by plan; validate's is the same writer",
+    "--source": "a URL on argv is visible in `ps` — the gate uses --source-env on purpose",
+    "--source-file": "the file form of --source; same reader, and --source-env is the one ops use",
+    "--s3-region": "carried with --s3-bucket on the s3 cells",
+    "--gcs-credentials-file": "fake-gcs takes no credentials; the real path is the bigquery cycle's",
+}
+
+
+def _cli_flags(cmd: str) -> set[str]:
+    """The flags `rivet <cmd>` ACTUALLY has, parsed from its own help.
+
+    Derived, never typed: a hand-written list grades only what its author knew,
+    and the whole reason this module exists is that hand-curated coverage missed
+    the axis that mattered.
+
+    Only OPTION lines count — a line whose first token is a dash. clap's prose
+    quotes flags too (`--validate`, `--type-report`), and scanning every token
+    turned those into two phantom findings on the first run of this guard.
+    """
+    out = rivet(cmd, "--help").out
+    got: set[str] = set()
+    for line in out.splitlines():
+        m = re.match(r"\s+(?:-\w,\s+)?(--[a-z0-9-]+)", line)
+        if m:
+            got.add(m.group(1))
+    return got
+
+
+def verify_flag_surface(led: Ledger) -> None:
+    """Every flag of every command in the chain is carried, or excused by name."""
+    led.phase("blessed flow · flag surface (derived from the CLI, not from a list)")
+    cells = cross_product(["postgres"])
+    cov = flag_coverage(cells)
+    carried = {f for fl in cov.values() for f in fl}
+    # `-c`, `-o` and load's two are carried by the executor rather than declared.
+    carried |= {"--config", "--output", "--rivet-bin", "--run-id", "--prefix", "--date"}
+    for cmd in ("plan", "apply", "run", "validate", "check", "load", "doctor", "init"):
+        real = _cli_flags(cmd)
+        if not real:
+            led.failed("-", "flow", "flow:flags", cmd,
+                       f"flag surface · `rivet {cmd} --help` produced no flags — cannot grade")
+            continue
+        gap = sorted(f for f in real if f not in carried and f not in FLAG_EXCUSED)
+        if gap:
+            led.failed("-", "flow", "flow:flags", cmd,
+                       f"flag surface · `{cmd}` has flags no cell carries and no excuse names: "
+                       f"{', '.join(gap)}", ",".join(gap))
+        else:
+            led.passed("-", "flow", "flow:flags", cmd,
+                       f"flag surface · `{cmd}`: {len(real)} flags, all carried or excused")
+
+
+#: What `--schema` means per engine. MySQL has no schema layer, so the flag
+#: names the DATABASE; Mongo has neither and takes no `--schema` at all.
+INIT_SCHEMA = {"postgres": "public", "mssql": "dbo", "mysql": "rivet"}
+
+
+def _qualified(cell: Cell) -> str:
+    """The cell's table as `--table` wants it: schema-qualified where the engine
+    has schemas, bare where it does not (MySQL puts the database in the URL)."""
+    schema = INIT_SCHEMA.get(cell.engine)
+    if not schema or cell.engine == "mysql" or "." in cell.table:
+        # Already qualified (the mssql CDC fixture is `dbo.orc_cdc_probe`) or the
+        # engine has no schema layer. Prepending anyway produced
+        # `dbo.dbo.orc_cdc_probe`, and init reported a table that does not exist.
+        return cell.table
+    return f"{schema}.{cell.table}"
+
+
+def _resolve_init(cell: Cell) -> list[str]:
+    """Fill the per-engine placeholders in the cell's declared init flags.
+
+    The flags are declared engine-agnostically so `flag_coverage` can read them
+    without an engine; `public.users` vs `dbo.users` vs `users` is resolved here,
+    at the one place that knows which engine is running.
+    """
+    schema = INIT_SCHEMA.get(cell.engine)
+    qualified = _qualified(cell)
+    out: list[str] = []
+    skip_next = False
+    for i, a in enumerate(cell.flags.get("init", [])):
+        if skip_next:
+            skip_next = False
+            continue
+        if a == "TABLE":
+            out.append(qualified)
+        elif a == "BUCKET":
+            out.append(_bucket(cell.store))
+        elif a == "GLOB":
+            # Addresses THIS cell's table. A fixed `user*` matched the golden
+            # seed and nothing on the CDC stands, whose only table is the
+            # per-engine probe — init refused with a clear message and the
+            # whole cdc column died at stage one.
+            out.append(cell.table.split(".")[-1][:4] + "*")
+        elif a == "SCHEMA":
+            out.append(schema or "")
+        elif a == "--schema" and not schema:
+            # Mongo: no schema layer, so the flag and its value both go.
+            skip_next = True
+        else:
+            out.append(a)
+    return out
+
+
+#: What each engine's shared CDC fixture calls its probe table. Read from the
+#: setup helpers rather than re-declared: `cdc._cdc_postgres` creates
+#: `orc_cdc_probe`, and a second name here would route the export at a table
+#: the fixture never made.
+_CDC_TABLE = {
+    "postgres": "orc_cdc_probe",
+    "mysql": "orc_cdc_probe",
+    "mssql": "dbo.orc_cdc_probe",
+    "mongo": "orc_cdc_probe",
+}
+
+
+# ── proving the chain can go red ─────────────────────────────────────────────
+#
+# A green stage that was never red is unverified. The repo has a 63-test audit
+# behind that sentence, so this module carries its own inertness probe rather
+# than asserting its sensitivity in prose.
+#
+# These perturb the ARTIFACTS, not the product — a product mutant needs a
+# fat-LTO rebuild per mutant, and what is being graded here is whether the
+# ORACLE bites, which an artifact-level break answers exactly. The product-level
+# equivalents live in the mutant corpus and the fault hooks.
+_PERTURB = [
+    ("oracle", "a lost part", "delete one manifested parquet"),
+    ("oracle", "a truncated dataset", "delete every parquet"),
+    ("artifacts", "a lost manifest", "delete manifest.json and its copies"),
+    ("state", "a ledger that recorded nothing", "scope to a run id that does not exist"),
+]
+
+
+def _bit(led: Ledger, engine: str, ok: bool, msg: str, why: str) -> None:
+    """Record one sensitivity result. A probe that cannot fail is itself the
+    defect being probed for, so the failing message names what stayed green."""
+    if ok:
+        led.passed(engine, "flow", "flow:inert", "local", msg)
+    else:
+        led.failed(engine, "flow", "flow:inert", "local", f"inertness · {why}", why)
+
+
+def sc_not_inert(led: Ledger, engine: str, url: str, state_url: str) -> None:
+    """Break each artifact class and require the matching stage to go RED."""
+    led.phase("blessed flow · inertness probe (each oracle must fail when its subject is broken)")
+    cell = Cell(engine=engine, pipeline="batch", lifecycle="clean", store="local",
+                state="sqlite", flags=_flags_for(0, "batch", "clean", "local"))
+    work = scenarios.work_dir() / f"inert_{engine}"
+    shutil.rmtree(work, ignore_errors=True)
+    work.mkdir(parents=True, exist_ok=True)
+    base = Ledger()
+    _run_chain(base, cell, url, state_url, work, "")
+    if base.red:
+        led.failed(engine, "flow", "flow:inert", "local",
+                   "inertness probe · the baseline chain is not green — cannot grade sensitivity")
+        return
+    dest = work / "out"
+    parts = sorted(dest.rglob("*.parquet"))
+    if not parts:
+        led.failed(engine, "flow", "flow:inert", "local",
+                   "inertness probe · baseline wrote no parquet — the fixture is inert")
+        return
+
+    # 1. NEGATIVE control first, because the naive version of this probe got it
+    #    backwards. The chain runs the export more than once (apply, then the
+    #    reconcile leg), so several manifests declare several complete copies.
+    #    Deleting ONE copy's part must NOT move the oracle — the union is still
+    #    the whole table, and a probe that demands a failure there would be
+    #    demanding a false alarm. This is what the first draft asserted, and it
+    #    went red against a correct oracle.
+    victim = parts[0]
+    keep = victim.read_bytes()
+    victim.unlink()
+    got = _flow_rows(dest)
+    want = blessed_path._source_rows(engine, url, cell.table)
+    _bit(led, engine, got == want,
+         f"inertness (negative control) · one redundant copy removed → oracle still reads "
+         f"{got} == source {want}",
+         f"the oracle moved to {got} when a REDUNDANT copy was removed — it would "
+         f"raise a false alarm on any repeated run")
+    victim.write_bytes(keep)
+
+    # 1b. POSITIVE control: remove every declared part. Now nothing is delivered
+    #     and the oracle must refuse to agree with the source.
+    declared = _manifest_files(dest) or []
+    saved_parts = {Path(f): Path(f).read_bytes() for f in declared}
+    for f in saved_parts:
+        f.unlink()
+    got = _flow_rows(dest)
+    _bit(led, engine, got != want,
+         f"inertness · every declared part removed → oracle reads {got}, source {want}",
+         f"the oracle read {got} with no parts on disk — it agrees with the source "
+         f"about a dataset that is gone")
+    for f, b in saved_parts.items():
+        f.write_bytes(b)
+
+    # 2. a lost manifest: an unmanifested prefix has delivered nothing, and the
+    #    oracle must say so rather than counting the parquet lying next to it.
+    mans = sorted(dest.rglob("manifest*.json"))
+    saved = {m: m.read_bytes() for m in mans}
+    for m in mans:
+        m.unlink()
+    got = _flow_rows(dest)
+    _bit(led, engine, got < 0, f"inertness · no manifest → oracle reports {got}",
+         "it counted undeclared parquet as delivered")
+    for m, b in saved.items():
+        m.write_bytes(b)
+
+    # 3. a ledger that recorded nothing: the state stage must be scoped tightly
+    #    enough that a run id which never ran cannot satisfy it. This is the
+    #    exact check that was passing on 37 rows of unrelated history.
+    ok, detail = _meta_rows(cell, work, state_url, 0, ["run-id-that-never-existed"])
+    _bit(led, engine, not ok,
+         f"inertness · a run id that never ran → state refuses ({detail})",
+         f"the state stage accepted a run id that never ran ({detail})")
+
+
+# ── the DAG, printed from the same data the executor walks ───────────────────
+#: What each stage asserts and WHO answers it. The oracle column is the point of
+#: the whole module: three different questions (rivet re-reads, DuckDB decodes,
+#: the source counts) and a chain that answers one of them is not verified.
+STAGE_ORACLE = {
+    "init":            ("rivet init",     "the config's SHAPE (exports, mode, dest kind, table)"),
+    "init:discover":   ("rivet init",     "the survey artifact: tables[] each with suggested_mode"),
+    "doctor":          ("rivet doctor",   "source + destination auth, CDC slot hygiene"),
+    "check":           ("rivet check",    "column types resolve; --strict admits no warning"),
+    "plan":            ("rivet plan",     "plan.json parses and names the export"),
+    "apply":           ("rivet apply",    "wave execution; resume cells crash FIRST (fault hook)"),
+    "run":             ("rivet run",      "cdc capture after an anchor run + real changes"),
+    "artifacts":       ("filesystem",     "parts, manifest.json, run-unique copies, _SUCCESS"),
+    "artifacts:checkpoint": ("filesystem", "the CDC resume anchor exists and is non-empty"),
+    "state":           ("state backend",  "export_metrics/file_log/run_status SCOPED to this run"),
+    "oracle":          ("DuckDB",         "rows in MANIFEST-DECLARED parts vs the source's own count"),
+    "validate":        ("rivet validate", "rivet re-reads its own output; then again ADDRESSED"),
+    "reconcile":       ("rivet run",      "destination count vs a fresh source count"),
+    "load":            ("BigQuery",       "a foreign reader decodes it; ledger has load_run"),
+    "load:cleanup":    ("bq show",        "the table is really gone (rm -f exits 0 regardless)"),
+}
+
+
+def print_dag() -> str:
+    """Render the matrix as a DAG. Built from CHAIN/axes, never hand-drawn."""
+    L: list[str] = []
+    cells = cross_product(["postgres", "mysql", "mssql", "mongo"])
+    run_n = sum(1 for c in cells if c.na_reason() is None)
+    L.append("blessed flow — the whole user journey as one cross-product")
+    L.append("")
+    L.append("  AXES                                                cells")
+    L.append("  ────────────────────────────────────────────────────────")
+    for name, vals in (("engine", ["postgres", "mysql", "mssql", "mongo"]),
+                       ("pipeline", ["batch", "cdc"]),
+                       ("lifecycle", ["clean", "repeat", "resume"]),
+                       ("store", ["local", "s3", "gcs"]),
+                       ("state", ["sqlite", "postgres"])):
+        L.append(f"  {name:<10} {' × '.join(vals):<40} {len(vals):>3}")
+    L.append(f"  {'':<10} {'=':<40} {len(cells):>3} declared, "
+             f"{run_n} runnable, {len(cells) - run_n} na")
+    L.append("")
+    for pipe in ("batch", "cdc"):
+        L.append(f"  {pipe.upper()} chain")
+        L.append("  " + "─" * 74)
+        steps = [s for s in CHAIN[pipe]]
+        if pipe == "cdc":
+            steps.insert(steps.index("artifacts") + 1, "artifacts:checkpoint")
+        for i, st in enumerate(steps):
+            who, what = STAGE_ORACLE.get(st, ("?", "?"))
+            arm = "└─" if i == len(steps) - 1 else "├─"
+            L.append(f"   {arm} {st:<22} [{who:<14}] {what}")
+        L.append("")
+    L.append("  A stage that fails leaves every later stage as SKIP \"not reached\" —")
+    L.append("  an absent row in a 900-row report reads as not-applicable.")
+    return "\n".join(L)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Standalone runner: the whole matrix, or only what last failed.
+
+        python3 -m release_oracle.blessed_flow                # everything
+        python3 -m release_oracle.blessed_flow --rerun-failed # only last run's failures
+        python3 -m release_oracle.blessed_flow --engines mysql,mssql
+
+    The gate itself calls `sc_blessed_flow` per engine from `run_scenarios`; this
+    entry point exists for the iteration loop, where re-running 76 cells to
+    re-check four is the difference between fixing a harness bug in a minute and
+    in a quarter of an hour.
+    """
+    import argparse
+
+    ap = argparse.ArgumentParser(prog="blessed_flow")
+    ap.add_argument("--engines", default="postgres,mysql,mssql,mongo")
+    ap.add_argument("--rerun-failed", action="store_true",
+                    help=f"only the cells marked fail in {VERDICTS}")
+    ap.add_argument("--state-url", default=os.environ.get("RIVET_GATE_STATE_URL", ""))
+    ap.add_argument("--verdicts", default="", help="path to the verdict ledger")
+    ns = ap.parse_args(argv)
+    if ns.verdicts:
+        os.environ["RIVET_FLOW_VERDICTS"] = ns.verdicts
+
+    only: set[str] | None = None
+    if ns.rerun_failed:
+        only = failed_cells()
+        if not only:
+            print(f"no failed cells recorded in {_verdict_path()} — nothing to re-run")
+            return 0
+        print(f"re-running {len(only)} failed cell(s): {', '.join(sorted(only))}")
+
+    led = Ledger()
+    verify_flag_surface(led)
+    for eng in [e for e in ns.engines.split(",") if e]:
+        url = os.environ.get(f"RIVET_ORACLE_{eng.upper()}_URL", "")
+        if not url:
+            led.skipped(eng, "flow", "flow:chain", "-",
+                        f"{eng} — no RIVET_ORACLE_{eng.upper()}_URL")
+            continue
+        sc_blessed_flow(led, eng, "live", url, state_url=ns.state_url, only=only)
+        if only is None:
+            sc_not_inert(led, eng, url, ns.state_url)
+    return led.report()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dev/release_oracle/blessed_flow.py
+++ b/dev/release_oracle/blessed_flow.py
@@ -556,7 +556,7 @@ def _manifest_files(prefix: Path) -> list[str] | None:
     return sorted(set(out))
 
 
-def run_cell(led: Ledger, cell: Cell, url: str, state_url: str) -> None:
+def run_cell(led: Ledger, cell: Cell, url: str, state_url: str, tag: str = "live") -> None:
     """Walk one cell's chain, with the CDC fixture raised and torn down around it.
 
     The teardown is a `finally` because on PostgreSQL it drops a replication
@@ -568,7 +568,7 @@ def run_cell(led: Ledger, cell: Cell, url: str, state_url: str) -> None:
     """
     tag = "flow"
     slug = f"{cell.pipeline}_{cell.lifecycle}_{cell.store}_{cell.state}"
-    work = scenarios.work_dir() / f"flow_{cell.engine}_{slug}_{cell.table}"
+    work = scenarios.work_dir() / f"flow_{cell.engine}{tag}_{slug}_{cell.table}"
     shutil.rmtree(work, ignore_errors=True)
     work.mkdir(parents=True, exist_ok=True)
 
@@ -618,14 +618,14 @@ def run_cell(led: Ledger, cell: Cell, url: str, state_url: str) -> None:
         cell.table = _CDC_TABLE.get(cell.engine, cell.table)
 
     try:
-        _run_chain(led, cell, url, state_url, work, cdc_block)
+        _run_chain(led, cell, url, state_url, work, cdc_block, tag)
     finally:
         if cell.pipeline == "cdc":
             cdc._ENGINES[cell.engine].cleanup(url, work)
 
 
 def _run_chain(led: Ledger, cell: Cell, url: str, state_url: str, work: Path,
-               cdc_block: str) -> None:
+               cdc_block: str, tag: str = "live") -> None:
     """Walk one cell's whole chain, recording a row per stage."""
     tag = "flow"
     slug = f"{cell.pipeline}_{cell.lifecycle}_{cell.store}_{cell.state}"
@@ -637,7 +637,13 @@ def _run_chain(led: Ledger, cell: Cell, url: str, state_url: str, work: Path,
     # it counts only manifested parts in a fresh tempdir; the cloud path had no
     # such filter, and the same defect came back one store over. Same shape as
     # the CDC leg's `oracle-cdc/<work-root>/…`.
-    prefix = (f"flow/{scenarios.work_dir().name}/{cell.engine}/{slug}/"
+    # The VERSION TAG belongs in the prefix, not just the engine. The gate runs
+    # this matrix once per gridded version — postgres 13, 14, 16, 18 — and
+    # `cell.engine` is "postgres" for all four, so they shared one object-store
+    # prefix and the readback counted every earlier version's parts as this
+    # one's: 450000 rows read from a 150000-row table (3x), then 750000 (5x) as
+    # the run progressed. Caught by the gate itself on its first full pass.
+    prefix = (f"flow/{scenarios.work_dir().name}/{cell.engine}{tag}/{slug}/"
               f"{cell.table.replace('.', '_')}")
     mark = 0
 
@@ -938,7 +944,9 @@ def _load_leg(led: Ledger, cell: Cell, tag: str, work: Path, env: dict, url: str
         return
 
     tbl = cell.table.split(".")[-1]
-    pfx = f"flow/{cell.engine}/{cell.pipeline}/{tbl}"
+    # Version-scoped for the same reason the readback prefix is: the gate runs
+    # this once per gridded version and `cell.engine` does not distinguish them.
+    pfx = f"flow/{cell.engine}{tag}/{cell.pipeline}/{tbl}"
     lcfg = work / "load.yaml"
     tls = "\n  tls: {accept_invalid_certs: true}" if cell.engine == "mssql" else ""
     lcfg.write_text(
@@ -962,7 +970,9 @@ def _load_leg(led: Ledger, cell: Cell, tag: str, work: Path, env: dict, url: str
         return
     # Unique per cell: the id is what the ledger check scopes on, and a shared
     # one would let one cell's rows satisfy another's assertion.
-    load_id = f"flow-{cell.engine}-{cell.lifecycle}-{cell.state}-{scenarios.work_dir().name}"
+    load_id = (
+        f"flow-{cell.engine}-{cell.lifecycle}-{cell.state}-{scenarios.work_dir().name}"
+    )
     p = rivet("load", "-c", str(lcfg), "--rivet-bin", str(rivet_bin()),
               "--run-id", load_id, env=env, timeout=scenarios.NO_TIMEOUT)
     if not p.ok:
@@ -1103,7 +1113,7 @@ def sc_blessed_flow(led: Ledger, engine: str, tag: str, url: str,
                         f"{cell.engine} {cell.label} — {cell.store} store not up")
             continue
         before = sum(1 for c in led.cells if c.status.value == "FAIL")
-        run_cell(led, cell, u, state_url)
+        run_cell(led, cell, u, state_url, tag)
         after = sum(1 for c in led.cells if c.status.value == "FAIL")
         verdicts[key] = "fail" if after > before else "pass"
         # Written after EVERY cell, not at the end: a matrix killed at minute ten

--- a/dev/release_oracle/blessed_flow.py
+++ b/dev/release_oracle/blessed_flow.py
@@ -1363,6 +1363,17 @@ def sc_not_inert(led: Ledger, engine: str, url: str, state_url: str) -> None:
     victim.unlink()
     got = _flow_rows(dest)
     want = blessed_path._source_rows(engine, url, cell.table)
+    if want < 0:
+        # An UNREADABLE source count cannot grade anything, and comparing against
+        # the sentinel is worse than not comparing: on mongo 4.4 — whose image
+        # ships no `mongosh`, so the count came back -1 — the negative control
+        # read "the oracle moved to 150000" and reported a false alarm about a
+        # false alarm. The `oracle` stage one layer up already SKIPs on this;
+        # the probe must too.
+        led.skipped(engine, "flow", "flow:inert", "local",
+                    f"inertness · {engine} — source count unreadable, cannot grade sensitivity")
+        victim.write_bytes(keep)
+        return
     _bit(led, engine, got == want,
          f"inertness (negative control) · one redundant copy removed → oracle still reads "
          f"{got} == source {want}",

--- a/dev/release_oracle/blessed_path.py
+++ b/dev/release_oracle/blessed_path.py
@@ -194,7 +194,12 @@ def _source_rows(engine: str, url: str, table: str) -> int:
                           "-h-1", "-W", "-Q",
                           f"SET NOCOUNT ON; SELECT count(*) FROM {table}").stdout.strip()
     elif engine == "mongo":
-        out = docker_exec(c, "mongosh", "--quiet", "rivet", "--eval",
+        # `mongosh` does not exist on 4.4 — see `scenarios.mongo_shell`. Asking
+        # for it there returned nothing, which this function turned into -1 and
+        # the oracle read as "source unreachable", SKIPping the comparison on the
+        # oldest gridded version. `countDocuments({})` and not the no-arg form:
+        # the legacy shell rejects it.
+        out = docker_exec(c, scenarios.mongo_shell(c), "--quiet", "rivet", "--eval",
                           f"print(db.{table}.countDocuments({{}}))").stdout.strip()
     else:
         return -1
@@ -560,7 +565,15 @@ def sc_bq_cycle(led: Ledger, engine: str, tag: str, url: str, table: str) -> Non
     """
     proj = os.environ.get("BQ_ORACLE_PROJECT") or run(
         ["gcloud", "config", "get-value", "project"]).stdout.strip()
-    dset = os.environ.get("BQ_ORACLE_DATASET", "rivet_blessed")
+    # PER SOURCE, which is what the gate's README already promises this variable
+    # does ("one dataset PER SOURCE is derived from this") and what this line did
+    # not do. `rivet load` derives the warehouse table from `table:`, so every
+    # engine's `users` landed on ONE table and rivet's cross-source guard refused
+    # the second one — correctly, and on six cells: mysql 8.0/8.4, mssql 2022 and
+    # mongo 4.4/5/6/7/8, each after postgres had already claimed
+    # `rivet_blessed.users`. The guard doing its job is not the same as the gate
+    # being configured right.
+    dset = os.environ.get("BQ_ORACLE_DATASET", "rivet_blessed") + "_" + engine
     bucket = os.environ.get("BQ_ORACLE_BUCKET", "rivet_data_test")
     if not have("bq") or not proj:
         led.skipped(engine, tag, "blessed:bq", "bigquery",

--- a/dev/release_oracle/blessed_path.py
+++ b/dev/release_oracle/blessed_path.py
@@ -130,6 +130,16 @@ SCENARIOS: dict[str, dict] = {
 }
 
 
+def cloud_prefix(engine: str, tag: str, table: str, scenario: str) -> str:
+    """The object-store prefix for one cell, unique per gate invocation.
+
+    ONE function so the write side and the readback cannot drift apart — they
+    are two call sites of the same string, and a prefix that differs between
+    them reads as "the export wrote nothing".
+    """
+    return f"blessed/{scenarios.work_dir().name}/{engine}/{tag}/{table}/{scenario}"
+
+
 def _duckdb_ok() -> bool:
     """Is there a usable DuckDB? The oracle is worthless if its absence is
     indistinguishable from agreement — `_duckdb_list` returns "" on exit 127
@@ -344,7 +354,13 @@ def sc_blessed_path(
     if store == "local":
         dest_block = f"    destination: {{type: local, path: {dest_dir}/}}"
     else:
-        raw = scenarios.store_dest(store, BUCKET, f"blessed/{engine}/{tag}/{table}/{scenario}")
+        # The work root's name makes this unique PER GATE INVOCATION. Without
+        # it two runs into the same bucket accumulate and the readback counts the
+        # earlier one's parts as this one's — measured on the gate's first
+        # back-to-back pass: `source=150000 duckdb=300000 manifest=150000`, with
+        # the manifest correctly reporting 150000 the whole time. Same token the
+        # CDC leg and blessed_flow already carry.
+        raw = scenarios.store_dest(store, BUCKET, cloud_prefix(engine, tag, table, scenario))
         if not raw:
             led.skipped(engine, tag, "blessed:init", store, f"{store} — no destination block")
             _downstream_unreached(led, engine, tag, store, "init")
@@ -488,7 +504,7 @@ def sc_blessed_path(
         if store == "local":
             duck_rows, duck_files = _parquet_rows_and_files(dest_dir)
         else:
-            pfx = f"blessed/{engine}/{tag}/{table}/{scenario}"
+            pfx = cloud_prefix(engine, tag, table, scenario)
             got = scenarios.store_readback(store, BUCKET, pfx, work)
             duck_rows = int(got.splitlines()[0]) if got.strip().isdigit() else -1
             duck_files = -1  # the readback helper reports rows only

--- a/dev/release_oracle/blessed_path.py
+++ b/dev/release_oracle/blessed_path.py
@@ -307,6 +307,17 @@ def sc_blessed_path(
     env = dict(scenarios._store_env(url))
     if state_url:
         env["RIVET_STATE_URL"] = state_url
+    else:
+        # NEUTRALISE an inherited one. `__main__` sets `RIVET_STATE_URL` on the
+        # PROCESS when the gate is pointed at a Postgres backend ("one variable
+        # decides the backend for the WHOLE gate"), and `run()` merges os.environ
+        # into every cell — so this module's SQLite cells wrote their ledger to
+        # Postgres and then looked for a `.rivet_state.db` that was never
+        # created. 84 cells failed that way on the gate's first full pass, each
+        # with its own message correctly naming the cause: "apply recorded its
+        # ledger elsewhere". An empty value is not a Postgres URL, so
+        # `StateStore::open` falls back to SQLite (`url.starts_with("postgres")`).
+        env["RIVET_STATE_URL"] = ""
 
     # ── init ──────────────────────────────────────────────────────────────────
     cfg = work / "rivet.yaml"

--- a/dev/release_oracle/cdc.py
+++ b/dev/release_oracle/cdc.py
@@ -57,6 +57,7 @@ try:  # imported as part of the package
         port_of,
         rivet,
         run,
+        wait_until,
     )
 except ImportError:  # run directly out of dev/release_oracle/
     import scenarios  # type: ignore[no-redef]
@@ -71,6 +72,7 @@ except ImportError:  # run directly out of dev/release_oracle/
         port_of,
         rivet,
         run,
+        wait_until,
     )
 
 CDC_HOOK_FLUSH = "cdc_after_flush_before_ack"  # flushed to store, anchor NOT yet advanced
@@ -306,14 +308,49 @@ def _cdc_mssql(url: str, work: Path) -> str | None:
     p = _sqlcmd(
         url,
         sql=(
+            # DISABLE BEFORE DROP, and guard on the capture instance rather than
+            # on a join to sys.tables.
+            #
+            # The original order was DROP TABLE first, then
+            # `IF EXISTS (cdc.change_tables ct JOIN sys.tables t ON
+            # ct.source_object_id = t.object_id WHERE t.name='orc_cdc_probe')`.
+            # Dropping the table ORPHANS its change table — the row survives in
+            # cdc.change_tables but `source_object_id` no longer resolves, so the
+            # join finds nothing, the disable is skipped, and the next
+            # `sp_cdc_enable_table` fails with 22926: "capture instance name
+            # 'dbo_orc_cdc_probe' already exists". It alternated pass/fail run to
+            # run, which read as a race and is not one: it is order-dependent
+            # state the guard could no longer see.
+            "IF EXISTS (SELECT 1 FROM cdc.change_tables WHERE capture_instance = 'dbo_orc_cdc_probe')\n"
+            "  EXEC sys.sp_cdc_disable_table @source_schema='dbo', @source_name='orc_cdc_probe', @capture_instance='dbo_orc_cdc_probe';\n"
             "IF OBJECT_ID('dbo.orc_cdc_probe') IS NOT NULL DROP TABLE dbo.orc_cdc_probe;\n"
             "CREATE TABLE dbo.orc_cdc_probe (id int PRIMARY KEY, amount decimal(18,4), meta nvarchar(200));\n"
-            "IF EXISTS (SELECT 1 FROM cdc.change_tables ct JOIN sys.tables t ON ct.source_object_id=t.object_id WHERE t.name='orc_cdc_probe')\n"
-            "  EXEC sys.sp_cdc_disable_table @source_schema='dbo', @source_name='orc_cdc_probe', @capture_instance='all';\n"
             "EXEC sys.sp_cdc_enable_table @source_schema='dbo', @source_name='orc_cdc_probe', @role_name=NULL, @capture_instance='dbo_orc_cdc_probe';\n"
         ),
     )
     if not p.ok:
+        return None
+    # `sp_cdc_enable_table` returning success does NOT mean the capture instance
+    # is queryable: `fn_cdc_get_min_lsn` stays NULL until the capture job has run
+    # once, and rivet's own preflight reads exactly that function. So the fixture
+    # is not ready when the enable call returns — it is ready when the LSN is.
+    #
+    # Every mssql CDC cell of blessed_flow failed at `doctor` on this
+    # ("fn_cdc_get_min_lsn returned NULL — the capture instance does not exist"),
+    # which is the preflight being right about a fixture that had lied about
+    # being up. Waiting on the enable call's exit code is waiting on the wrong
+    # signal; a `time.sleep` here would be the same guess with a nicer face.
+    ready = wait_until(
+        lambda: "NULL"
+        not in _sqlcmd(
+            url,
+            q="SET NOCOUNT ON; SELECT ISNULL(CONVERT(varchar(64), "
+            "sys.fn_cdc_get_min_lsn('dbo_orc_cdc_probe'), 1), 'NULL')",
+        ).stdout,
+        tries=20,
+        delay=1.5,
+    )
+    if not ready:
         return None
     return (
         "cdc: { capture_instance: dbo_orc_cdc_probe, until_current: true, "

--- a/dev/release_oracle/scenarios.py
+++ b/dev/release_oracle/scenarios.py
@@ -828,6 +828,22 @@ def run_scenarios(led: Ledger, engine: str, tag: str, url: str) -> None:
         sc_load(led, engine, tag, url, store)
     if engine == "postgres":
         sc_gc_survival(led, engine, tag, url)
+    # The COMMAND CHAIN, end to end. Both of these were registered in
+    # docs/release-gate-matrix.yaml as `test` while `verify_blessed_path` had no
+    # caller anywhere in the tree — the matrix guard checks that a gate function
+    # has a ROW, not that anything calls it, so a dead check reads as coverage.
+    # `every_test_cell_has_a_call_site` now closes that.
+    from . import blessed_flow, blessed_path
+
+    state_url = os.environ.get("RIVET_GATE_STATE_URL", "") or os.environ.get(
+        "RIVET_CDC_STATE_URL", ""
+    )
+    blessed_path.verify_blessed_path(led, engine, tag, url, state_url=state_url)
+    blessed_flow.sc_blessed_flow(led, engine, tag, url, state_url=state_url)
+    # Does the chain above have working oracles at all? Breaks each artifact
+    # class and requires the matching stage to go RED — a green stage that was
+    # never red is unverified, and this module's own first draft had one.
+    blessed_flow.sc_not_inert(led, engine, url, state_url)
 
 
 # ── state-migration parity PREFLIGHT (source-agnostic, runs once) ────────────

--- a/dev/release_oracle/scenarios.py
+++ b/dev/release_oracle/scenarios.py
@@ -426,9 +426,7 @@ def _source_count_distinct(engine: str, url: str, table: str, id_col: str) -> st
         # mongo:4.4 ships the legacy `mongo` shell, 5.0+ ships `mongosh`. Pick
         # whichever the container actually has, or the count comes back as an OCI
         # "executable not found" string and the gate false-fails on good data.
-        shell = "mongosh"
-        if not docker_exec(container, "sh", "-c", "command -v mongosh >/dev/null 2>&1").ok:
-            shell = "mongo"
+        shell = mongo_shell(container)
         # countDocuments({}) NOT countDocuments() — the legacy 4.4 shell rejects
         # the no-arg form ("match filter must be an expression in an object").
         return docker_exec(
@@ -437,6 +435,25 @@ def _source_count_distinct(engine: str, url: str, table: str, id_col: str) -> st
             f"print(db.{table}.countDocuments({{}})+' '+db.{table}.distinct('_id').length)",
         ).stdout.strip()
     return ""
+
+
+def mongo_shell(container: str) -> str:
+    """`mongosh`, or the legacy `mongo` on an image that predates it.
+
+    Mongo 4.4 ships only the old shell — `mongosh` became standard in 5.0. A
+    caller that assumes the new name gets "executable not found" and, if it
+    parses the empty output as a count, a silent -1 that reads as "the source is
+    unreachable". That is what happened to `blessed_path._source_rows`: every
+    mongo 4.4 oracle cell SKIPped with `source=-1 duckdb=150000` while 5, 6, 7
+    and 8 passed, so the one version most likely to expose an old-shell
+    incompatibility was the one version not being compared.
+
+    Extracted here because the knowledge already existed in this file and a
+    second caller had gone without it; a third would too.
+    """
+    if docker_exec(container, "sh", "-c", "command -v mongosh >/dev/null 2>&1").ok:
+        return "mongosh"
+    return "mongo"
 
 
 def _fidelity_check(engine: str, key: str, got: str) -> bool:

--- a/docs/attestation-matrix.yaml
+++ b/docs/attestation-matrix.yaml
@@ -41,6 +41,7 @@ claims:
     independence: independent
     evidence: "dev/release_oracle/rowhash.py; PASS on postgres/mysql/mssql 2026-08-02"
     note: "the IN-TREE auditor recomputes with rivet's own `enrich` by design — that is a `self` check and stays one; this row is about the gate's second opinion."
+    type_coverage: "every RivetType via `rivet_type_matrix`, run through row_hash on all three SQL engines by `stand_type_matrix_every_consumer_*` (tests/live/chunking_stand.rs). ADDED 2026-08-05 after the gap it closes: the gate cell verified the hash INDEPENDENTLY and still missed `Timestamp(µs, Some(\"UTC\"))` — 278 of 1184 columns in a real production database — because its probe did not carry that type. `verified_by` says WHO checks; this field says WHAT they saw, and the second question is the one that went unasked for four months."
 
   - id: column_checksums_form_b
     what: "`column_checksums` — per-column value digests re-derived from the written Parquet."
@@ -48,12 +49,14 @@ claims:
     independence: self
     negative_proof: "gate cell `corruption_is_detected` (batch) and `cdc_corruption_is_detected` (CDC): a same-length in-place byte flip must produce exit 3 naming the diverging column. Both RED-proven against the live defect."
     evidence: "dev/release_oracle/corruption.py; PASS on postgres/mysql/mssql 2026-08-02"
+    type_coverage: "every RivetType via `rivet_type_matrix`, exercised through the sink's `track_checksum` and re-read by `--validate` in `stand_type_matrix_every_consumer_*` — the SAME export that exercises row_hash, so a type cannot reach one consumer and miss the other."
 
   - id: column_checksums_form_a
     what: "the source-side value digest, computed from `CellSource` as rows are read."
     verified_by: "compared against Form B at the end of every run — a genuine cross-check between two different extractions of the same values."
     independence: self
     note: "Form A shares the writer's own rendering, so the pair detects an Arrow-build fault and cannot detect a shared misreading of the source. Its accessors gained their first unit tests on 2026-08-02."
+    type_coverage: "every RivetType via `rivet_type_matrix`, same export as Form B (they are compared to each other at the end of every run, so a type absent from one is absent from both)."
 
   - id: checksum_render
     what: "which fold produced `column_checksums` (`xxh3-64-sum-v2`; absent ⇒ the v1 XOR)."

--- a/docs/release-gate-matrix.yaml
+++ b/docs/release-gate-matrix.yaml
@@ -51,6 +51,18 @@ scenarios:
     mysql:    test
     mssql:    test
     mongo:    test
+  - id: blessed_flow
+    what: "The WHOLE journey as ONE declared cross-product, not per-defect additions: pipeline{batch,cdc} x lifecycle{clean,repeat,resume} x store{local,s3,gcs} x state{sqlite,postgres} x engine = 144 cells, 76 runnable, 68 `na` each carrying its reason in the ledger. Where blessed_path walks init->apply for one strategy, this adds what that chain cannot reach: the CDC pipeline (plan/apply REFUSE a cdc export, so those cells run `run`), the crash-then-resume lifecycle (a fault hook kills the first apply, and the probe FAILS the cell if the hook did not stop it — a resume whose first run succeeded is a clean re-run wearing a flag), the repeat lifecycle asserted on the MANIFEST COPIES rather than the parquet (the data surviving is what makes a sidecar clobber invisible), and `load` with load_run/loaded_source_run. Values are read ONLY by DuckDB, and only from parts a manifest DECLARES as committed — counting every parquet under the prefix reads a crashed run's orphans as delivered data. State is scoped per-run (watermark on export_metrics, which has no run_id; run ids from the manifests for file_log/run_status): the first draft counted `export_name='flow'` and read 37 rows of unrelated history on a cell that wrote one."
+    postgres: test
+    mysql:    test
+    mssql:    test
+    mongo:    test
+  - id: not_inert
+    what: "The chain's own oracles must be able to go RED. Breaks each artifact class and requires the matching stage to fail: every declared part removed (oracle must stop agreeing with the source), no manifest (must report undelivered, not count the parquet lying next to it), a run id that never ran (state must refuse). Carries a NEGATIVE control too — removing ONE redundant copy of a repeated export must NOT move the oracle; the first draft demanded a failure there and went red against a correct oracle."
+    postgres: test
+    mysql:    test
+    mssql:    test
+    mongo:    test
   - id: verdicts
     what: "init -> the strategy per table matches the golden (keyset/full/range/name-trap), zero phantom heavy-chunk."
     postgres: test
@@ -84,6 +96,9 @@ scenarios:
 
 # ── Source-agnostic PREFLIGHTS (run ONCE before the engine loop, not per engine/version) ──
 preflights:
+  - id: flag_surface
+    what: "Every flag of every command in the chain is carried by some cell or excused BY NAME, with the surface DERIVED from `rivet <cmd> --help` rather than typed in. Found on its first run that init — the first stage of every chain — was being driven with one of its thirteen flags; --mode now tracks the pipeline axis and --s3-bucket/--gcs-bucket the store axis, so init's own scaffold is graded instead of discarded. The rotation that distributes flags across cells is keyed on a DIGEST of the coordinates, not the enumeration index: `% 3` over a nested cross-product aliased with the inner loops and drew --discover for every postgres-backend cell."
+    status: test        # verify_flag_surface (blessed_flow.py) — no containers, runs with the file-level guards
   - id: release_build_path
     what: "the RELEASE build/publish path itself, not `cargo build` (the stricter tooling the TAG runs, which failed AFTER publish for 0.16.0/0.16.1): Cargo.lock in sync (`cargo metadata --locked` — publish + Docker cook are `--locked`), the cargo-manifest strict parse (no multi-line inline tables, the cargo_manifest_chef guard) + JSON-schema regen (schema_drift guard), and `cargo chef prepare` (the Dockerfile's actual planner step, cheap — no compile). Full `docker build` opt-in via RIVET_ORACLE_DOCKER=1. Runs FIRST, before any cargo reconciles the working-tree lock."
     status: test        # verify_release_build_path (dev/release_oracle/release_path.py)

--- a/seeds/mongo_seed.py
+++ b/seeds/mongo_seed.py
@@ -3,8 +3,15 @@
 
 Reproduces the benchmark fixture in Python (the project's scripting language;
 see dev/bench/smoke.py, dev/cdc/harm_mongo.py), sized to mirror the SQL
-`orders`/`users` fixture: rivet.users=150000, rivet.orders=150000. Idempotent —
-each collection is dropped and rebuilt.
+`orders`/`users`/`content_items` fixture: rivet.users=150000,
+rivet.orders=150000, rivet.content_items=5000. Idempotent — each collection is
+dropped and rebuilt.
+
+`content_items` is the WIDE one, and it is why the count is small: its purpose is
+a document whose body dwarfs its key, not volume. Without it Mongo was the only
+engine whose blessed path never read a wide row — `GOLDEN_TABLES` asks for three
+collections and this seed made two, so every `content_items` cell exported ZERO
+rows and reported success, which the gate caught as `0 parquet, manifest=True`.
 
 Run:   RIVET_MONGO_URI="mongodb://127.0.0.1:27017/rivet" python3 seeds/common/mongo.py
 Needs: pip install pymongo
@@ -17,6 +24,9 @@ from pymongo import MongoClient
 URI = os.environ.get("RIVET_MONGO_URI", "mongodb://127.0.0.1:27017/rivet")
 USERS = int(os.environ.get("RIVET_SEED_USERS", "150000"))
 ORDERS = int(os.environ.get("RIVET_SEED_ORDERS", "150000"))
+# 5000, matching the size docs/bench/matrix.yaml already names for this
+# collection. Wide documents, few of them.
+CONTENT = int(os.environ.get("RIVET_SEED_CONTENT_ITEMS", "5000"))
 PRODUCTS = ["widget", "gadget", "sprocket", "cog", "bearing", "gasket"]
 STATUSES = ["pending", "shipped", "delivered", "cancelled"]
 
@@ -51,9 +61,35 @@ def main() -> None:
         ]
     )
 
+    # The wide analogue of the SQL `content_items`: a body and raw_html that
+    # dominate the document, plus the nested `metadata` a JSONB column becomes in
+    # a document store.
+    db.content_items.drop()
+    db.content_items.insert_many(
+        [
+            {
+                "_id": i,
+                "title": f"item {i}",
+                "body": f"body-{i} " * 120,
+                "raw_html": f"<p>item {i}</p>" * 60,
+                "metadata": {"source": "seed", "rev": i % 7, "tags": ["a", "b", "c"]},
+                "author_name": f"author{i % 50}",
+                "author_email": f"author{i % 50}@example.com",
+                "category": ["news", "blog", "docs"][i % 3],
+                "status": ["draft", "published", "archived"][i % 3],
+                "view_count": i * 3,
+                "word_count": 120,
+                "created_at": now,
+                "updated_at": now,
+            }
+            for i in range(1, CONTENT + 1)
+        ]
+    )
+
     print(
         f"seeded {db.name}.users={db.users.count_documents({})} "
-        f"{db.name}.orders={db.orders.count_documents({})}"
+        f"{db.name}.orders={db.orders.count_documents({})} "
+        f"{db.name}.content_items={db.content_items.count_documents({})}"
     )
 
 

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -279,6 +279,11 @@ fn dispatch_cdc(a: CdcArgs) -> Result<()> {
             },
             CdcEngine::Postgres => CdcEngineOpts::Postgres { slot: a.slot },
             CdcEngine::Mssql => CdcEngineOpts::Mssql {
+                // The `rivet cdc` CLI names no tables — it captures whatever the
+                // capture instance emits — so there is nothing to cross-check
+                // against and the guard stays off. Config mode (`mode: cdc`)
+                // supplies them.
+                configured_tables: Vec::new(),
                 capture_instance: a.capture_instance,
             },
             CdcEngine::Mongo => CdcEngineOpts::Mongo { canonical: false },

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -939,6 +939,65 @@ fn require_pk<'a>(plan: &'a load::plan::LoadPlan, mode: &str) -> Result<&'a [Str
 /// (`has_active_running_manifest`, the cross-boundary signal a stateless /
 /// foreign-host load reads when it cannot see the extract's state DB). Only when
 /// NEITHER says active does a no-manifest part count as dead crash debris.
+/// Is a run writing into this prefix right now?
+///
+/// The verdict `maybe_gc_orphans` already computes, extracted so the DESTRUCTIVE
+/// delete can ask the same question. `cleanup_source` recursively removes the
+/// whole prefix — every part, every manifest, `_SUCCESS` — while `gc_orphans`
+/// removes only parts no `Success` manifest references. The gentler of the two
+/// consulted the ledger and the total one did not, which is the guard placed in
+/// inverse proportion to what it protects. `src/load/plan.rs` states the
+/// relationship in its own words: gc_orphans is "strictly gentler than
+/// `cleanup_source`, which wipes the whole prefix".
+///
+/// Conservative in both directions, deliberately: a ledger query ERROR counts as
+/// active (a delete that spares too much costs disk; one that deletes a live
+/// run's committed parts costs data, and on a CDC or incremental export the
+/// source side has already advanced past them). No state store at all —
+/// a stateless or foreign-host load — falls back to the manifest signal alone,
+/// exactly as the orphan path does.
+fn prefix_has_active_run(plan: &load::plan::LoadPlan, state: Option<&StateStore>) -> bool {
+    let ledger_active = match state {
+        Some(s) => s.has_active_run_on_prefix(&plan.gcs_prefix).unwrap_or(true),
+        None => false,
+    };
+    if ledger_active {
+        return true;
+    }
+    match load::open_store(&plan.destination)
+        .and_then(|st| load::reconcile::fetch_manifests_keyed(&st, &plan.gcs_prefix))
+    {
+        Ok(keyed) => load::reconcile::has_active_running_manifest(&keyed),
+        // Cannot read the manifests → cannot rule a live run out. Spare.
+        Err(_) => true,
+    }
+}
+
+/// The delete target for `cleanup_source`, or `None` when a run is writing here.
+///
+/// Refusing is announced, not silent: an operator who asked for cleanup and did
+/// not get it must know the prefix still holds the staged Parquet.
+fn cleanup_target<'a>(
+    plan: &'a load::plan::LoadPlan,
+    store: &'a crate::destination::gcs::GcsStore,
+    state: Option<&StateStore>,
+) -> Option<(&'a crate::destination::gcs::GcsStore, &'a str)> {
+    if !plan.load.cleanup_source {
+        return None;
+    }
+    if prefix_has_active_run(plan, state) {
+        eprintln!(
+            "  cleanup [{}]: SKIPPED — a run is writing into {} right now. Deleting the prefix \
+             would remove parts that run has already committed, and on a CDC/incremental export \
+             the source position has advanced past them. Re-run the load once the extract has \
+             finished.",
+            plan.table, plan.gcs_prefix
+        );
+        return None;
+    }
+    Some((store, plan.gcs_prefix.as_str()))
+}
+
 fn maybe_gc_orphans(plan: &load::plan::LoadPlan, state: Option<&StateStore>) {
     let store = match load::open_store(&plan.destination) {
         Ok(s) => s,
@@ -1338,10 +1397,7 @@ fn load_one_cdc(
         |loader, store, inputs| {
             // The driver gates the appended delta against the manifests' summed
             // `row_count` and cleans up (only) after the gate passes.
-            let cleanup = plan
-                .load
-                .cleanup_source
-                .then_some((store, plan.gcs_prefix.as_str()));
+            let cleanup = cleanup_target(plan, store, state);
             let report = load::run_load_cdc(
                 loader,
                 &plan.table,
@@ -1401,10 +1457,7 @@ fn load_one_incremental(
             );
         },
         |loader, store, inputs| {
-            let cleanup = plan
-                .load
-                .cleanup_source
-                .then_some((store, plan.gcs_prefix.as_str()));
+            let cleanup = cleanup_target(plan, store, state);
             let report = load::run_load_incremental(
                 loader,
                 &plan.table,
@@ -1462,10 +1515,7 @@ fn load_one(
             );
         },
         |loader, store, inputs| {
-            let cleanup = plan
-                .load
-                .cleanup_source
-                .then_some((store, plan.gcs_prefix.as_str()));
+            let cleanup = cleanup_target(plan, store, state);
             let report = load::run_load(
                 loader,
                 &plan.table,

--- a/src/enrich.rs
+++ b/src/enrich.rs
@@ -440,6 +440,58 @@ mod tests {
     use arrow::array::StringArray;
     use arrow::datatypes::Field;
 
+    /// A timestamp whose timezone is a NAME must hash, not refuse.
+    ///
+    /// Arrow's `ArrayFormatter` rejects `Timestamp(_, Some("UTC"))` unless the
+    /// `chrono-tz` feature is on — "only offset based timezones supported
+    /// without chrono-tz feature". rivet maps EVERY timestamp to
+    /// `Some("UTC")` (`types/mapping.rs`), so `meta_columns.row_hash` bailed on
+    /// every temporal column with
+    ///
+    ///   row_hash: column 'action_date' has type Timestamp(µs, "UTC") which
+    ///   Arrow cannot render
+    ///
+    /// Measured on a real MySQL config, 2026-08-05: 63 of 65 finished exports
+    /// failed on exactly this, and the run recorded them as `failed` with zero
+    /// rows. Nothing in the suite caught it because a NAIVE timestamp and an
+    /// OFFSET timezone (`+03:00`) both render fine — only the NAMED form, which
+    /// is the only form rivet produces, does not.
+    ///
+    /// This test is the reason the feature cannot be dropped again: without
+    /// `chrono-tz` it fails at the `unwrap`, naming the column.
+    #[test]
+    fn row_hash_covers_a_named_timezone_timestamp() {
+        use arrow::array::TimestampMicrosecondArray;
+        let ts = TimestampMicrosecondArray::from(vec![Some(1_700_000_000_000_000i64), Some(1i64)])
+            .with_timezone("UTC".to_string());
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new(
+                "action_date",
+                DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+                true,
+            ),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int64Array::from(vec![1, 2])), Arc::new(ts)],
+        )
+        .unwrap();
+
+        let hashes = row_hash_array(&batch, &["id".to_string(), "action_date".to_string()]).expect(
+            "a named-timezone timestamp must hash — if this is an Arrow render error, the \
+                 `chrono-tz` feature has been dropped from the arrow dependency",
+        );
+        let h = hashes.as_any().downcast_ref::<Int64Array>().unwrap();
+        // Two rows differing ONLY in the timestamp must not collide: proves the
+        // value reached the hash rather than being rendered as a constant.
+        assert_ne!(
+            h.value(0),
+            h.value(1),
+            "rows differing only in the timestamp collided — the column did not reach the hash"
+        );
+    }
+
     fn sample_batch() -> (SchemaRef, RecordBatch) {
         let schema = Arc::new(Schema::new(vec![
             Field::new("id", DataType::Int64, false),

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -443,7 +443,7 @@ pub fn init(
     mode_override: Option<&str>,
 ) -> Result<()> {
     yaml_destination.validate()?;
-    let (text, yaml_decimal_review) = match format {
+    let (text, yaml_decimal_review, snapshots) = match format {
         InitFormat::Yaml => init_yaml(
             source_url,
             provenance,
@@ -474,6 +474,9 @@ pub fn init(
             (
                 init_discovery_json(source_url, table, schema, filter)?,
                 false,
+                // `--discover` writes a SURVEY, not a config — there is no
+                // strategy decision to record the evidence for.
+                Vec::new(),
             )
         }
     };
@@ -481,6 +484,7 @@ pub fn init(
     match output {
         Some(path) => {
             write_config_output(path, &text)?;
+            record_strategy_snapshots(path, &snapshots);
             let label_written = match format {
                 InitFormat::Yaml => "Config",
                 InitFormat::DiscoveryJson => "Discovery artifact",
@@ -681,13 +685,14 @@ fn init_yaml(
     dest: &InitYamlDestination,
     filter: &TableFilter,
     mode_override: Option<&str>,
-) -> Result<(String, bool)> {
+) -> Result<(String, bool, Vec<crate::state::StrategySnapshot>)> {
     if let Some(t) = table {
         let info = introspect_single_table(source_url, t, schema)?;
         let hint = yaml_scaffold::table_has_unbounded_decimal_columns(&info);
+        let snaps = vec![snapshot_of(&info, mode_override)];
         let yaml =
             yaml_scaffold::generate_config(&info, source_url, provenance, dest, mode_override)?;
-        return Ok((yaml, hint));
+        return Ok((yaml, hint, snaps));
     }
     let infos = introspect_all(source_url, schema, filter)?;
     if infos.is_empty() {
@@ -705,7 +710,31 @@ fn init_yaml(
         dest,
         mode_override,
     )?;
-    Ok((yaml, hint))
+    let snaps = infos
+        .iter()
+        .map(|i| snapshot_of(i, mode_override))
+        .collect();
+    Ok((yaml, hint, snaps))
+}
+
+/// The decision plus the EVIDENCE it was made from, for the state store.
+///
+/// Every field here is something `init` already read from the catalog to make
+/// the choice; before this they were discarded the moment the YAML was written.
+fn snapshot_of(info: &TableInfo, mode_override: Option<&str>) -> crate::state::StrategySnapshot {
+    let d = yaml_scaffold::decided_strategy(info, mode_override);
+    crate::state::StrategySnapshot {
+        export_name: info.table.clone(),
+        source_schema: (!info.schema.is_empty()).then(|| info.schema.clone()),
+        source_table: info.table.clone(),
+        row_estimate: (info.row_estimate > 0).then_some(info.row_estimate),
+        total_bytes: info.total_bytes,
+        avg_row_bytes: info.avg_row_bytes(),
+        chosen_mode: d.mode,
+        strategy_kind: Some(d.kind.to_string()),
+        key_column: d.key_column,
+        chunk_size: d.chunk_size,
+    }
 }
 
 fn init_discovery_json(
@@ -911,6 +940,38 @@ fn schema_scope_label(source_url: &str, schema: Option<&str>, n: usize) -> Resul
     })
 }
 
+/// Persist the shape each strategy was chosen from, into the state store the
+/// runs will use — the one beside the config just written.
+///
+/// Best-effort and NEVER fatal: `init`'s product is the config, and a scaffold
+/// that fails because an audit row could not be written would be trading the
+/// thing the user asked for against a convenience. A failure is logged at
+/// `debug`, matching how the run path treats its own harm-metric write.
+///
+/// Only on the `-o <path>` route, deliberately: without an output path there is
+/// no config, so there is no `.rivet_state.db` beside one and nowhere the run
+/// would later look. Printing a scaffold to stdout leaves no trace by design.
+fn record_strategy_snapshots(config_path: &str, snapshots: &[crate::state::StrategySnapshot]) {
+    if snapshots.is_empty() {
+        return;
+    }
+    let store = match crate::state::StateStore::open(config_path) {
+        Ok(s) => s,
+        Err(e) => {
+            log::debug!("init: strategy snapshot skipped (state store unavailable): {e:#}");
+            return;
+        }
+    };
+    for s in snapshots {
+        if let Err(e) = store.record_strategy_snapshot(s) {
+            log::debug!(
+                "init: strategy snapshot for '{}' not written (informational): {e:#}",
+                s.export_name
+            );
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1099,6 +1160,92 @@ mod tests {
             vec![col("id", "uuid", true), col("n", "int", false)],
         );
         assert_eq!(small_uuid.suggest_mode(), "full");
+    }
+
+    /// The snapshot's decision must be the one the YAML actually carries.
+    ///
+    /// `decided_strategy` feeds the strategy snapshot; `generate_config` writes
+    /// the config. They share the same underlying rules, and this asserts they
+    /// still AGREE — by parsing what the scaffold emitted, not by re-deriving
+    /// the rule a second time. A snapshot that describes a choice the config did
+    /// not make is worse than no snapshot: it is an audit trail that lies.
+    ///
+    /// The matrix crosses the three shapes the scaffold can pick, so a change to
+    /// any one arm is caught rather than only the one an author remembered.
+    #[test]
+    fn decided_strategy_agrees_with_the_generated_yaml() {
+        let cases: Vec<(&str, TableInfo)> = vec![
+            (
+                "single int PK, large → keyset",
+                make_table(
+                    2_000_000,
+                    vec![col("id", "bigint", true), col("name", "text", false)],
+                ),
+            ),
+            (
+                "no single PK, int column, large → range",
+                make_table(
+                    2_000_000,
+                    vec![col("order_id", "bigint", false), col("name", "text", false)],
+                ),
+            ),
+            (
+                "small → full",
+                make_table(10, vec![col("id", "bigint", true)]),
+            ),
+        ];
+        for (label, info) in cases {
+            let d = yaml_scaffold::decided_strategy(&info, None);
+            let yaml = yaml_scaffold::generate_config(
+                &info,
+                "postgresql://localhost/db",
+                &super::SourceProvenance::Inline,
+                &Default::default(),
+                None,
+            )
+            .expect("scaffold");
+            // COMMENTS STRIPPED. The keyset scaffold's hint line mentions
+            // `chunk_column:` as the alternative to consider, and matching raw
+            // text read that as the config choosing range — the first run of
+            // this test failed on exactly that. Compare against what the config
+            // SAYS, not what it discusses.
+            let yaml: String = yaml
+                .lines()
+                .filter(|l| !l.trim_start().starts_with('#'))
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            assert!(
+                yaml.contains(&format!("mode: {}", d.mode)),
+                "{label}: snapshot says mode {:?}, YAML says otherwise:\n{yaml}",
+                d.mode
+            );
+            // The KIND is not written as a field — it is implied by which key
+            // line the scaffold emitted, so that is what gets compared.
+            let (expect, forbid) = match d.kind {
+                "keyset" => ("chunk_by_key:", Some("chunk_column:")),
+                "range" => ("chunk_column:", Some("chunk_by_key:")),
+                _ => ("mode:", None),
+            };
+            assert!(
+                yaml.contains(expect),
+                "{label}: snapshot kind {:?} implies `{expect}` in the YAML:\n{yaml}",
+                d.kind
+            );
+            if let Some(f) = forbid {
+                assert!(
+                    !yaml.contains(f),
+                    "{label}: snapshot kind {:?} but the YAML also carries `{f}`:\n{yaml}",
+                    d.kind
+                );
+            }
+            if let Some(k) = &d.key_column {
+                assert!(
+                    yaml.contains(k),
+                    "{label}: snapshot names key {k:?}, absent from the YAML:\n{yaml}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/init/yaml_scaffold.rs
+++ b/src/init/yaml_scaffold.rs
@@ -1461,3 +1461,64 @@ mod tests {
         );
     }
 }
+
+/// What the scaffold DECIDED for a table, as data rather than as YAML text.
+///
+/// Exists so the strategy snapshot written to the state store and the config
+/// written to disk come from ONE rule. Re-deriving the decision for the snapshot
+/// would be the self-oracle shape this repo has paid for: two copies of a rule
+/// agree until one is edited, and then the audit trail describes a choice that
+/// was never made.
+///
+/// `agrees_with_the_generated_yaml` keeps them honest — it parses what
+/// `generate_config` actually emitted and compares, so the check's oracle is the
+/// artifact rather than a second implementation.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct DecidedStrategy {
+    pub mode: String,
+    /// Finer than `mode:` — both keyset and range are `mode: chunked`.
+    pub kind: &'static str,
+    pub key_column: Option<String>,
+    pub chunk_size: Option<i64>,
+}
+
+pub(crate) fn decided_strategy(
+    info: &crate::init::TableInfo,
+    mode_override: Option<&str>,
+) -> DecidedStrategy {
+    let mode = mode_override
+        .map(str::to_string)
+        .unwrap_or_else(|| info.suggest_mode().to_string());
+    match mode.as_str() {
+        "chunked" => {
+            let size = info.suggest_chunk_size() as i64;
+            if let Some(pk) = info.keysettable_pk_column() {
+                DecidedStrategy {
+                    mode,
+                    kind: "keyset",
+                    key_column: Some(pk.to_string()),
+                    chunk_size: Some(size),
+                }
+            } else {
+                DecidedStrategy {
+                    mode,
+                    kind: "range",
+                    key_column: info.best_chunk_column().map(str::to_string),
+                    chunk_size: Some(size),
+                }
+            }
+        }
+        "incremental" => DecidedStrategy {
+            kind: "incremental",
+            key_column: info.cursor_candidates().first().map(|c| c.column.clone()),
+            chunk_size: None,
+            mode,
+        },
+        _ => DecidedStrategy {
+            kind: "full",
+            key_column: None,
+            chunk_size: None,
+            mode,
+        },
+    }
+}

--- a/src/pipeline/cdc_job.rs
+++ b/src/pipeline/cdc_job.rs
@@ -532,6 +532,8 @@ fn run_cdc_inner(
                 },
                 crate::config::SourceType::Mssql => CdcEngineOpts::Mssql {
                     capture_instance: cdc.capture_instance.clone(),
+                    // The same strings the sink will route by — see the field's doc.
+                    configured_tables: wired.iter().map(|(t, _, _)| t.clone()).collect(),
                 },
                 crate::config::SourceType::Mongo => {
                     CdcEngineOpts::Mongo {

--- a/src/pipeline/chunked/detect.rs
+++ b/src/pipeline/chunked/detect.rs
@@ -313,14 +313,81 @@ pub(crate) fn detect_and_generate_chunks(
     let min_sql = crate::sql::aggregate_sql(source_type, "min", chunk_column, base_query);
     let max_sql = crate::sql::aggregate_sql(source_type, "max", chunk_column, base_query);
 
-    let min_val = src
-        .query_scalar(&min_sql)?
-        .and_then(|s| s.trim().parse::<i64>().ok())
-        .unwrap_or(0);
-    let max_val = src
-        .query_scalar(&max_sql)?
-        .and_then(|s| s.trim().parse::<i64>().ok())
-        .unwrap_or(0);
+    // An UNREADABLE bound is not zero. Three different inputs used to land on the
+    // same `unwrap_or(0)` and only the first is legitimate:
+    //
+    //   1. the scalar is NULL — the table really is empty, and one empty window
+    //      is the right plan (`integer_range_null_minmax_collapses_to_zero_zero`);
+    //   2. the text does not parse as a whole integer — a DECIMAL/NUMERIC/float key;
+    //   3. `query_scalar` cannot render the type at all — PostgreSQL's tries
+    //      i64, i32, f64, timestamp, date, uuid, String and falls through to
+    //      `Ok(None)`, and no arm matches a numeric OID.
+    //
+    // Cases 2 and 3 made min = max = 0, so the plan became the single window
+    // `WHERE col BETWEEN 0 AND 0`. PostgreSQL compares numeric to integer
+    // happily, so the query was VALID and returned nothing: a 100-row table
+    // exported 0 rows with `status: success` and exit 0 (measured; the sparsity
+    // diagnostic even reassured, since a span of 1 over a 100-row estimate reads
+    // as perfectly dense).
+    //
+    // Case 3 is indistinguishable from case 1 at this layer — both arrive as
+    // `None` — so emptiness is CHECKED rather than assumed. The extra COUNT runs
+    // only on the None path, i.e. only when something is already unusual.
+    //
+    // The parse is STRICT, deliberately not the float-tolerant `parse_scalar_i64`
+    // used for the row count above: that one reads "998.75" as 998, and a max
+    // bound rounded DOWN drops every row above it — trading a loud zero-row
+    // export for a quiet partial one. The DATE branch sixty lines up already
+    // hard-errors on both an absent and an unparseable bound; this matches it.
+    let strict_i64 = |text: &str| -> Option<i64> {
+        let t = text.trim();
+        if let Ok(v) = t.parse::<i64>() {
+            return Some(v);
+        }
+        // Accept a float rendering ONLY when it carries no fraction — some
+        // drivers stringify an integer min/max as `42.0`.
+        match t.split_once('.') {
+            Some((head, frac)) if frac.bytes().all(|b| b == b'0') => head.parse::<i64>().ok(),
+            _ => None,
+        }
+    };
+    let read_bound = |src: &mut dyn Source, raw: Option<String>, which: &str| -> Result<i64> {
+        match raw {
+            Some(text) => strict_i64(&text).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "export '{}': {}({}) = {:?} is not a whole integer — range chunking slices \
+                     with an integer BETWEEN, so a fractional key silently drops rows between \
+                     windows. Use `chunk_by_key:` (keyset — any orderable unique indexed key) \
+                     or an integer column.",
+                    export_name,
+                    which,
+                    chunk_column,
+                    text
+                )
+            }),
+            None => {
+                let rows = query_wrapped_row_count(src, base_query)?;
+                if rows <= 0 {
+                    return Ok(0); // genuinely empty — the one legitimate zero
+                }
+                Err(anyhow::anyhow!(
+                    "export '{}': {}({}) returned no readable value although the table has ~{} \
+                     row(s) — the driver cannot render this key's type (PostgreSQL `numeric` is \
+                     the known case). Range chunking would plan the single window `BETWEEN 0 AND \
+                     0` and export NOTHING while reporting success. Use `chunk_by_key:` (keyset) \
+                     or an integer column.",
+                    export_name,
+                    which,
+                    chunk_column,
+                    rows
+                ))
+            }
+        }
+    };
+    let min_raw = src.query_scalar(&min_sql)?;
+    let min_val = read_bound(src, min_raw, "min")?;
+    let max_raw = src.query_scalar(&max_sql)?;
+    let max_val = read_bound(src, max_raw, "max")?;
 
     let effective_chunk_size = if let Some(count) = chunk_count {
         let span = (max_val - min_val).max(0) as usize + 1;
@@ -514,12 +581,58 @@ mod tests {
         assert_eq!(chunks[9], (901, 1000));
     }
 
+    /// An EMPTY table plans one empty window — the single legitimate zero.
+    ///
+    /// Renamed from `…_collapses_to_zero_zero`: the zero is now REACHED rather
+    /// than fallen into. An absent bound used to be indistinguishable from an
+    /// unrenderable one, so both produced `(0,0)`; the emptiness is checked now,
+    /// which is why the script carries a `0` row count for each bound probe.
     #[test]
-    fn integer_range_null_minmax_collapses_to_zero_zero() {
-        // NULL min/max → unwrap_or(0) on both → single chunk (0,0)
-        let mut src = ScriptedSource::new([null(), null(), ok("0")]);
+    fn integer_range_empty_table_plans_one_empty_window() {
+        // min → NULL, count → 0, max → NULL, count → 0, then the sparsity estimate.
+        let mut src = ScriptedSource::new([null(), ok("0"), null(), ok("0"), ok("0")]);
         let chunks = detect(&mut src, 100, false, None).unwrap();
         assert_eq!(chunks, vec![(0, 0)]);
+    }
+
+    /// The case that made the rename necessary: the table HAS rows and the
+    /// driver cannot render the key's type, so the bound arrives as `None` for a
+    /// reason that has nothing to do with emptiness. PostgreSQL `numeric` is the
+    /// known instance — its `query_scalar` matches no arm and falls to `Ok(None)`.
+    /// Measured before the fix: 100 rows in, 0 rows out, `status: success`.
+    #[test]
+    fn unrenderable_bound_on_a_non_empty_table_is_an_error() {
+        let mut src = ScriptedSource::new([null(), ok("100")]);
+        let err = detect(&mut src, 10, false, None)
+            .expect_err("a None bound over a NON-empty table must abort, not plan (0,0)");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("no readable value") && msg.contains("chunk_by_key"),
+            "the error must name the cause and the escape; got: {msg}"
+        );
+    }
+
+    /// A NON-EMPTY table whose bounds cannot be read as i64 must ERROR, not
+    /// silently become the single window `BETWEEN 0 AND 0`.
+    ///
+    /// Distinct from `integer_range_null_minmax_collapses_to_zero_zero` above,
+    /// which pins the one legitimate zero: NULL bounds mean the table is empty
+    /// and one empty window is right. Nothing covered a table that HAS rows and
+    /// whose key the reader cannot render — the case that exported 0 of 100 rows
+    /// with `status: success`.
+    #[test]
+    fn unparseable_integer_range_bounds_are_an_error_not_a_zero_window() {
+        // The count reply is scripted third because the None path does not fire
+        // here — the bounds ARE readable, they are simply not whole integers.
+        let mut src = ScriptedSource::new([ok("1.50"), ok("998.75"), ok("100")]);
+        let err = detect(&mut src, 10, false, None).expect_err(
+            "an unreadable bound must abort the plan, not collapse to (0,0) and export nothing",
+        );
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("not a whole integer") && msg.contains("chunk_by_key"),
+            "the error must name the problem and the escape; got: {msg}"
+        );
     }
 
     #[test]

--- a/src/pipeline/chunked/exec.rs
+++ b/src/pipeline/chunked/exec.rs
@@ -31,10 +31,10 @@ pub(crate) fn run_chunked_sequential(
         // Detect: compute ranges + run the pre-chunk drift check once (ADR-0021).
         super::ChunkSource::Detect => super::prepare_chunk_plan(src, plan, state, summary)?,
         super::ChunkSource::Precomputed(ranges) => {
-            // Records that the drift gate was skipped BY CONTRACT, not by a
-            // runner forgetting its facade — `prepare_chunk_plan` is its only
-            // caller and a precomputed source deliberately does not call it.
+            // Ranges come from the artifact; the DRIFT GATE still runs. It does
+            // not depend on them.
             summary.chunks_precomputed = true;
+            super::check_drift_only(src, plan, state, summary)?;
             ranges
         }
     };
@@ -193,7 +193,13 @@ pub(crate) fn run_chunked_parallel(
         // drift check (ADR-0021), then closes before the workers open theirs.
         super::ChunkSource::Detect => super::prepare_chunk_plan_fresh(plan, state, summary)?,
         super::ChunkSource::Precomputed(ranges) => {
-            summary.chunks_precomputed = true; // drift gate skipped by contract
+            // Ranges come from the artifact; the DRIFT GATE still runs.
+            summary.chunks_precomputed = true;
+            // No ranges ⇒ no rows will be read, so there is nothing for the gate
+            // to protect and no reason to open a connection to say so.
+            if !ranges.is_empty() {
+                super::check_drift_only_fresh(plan, state, summary)?;
+            }
             ranges
         }
     };

--- a/src/pipeline/chunked/mod.rs
+++ b/src/pipeline/chunked/mod.rs
@@ -162,8 +162,9 @@ use crate::state::StateStore;
 /// way `commit::record_part` shares the per-part tail (ADR-0018).
 ///
 /// `Precomputed`/resume chunk sources never call this — drift was evaluated on
-/// the original planning run that produced the ranges. Drift runs only when the
-/// runner is stateful (`state.is_some()`).
+/// the original planning run that produced the ranges — a claim that was FALSE
+/// (see [`check_drift_only`], which the precomputed arms now call instead).
+/// Drift runs only when the runner is stateful (`state.is_some()`).
 pub(super) fn prepare_chunk_plan(
     src: &mut dyn crate::source::Source,
     plan: &ResolvedRunPlan,
@@ -186,6 +187,52 @@ pub(super) fn prepare_chunk_plan(
         super::schema_drift::check_from_type_mappings(src, st, plan, summary)?;
     }
     Ok(ranges)
+}
+
+/// Run the pre-chunk drift gate WITHOUT computing ranges.
+///
+/// The gate compares the source's current column types against the stored ones;
+/// it has nothing to do with chunk boundaries. That is why a run whose ranges
+/// come from a plan artifact can — and must — still take it.
+///
+/// It used to be reachable only through [`prepare_chunk_plan`], which only the
+/// `ChunkSource::Detect` arm calls, so `rivet apply` of any chunked plan skipped
+/// `on_schema_drift` entirely. Four runners recorded that as
+/// `chunks_precomputed = true; // drift gate skipped by contract`, citing a
+/// contract that said drift "was evaluated on the original planning run that
+/// produced the ranges". It was not: `src/plan/` performs no drift evaluation —
+/// `plan/build.rs` only COPIES `on_schema_drift` into the artifact. And a
+/// planning-time check could not have helped anyway, because the drift this
+/// guards against happens BETWEEN plan and apply, which is the whole reason the
+/// plan → review → apply workflow exists.
+///
+/// Measured: one config, `on_schema_drift: fail`, a column dropped after the
+/// plan was sealed — `rivet run` aborted ("schema drift detected — removed:
+/// dropme") while `rivet apply` of the same policy exported 500 rows and exited
+/// 0. The non-chunked half of `apply` applied the gate throughout
+/// (`single.rs`), so the split was never "apply skips it" but "apply skips it
+/// for chunked exports" — the ones moving the most data.
+pub(super) fn check_drift_only(
+    src: &mut dyn crate::source::Source,
+    plan: &ResolvedRunPlan,
+    state: Option<&StateStore>,
+    summary: &mut RunSummary,
+) -> Result<()> {
+    let Some(st) = state else { return Ok(()) };
+    super::schema_drift::check_from_type_mappings(src, st, plan, summary)
+}
+
+/// [`check_drift_only`] for the parallel runners, which hold no `Source`: open a
+/// short-lived connection just for the type probe and drop it before the workers
+/// spawn — the same shape as [`prepare_chunk_plan_fresh`].
+pub(super) fn check_drift_only_fresh(
+    plan: &ResolvedRunPlan,
+    state: &StateStore,
+    summary: &mut RunSummary,
+) -> Result<()> {
+    let mut src = crate::source::create_source(&plan.source)
+        .map_err(|e| crate::pipeline::single::attach_connect_hint(e, &plan.source))?;
+    check_drift_only(&mut *src, plan, Some(state), summary)
 }
 
 /// Like [`prepare_chunk_plan`], but for the parallel runners that don't already

--- a/src/pipeline/chunked/parallel_checkpoint.rs
+++ b/src/pipeline/chunked/parallel_checkpoint.rs
@@ -207,6 +207,7 @@ pub(crate) fn run_chunked_parallel_checkpoint(
                                 run_id_arc.as_str(),
                                 chunk_index,
                                 "invalid start_key",
+                                false, // a malformed key parses the same way every time
                             );
                             continue;
                         }
@@ -219,6 +220,7 @@ pub(crate) fn run_chunked_parallel_checkpoint(
                                 run_id_arc.as_str(),
                                 chunk_index,
                                 "invalid end_key",
+                                false, // a malformed key parses the same way every time
                             );
                             continue;
                         }
@@ -483,6 +485,7 @@ pub(crate) fn run_chunked_parallel_checkpoint(
                                 run_id_arc.as_str(),
                                 chunk_index,
                                 &msg,
+                                crate::pipeline::retry::is_transient(&e),
                             );
                             poison::lock_recover(errors)
                                 .push(format!("chunk {}: {}", chunk_index, msg));

--- a/src/pipeline/chunked/parallel_checkpoint.rs
+++ b/src/pipeline/chunked/parallel_checkpoint.rs
@@ -60,7 +60,13 @@ pub(crate) fn run_chunked_parallel_checkpoint(
             // pre-chunk drift check (ADR-0021), then closes before workers spawn.
             ChunkSource::Detect => super::prepare_chunk_plan_fresh(plan, state, summary)?,
             ChunkSource::Precomputed(ranges) => {
-                summary.chunks_precomputed = true; // drift gate skipped by contract
+                // Ranges come from the artifact; the DRIFT GATE still runs.
+                summary.chunks_precomputed = true;
+                // No ranges ⇒ no rows will be read, so there is nothing for the
+                // gate to protect and no reason to open a connection to say so.
+                if !ranges.is_empty() {
+                    super::check_drift_only_fresh(plan, state, summary)?;
+                }
                 ranges
             }
         }

--- a/src/pipeline/chunked/sequential_checkpoint.rs
+++ b/src/pipeline/chunked/sequential_checkpoint.rs
@@ -368,6 +368,9 @@ pub(crate) fn run_chunked_sequential_checkpoint(
             }
             Err(e) => {
                 let msg = crate::redact::redact_error(&e);
+                // The classifier already knows whether another attempt can help;
+                // the chunk layer used to re-dispatch regardless.
+                let retryable = crate::pipeline::retry::is_transient(&e);
                 log::error!(
                     "export '{}': chunk {} failed: {}",
                     plan.export_name,
@@ -379,7 +382,7 @@ pub(crate) fn run_chunked_sequential_checkpoint(
                     error: msg.clone(),
                     attempt: 1,
                 });
-                state.fail_chunk_task(&run_id, chunk_index, &msg)?;
+                state.fail_chunk_task(&run_id, chunk_index, &msg, retryable)?;
             }
         }
     }

--- a/src/pipeline/chunked/sequential_checkpoint.rs
+++ b/src/pipeline/chunked/sequential_checkpoint.rs
@@ -241,7 +241,9 @@ pub(crate) fn run_chunked_sequential_checkpoint(
             // Detect: compute ranges + run the pre-chunk drift check (ADR-0021).
             ChunkSource::Detect => super::prepare_chunk_plan(src, plan, Some(state), summary)?,
             ChunkSource::Precomputed(ranges) => {
-                summary.chunks_precomputed = true; // drift gate skipped by contract
+                // Ranges come from the artifact; the DRIFT GATE still runs.
+                summary.chunks_precomputed = true;
+                super::check_drift_only(src, plan, Some(state), summary)?;
                 ranges
             }
         }

--- a/src/pipeline/finalize.rs
+++ b/src/pipeline/finalize.rs
@@ -110,6 +110,19 @@ pub(super) fn finalize_run_report(config_path: &str, summary: &RunSummary, kind:
 ///
 /// The parts are still durable, which is exactly why this must be loud. Nothing
 /// about the failure is visible in the data; it is visible only here.
+/// A run that SKIPPED and committed no parts has nothing to describe.
+///
+/// Split out of `finalize_manifest` so the decision is reachable without a
+/// `ResolvedRunPlan` and a `StateStore` — the mutation gate found both halves
+/// of this condition unguarded (`==`→`!=` and `&&`→`||` both survived), and
+/// each inversion is a real regression: flipping the equality makes every
+/// SUCCESSFUL run skip its manifest, and widening the `&&` to `||` throws away
+/// the manifest of a skipped run that DID commit parts — the
+/// `[RIVET_VERIFY_SUCCESS_STALE]` shape this guard was added to end.
+pub(super) fn skipped_run_wrote_nothing(summary: &RunSummary) -> bool {
+    summary.status == "skipped" && summary.manifest_parts.is_empty()
+}
+
 pub(super) fn finalize_manifest(
     plan: &ResolvedRunPlan,
     // The export FAMILY (`ExportConfig::family()`), passed at RUNTIME and
@@ -198,7 +211,7 @@ pub(super) fn finalize_manifest(
     // reason: there is no committed work to describe. The run itself is recorded
     // where run history belongs — `export_metrics`, `file_log`, `run_status` —
     // and the prefix keeps describing the last run that actually delivered.
-    if summary.status == "skipped" && summary.manifest_parts.is_empty() {
+    if skipped_run_wrote_nothing(summary) {
         log::debug!(
             "{} '{}': skipped run wrote no parts — leaving the prefix's manifest as it stands",
             kind,
@@ -953,6 +966,53 @@ mod tests {
             shape_drift_warn_factor: 0.0,
             parquet: None,
         }
+    }
+
+    /// The four corners of "is there anything to describe".
+    ///
+    /// Both halves of the condition were unguarded until the mutation gate said
+    /// so — `==`→`!=` and `&&`→`||` each survived the whole suite. The table
+    /// below fails against either: invert the equality and the SUCCESS row
+    /// stops writing a manifest; widen the `&&` and the skipped-WITH-parts row
+    /// throws away a manifest that describes real committed data.
+    #[test]
+    fn only_a_skipped_run_with_no_parts_has_nothing_to_describe() {
+        let with_part = |status: &str| {
+            let mut s = RunSummary::stub_for_testing("r", String::from("e"));
+            s.status = status.into();
+            s.manifest_parts.push(crate::manifest::ManifestPart {
+                part_id: 1,
+                path: "part-000001.parquet".into(),
+                rows: 5,
+                size_bytes: 7,
+                content_fingerprint: "xxh3:1".into(),
+                content_md5: String::new(),
+                status: crate::manifest::PartStatus::Committed,
+            });
+            s
+        };
+        let bare = |status: &str| {
+            let mut s = RunSummary::stub_for_testing("r", String::from("e"));
+            s.status = status.into();
+            s
+        };
+
+        assert!(
+            skipped_run_wrote_nothing(&bare("skipped")),
+            "a skipped run with no parts is the one case that writes no manifest"
+        );
+        assert!(
+            !skipped_run_wrote_nothing(&with_part("skipped")),
+            "a skipped run that DID commit parts must still describe them"
+        );
+        assert!(
+            !skipped_run_wrote_nothing(&bare("success")),
+            "a successful run always writes its manifest, parts or not"
+        );
+        assert!(
+            !skipped_run_wrote_nothing(&with_part("failed")),
+            "a failed run's committed parts must reach the manifest too"
+        );
     }
 
     /// A summary that carries everything finalize_manifest is supposed to

--- a/src/pipeline/finalize.rs
+++ b/src/pipeline/finalize.rs
@@ -178,6 +178,35 @@ pub(super) fn finalize_manifest(
         }
     };
 
+    // A HEALTHY no-op describes nothing, so it must not describe the prefix.
+    //
+    // `"skipped"` is a real production status — `single.rs` sets it when a run
+    // reads 0 rows under `skip_empty: true`, the ordinary outcome of an
+    // incremental export with nothing new past the cursor. It used to fall
+    // through the `_` arm below to `Interrupted`, and `write_manifest` then
+    // OVERWROTE the canonical manifest with a zero-part interrupted document
+    // while leaving the previous good run's `_SUCCESS` in place, now stale.
+    //
+    // Measured: run 1 exported 10 rows (manifest success, 1 part, _SUCCESS); run
+    // 2 found nothing new and left `manifest.json` saying `interrupted, 0 parts,
+    // 0 rows` over a prefix still holding the parquet. `rivet validate` then
+    // refused the export — `[RIVET_VERIFY_SUCCESS_STALE]` plus the 10 delivered
+    // rows reported as an `untracked object` — after a run that did nothing
+    // wrong.
+    //
+    // The same early return the no-plan-snapshot case above takes, for the same
+    // reason: there is no committed work to describe. The run itself is recorded
+    // where run history belongs — `export_metrics`, `file_log`, `run_status` —
+    // and the prefix keeps describing the last run that actually delivered.
+    if summary.status == "skipped" && summary.manifest_parts.is_empty() {
+        log::debug!(
+            "{} '{}': skipped run wrote no parts — leaving the prefix's manifest as it stands",
+            kind,
+            summary.export_name
+        );
+        return None;
+    }
+
     let status = match summary.status.as_str() {
         "success" => ManifestStatus::Success,
         "failed" => ManifestStatus::Failed,

--- a/src/pipeline/retry.rs
+++ b/src/pipeline/retry.rs
@@ -428,7 +428,12 @@ fn classify_mongo_error(err: &mongodb::error::Error) -> Option<RetryClass> {
     }
 }
 
-#[cfg(test)]
+/// Is this error worth another attempt at all?
+///
+/// The one question the CHUNK layer needs answered. It used to be test-only,
+/// which is why the chunk-level re-claim had no way to ask it and re-dispatched
+/// a deterministically failing chunk to its attempt cap — 300 minutes of
+/// production query time on a 300 s statement timeout, measured in the field.
 pub(crate) fn is_transient(err: &anyhow::Error) -> bool {
     classify_error(err).is_transient()
 }

--- a/src/pipeline/sink/cursor.rs
+++ b/src/pipeline/sink/cursor.rs
@@ -31,11 +31,24 @@ pub(crate) fn extract_last_cursor_value(
 ) -> Option<String> {
     let col_idx = schema.index_of(cursor_column).ok()?;
     let array = batch.column(col_idx);
-    let last_row = batch.num_rows().checked_sub(1)?;
 
-    if array.is_null(last_row) {
-        return None;
-    }
+    // The last NON-NULL row, not simply the last row.
+    //
+    // Incremental queries append `ORDER BY <cursor>`, and PostgreSQL sorts NULLs
+    // LAST in ASC — so on a nullable cursor column the final row of the final
+    // batch carries no value, and returning None here handed the caller nothing
+    // to record. The high-water mark was then never written and the export
+    // re-read the whole table on every run, forever (measured: 21 rows exported
+    // three times over, `export_state` empty throughout).
+    //
+    // Scanning back finds the real maximum: the rows are ordered by this very
+    // column, so the last non-null IS the greatest value present. MySQL and SQL
+    // Server sort NULLs FIRST and were never affected — this restores their
+    // behaviour on PostgreSQL rather than inventing one.
+    //
+    // An all-NULL batch still yields None, which the caller must treat as "this
+    // batch says nothing" and NOT as "reset the mark" — see `ExportSink::on_batch`.
+    let last_row = (0..batch.num_rows()).rev().find(|&i| !array.is_null(i))?;
 
     match array.data_type() {
         DataType::Int16 => Some(
@@ -390,12 +403,60 @@ mod tests {
         assert_eq!(extract_last_cursor_value(&batch, "id", &schema), None);
     }
 
+    /// A NULL in the last row must not hide the value above it.
+    ///
+    /// This test used to assert `None` for exactly this batch — it pinned the
+    /// mechanism as if it were the contract. On PostgreSQL, which sorts NULLs
+    /// LAST in ASC, that None was then written over the high-water mark
+    /// accumulated from every prior batch, the cursor was never committed, and
+    /// the export re-read the whole table on every run forever. The rows are
+    /// ordered BY this column, so the last non-null is the greatest value
+    /// present; that is what the mark should be.
     #[test]
-    fn cursor_null_last_row_returns_none() {
+    fn cursor_null_last_row_uses_the_last_non_null() {
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, true)]));
         let batch = RecordBatch::try_new(
             schema.clone(),
             vec![Arc::new(Int64Array::from(vec![Some(1), None]))],
+        )
+        .unwrap();
+        assert_eq!(
+            extract_last_cursor_value(&batch, "id", &schema),
+            Some("1".to_string())
+        );
+    }
+
+    /// Several trailing NULLs are the realistic shape — a soft-deleted or
+    /// never-touched population all sorts to the end together.
+    #[test]
+    fn cursor_many_trailing_nulls_still_find_the_maximum() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, true)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int64Array::from(vec![
+                Some(1),
+                Some(7),
+                None,
+                None,
+                None,
+            ]))],
+        )
+        .unwrap();
+        assert_eq!(
+            extract_last_cursor_value(&batch, "id", &schema),
+            Some("7".to_string())
+        );
+    }
+
+    /// The control: a batch with NOTHING readable genuinely says nothing, and
+    /// must still report None so the caller keeps the mark it already has rather
+    /// than inventing one.
+    #[test]
+    fn cursor_all_null_batch_reports_nothing() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, true)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int64Array::from(vec![None, None]))],
         )
         .unwrap();
         assert_eq!(extract_last_cursor_value(&batch, "id", &schema), None);

--- a/src/pipeline/sink/mod.rs
+++ b/src/pipeline/sink/mod.rs
@@ -728,7 +728,14 @@ impl BatchSink for ExportSink {
         // Extract cursor value inline so the batch can be freed immediately after
         // on_batch returns — avoids holding one full batch in memory for the rest of the run.
         if let (Some(col), Some(schema)) = (&self.cursor_column, &self.schema) {
-            self.last_cursor_value = extract_last_cursor_value(batch, col, schema);
+            // Only ADVANCE the mark, never erase it. A batch with no readable
+            // cursor value (every row NULL) says nothing about progress; the
+            // unconditional assignment let it overwrite the good mark
+            // accumulated from every prior batch with None, after which nothing
+            // was recorded and nothing committed.
+            if let Some(v) = extract_last_cursor_value(batch, col, schema) {
+                self.last_cursor_value = Some(v);
+            }
         }
         Ok(())
     }

--- a/src/pipeline/summary.rs
+++ b/src/pipeline/summary.rs
@@ -838,11 +838,16 @@ impl RunSummary {
             // diagnosis (`resumed`) AND the raw `--resume` flag (`is_resume_run`) — a
             // resume that crashed before its first commit adopts nothing yet still
             // skipped the gate.
-            if !self.resumed
-                && !is_resume_run
-                && !self.chunks_precomputed
-                && self.schema_changed.is_none()
-            {
+            //
+            // `chunks_precomputed` is NO LONGER an exemption. It was one because
+            // `rivet apply` of a chunked artifact skipped the gate "by contract",
+            // and the contract was false — `src/plan/` evaluates no drift, it only
+            // copies the policy, and the drift being guarded against happens
+            // BETWEEN plan and apply. The precomputed arms now call
+            // `check_drift_only`, so they leave `schema_changed = Some(_)` like
+            // every other path, and an exemption here would go back to excusing
+            // exactly the bypass this invariant exists to catch.
+            if !self.resumed && !is_resume_run && self.schema_changed.is_none() {
                 return Err(
                     "state_backed success committed parts but schema_changed is None — \
                      the on_schema_drift gate was never applied (no runner called \
@@ -1616,18 +1621,21 @@ mod tests {
             "a non-run_export run must not be held to the facade contract"
         );
 
-        // `rivet apply` with PRECOMPUTED chunk boundaries legitimately skips the
-        // drift gate too: the gate lives inside `prepare_chunk_plan`, whose own
-        // contract says a precomputed source never calls it ("drift was evaluated
-        // on the original planning run that produced the ranges"). Without this
-        // exemption the guard reads a correct apply as a runner-bypass — which is
-        // exactly what happened the moment `apply` was fixed to actually replay
-        // its artifact instead of re-detecting: every chunked apply started
-        // aborting at finalize with exit 101.
+        // `rivet apply` with PRECOMPUTED chunk boundaries is NO LONGER exempt.
+        //
+        // It was, on the stated grounds that "drift was evaluated on the original
+        // planning run that produced the ranges" — which was false: `src/plan/`
+        // evaluates no drift, and the drift being guarded against happens BETWEEN
+        // plan and apply. Measured: `rivet run` aborted on a dropped column while
+        // `rivet apply` of the same `on_schema_drift: fail` exported 500 rows and
+        // exited 0. The precomputed arms now call `check_drift_only`, so they
+        // leave `schema_changed = Some(_)` like every other path and need no
+        // exemption — and an exemption would go back to excusing the very bypass
+        // this invariant exists to catch.
         let mut applied = base();
         applied.chunks_precomputed = true;
         applied.column_checksums.push(ck());
-        // schema_changed stays None
+        applied.schema_changed = Some(false); // the gate ran, as it now must
         assert!(
             applied.check_post_run_invariants(false).is_ok(),
             "an apply replaying precomputed chunks must not trip the drift-gate branch"

--- a/src/plan/build.rs
+++ b/src/plan/build.rs
@@ -220,6 +220,49 @@ fn full_strategy(config: &Config, export: &ExportConfig) -> ExtractionStrategy {
 ///
 /// Steps 1–3 each only fire on PG with `table:` shortcut; everything else
 /// falls back to the original "explicit column required" path.
+/// Why a `mode: chunked` export with no `table:` cannot be planned — `None`
+/// when it can.
+///
+/// PURE, and deliberately reachable from outside the planner. `rivet check`
+/// resolved its own view of the config and printed `Verdict: ACCEPTABLE` for
+/// two shapes `plan` refuses outright (`query:` + `chunk_size_memory_mb`,
+/// `query:` + `chunk_by_key`) — a preflight blessing a config that cannot run
+/// is the diagnostic-bypass class at its sharpest, because the operator reads
+/// the verdict and stops looking. One function, both callers: the planner
+/// bails on it, the preflight reports it (`src/preflight/mod.rs`).
+///
+/// Mirrors the fast path above: an explicit `chunk_column:` with no memory
+/// budget plans fine without a relation, so that shape is `None` here too.
+pub(crate) fn chunked_without_table_error(export: &ExportConfig) -> Option<String> {
+    if export.table.is_some() {
+        return None;
+    }
+    // The no-probe fast path: explicit column, no budget to divide.
+    if export.chunk_column.is_some() && export.chunk_size_memory_mb.is_none() {
+        return None;
+    }
+    if export.chunk_by_key.is_some() {
+        return Some(format!(
+            "export '{}': `chunk_by_key:` needs the `table:` shortcut so the planner can \
+             verify the key is backed by a unique index (an unindexed ORDER BY key would \
+             filesort the whole table). Set `table:` instead of `query:`.",
+            export.name
+        ));
+    }
+    if export.chunk_size_memory_mb.is_some() {
+        return Some(format!(
+            "export '{}': `chunk_size_memory_mb:` only applies with the `table:` shortcut — \
+             set `table:` (preferred) or remove `chunk_size_memory_mb:` and keep an explicit `chunk_size:`",
+            export.name
+        ));
+    }
+    Some(format!(
+        "export '{}': chunked mode requires 'chunk_column' \
+         (auto-resolve from PK is only supported with the `table:` shortcut)",
+        export.name
+    ))
+}
+
 fn resolve_chunked_strategy(
     config: &Config,
     export: &ExportConfig,
@@ -306,27 +349,14 @@ fn resolve_chunked_strategy(
     }
 
     // Anything beyond the fast path requires the `table:` shortcut so we have
-    // a known relation to probe in either Postgres or MySQL.
+    // a known relation to probe in either Postgres or MySQL. The rule lives in
+    // `chunked_without_table_error` so the PREFLIGHT can ask the same question
+    // — `rivet check` used to bless configs this bails on (see that function).
     let Some(tbl) = export.table.as_ref() else {
-        if export.chunk_by_key.is_some() {
-            anyhow::bail!(
-                "export '{}': `chunk_by_key:` needs the `table:` shortcut so the planner can \
-                 verify the key is backed by a unique index (an unindexed ORDER BY key would \
-                 filesort the whole table). Set `table:` instead of `query:`.",
-                export.name
-            );
-        }
-        if export.chunk_size_memory_mb.is_some() {
-            anyhow::bail!(
-                "export '{}': `chunk_size_memory_mb:` only applies with the `table:` shortcut — \
-                 set `table:` (preferred) or remove `chunk_size_memory_mb:` and keep an explicit `chunk_size:`",
-                export.name
-            );
-        }
         anyhow::bail!(
-            "export '{}': chunked mode requires 'chunk_column' \
-             (auto-resolve from PK is only supported with the `table:` shortcut)",
-            export.name
+            "{}",
+            chunked_without_table_error(export)
+                .expect("no `table:` in chunked mode past the fast path is always an error")
         );
     };
 
@@ -791,6 +821,53 @@ mod tests {
             },
             ..crate::config::sample_export("test_export")
         }
+    }
+
+    /// The rule `rivet check` and `rivet plan` now share, in every direction.
+    ///
+    /// RED-proven the expensive way: the live audit
+    /// (`check_must_not_accept_a_config_the_planner_refuses`) failed in CI on
+    /// two of these shapes while `check` still had its own opinion. The unit
+    /// test exists so the next regression is caught before a live stack is
+    /// needed — and so a mutant that flips one arm has something to bite.
+    #[test]
+    fn chunked_without_table_names_the_reason_and_spares_the_fast_path() {
+        let base = || ExportConfig {
+            mode: crate::config::ExportMode::Chunked,
+            table: None,
+            query: Some("SELECT * FROM t".into()),
+            ..minimal_export()
+        };
+
+        // The fast path: an explicit column with no budget plans without a
+        // relation, so the preflight must NOT refuse it.
+        let mut ok = base();
+        ok.chunk_column = Some("id".into());
+        assert_eq!(chunked_without_table_error(&ok), None);
+
+        // …and a `table:` is always fine, whatever else is set.
+        let mut with_table = base();
+        with_table.table = Some("public.t".into());
+        with_table.query = None;
+        with_table.chunk_by_key = Some("id".into());
+        assert_eq!(chunked_without_table_error(&with_table), None);
+
+        // The three refusals, each naming its own knob rather than a generic
+        // "bad config" — the operator has to know WHICH line to change.
+        let mut by_key = base();
+        by_key.chunk_by_key = Some("id".into());
+        let m = chunked_without_table_error(&by_key).expect("chunk_by_key needs a relation");
+        assert!(m.contains("chunk_by_key"), "{m}");
+
+        let mut budget = base();
+        budget.chunk_column = Some("id".into());
+        budget.chunk_size_memory_mb = Some(64);
+        let m = chunked_without_table_error(&budget).expect("a budget needs a row width");
+        assert!(m.contains("chunk_size_memory_mb"), "{m}");
+
+        let bare = base();
+        let m = chunked_without_table_error(&bare).expect("no column, no table, no plan");
+        assert!(m.contains("chunk_column"), "{m}");
     }
 
     #[test]

--- a/src/preflight/mod.rs
+++ b/src/preflight/mod.rs
@@ -245,6 +245,36 @@ pub fn check(
         config.exports.iter().collect()
     };
 
+    // A preflight must never bless a config the RUNNER refuses.
+    //
+    // `check` resolved its own view of the strategy and printed `Verdict:
+    // ACCEPTABLE` for two shapes `plan::build` bails on — `query:` (no
+    // `table:`) with `chunk_size_memory_mb`, and the same with `chunk_by_key`.
+    // The operator reads ACCEPTABLE, schedules the export, and the run refuses
+    // the file: the trust the preflight exists to earn is spent on something
+    // that cannot run. Asking the planner's own rule (one function, both
+    // callers) is what keeps the two from drifting again — a re-implemented
+    // copy here would be a second definition, and it would drift on the first
+    // change.
+    //
+    // Reported BEFORE the engine probe: the config is illegal on its face, so
+    // connecting to say so would only delay the answer (and fail differently
+    // when the source is unreachable).
+    let illegal: Vec<String> = exports
+        .iter()
+        .filter(|e| e.mode == crate::config::ExportMode::Chunked)
+        .filter_map(|e| crate::plan::build::chunked_without_table_error(e))
+        .collect();
+    if !illegal.is_empty() {
+        for why in &illegal {
+            eprintln!("✗ {why}");
+        }
+        anyhow::bail!(
+            "rivet check: {} export(s) cannot be planned — `rivet run` would refuse this config",
+            illegal.len()
+        );
+    }
+
     let url = config.source.resolve_url()?;
     let tls = config.source.tls.as_ref();
     // Surface the plaintext-transport warning at preflight time too —

--- a/src/preflight/mod.rs
+++ b/src/preflight/mod.rs
@@ -223,6 +223,22 @@ where
     exports.iter().map(|&e| diagnose(e)).collect()
 }
 
+/// The exports in this config the PLANNER would refuse, each with its reason.
+///
+/// Pure, and separate from [`check`] so the rule is testable without a live
+/// source — `check` itself needs one, so a mutant inside it (the `mode ==
+/// Chunked` filter, say) survives every offline test by construction. Asks
+/// `plan::build`'s own function rather than re-deriving the rule: two copies
+/// of "what is plannable" is exactly how the preflight and the runner drifted
+/// apart in the first place.
+pub(crate) fn unplannable_exports(exports: &[&ExportConfig]) -> Vec<String> {
+    exports
+        .iter()
+        .filter(|e| e.mode == crate::config::ExportMode::Chunked)
+        .filter_map(|e| crate::plan::build::chunked_without_table_error(e))
+        .collect()
+}
+
 pub fn check(
     config_path: &str,
     export_name: Option<&str>,
@@ -260,11 +276,7 @@ pub fn check(
     // Reported BEFORE the engine probe: the config is illegal on its face, so
     // connecting to say so would only delay the answer (and fail differently
     // when the source is unreachable).
-    let illegal: Vec<String> = exports
-        .iter()
-        .filter(|e| e.mode == crate::config::ExportMode::Chunked)
-        .filter_map(|e| crate::plan::build::chunked_without_table_error(e))
-        .collect();
+    let illegal = unplannable_exports(&exports);
     if !illegal.is_empty() {
         for why in &illegal {
             eprintln!("✗ {why}");
@@ -564,6 +576,53 @@ fn print_diagnostic(diag: &ExportDiagnostic) {
 
 #[cfg(test)]
 mod tests {
+
+    /// The preflight must refuse exactly what the planner refuses — no more.
+    ///
+    /// The `mode == Chunked` filter is the part a live-only `check` cannot have
+    /// tested: an `incremental` export with no `table:` is perfectly legal, and
+    /// a filter that forgot the mode would refuse it. Both directions, so
+    /// neither an over-strict nor an under-strict preflight passes.
+    #[test]
+    fn unplannable_lists_the_chunked_refusals_and_leaves_other_modes_alone() {
+        let chunked_no_table = ExportConfig {
+            mode: crate::config::ExportMode::Chunked,
+            table: None,
+            query: Some("SELECT * FROM t".into()),
+            chunk_by_key: Some("id".into()),
+            ..crate::config::sample_export("bad")
+        };
+        let incremental_no_table = ExportConfig {
+            mode: crate::config::ExportMode::Incremental,
+            table: None,
+            query: Some("SELECT * FROM t".into()),
+            ..crate::config::sample_export("fine")
+        };
+        let chunked_with_column = ExportConfig {
+            mode: crate::config::ExportMode::Chunked,
+            table: None,
+            query: Some("SELECT * FROM t".into()),
+            chunk_column: Some("id".into()),
+            ..crate::config::sample_export("fast_path")
+        };
+
+        let out = unplannable_exports(&[
+            &chunked_no_table,
+            &incremental_no_table,
+            &chunked_with_column,
+        ]);
+        assert_eq!(
+            out.len(),
+            1,
+            "only the chunked keyset export is refused: {out:?}"
+        );
+        assert!(out[0].contains("chunk_by_key"), "{}", out[0]);
+
+        assert!(
+            unplannable_exports(&[&incremental_no_table, &chunked_with_column]).is_empty(),
+            "a legal config must produce no refusals at all"
+        );
+    }
     use super::*;
     use crate::config::{DestinationConfig, DestinationType, ExportConfig, ExportMode, FormatType};
     use doctor::{

--- a/src/quality.rs
+++ b/src/quality.rs
@@ -17,77 +17,123 @@ use xxhash_rust::xxh3::xxh3_64;
 use crate::config::QualityConfig;
 use crate::error::Result;
 
-/// Hash a single non-null array value using typed dispatch to avoid string formatting.
-/// Returns `None` for null values; caller skips those in uniqueness tracking.
-fn hash_value(array: &dyn Array, row: usize) -> Option<u64> {
+/// Hash a single array value using typed dispatch to avoid string formatting.
+///
+/// The return distinguishes the two reasons there may be no hash, because
+/// conflating them made a uniqueness check pass over rows it never examined:
+///
+///   `Ok(None)`  the cell is NULL — skip it, which is correct for uniqueness.
+///   `Err(_)`    the cell is PRESENT but its type could not be rendered. The
+///               caller must NOT treat this as "nothing to compare".
+///
+/// Both used to be `None`. Arrow's `ArrayFormatter` refuses a timestamp whose
+/// timezone is a NAME (`Some("UTC")` — the only form rivet emits) without the
+/// `chrono-tz` feature, so `unique: true` on any temporal column silently
+/// examined ZERO rows and reported no duplicates. The feature is now on
+/// (`Cargo.toml`), which removes that trigger — but the conflation was the
+/// defect, and it would return with the next unrenderable type.
+fn hash_value(array: &dyn Array, row: usize) -> Result<Option<u64>> {
     if array.is_null(row) {
-        return None;
+        return Ok(None);
     }
     let h = match array.data_type() {
         DataType::Boolean => {
-            let v = array.as_any().downcast_ref::<BooleanArray>()?.value(row);
+            let v = array
+                .as_any()
+                .downcast_ref::<BooleanArray>()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("quality: column is not a BooleanArray despite its DataType")
+                })?
+                .value(row);
             xxh3_64(&[v as u8])
         }
         DataType::Int8 => xxh3_64(
             &array
                 .as_any()
-                .downcast_ref::<Int8Array>()?
+                .downcast_ref::<Int8Array>()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("quality: column is not a Int8Array despite its DataType")
+                })?
                 .value(row)
                 .to_le_bytes(),
         ),
         DataType::Int16 => xxh3_64(
             &array
                 .as_any()
-                .downcast_ref::<Int16Array>()?
+                .downcast_ref::<Int16Array>()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("quality: column is not a Int16Array despite its DataType")
+                })?
                 .value(row)
                 .to_le_bytes(),
         ),
         DataType::Int32 => xxh3_64(
             &array
                 .as_any()
-                .downcast_ref::<Int32Array>()?
+                .downcast_ref::<Int32Array>()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("quality: column is not a Int32Array despite its DataType")
+                })?
                 .value(row)
                 .to_le_bytes(),
         ),
         DataType::Int64 => xxh3_64(
             &array
                 .as_any()
-                .downcast_ref::<Int64Array>()?
+                .downcast_ref::<Int64Array>()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("quality: column is not a Int64Array despite its DataType")
+                })?
                 .value(row)
                 .to_le_bytes(),
         ),
         DataType::UInt8 => xxh3_64(
             &array
                 .as_any()
-                .downcast_ref::<UInt8Array>()?
+                .downcast_ref::<UInt8Array>()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("quality: column is not a UInt8Array despite its DataType")
+                })?
                 .value(row)
                 .to_le_bytes(),
         ),
         DataType::UInt16 => xxh3_64(
             &array
                 .as_any()
-                .downcast_ref::<UInt16Array>()?
+                .downcast_ref::<UInt16Array>()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("quality: column is not a UInt16Array despite its DataType")
+                })?
                 .value(row)
                 .to_le_bytes(),
         ),
         DataType::UInt32 => xxh3_64(
             &array
                 .as_any()
-                .downcast_ref::<UInt32Array>()?
+                .downcast_ref::<UInt32Array>()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("quality: column is not a UInt32Array despite its DataType")
+                })?
                 .value(row)
                 .to_le_bytes(),
         ),
         DataType::UInt64 => xxh3_64(
             &array
                 .as_any()
-                .downcast_ref::<UInt64Array>()?
+                .downcast_ref::<UInt64Array>()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("quality: column is not a UInt64Array despite its DataType")
+                })?
                 .value(row)
                 .to_le_bytes(),
         ),
         DataType::Float32 => {
             let bits = array
                 .as_any()
-                .downcast_ref::<Float32Array>()?
+                .downcast_ref::<Float32Array>()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("quality: column is not a Float32Array despite its DataType")
+                })?
                 .value(row)
                 .to_bits();
             xxh3_64(&bits.to_le_bytes())
@@ -95,7 +141,10 @@ fn hash_value(array: &dyn Array, row: usize) -> Option<u64> {
         DataType::Float64 => {
             let bits = array
                 .as_any()
-                .downcast_ref::<Float64Array>()?
+                .downcast_ref::<Float64Array>()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("quality: column is not a Float64Array despite its DataType")
+                })?
                 .value(row)
                 .to_bits();
             xxh3_64(&bits.to_le_bytes())
@@ -103,53 +152,91 @@ fn hash_value(array: &dyn Array, row: usize) -> Option<u64> {
         DataType::Decimal128(_, _) => xxh3_64(
             &array
                 .as_any()
-                .downcast_ref::<Decimal128Array>()?
+                .downcast_ref::<Decimal128Array>()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("quality: column is not a Decimal128Array despite its DataType")
+                })?
                 .value(row)
                 .to_le_bytes(),
         ),
         DataType::Date32 => xxh3_64(
             &array
                 .as_any()
-                .downcast_ref::<Date32Array>()?
+                .downcast_ref::<Date32Array>()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("quality: column is not a Date32Array despite its DataType")
+                })?
                 .value(row)
                 .to_le_bytes(),
         ),
         DataType::Date64 => xxh3_64(
             &array
                 .as_any()
-                .downcast_ref::<Date64Array>()?
+                .downcast_ref::<Date64Array>()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("quality: column is not a Date64Array despite its DataType")
+                })?
                 .value(row)
                 .to_le_bytes(),
         ),
         DataType::Utf8 => xxh3_64(
             array
                 .as_any()
-                .downcast_ref::<StringArray>()?
+                .downcast_ref::<StringArray>()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("quality: column is not a StringArray despite its DataType")
+                })?
                 .value(row)
                 .as_bytes(),
         ),
         DataType::LargeUtf8 => xxh3_64(
             array
                 .as_any()
-                .downcast_ref::<LargeStringArray>()?
+                .downcast_ref::<LargeStringArray>()
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "quality: column is not a LargeStringArray despite its DataType"
+                    )
+                })?
                 .value(row)
                 .as_bytes(),
         ),
-        DataType::Binary => xxh3_64(array.as_any().downcast_ref::<BinaryArray>()?.value(row)),
+        DataType::Binary => xxh3_64(
+            array
+                .as_any()
+                .downcast_ref::<BinaryArray>()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("quality: column is not a BinaryArray despite its DataType")
+                })?
+                .value(row),
+        ),
         DataType::LargeBinary => xxh3_64(
             array
                 .as_any()
-                .downcast_ref::<LargeBinaryArray>()?
+                .downcast_ref::<LargeBinaryArray>()
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "quality: column is not a LargeBinaryArray despite its DataType"
+                    )
+                })?
                 .value(row),
         ),
         _ => {
             // Fallback for exotic types (Timestamp variants, Duration, etc.)
             let options = arrow::util::display::FormatOptions::default();
-            let fmt = arrow::util::display::ArrayFormatter::try_new(array, &options).ok()?;
+            let fmt =
+                arrow::util::display::ArrayFormatter::try_new(array, &options).map_err(|e| {
+                    anyhow::anyhow!(
+                        "quality: a PRESENT value of type {} cannot be rendered ({e}), so it \
+                         cannot take part in a uniqueness check. Skipping it silently would \
+                         report 'no duplicates' over rows never examined.",
+                        array.data_type()
+                    )
+                })?;
             xxh3_64(fmt.value(row).to_string().as_bytes())
         }
     };
-    Some(h)
+    Ok(Some(h))
 }
 
 #[derive(Debug, Clone)]
@@ -375,6 +462,7 @@ pub fn check_uniqueness(
         let mut seen: HashSet<u64> = HashSet::new();
         let mut duplicates = 0usize;
         let mut capped = false;
+        let mut unhashable: Option<String> = None;
 
         'batches: for batch in batches {
             if let Ok(idx) = batch.schema().index_of(col_name) {
@@ -384,13 +472,35 @@ pub fn check_uniqueness(
                         capped = true;
                         break 'batches;
                     }
-                    if let Some(h) = hash_value(col.as_ref(), row)
-                        && !seen.insert(h)
-                    {
-                        duplicates += 1;
+                    // An UNRENDERABLE cell is not an absent one. Both used to be
+                    // `None` and both were skipped, which is how `unique: true`
+                    // on a named-timezone timestamp examined ZERO rows and
+                    // reported no duplicates.
+                    match hash_value(col.as_ref(), row) {
+                        Ok(Some(h)) => {
+                            if !seen.insert(h) {
+                                duplicates += 1;
+                            }
+                        }
+                        Ok(None) => {} // NULL — correctly excluded from uniqueness
+                        Err(e) => {
+                            unhashable = Some(format!("{e:#}"));
+                            break 'batches;
+                        }
                     }
                 }
             }
+        }
+
+        // Reported BEFORE the duplicate verdict: a check that could not read its
+        // column has no verdict to give, and "0 duplicates" over zero examined
+        // rows is exactly the shape of a gate that passes on nothing.
+        if let Some(why) = unhashable {
+            issues.push(QualityIssue {
+                severity: Severity::Fail,
+                message: format!("column '{col_name}': uniqueness check DID NOT RUN — {why}"),
+            });
+            continue;
         }
 
         if capped {
@@ -723,6 +833,55 @@ mod tests {
     // (CLAUDE.md "never a silent no-op"). The old code skipped a missing
     // uniqueness column (index_of → Err → 0 dups → pass) and treated a missing
     // null-ratio column as 0 nulls (unwrap_or(0) → pass); both vanished.
+
+    /// A PRESENT cell that cannot be hashed must FAIL the check, not shrink it.
+    ///
+    /// `hash_value` returned `None` for two unrelated reasons — "this cell is
+    /// NULL" and "I cannot render this type" — and the caller skipped both. So
+    /// `unique: true` on a column Arrow refuses examined ZERO rows and reported
+    /// no duplicates: a gate passing over data it never read.
+    ///
+    /// The trigger was real. Arrow's `ArrayFormatter` rejects a timestamp whose
+    /// timezone is a NAME unless the `chrono-tz` feature is on — the refusal
+    /// that cost 63 of 65 exports on a production MySQL config, 2026-08-05.
+    ///
+    /// SCOPE, stated because it changes what this proves: with `chrono-tz` on,
+    /// `Some("UTC")` — the only zone rivet emits — renders, so rivet's own
+    /// output can no longer reach the Err arm. An UNPARSEABLE zone still can,
+    /// and that is what this uses. The test therefore pins the CONTRACT ("a
+    /// present-but-unhashable value fails the check") rather than a live
+    /// production path. It is RED-proven against the conflation: restore the
+    /// silent skip and it fails.
+    #[test]
+    fn uniqueness_refuses_when_a_present_value_cannot_be_hashed() {
+        use arrow::array::{ArrayRef, TimestampMicrosecondArray};
+
+        // Two IDENTICAL values: were they hashable, the check would find a
+        // duplicate. Either outcome is acceptable; a clean pass is not.
+        let arr: ArrayRef = Arc::new(
+            TimestampMicrosecondArray::from(vec![1_700_000_000_000_000i64; 2])
+                .with_timezone("Mars/Olympus".to_string()),
+        );
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "seen_at",
+            arr.data_type().clone(),
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema, vec![arr]).unwrap();
+
+        let issues = check_uniqueness(&[batch], &["seen_at".into()], None);
+        assert!(
+            !issues.is_empty(),
+            "an unhashable PRESENT value produced a clean pass — the rows were skipped, \
+             which is the defect: the check reports 'no duplicates' over nothing"
+        );
+        assert_eq!(issues[0].severity, Severity::Fail);
+        assert!(
+            issues[0].message.contains("DID NOT RUN"),
+            "the message must say the check did not run, not that the data is clean: {}",
+            issues[0].message
+        );
+    }
 
     #[test]
     fn uniqueness_missing_column_is_loud_fail() {

--- a/src/source/cdc/mod.rs
+++ b/src/source/cdc/mod.rs
@@ -311,7 +311,17 @@ pub(crate) enum CdcEngineOpts {
     /// PostgreSQL logical slot name.
     Postgres { slot: String },
     /// SQL Server capture instance (required for `sqlserver://`).
-    Mssql { capture_instance: Option<String> },
+    Mssql {
+        capture_instance: Option<String>,
+        /// The `table:` values the CONFIG asked for.
+        ///
+        /// SQL Server resolves an event's identity from `cdc.change_tables`, but
+        /// the sink routes by byte-exact comparison against these strings. The
+        /// two were never compared, and SQL Server's default collation is
+        /// case-INSENSITIVE — so `table: dbo.orders` against a catalog
+        /// `dbo.Orders` resolved its schema perfectly and then matched no event.
+        configured_tables: Vec<String>,
+    },
     /// Render the `document` blob as canonical (type-tagged) extended JSON — the
     /// `source.mongo.json: canonical` mode, so a CDC stream and a full export
     /// produce identical text. Config-driven only; the CLI defaults to relaxed.
@@ -520,7 +530,9 @@ impl CdcEngine {
                 // else either sums across instances (masking a partial one) or
                 // matches a same-named table in another schema.
                 let ci = match opts {
-                    CdcEngineOpts::Mssql { capture_instance } => capture_instance.as_deref(),
+                    CdcEngineOpts::Mssql {
+                        capture_instance, ..
+                    } => capture_instance.as_deref(),
                     _ => None,
                 };
                 crate::source::mssql::cdc::row_image(url, tls, tables, ci)
@@ -698,7 +710,10 @@ pub(crate) fn create_change_stream(
                 .context(PG_CDC_HINT)?,
             ))
         }
-        CdcEngineOpts::Mssql { capture_instance } => {
+        CdcEngineOpts::Mssql {
+            capture_instance,
+            configured_tables,
+        } => {
             let ci = capture_instance.as_deref().ok_or_else(|| {
                 anyhow::anyhow!("sqlserver cdc requires --capture-instance (e.g. dbo_orders)")
             })?;
@@ -737,6 +752,7 @@ pub(crate) fn create_change_stream(
                     tls,
                     peek,
                     cfg.drain,
+                    configured_tables,
                 )
                 .context(MSSQL_CDC_HINT)?,
             ))

--- a/src/source/cdc/sink.rs
+++ b/src/source/cdc/sink.rs
@@ -217,7 +217,7 @@ impl TableSink<'_> {
 /// (`public.orders` — matches schema AND table). Adapters always emit schema
 /// and table separately; comparing the config string verbatim against the
 /// bare event table silently routed ZERO events for qualified configs.
-pub(super) fn table_matches(cfg: &str, schema: &str, table: &str) -> bool {
+pub(crate) fn table_matches(cfg: &str, schema: &str, table: &str) -> bool {
     // Full-name match FIRST: a MongoDB collection name may contain dots
     // (`my.coll`) and has no schema qualifier, so splitting it into a bogus
     // `schema.table` dropped every event (bug-hunt: 0-row success forever). This

--- a/src/source/mssql/cdc.rs
+++ b/src/source/mssql/cdc.rs
@@ -367,6 +367,10 @@ impl MssqlChangeStream {
         tls: Option<&TlsConfig>,
         peek: crate::source::cdc::PeekBound,
         mode: DrainMode,
+        // The `table:` values the config asked for, checked against the catalog
+        // identity this stream will actually emit. Empty ⇒ no check (the
+        // `rivet cdc` CLI path supplies none).
+        configured_tables: &[String],
     ) -> Result<Self> {
         if !cfg
             .capture_instance
@@ -420,6 +424,44 @@ impl MssqlChangeStream {
                 .map(|(s, t)| (s.to_string(), t.to_string()))
                 .unwrap_or_else(|| (String::new(), cfg.capture_instance.clone()))
         });
+
+        // The config's name is a LABEL; this identity is the truth — and until
+        // now nothing compared them. The sink routes with
+        // `cdc::sink::table_matches`, a byte-exact comparison, while SQL Server's
+        // default collation is case-INSENSITIVE: `table: dbo.orders` against a
+        // catalog `dbo.Orders` resolves its schema perfectly (a full, correct
+        // column list) and then matches ZERO events.
+        //
+        // That is not merely a delay. The commit boundary is recorded BEFORE the
+        // routing filter and the end-of-pass roll fires on `unacked_commit`
+        // alone, so the checkpoint advances over events that were never
+        // captured. Measured: 6 change rows, 0 captured, exit 0 — and re-running
+        // with the case FIXED against the same checkpoint recovered NOTHING,
+        // while the same run with the checkpoint deleted recovered all 5 events.
+        // The rows never left the change table; only the advanced LSN skipped
+        // them.
+        //
+        // Checked with the SAME predicate the sink routes by, deliberately: a
+        // check that asks a different question is not a check.
+        if !configured_tables.is_empty()
+            && !configured_tables
+                .iter()
+                .any(|c| crate::source::cdc::sink::table_matches(c, &schema, &table))
+        {
+            anyhow::bail!(
+                "sqlserver cdc: capture instance '{}' emits changes for `{}.{}` (from \
+                 cdc.change_tables), but no configured table matches it — the config asks for \
+                 {:?}. Routing is byte-exact while SQL Server's collation is not, so every \
+                 event would be dropped AND the checkpoint would advance past it, losing the \
+                 changes for good. Set `table:` to `{}.{}` exactly as the catalog spells it.",
+                cfg.capture_instance,
+                schema,
+                table,
+                configured_tables,
+                schema,
+                table
+            );
+        }
 
         // Bounded run: snapshot the ceiling once, at open. A NULL max LSN (CDC
         // not enabled yet) keeps `bound = None` so the first poll surfaces the
@@ -476,6 +518,8 @@ impl MssqlChangeStream {
         tls: Option<&TlsConfig>,
         peek: crate::source::cdc::PeekBound,
         mode: DrainMode,
+        // Passed through to `open`, which cross-checks it against the catalog.
+        configured_tables: &[String],
     ) -> Result<Self> {
         // Refuse remote plaintext / unauthenticated TLS before any dial (the gate
         // the batch MssqlSource uses).
@@ -495,6 +539,7 @@ impl MssqlChangeStream {
             tls,
             peek,
             mode,
+            configured_tables,
         )
     }
 
@@ -1191,6 +1236,7 @@ mod tests {
             None,
             crate::source::cdc::PeekBound::Sized(10_000),
             DrainMode::Continuous,
+            &[], // no configured tables in this fixture → cross-check inactive
         )
         .unwrap();
         let mut ops = Vec::new();

--- a/src/source/mssql/mod.rs
+++ b/src/source/mssql/mod.rs
@@ -1129,7 +1129,8 @@ pub(crate) fn introspect_mssql_table_for_chunking(
              JOIN sys.types kt ON kt.user_type_id = c.user_type_id \
              JOIN sys.objects o ON o.object_id = i.object_id \
              JOIN sys.schemas s ON s.schema_id = o.schema_id \
-             WHERE i.is_unique = 1 AND c.is_nullable = 0 AND s.name = N'{}' AND o.name = N'{}' \
+             WHERE i.is_unique = 1 AND i.has_filter = 0 AND i.is_disabled = 0 \
+               AND c.is_nullable = 0 AND s.name = N'{}' AND o.name = N'{}' \
                AND kt.name NOT IN ('decimal', 'numeric') \
              GROUP BY i.object_id, i.index_id HAVING COUNT(*) = 1 \
            ) per_index GROUP BY col \

--- a/src/source/postgres/mod.rs
+++ b/src/source/postgres/mod.rs
@@ -371,6 +371,17 @@ pub(crate) fn introspect_pg_table_for_chunking(
     // failing at runtime AFTER a partial write, and stops `rivet check` from
     // green-lighting it (#dogfood: keyset on a DECIMAL PK check=ACCEPTABLE, run
     // failed after 100/250 rows "could not read the key value … unsupported type").
+    // `indpred IS NULL` excludes a PARTIAL index and `indisvalid` an INVALID one.
+    // Keyset's whole correctness argument is that the key is GLOBALLY unique, so
+    // `WHERE k > <last> ORDER BY k LIMIT n` cannot skip a row sharing the
+    // boundary key. A partial unique index guarantees uniqueness only over the
+    // rows it covers — and the standard soft-delete shape,
+    // `CREATE UNIQUE INDEX ON users (email) WHERE deleted_at IS NULL`, permits
+    // duplicates among everything else. Measured: 50 duplicate + 50 distinct
+    // keys at page size 10 exported 60 of 100 rows with `status: success`, the
+    // duplicate contributing exactly ONE page. All 51 distinct values were
+    // present, so a `count(DISTINCT)` check against the source matched perfectly
+    // while 40 rows were gone.
     let keyset_rows = client.query(
         "SELECT a.attname::text, i.indisprimary \
          FROM pg_index i \
@@ -378,6 +389,7 @@ pub(crate) fn introspect_pg_table_for_chunking(
          JOIN pg_type t ON t.oid = a.atttypid \
          WHERE i.indrelid = (($1::text || '.' || $2::text)::regclass) \
            AND i.indisunique AND i.indnkeyatts = 1 AND a.attnotnull \
+           AND i.indpred IS NULL AND i.indisvalid \
            AND t.typname <> 'numeric'",
         &[&schema, &table],
     )?;

--- a/src/state/checkpoint.rs
+++ b/src/state/checkpoint.rs
@@ -751,3 +751,107 @@ mod tests {
         );
     }
 }
+
+/// One table's SHAPE at the moment a strategy was chosen for it.
+///
+/// Recorded by `rivet init`, which reads every one of these facts from the
+/// catalog to make the choice and — before this — threw them away. The config it
+/// writes carries the DECISION; nothing carried the EVIDENCE, so six months
+/// later there is no way to ask "what did the table look like when we picked
+/// this?" without guessing.
+///
+/// The field pipeline's own generator already works this way: its
+/// `aa_imports_config.json` stores `table_size_gb` beside `copying_strategy`,
+/// which is exactly what makes their choices auditable. This is that idea with
+/// the two facts they omit and today's failures needed — the ROW WIDTH and the
+/// KEY — plus a timestamp, because a snapshot with no date cannot tell you it
+/// has gone stale.
+///
+/// Why those two. `aa_import_partnerize` was 94k rows — BELOW the 100k threshold
+/// that routes to `mode: full` — and 1010 bytes per row, four to ten times wider
+/// than its siblings. It is the one that crossed the statement timeout. The
+/// threshold counted rows where the cost is bytes, and the byte figure was read
+/// and discarded. Separately, `ref_id` on the versioned tables is indexed but
+/// NOT unique (2.16 rows per key, measured), which is why keyset is impossible
+/// there — a property of the data that no config field records.
+///
+/// INIT ONLY, deliberately: writing this on every run would show a shape
+/// DRIFTING away from the strategy that suits it, which is the more useful
+/// signal and the larger feature. This is the decision point alone.
+#[derive(Debug, Clone)]
+pub struct StrategySnapshot {
+    pub export_name: String,
+    pub source_schema: Option<String>,
+    pub source_table: String,
+    pub row_estimate: Option<i64>,
+    /// Physical size from the catalog — `DATA_LENGTH` on MySQL, `pg_total_
+    /// relation_size` on PostgreSQL. `None` where the engine has no scan-free
+    /// figure (SQL Server and Mongo do not populate it), and `None` is recorded
+    /// as `None` rather than 0: "unknown" and "empty" are different answers.
+    pub total_bytes: Option<i64>,
+    pub avg_row_bytes: Option<i64>,
+    pub chosen_mode: String,
+    /// `keyset` / `range` / `full` / `incremental` — the shape the scaffold
+    /// emitted, which is finer than `mode:` alone (both keyset and range are
+    /// `mode: chunked`).
+    pub strategy_kind: Option<String>,
+    pub key_column: Option<String>,
+    pub chunk_size: Option<i64>,
+}
+
+impl StateStore {
+    /// Append a strategy snapshot. Append-only: a later `init` over the same
+    /// config adds a row rather than replacing one, so the sequence shows how
+    /// the answer changed.
+    pub fn record_strategy_snapshot(&self, s: &StrategySnapshot) -> Result<()> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let ver = env!("CARGO_PKG_VERSION");
+        let sql = "INSERT INTO strategy_snapshot (
+                 export_name, source_schema, source_table, row_estimate, total_bytes,
+                 avg_row_bytes, chosen_mode, strategy_kind, key_column, chunk_size,
+                 rivet_version, captured_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)";
+        match &self.conn {
+            StateConn::Sqlite(c) => {
+                c.execute(
+                    sql,
+                    rusqlite::params![
+                        s.export_name,
+                        s.source_schema,
+                        s.source_table,
+                        s.row_estimate,
+                        s.total_bytes,
+                        s.avg_row_bytes,
+                        s.chosen_mode,
+                        s.strategy_kind,
+                        s.key_column,
+                        s.chunk_size,
+                        ver,
+                        now,
+                    ],
+                )?;
+            }
+            StateConn::Postgres(client) => {
+                let mut c = client.borrow_mut();
+                c.execute(
+                    &pg_sql(sql),
+                    &[
+                        &s.export_name,
+                        &s.source_schema,
+                        &s.source_table,
+                        &s.row_estimate,
+                        &s.total_bytes,
+                        &s.avg_row_bytes,
+                        &s.chosen_mode,
+                        &s.strategy_kind,
+                        &s.key_column,
+                        &s.chunk_size,
+                        &ver,
+                        &now,
+                    ],
+                )?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/state/checkpoint.rs
+++ b/src/state/checkpoint.rs
@@ -289,10 +289,37 @@ impl StateStore {
         Ok(())
     }
 
-    pub fn fail_chunk_task(&self, run_id: &str, chunk_index: i64, err: &str) -> Result<()> {
+    /// Mark a chunk failed.
+    ///
+    /// `retryable` is the CALLER's verdict on the error, not a guess made here:
+    /// the pipeline holds the typed error and already classifies it
+    /// (`retry::classify_error`), while this layer sees only text. When it is
+    /// false the attempt counter is driven to the run's cap, so
+    /// `claim_next_chunk_task` — whose predicate is `attempts <
+    /// max_chunk_attempts` — will not hand the chunk out again.
+    ///
+    /// Before this, the classification stopped at the inner retry loop and the
+    /// chunk-level re-claim re-dispatched a deterministically failing chunk to
+    /// exhaustion. Measured in the field: 15 chunks x 4 attempts x a 300 s
+    /// statement timeout, 300 minutes of production query time for nothing.
+    /// Exhausting the counter rather than adding a column keeps the existing
+    /// claim predicate as the single place that decides eligibility.
+    pub fn fail_chunk_task(
+        &self,
+        run_id: &str,
+        chunk_index: i64,
+        err: &str,
+        retryable: bool,
+    ) -> Result<()> {
         let now = chrono::Utc::now().to_rfc3339();
-        let sql = "UPDATE chunk_task SET status = 'failed', last_error = ?1, updated_at = ?2
-             WHERE run_id = ?3 AND chunk_index = ?4";
+        let sql = if retryable {
+            "UPDATE chunk_task SET status = 'failed', last_error = ?1, updated_at = ?2
+             WHERE run_id = ?3 AND chunk_index = ?4"
+        } else {
+            "UPDATE chunk_task SET status = 'failed', last_error = ?1, updated_at = ?2,
+                    attempts = (SELECT max_chunk_attempts FROM chunk_run WHERE run_id = ?3)
+             WHERE run_id = ?3 AND chunk_index = ?4"
+        };
         match &self.conn {
             StateConn::Sqlite(c) => {
                 c.execute(sql, rusqlite::params![err, now, run_id, chunk_index])?;
@@ -305,15 +332,24 @@ impl StateStore {
         Ok(())
     }
 
+    /// The parallel workers' twin of [`Self::fail_chunk_task`] — same contract,
+    /// including `retryable`.
     pub fn fail_chunk_task_at_ref(
         state_ref: &StateRef,
         run_id: &str,
         chunk_index: i64,
         err: &str,
+        retryable: bool,
     ) -> Result<()> {
         let now = chrono::Utc::now().to_rfc3339();
-        let sql = "UPDATE chunk_task SET status = 'failed', last_error = ?1, updated_at = ?2
-             WHERE run_id = ?3 AND chunk_index = ?4";
+        let sql = if retryable {
+            "UPDATE chunk_task SET status = 'failed', last_error = ?1, updated_at = ?2
+             WHERE run_id = ?3 AND chunk_index = ?4"
+        } else {
+            "UPDATE chunk_task SET status = 'failed', last_error = ?1, updated_at = ?2,
+                    attempts = (SELECT max_chunk_attempts FROM chunk_run WHERE run_id = ?3)
+             WHERE run_id = ?3 AND chunk_index = ?4"
+        };
         match state_ref {
             StateRef::Sqlite(db_path) => {
                 let conn = open_connection(db_path)?;
@@ -590,6 +626,59 @@ mod tests {
         assert!(s.create_chunk_run("run_4", "orders", "h", 1).is_ok());
     }
 
+    /// A chunk that failed for a DETERMINISTIC reason must not be re-claimed.
+    ///
+    /// `retry.rs` already classifies a MySQL statement timeout (3024) as
+    /// PERMANENT and `should_retry` honours it — inside one chunk's attempt. The
+    /// chunk-level re-claim then re-dispatches the same chunk anyway, because it
+    /// tests only `attempts < max_chunk_attempts` with no notion of WHY the
+    /// attempt failed. Measured in the field: a 6M-row export burned 97.9 minutes
+    /// on 15 chunks x 4 attempts x 300s, every attempt hitting the same wall,
+    /// 300 minutes of source query time against a production replica for nothing.
+    ///
+    /// The classification is correct; the layer above never asks. Same shape as
+    /// the runner-bypass class — a value computed right and dropped on the floor.
+    #[test]
+    fn a_permanently_failed_chunk_is_not_reclaimed() {
+        let (_dir, s) = store_on_disk();
+        s.create_chunk_run("run_p", "orders", "h", 4).unwrap();
+        s.insert_chunk_tasks("run_p", &[(1, 5)]).unwrap();
+        s.claim_next_chunk_task("run_p").unwrap().expect("claim");
+
+        // The exact text the field produced.
+        s.fail_chunk_task(
+            "run_p",
+            0,
+            "mysql: statement timeout after 300s (max_execution_time from \
+             tuning.statement_timeout_s) — this query exceeded its time budget (ERROR 3024)",
+            false,
+        )
+        .unwrap();
+
+        assert!(
+            s.claim_next_chunk_task("run_p").unwrap().is_none(),
+            "a chunk that failed on a deterministic error was re-claimed; the next attempt runs \
+             the identical query against the identical data and cannot succeed. Retrying it to \
+             the attempt cap spends the source's time budget N times over."
+        );
+    }
+
+    /// The control: a TRANSIENT failure must still be retried, or the fix above
+    /// would have turned a retry budget into a one-shot.
+    #[test]
+    fn a_transiently_failed_chunk_is_still_reclaimed() {
+        let (_dir, s) = store_on_disk();
+        s.create_chunk_run("run_t", "orders", "h", 4).unwrap();
+        s.insert_chunk_tasks("run_t", &[(1, 5)]).unwrap();
+        s.claim_next_chunk_task("run_t").unwrap().expect("claim");
+        s.fail_chunk_task("run_t", 0, "connection reset by peer", true)
+            .unwrap();
+        assert!(
+            s.claim_next_chunk_task("run_t").unwrap().is_some(),
+            "a transient failure must still be retried"
+        );
+    }
+
     #[test]
     fn chunk_claim_complete_and_finalize() {
         let (_dir, s) = store_on_disk();
@@ -620,13 +709,16 @@ mod tests {
         s.create_chunk_run("run_b", "orders", "ab", 2).unwrap();
         s.insert_chunk_tasks("run_b", &[(1, 2)]).unwrap();
 
+        // `true` — this test's subject is the ATTEMPT CAP, so the failures must be
+        // retryable ones; a permanent failure is exhausted on the spot and is
+        // covered by `a_permanently_failed_chunk_is_not_reclaimed`.
         let t = s.claim_next_chunk_task("run_b").unwrap().unwrap();
         assert_eq!(t.0, 0);
-        s.fail_chunk_task("run_b", 0, "boom").unwrap();
+        s.fail_chunk_task("run_b", 0, "boom", true).unwrap();
 
         let t2 = s.claim_next_chunk_task("run_b").unwrap().unwrap();
         assert_eq!(t2.0, 0);
-        s.fail_chunk_task("run_b", 0, "again").unwrap();
+        s.fail_chunk_task("run_b", 0, "again", true).unwrap();
 
         assert!(s.claim_next_chunk_task("run_b").unwrap().is_none());
         assert_eq!(s.count_chunk_tasks_not_completed("run_b").unwrap(), 1);

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -21,7 +21,7 @@ mod shape;
 // Items below may not be explicitly named by all internal callers (often used
 // as inferred return types), but are part of the public integration-test API.
 #[allow(unused_imports)]
-pub use checkpoint::ChunkTaskInfo;
+pub use checkpoint::{ChunkTaskInfo, StrategySnapshot};
 #[allow(unused_imports)]
 pub use file_log::{DurablePart, FilePart, FileRecord};
 #[allow(unused_imports)]
@@ -421,6 +421,26 @@ const MIGRATIONS: &[(i64, &str)] = &[
          CREATE UNIQUE INDEX IF NOT EXISTS export_metrics_one_running_per_run
              ON export_metrics(run_id) WHERE status = 'running';",
     ),
+    (
+        22,
+        "CREATE TABLE IF NOT EXISTS strategy_snapshot (
+             id INTEGER PRIMARY KEY AUTOINCREMENT,
+             export_name TEXT NOT NULL,
+             source_schema TEXT,
+             source_table TEXT NOT NULL,
+             row_estimate BIGINT,
+             total_bytes BIGINT,
+             avg_row_bytes BIGINT,
+             chosen_mode TEXT NOT NULL,
+             strategy_kind TEXT,
+             key_column TEXT,
+             chunk_size BIGINT,
+             rivet_version TEXT NOT NULL,
+             captured_at TEXT NOT NULL
+         );
+         CREATE INDEX IF NOT EXISTS idx_strategy_snapshot_export
+             ON strategy_snapshot(export_name, id DESC);",
+    ),
 ];
 
 /// PostgreSQL-compatible DDL.  Column types differ from SQLite (BIGSERIAL,
@@ -754,6 +774,26 @@ const PG_MIGRATIONS: &[(i64, &str)] = &[
                             WHERE b.run_id = a.run_id AND b.status = 'running');
          CREATE UNIQUE INDEX IF NOT EXISTS export_metrics_one_running_per_run
              ON export_metrics(run_id) WHERE status = 'running';",
+    ),
+    (
+        22,
+        "CREATE TABLE IF NOT EXISTS strategy_snapshot (
+             id BIGSERIAL PRIMARY KEY,
+             export_name TEXT NOT NULL,
+             source_schema TEXT,
+             source_table TEXT NOT NULL,
+             row_estimate BIGINT,
+             total_bytes BIGINT,
+             avg_row_bytes BIGINT,
+             chosen_mode TEXT NOT NULL,
+             strategy_kind TEXT,
+             key_column TEXT,
+             chunk_size BIGINT,
+             rivet_version TEXT NOT NULL,
+             captured_at TEXT NOT NULL
+         );
+         CREATE INDEX IF NOT EXISTS idx_strategy_snapshot_export
+             ON strategy_snapshot(export_name, id DESC);",
     ),
 ];
 

--- a/src/types/decimal.rs
+++ b/src/types/decimal.rs
@@ -93,6 +93,16 @@ pub fn decimal_str_to_scaled_i128(s: &str, scale: i8) -> Option<i128> {
     };
 
     let frac_aligned: i128 = if scale_u == 0 {
+        // Scale 0 is a down-scale like any other: dropping "45" from "123.45"
+        // loses the cents. It used to short-circuit here, BEFORE the
+        // lossy-down-scale guard below, so a `columns:` override declaring
+        // `decimal(20,0)` over a `numeric(10,2)` truncated every value and the
+        // run exited 0 with no warning — while the SAME override one scale over
+        // failed loudly (`cannot parse DECIMAL "1.234567" as decimal(scale=2)`).
+        // The behaviour at scale 2 is the specification; zero was escaping it.
+        if frac_part.bytes().any(|b| b != b'0') {
+            return None;
+        }
         0
     } else if frac_part.len() < scale_u as usize {
         // Pad right with zeros: "0.1" with scale=2 → frac "10" → 10
@@ -159,6 +169,11 @@ pub fn decimal_str_to_scaled_i256(s: &str, scale: i8) -> Option<i256> {
         i256::from_string(int_part)?
     };
     let frac_aligned = if scale_u == 0 {
+        // See the i128 sibling: scale 0 is a down-scale and must honour the same
+        // loss guard, not bypass it.
+        if frac_part.bytes().any(|b| b != b'0') {
+            return None;
+        }
         i256::ZERO
     } else if frac_part.len() < scale_u as usize {
         let mut buf = String::with_capacity(scale_u as usize);
@@ -211,6 +226,33 @@ fn pow10_i256(n: u32) -> Option<i256> {
 
 #[cfg(test)]
 mod tests {
+
+    /// Scale 0 refuses a lossy down-scale like every other scale.
+    ///
+    /// It used to short-circuit before the guard, so a `columns:` override
+    /// declaring `decimal(20,0)` over a `numeric(10,2)` silently truncated every
+    /// value — money losing its cents on a run that exited 0. The control is the
+    /// line below it: the SAME override one scale over already failed loudly, and
+    /// that behaviour is the specification zero was escaping.
+    #[test]
+    fn scale_zero_refuses_a_lossy_down_scale() {
+        assert_eq!(decimal_str_to_scaled_i128("123.45", 0), None);
+        assert_eq!(decimal_str_to_scaled_i128("-99.99", 0), None);
+        assert_eq!(decimal_str_to_scaled_i128("0.01", 0), None);
+        // the control: the same loss at another scale was always refused
+        assert_eq!(decimal_str_to_scaled_i128("1.234567", 2), None);
+    }
+
+    /// …and still accepts what is NOT a loss, or the fix would have broken every
+    /// integer-valued decimal.
+    #[test]
+    fn scale_zero_still_accepts_whole_values() {
+        assert_eq!(decimal_str_to_scaled_i128("123", 0), Some(123));
+        assert_eq!(decimal_str_to_scaled_i128("-42", 0), Some(-42));
+        // trailing zeros drop harmlessly — the value is unchanged
+        assert_eq!(decimal_str_to_scaled_i128("123.00", 0), Some(123));
+        assert_eq!(decimal_str_to_scaled_i128("7.0", 0), Some(7));
+    }
     use super::*;
 
     #[test]

--- a/src/types/decimal.rs
+++ b/src/types/decimal.rs
@@ -243,6 +243,35 @@ mod tests {
         assert_eq!(decimal_str_to_scaled_i128("1.234567", 2), None);
     }
 
+    /// The i256 TWIN of the two tests above.
+    ///
+    /// The scale-0 guard was fixed in both converters and tested in only one —
+    /// the ≥2-twins lesson, arriving by mutant: `cargo mutants --in-diff`
+    /// reported `replace != with == in decimal_str_to_scaled_i256` MISSED while
+    /// its i128 sibling was covered. Inverted, the guard refuses `1.00` (whose
+    /// fraction is all zeros — no loss) and ACCEPTS `1.05` at scale 0, which is
+    /// the truncation the guard exists to stop.
+    #[test]
+    fn scale_zero_guard_holds_on_the_i256_path_too() {
+        assert_eq!(decimal_str_to_scaled_i256("123.45", 0), None);
+        assert_eq!(decimal_str_to_scaled_i256("-99.99", 0), None);
+        assert_eq!(decimal_str_to_scaled_i256("0.01", 0), None);
+        // …and the non-loss cases still pass, or the guard would refuse every
+        // integer-valued wide decimal.
+        assert_eq!(
+            decimal_str_to_scaled_i256("123", 0),
+            Some(i256::from_i128(123))
+        );
+        assert_eq!(
+            decimal_str_to_scaled_i256("123.00", 0),
+            Some(i256::from_i128(123))
+        );
+        assert_eq!(
+            decimal_str_to_scaled_i256("-42.0", 0),
+            Some(i256::from_i128(-42))
+        );
+    }
+
     /// …and still accepts what is NOT a loss, or the fix would have broken every
     /// integer-valued decimal.
     #[test]

--- a/tests/cdc_conformance_gate.rs
+++ b/tests/cdc_conformance_gate.rs
@@ -441,7 +441,7 @@ fn every_live_cdc_test_asserts_an_outcome() {
                 || chunk.contains("distinct_ids(")
                 || chunk.contains("distinct_int_ids(")
                 || chunk.contains("read_mongo_cdc_changes(") // Mongo blob-CDC oracle
-                || chunk.contains("dir_parquet_distinct_strings(")
+                || chunk.contains("duckdb_dir_parquet_distinct_strings(")
                 // DuckDB read-backs. The strongest oracle in the suite for a
                 // COMPLETENESS claim: DuckDB does not share the parquet crate
                 // rivet ENCODES with, so a fault in that shared encode/decode

--- a/tests/common/parquet.rs
+++ b/tests/common/parquet.rs
@@ -34,12 +34,25 @@ use super::files_with_extension;
 /// assert on it afterwards. Test outputs here are kilobytes, and one DuckDB
 /// round trip is ~38 ms, so the copy is not the cost that matters.
 fn stage_for_duckdb(dir: &Path) -> String {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static SEQ: AtomicU64 = AtomicU64::new(0);
+    // ONE stable directory per THREAD, contents cleared — never a fresh
+    // directory per call.
+    //
+    // The first version minted `stage_<pid>_<seq>` on every call: 193 new
+    // directories in a single parallel run, on a gRPC-FUSE bind mount whose
+    // documented failure mode (see `live_shared_workdir`) is that a container
+    // which has resolved a path keeps the OLD inode after a recreate and sees
+    // an empty directory forever. It showed up exactly as that comment
+    // predicts — green alone, one failure in the parallel suite, reading zero
+    // rows from a directory that was full.
+    //
+    // A per-thread name is stable across the thousands of calls one test binary
+    // makes, so the container resolves each path once and keeps seeing it.
+    let tid = format!("{:?}", std::thread::current().id());
     let label = format!(
-        "stage_{}_{}",
-        std::process::id(),
-        SEQ.fetch_add(1, Ordering::Relaxed)
+        "stage_t{}",
+        tid.chars()
+            .filter(|c| c.is_ascii_digit())
+            .collect::<String>()
     );
     let (host, container) = super::live_shared_workdir(&label);
     for f in files_with_extension(dir, "parquet") {
@@ -63,6 +76,72 @@ pub fn duckdb_total_parquet_rows(dir: &Path) -> usize {
     }
     let c = stage_for_duckdb(dir);
     super::duckdb_parquet_rows(&c) as usize
+}
+
+/// Every `id` value under `dir`, WITH multiplicity, read by DuckDB.
+///
+/// Multiplicity is the point: a completeness claim needs to tell LOSS (fewer
+/// values) from DUPLICATION (same count, fewer distinct), and a set cannot.
+pub fn duckdb_dir_parquet_ids(dir: &Path) -> Vec<i64> {
+    duckdb_dir_parquet_i64(dir, "id")
+}
+
+/// The distinct `id` values under `dir`, read by DuckDB.
+pub fn duckdb_dir_parquet_id_set(dir: &Path) -> BTreeSet<i64> {
+    duckdb_dir_parquet_ids(dir).into_iter().collect()
+}
+
+/// Every value of an integer column under `dir`, in file/row order, by DuckDB.
+pub fn duckdb_dir_parquet_i64(dir: &Path, col: &str) -> Vec<i64> {
+    if files_with_extension(dir, "parquet").is_empty() {
+        return Vec::new();
+    }
+    let c = stage_for_duckdb(dir);
+    let v = super::duckdb_run_sql_json(&format!(
+        "SELECT CAST({col} AS BIGINT) FROM read_parquet('{c}/**/*.parquet')"
+    ));
+    v["rows"]
+        .as_array()
+        .unwrap_or_else(|| panic!("duckdb returned no rows array for {col}"))
+        .iter()
+        .map(|r| {
+            r[0].as_str()
+                .unwrap_or_else(|| panic!("{col} cell is not a string: {r:?}"))
+                .parse::<i64>()
+                .unwrap_or_else(|e| panic!("{col} does not parse as i64: {e}"))
+        })
+        .collect()
+}
+
+/// The distinct values of a text column under `dir`, read by DuckDB.
+pub fn duckdb_dir_parquet_distinct_strings(dir: &Path, col: &str) -> BTreeSet<String> {
+    if files_with_extension(dir, "parquet").is_empty() {
+        return BTreeSet::new();
+    }
+    let c = stage_for_duckdb(dir);
+    let v = super::duckdb_run_sql_json(&format!(
+        "SELECT DISTINCT CAST({col} AS VARCHAR) FROM read_parquet('{c}/**/*.parquet') \
+         WHERE {col} IS NOT NULL"
+    ));
+    v["rows"]
+        .as_array()
+        .unwrap_or_else(|| panic!("duckdb returned no rows array for {col}"))
+        .iter()
+        .map(|r| r[0].as_str().unwrap_or_default().to_string())
+        .collect()
+}
+
+/// Does any part under `dir` carry `col`? Answered from DuckDB's own schema
+/// read, so a column rivet believes it wrote is confirmed by a foreign decoder.
+pub fn duckdb_dir_parquet_has_column(dir: &Path, col: &str) -> bool {
+    if files_with_extension(dir, "parquet").is_empty() {
+        return false;
+    }
+    let c = stage_for_duckdb(dir);
+    let described = super::duckdb_run_sql_json(&format!(
+        "DESCRIBE SELECT * FROM read_parquet('{c}/**/*.parquet')"
+    ));
+    super::duckdb_parse_describe(&described).contains_key(col)
 }
 
 /// Row count of a single `.parquet` file.

--- a/tests/common/parquet.rs
+++ b/tests/common/parquet.rs
@@ -17,6 +17,54 @@ use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 
 use super::files_with_extension;
 
+/// Stage a host directory of Parquet under the shared bind mount and hand back
+/// its in-container path, so a value claim can be read by DuckDB instead of by
+/// the same `parquet` crate rivet wrote it with.
+///
+/// The bridge exists because of a NAMESPACE boundary, not a data one. Tests
+/// write to their own `tempfile::tempdir()` — a real directory the host reads
+/// fine — but the validator containers have exactly ONE path mounted
+/// (`tests/.live-tmp` → `/work`), so from inside them that tempdir does not
+/// exist. The failure then surfaces as `0 rows` or "no files match", which
+/// reads as data loss and costs an hour before anyone suspects the mount. (It
+/// cost exactly that on 2026-08-05, when three tests run from a secondary git
+/// worktree failed and a merge was suspected first.)
+///
+/// Copying rather than moving: the caller still owns its directory and may
+/// assert on it afterwards. Test outputs here are kilobytes, and one DuckDB
+/// round trip is ~38 ms, so the copy is not the cost that matters.
+fn stage_for_duckdb(dir: &Path) -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let label = format!(
+        "stage_{}_{}",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    );
+    let (host, container) = super::live_shared_workdir(&label);
+    for f in files_with_extension(dir, "parquet") {
+        let name = f.file_name().expect("parquet file has a name");
+        std::fs::copy(&f, host.join(name))
+            .unwrap_or_else(|e| panic!("stage {} for duckdb: {e}", f.display()));
+    }
+    container
+}
+
+/// Row count of every `.parquet` under `dir`, read by DuckDB.
+///
+/// The independent-decoder twin of [`total_parquet_rows`]. rivet writes Parquet
+/// with the `parquet` crate and the old helper read it back with the SAME
+/// crate, so a symmetric write/read fault is invisible by construction — the
+/// class that let a whole column render as empty for four months. DuckDB shares
+/// no code with the writer.
+pub fn duckdb_total_parquet_rows(dir: &Path) -> usize {
+    if files_with_extension(dir, "parquet").is_empty() {
+        return 0; // an empty destination is a legitimate expected value
+    }
+    let c = stage_for_duckdb(dir);
+    super::duckdb_parquet_rows(&c) as usize
+}
+
 /// Row count of a single `.parquet` file.
 pub fn parquet_rows(path: &Path) -> usize {
     let bytes = std::fs::read(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));

--- a/tests/invariants.rs
+++ b/tests/invariants.rs
@@ -56,7 +56,10 @@ fn i5_failed_chunk_task_retryable_within_max_attempts() {
     let (idx, _, _) = state.claim_next_chunk_task("run-2").unwrap().unwrap();
     assert_eq!(idx, 0);
     state
-        .fail_chunk_task("run-2", 0, "transient network error")
+        // `true` — this invariant is about the ATTEMPT BUDGET, so the failure must
+        // be a retryable one. A permanent failure exhausts the budget on the spot
+        // (state::checkpoint::tests::a_permanently_failed_chunk_is_not_reclaimed).
+        .fail_chunk_task("run-2", 0, "transient network error", true)
         .unwrap();
 
     // Attempt 2: still claimable (failed but attempts=1 < max=3).
@@ -83,7 +86,11 @@ fn i5_failed_chunk_task_not_retryable_beyond_max_attempts() {
 
     // Only attempt: claim → fail.
     state.claim_next_chunk_task("run-3").unwrap().unwrap();
-    state.fail_chunk_task("run-3", 0, "fatal error").unwrap();
+    // `true` — the subject here is max_chunk_attempts = 1 exhausting on its own,
+    // not the error class doing it.
+    state
+        .fail_chunk_task("run-3", 0, "fatal error", true)
+        .unwrap();
 
     // Must not be reclaimable.
     let none = state.claim_next_chunk_task("run-3").unwrap();

--- a/tests/live/audit_column_validation.rs
+++ b/tests/live/audit_column_validation.rs
@@ -290,3 +290,110 @@ exports:
          reported fidelity={fidelity:?}\nstdout:\n{stdout}"
     );
 }
+
+// ─── a scale-0 override truncates money, and only scale 0 does ───────────────
+
+/// A `columns:` override that drops non-zero fractional digits must behave the
+/// same at scale 0 as at every other scale: refuse, not truncate.
+///
+/// `decimal_str_to_scaled_i128` refuses a lossy down-scale by returning `None`
+/// so the caller fails loudly — its own comment says the guard exists "rather
+/// than silently truncating financial digits". But the scale-0 arm
+/// short-circuits before ever reaching it (src/types/decimal.rs:95, and the
+/// i256 twin at :161 identically):
+///
+///   ("123.45",   0) -> Some(123)    the cents are gone
+///   ("-99.99",   0) -> Some(-99)
+///   ("1.234567", 2) -> None         the guard fires
+///   ("1.500",    2) -> Some(150)    trailing zeros drop harmlessly, correct
+///
+/// End to end on this stand, `numeric(10,2)` overridden to `decimal(20,0)`:
+///
+///   source   1=123.45  2=-99.99  3=1000.01  4=5.50
+///   parquet  1=123     2=-99     3=1000     4=5      status: success
+///
+/// The product's own behaviour one scale over IS the specification, and this
+/// test carries it as the control arm: `numeric(18,6)` overridden to
+/// `decimal(20,2)` FAILS the run —
+/// `cannot parse DECIMAL "1.234567" as decimal(scale=2)`. Same class of loss,
+/// same override mechanism, opposite outcome; the only difference is that the
+/// target scale is 0.
+///
+/// Distinct from its sibling `audit_type_report_flags_lossy_scale_reduction`,
+/// which is GREEN: that one asserts `check --type-report` labels the column
+/// `lossy`, and it does. The diagnostic was fixed; the RUN was not. Nothing
+/// asserted the exported VALUES — and that sibling could not have, because its
+/// fixture (`orders.price`) holds 5000 rows and not one of them has a non-zero
+/// cent, so no truncation is expressible in it.
+// AUDIT-RED decimal-scale0: a scale-0 `columns:` override silently truncates cents while every other scale fails loudly. Asserts CORRECT behavior; expected to FAIL until fixed.
+#[test]
+#[ignore = "live: postgres"]
+fn audit_scale_zero_override_must_not_silently_truncate() {
+    require_alive(LiveService::Postgres);
+
+    let table = unique_name("audit_scale0");
+    let mut c = postgres::Client::connect(POSTGRES_URL, postgres::NoTls).expect("connect");
+    c.batch_execute(&format!(
+        "CREATE TABLE {table} (id int PRIMARY KEY, amount numeric(10,2));
+         INSERT INTO {table} VALUES (1, 123.45), (2, -99.99), (3, 1000.01), (4, 5.50);"
+    ))
+    .expect("seed");
+    // The fixture MUST carry non-zero cents or the test cannot express the bug —
+    // the sibling test's table does not, which is why it never saw this.
+    let fractional: i64 = c
+        .query_one(
+            &format!("SELECT count(*) FROM {table} WHERE amount <> trunc(amount)"),
+            &[],
+        )
+        .expect("count")
+        .get(0);
+    assert!(
+        fractional >= 3,
+        "fixture is inert: {fractional} row(s) have a non-zero fractional part"
+    );
+
+    let out = tempfile::tempdir().unwrap();
+    let yaml = format!(
+        r#"
+source: {{type: postgres, url: "{POSTGRES_URL}"}}
+exports:
+  - name: {table}
+    table: "public.{table}"
+    mode: full
+    format: parquet
+    columns:
+      amount: "decimal(20,0)"
+    destination: {{type: local, path: {dir}}}
+"#,
+        dir = out.path().display()
+    );
+    let (_cfgdir, cfgpath) = cfg(&yaml);
+    let run = std::process::Command::new(RIVET_BIN)
+        .args(["run", "--config", cfgpath.to_str().unwrap()])
+        .output()
+        .expect("spawn rivet run");
+
+    let _ = c.execute(&format!("DROP TABLE IF EXISTS {table}"), &[]);
+
+    // Refusing is the correct outcome — it is what scale 2 already does.
+    if !run.status.success() {
+        return;
+    }
+    // It ran. Then the values must be intact. DuckDB, not the parquet crate
+    // rivet wrote with.
+    let got = duckdb_dir_parquet_distinct_strings(out.path(), "CAST(amount AS VARCHAR)");
+    let truncated: Vec<&String> = got.iter().filter(|s| !s.contains('.')).collect();
+    assert!(
+        truncated.is_empty(),
+        "a scale-0 `columns:` override exported {} of {} values with the fractional part REMOVED, \
+         and the run exited 0 with no warning: {:?}\n\n\
+         The same override one scale over refuses: `numeric(18,6)` -> `decimal(20,2)` fails the \
+         run with `cannot parse DECIMAL \"1.234567\" as decimal(scale=2)`. The loss is identical \
+         in kind; only the target scale differs. src/types/decimal.rs short-circuits scale 0 \
+         (line 95, and the i256 twin at 161) before the lossy-down-scale guard whose own comment \
+         says it exists \"rather than silently truncating financial digits\".",
+        truncated.len(),
+        got.len(),
+        got
+    );
+}

--- a/tests/live/audit_plan_apply.rs
+++ b/tests/live/audit_plan_apply.rs
@@ -377,3 +377,133 @@ exports:
         "a run whose manifest did not land must not report success; stderr:\n{stderr}"
     );
 }
+
+// ─── the drift gate must survive the plan → apply handoff ────────────────────
+
+/// `on_schema_drift: fail` must mean the same thing whether the export is run
+/// directly or applied from a plan artifact.
+///
+/// The gate lives inside `prepare_chunk_plan` (src/pipeline/chunked/mod.rs:186,
+/// the sole caller of `check_from_type_mappings`), which only the
+/// `ChunkSource::Detect` arm reaches. `rivet apply plan.json` supplies
+/// `ChunkSource::Precomputed` for any artifact carrying chunk ranges, and all
+/// four chunked runners then set `summary.chunks_precomputed = true` with the
+/// comment `// drift gate skipped by contract`.
+///
+/// The contract they cite is "drift was evaluated on the original planning run
+/// that produced the ranges". That is not what happens: `src/plan/` contains no
+/// drift evaluation at all — `plan/build.rs:153` only COPIES the policy
+/// (`schema_drift_policy: export.on_schema_drift`) into the artifact. And even a
+/// planning-time evaluation would not help, because the drift this guards
+/// against happens BETWEEN plan and apply. That window is the entire reason the
+/// plan → review → apply workflow exists.
+///
+/// Measured on this stand — one config, one source state, `on_schema_drift:
+/// fail`, a column dropped after the plan was sealed:
+///
+///   rivet run    ERROR schema drift detected — aborting (on_schema_drift: fail)
+///                      removed: dropme
+///   rivet apply  status: success, 500 rows
+///
+/// The `run` arm is the CONTROL and it is what makes this a contradiction rather
+/// than an observation: the same policy, the same drift, refused one way and
+/// honoured the other. The non-chunked half of `apply` also applies the gate
+/// (single.rs:481), so the split is not even "apply skips it" — it is "apply
+/// skips it for chunked exports", which are the ones moving the most data.
+// AUDIT-RED plan-apply-drift: `apply` of a chunked plan skips `on_schema_drift`, exporting against a changed source and exiting 0, while `run` with the same config refuses. Asserts CORRECT behavior; expected to FAIL until fixed.
+#[test]
+#[ignore = "live: requires docker compose postgres"]
+fn audit_apply_honours_on_schema_drift_for_a_chunked_plan() {
+    require_alive(LiveService::Postgres);
+
+    let table = unique_name("audit_drift");
+    let mut c = postgres::Client::connect(POSTGRES_URL, postgres::NoTls).expect("connect");
+    c.batch_execute(&format!(
+        "CREATE TABLE {table} (id int PRIMARY KEY, keepme text, dropme text);
+         INSERT INTO {table} SELECT g, 'k'||g, 'd'||g FROM generate_series(1,500) g;"
+    ))
+    .expect("seed");
+    let _guard = PgTable::adopt(table.clone());
+
+    let out = tempfile::tempdir().unwrap();
+    let cfgdir = tempfile::tempdir().unwrap();
+    let yaml = format!(
+        r#"
+source: {{type: postgres, url_env: DATABASE_URL}}
+exports:
+  - name: {table}
+    table: "public.{table}"
+    mode: chunked
+    chunk_column: id
+    chunk_size: 100
+    on_schema_drift: fail
+    format: parquet
+    destination: {{type: local, path: {dir}}}
+"#,
+        dir = out.path().display()
+    );
+    let cfg = write_config(&cfgdir, &yaml);
+    let env = [("DATABASE_URL", POSTGRES_URL)];
+
+    // 1. A first run records the schema the drift gate will compare against.
+    let first = run_rivet_env(&["run", "--config", cfg.to_str().unwrap()], &env);
+    assert!(
+        first.status.success(),
+        "first run must succeed; stderr:\n{}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+
+    // 2. Seal a plan against that schema.
+    let plan = cfgdir.path().join("plan.json");
+    let planned = run_rivet_env(
+        &[
+            "plan",
+            "--config",
+            cfg.to_str().unwrap(),
+            "--output",
+            plan.to_str().unwrap(),
+            "--format",
+            "json",
+        ],
+        &env,
+    );
+    assert!(
+        planned.status.success() && plan.is_file(),
+        "plan must be written; stderr:\n{}",
+        String::from_utf8_lossy(&planned.stderr)
+    );
+
+    // 3. The source changes between review and execution — the window the
+    //    plan/apply workflow is FOR.
+    c.batch_execute(&format!("ALTER TABLE {table} DROP COLUMN dropme"))
+        .expect("drop column");
+
+    // 4. CONTROL: the same config, run directly, must refuse. If this passes,
+    //    the fixture never produced drift and the apply arm below proves nothing.
+    let control = run_rivet_env(&["run", "--config", cfg.to_str().unwrap()], &env);
+    let control_text = String::from_utf8_lossy(&control.stderr).into_owned();
+    assert!(
+        !control.status.success() && control_text.contains("schema drift"),
+        "fixture is inert: `rivet run` did NOT refuse after the column was dropped, so there is \
+         no drift for `apply` to skip.\nstderr:\n{control_text}"
+    );
+
+    // 5. The same policy, the same drift, through the plan artifact.
+    let applied = run_rivet_env(&["apply", plan.to_str().unwrap()], &env);
+    let applied_text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&applied.stdout),
+        String::from_utf8_lossy(&applied.stderr)
+    );
+    assert!(
+        !applied.status.success(),
+        "`rivet apply` of a CHUNKED plan exported against a source whose schema had changed and \
+         exited 0, while `rivet run` with the SAME config and the SAME `on_schema_drift: fail` \
+         refused the identical drift (control arm above). The gate lives in `prepare_chunk_plan`, \
+         which only the `Detect` arm reaches; a precomputed artifact sets \
+         `chunks_precomputed = true` and skips it \"by contract\". The cited contract — that \
+         drift was evaluated on the planning run — does not hold: `src/plan/` evaluates no \
+         drift, it only copies the policy, and the drift here happened AFTER the plan was \
+         sealed.\n\napply said:\n{applied_text}"
+    );
+}

--- a/tests/live/audit_plan_apply.rs
+++ b/tests/live/audit_plan_apply.rs
@@ -495,8 +495,13 @@ exports:
         String::from_utf8_lossy(&applied.stdout),
         String::from_utf8_lossy(&applied.stderr)
     );
+    // Asserting only "did not succeed" would pass on ANY failure — including the
+    // post-run invariant that also fires when the gate is absent. Measured: with
+    // the gate removed the run still failed, and this test still went green, for
+    // entirely the wrong reason. It must fail ON DRIFT.
+    let refused_for_drift = !applied.status.success() && applied_text.contains("schema drift");
     assert!(
-        !applied.status.success(),
+        refused_for_drift,
         "`rivet apply` of a CHUNKED plan exported against a source whose schema had changed and \
          exited 0, while `rivet run` with the SAME config and the SAME `on_schema_drift: fail` \
          refused the identical drift (control arm above). The gate lives in `prepare_chunk_plan`, \

--- a/tests/live/audit_preflight_table.rs
+++ b/tests/live/audit_preflight_table.rs
@@ -212,3 +212,140 @@ fn audit_chunked_table_shortcut_reports_cursor_range() {
          (orders.id spans 1..{SEEDED_ROWS}); it was missing.\nfull check output:\n{stdout}"
     );
 }
+
+// ─── check must not bless what plan refuses ──────────────────────────────────
+
+/// Run `rivet plan` on a config and report whether it was accepted, with the
+/// reason when it was not. `plan` is the runner's own gate: `apply` executes the
+/// artifact it produces, so a config `plan` rejects is a config that cannot run.
+fn plan_verdict(config_path: &std::path::Path) -> Result<(), String> {
+    let out = std::process::Command::new(RIVET_BIN)
+        .args(["plan", "--config", config_path.to_str().unwrap()])
+        .env("DATABASE_URL", POSTGRES_URL)
+        .output()
+        .expect("spawn rivet plan");
+    if out.status.success() {
+        return Ok(());
+    }
+    let err = String::from_utf8_lossy(&out.stderr);
+    let msg = err
+        .lines()
+        .find(|l| l.starts_with("Error:"))
+        .unwrap_or_else(|| err.lines().last().unwrap_or(""));
+    Err(msg.trim().to_string())
+}
+
+/// Like [`run_check`] but reports the exit status instead of asserting it, so
+/// the two commands can be COMPARED rather than one of them assumed green.
+fn check_accepts(config_path: &std::path::Path, export_name: &str) -> bool {
+    std::process::Command::new(RIVET_BIN)
+        .args([
+            "check",
+            "--config",
+            config_path.to_str().unwrap(),
+            "--export",
+            export_name,
+        ])
+        .env("DATABASE_URL", POSTGRES_URL)
+        .output()
+        .expect("spawn rivet check")
+        .status
+        .success()
+}
+
+/// Every config `check` blesses must be one `plan` will accept.
+///
+/// `check` is a PREFLIGHT: an operator runs it, reads `Verdict: ACCEPTABLE`,
+/// and schedules the export. If the runner then refuses the same file, the
+/// preflight has spent the operator's trust on a config that cannot run — the
+/// diagnostic-bypass class, in its sharpest form. It is not that `check`
+/// mis-analyses something; it is that `check` and the runner disagree about
+/// whether the config is legal at all.
+///
+/// Found live 2026-08-05 while diagnosing a field run. `chunk_size_memory_mb`
+/// on a `query:`-form export (no `table:`) is refused by `plan::build` —
+/// "`chunk_size_memory_mb:` only applies with the `table:` shortcut" — because
+/// there is no relation to probe for the row width the budget divides by.
+/// `check` printed `Strategy: chunked(id, size=100000)` and `Verdict:
+/// ACCEPTABLE` for the same file: it neither applied the budget nor noticed it
+/// could not.
+///
+/// The size in that Strategy line is the second tell — 100000 is the config
+/// DEFAULT, printed unchanged at every budget, so even where the budget IS
+/// legal the line does not describe what will run.
+///
+/// Deliberately a MATRIX over shapes rather than one case: the invariant is
+/// "check and plan agree", and a single case pins one bug instead of the
+/// property. Shapes that BOTH reject are fine — the guard is one-directional.
+/// The matrix earned that immediately: it found a SECOND disagreement nobody
+/// was looking for — `query:` + `chunk_by_key`, where keyset needs the relation
+/// to verify the unique index and `check` blesses it anyway.
+// AUDIT-RED preflight/planner-agreement: `check` accepts `query:` + `chunk_size_memory_mb` and `query:` + `chunk_by_key`, both of which `plan` refuses. Asserts CORRECT behavior; expected to FAIL until fixed.
+#[test]
+#[ignore = "live: postgres"]
+fn check_must_not_accept_a_config_the_planner_refuses() {
+    require_alive(LiveService::Postgres);
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = dir.path().join("out");
+
+    // (label, config body) — every shape an operator plausibly writes around the
+    // width-aware knob, in both source forms.
+    let shapes: Vec<(&str, String)> = vec![
+        (
+            "table: + chunk_column + chunk_size_memory_mb",
+            config_table_form(
+                &out,
+                "t",
+                "mode: chunked\n    chunk_column: id\n    chunk_size_memory_mb: 64",
+            ),
+        ),
+        (
+            "query: + chunk_column + chunk_size_memory_mb",
+            config_query_form(
+                &out,
+                "t",
+                "mode: chunked\n    chunk_column: id\n    chunk_size_memory_mb: 64",
+            ),
+        ),
+        (
+            "table: + chunk_by_key + chunk_size_memory_mb",
+            config_table_form(
+                &out,
+                "t",
+                "mode: chunked\n    chunk_by_key: id\n    chunk_size_memory_mb: 64",
+            ),
+        ),
+        (
+            "query: + chunk_by_key (keyset needs the relation)",
+            config_query_form(&out, "t", "mode: chunked\n    chunk_by_key: id"),
+        ),
+        (
+            "table: + plain chunk_size (the shape init emits)",
+            config_table_form(
+                &out,
+                "t",
+                "mode: chunked\n    chunk_column: id\n    chunk_size: 500",
+            ),
+        ),
+    ];
+
+    let mut disagreements = Vec::new();
+    for (label, body) in &shapes {
+        let cfg = dir.path().join("c.yaml");
+        std::fs::write(&cfg, body).expect("write config");
+        let checked = check_accepts(&cfg, "t");
+        let planned = plan_verdict(&cfg);
+        if let (true, Err(why)) = (checked, &planned) {
+            disagreements.push(format!("  {label}\n      plan: {why}"));
+        }
+    }
+
+    assert!(
+        disagreements.is_empty(),
+        "`rivet check` accepted {} config(s) that `rivet plan` refuses — a preflight that \
+         blesses an unrunnable config is worse than no preflight, because the operator \
+         stops looking:\n{}",
+        disagreements.len(),
+        disagreements.join("\n")
+    );
+}

--- a/tests/live/audit_rerun.rs
+++ b/tests/live/audit_rerun.rs
@@ -240,3 +240,121 @@ fn audit_chunked_rerun_does_not_double() {
          and the second run neither refused nor warned.\nstderr:\n{second_stderr}"
     );
 }
+
+// ─── (c) a healthy no-op run must not clobber the canonical manifest ─────────
+
+/// An incremental run that finds nothing new is a HEALTHY outcome, and it must
+/// not leave the prefix describing itself as interrupted.
+///
+/// `finalize_manifest` maps the run's status with
+/// `match summary.status.as_str() { "success" => Success, "failed" => Failed,
+/// _ => Interrupted }` (src/pipeline/finalize.rs:181-185). But `"skipped"` is a
+/// real production value: `single.rs:361` sets it for a completely healthy run
+/// that read 0 rows under `skip_empty: true`, and nothing rewrites it before
+/// finalize. So the healthy no-op falls through the `_` arm.
+///
+/// `write_manifest` then sets `emit_success_marker = matches!(status, Success)`
+/// — false — while still passing `write_canonical = true`
+/// (manifest_writer.rs:358-360), so the canonical `manifest.json` is
+/// OVERWRITTEN with an `interrupted`, zero-part document and the `_SUCCESS`
+/// marker from the previous good run is left in place, now stale.
+///
+/// Measured on this stand — incremental into a stable prefix, `skip_empty: true`:
+///
+///   run 1 (10 rows)      manifest.json  success      1 part   10 rows   _SUCCESS ✓
+///   run 2 (no new rows)  manifest.json  interrupted  0 parts   0 rows   _SUCCESS ✓ stale
+///   on disk after both:  1 parquet holding the 10 rows
+///
+/// and the consequence, from rivet's own verifier:
+///
+///   _SUCCESS:  INCONSISTENT
+///   failure:   [RIVET_VERIFY_SUCCESS_STALE] _SUCCESS body … != manifest fingerprint …
+///   warning:   [RIVET_VERIFY_UNTRACKED_OBJECT] untracked object: …parquet (1669 bytes)
+///   Error: rivet validate: 1 export(s) failed verification
+///
+/// The delivered rows become an "untracked object" and the export stops passing
+/// verification — after a run that did nothing wrong. The run-unique manifest
+/// copies both survive, so the data is recoverable; the canonical pointer and
+/// the marker are what desync.
+///
+/// Asserted on `validate`'s verdict rather than on the manifest's status string:
+/// what matters is that a healthy no-op leaves a prefix a consumer still trusts,
+/// not which enum arm it took to get there.
+// AUDIT-RED skipped-status-fallthrough: a healthy `skipped` run writes an `interrupted` canonical manifest over a good one and leaves a stale _SUCCESS, so validate fails. Asserts CORRECT behavior; expected to FAIL until fixed.
+#[test]
+#[ignore = "live: requires docker compose postgres"]
+fn audit_a_healthy_noop_run_does_not_invalidate_the_prefix() {
+    require_alive(LiveService::Postgres);
+
+    let table = seed_pg_numeric_table(10);
+    let out = tempfile::tempdir().unwrap();
+    let cfg_dir = tempfile::tempdir().unwrap();
+    let yaml = format!(
+        r#"
+source:
+  type: postgres
+  url: "{POSTGRES_URL}"
+
+exports:
+  - name: {name}
+    table: "public.{name}"
+    mode: incremental
+    cursor_column: created_at
+    skip_empty: true
+    format: parquet
+    destination:
+      type: local
+      path: {out}
+"#,
+        name = table.name(),
+        out = out.path().display()
+    );
+    let cfg = write_config(&cfg_dir, &yaml);
+
+    let first = run_rivet_with_warn_log(&["run", "--config", cfg.to_str().unwrap()]);
+    assert!(
+        first.status.success(),
+        "first run must succeed; stderr:\n{}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    let rows_after_first = duckdb_total_parquet_rows(out.path());
+    assert!(
+        rows_after_first > 0,
+        "fixture is inert: the first run wrote no rows, so the second cannot be a no-op over \
+         anything worth protecting"
+    );
+
+    // Second run: nothing new past the cursor. This is the healthy path.
+    let second = run_rivet_with_warn_log(&["run", "--config", cfg.to_str().unwrap()]);
+    assert!(
+        second.status.success(),
+        "the no-op run must succeed; stderr:\n{}",
+        String::from_utf8_lossy(&second.stderr)
+    );
+
+    // The data is still there — the question is whether the prefix still says so.
+    assert_eq!(
+        duckdb_total_parquet_rows(out.path()),
+        rows_after_first,
+        "the no-op run changed the data on disk"
+    );
+
+    let v = std::process::Command::new(RIVET_BIN)
+        .args(["validate", "--config", cfg.to_str().unwrap()])
+        .output()
+        .expect("spawn rivet validate");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&v.stdout),
+        String::from_utf8_lossy(&v.stderr)
+    );
+    assert!(
+        v.status.success(),
+        "after a HEALTHY no-op incremental run (nothing new past the cursor), the prefix no \
+         longer verifies. `finalize_manifest` maps the run's `skipped` status through its `_` arm \
+         to `Interrupted`, so the canonical manifest.json is overwritten with a zero-part \
+         interrupted document while the previous run's _SUCCESS marker is left behind, now \
+         stale. The {rows_after_first} delivered row(s) are still on disk and are reported as an \
+         untracked object.\n\nvalidate said:\n{text}"
+    );
+}

--- a/tests/live/audit_rerun.rs
+++ b/tests/live/audit_rerun.rs
@@ -70,7 +70,7 @@ exports:
 
 /// Total Parquet rows across every `*.parquet` file directly under `dir`.
 /// Mirrors what a glob reader (`read_parquet('<dir>/*.parquet')`) would count.
-fn total_parquet_rows(dir: &Path) -> i64 {
+fn duckdb_total_parquet_rows(dir: &Path) -> i64 {
     let mut total = 0i64;
     for path in files_with_extension(dir, "parquet") {
         let bytes =
@@ -204,7 +204,7 @@ fn audit_chunked_rerun_does_not_double() {
         String::from_utf8_lossy(&first.stderr)
     );
     assert_eq!(
-        total_parquet_rows(out.path()),
+        duckdb_total_parquet_rows(out.path()),
         ROWS,
         "sanity: after one chunked run the prefix must hold exactly {ROWS} rows"
     );
@@ -232,7 +232,7 @@ fn audit_chunked_rerun_does_not_double() {
 
     // Otherwise: a glob reader over the prefix must see exactly the source row
     // count, not 2x.  Currently the orphaned first-run parts double it.
-    let rows_on_disk = total_parquet_rows(out.path());
+    let rows_on_disk = duckdb_total_parquet_rows(out.path());
     assert_eq!(
         rows_on_disk, ROWS,
         "silent re-run doubling: a glob over the prefix counts {rows_on_disk} rows after two \

--- a/tests/live/chunking_stand.rs
+++ b/tests/live/chunking_stand.rs
@@ -1735,3 +1735,120 @@ fn stand_environment_profile_mysql() {
 fn stand_environment_profile_mssql() {
     run_environment_profile(Eng::Ms);
 }
+
+// ─── range bounds that cannot be read must not become an empty export ────────
+
+/// A range-chunked export whose min/max the planner cannot read as `i64` must
+/// NOT report success having written nothing.
+///
+/// `detect::detect` reads the window bounds as
+/// `src.query_scalar(min|max)?.and_then(|s| s.trim().parse::<i64>().ok()).unwrap_or(0)`
+/// (src/pipeline/chunked/detect.rs:316-323). Three different inputs land on the
+/// same `0`, and only the first is legitimate:
+///
+///   1. the scalar is NULL — the table really is empty, one empty window is right;
+///   2. the text does not parse as `i64` — a DECIMAL/NUMERIC/float key;
+///   3. `query_scalar` cannot render the type at all — PostgreSQL's
+///      (src/source/postgres/mod.rs) tries i64, i32, f64, timestamp, date, uuid,
+///      String and falls through to `Ok(None)`; NUMERIC matches no arm.
+///
+/// With min = max = 0 the plan is the single window `(0, 0)` and the runner
+/// emits `WHERE col BETWEEN 0 AND 0`. PostgreSQL compares numeric to integer
+/// happily, so the query is VALID and returns nothing: the export writes no
+/// parts and reports `status: success`, exit 0.
+///
+/// Measured on this stand, `numeric(20,0)` PK with 100 rows:
+///   `chunk_column `id` range 0 .. 0` → `0 rows  0 files  0 B` → `status: success`
+/// One hundred rows of a hundred, gone, with a green run.
+///
+/// PER-ENGINE, and the matrix is what established it: only PostgreSQL goes RED.
+/// MySQL and SQL Server return the DECIMAL bound as the text `"1"`, which parses
+/// as `i64` and chunks correctly — they are the CONTROL arms here, not padding.
+/// PostgreSQL is alone in case 3: its `query_scalar` renders no numeric OID at
+/// all, so the bound never reaches the parser. Stating this as "decimal keys are
+/// broken" would have been wrong on two engines out of three; the engine axis is
+/// what made the claim precise enough to act on.
+///
+/// The plan-time guard does not save it: `build.rs` only verifies the column is
+/// integer-family when introspection SUCCEEDED, and the `query:`-form path warns
+/// and emits the Chunked plan anyway. The warning is also wrong about the
+/// damage — it says "silently drops rows between windows" when the outcome is
+/// every row.
+///
+/// Two things in the same file show this is an oversight, not a decision. Sixty
+/// lines above, the DATE branch hard-errors on both a NULL bound and an
+/// unparseable one (detect.rs:240-266). And the shared, error-RETURNING
+/// `parse_scalar_i64` (src/scalar.rs:52) is used at detect.rs:25 for the
+/// `COUNT(*)` — where a wrong value is harmless — and not for the bounds, where
+/// it is catastrophic.
+///
+/// The existing unit test `integer_range_null_minmax_collapses_to_zero_zero`
+/// pins case 1 with `null(), null()`, which is correct for an EMPTY table. No
+/// test covers a NON-empty table whose bounds cannot be read — that is the hole
+/// this fills.
+// AUDIT-RED chunk-bounds-collapse: unreadable min/max → `unwrap_or(0)` → one `BETWEEN 0 AND 0` window → 0 of N rows exported, status success, exit 0. Asserts CORRECT behavior; expected to FAIL until fixed.
+fn run_unreadable_range_bounds_must_not_export_nothing(eng: Eng) {
+    eng.require();
+    const ROWS: i64 = 100;
+    let (table, _guard) = seed_decimal_pk(eng, ROWS);
+
+    // `query:` rather than `table:` on purpose: with `table:` the planner
+    // introspects the column type and refuses at plan time, which is the
+    // behaviour we WANT. The curated-query form is what `rivet init` emits for
+    // every non-keyset chunked export, and it is the shape that reaches the
+    // runner unchecked.
+    let rig = eng
+        .rig(&table)
+        .mode("chunked")
+        .query(&format!("SELECT dkey, v FROM {table}"))
+        .export_line("chunk_column: dkey")
+        .export_line("chunk_size: 10");
+    let cfg = rig.config_path();
+    let out = run_rivet_env(
+        &["run", "--config", cfg.to_str().unwrap()],
+        &[("RUST_LOG", "warn")],
+    );
+
+    // Either outcome is acceptable — refuse loudly, or export the rows. What
+    // must never happen is the third: exit 0 having written nothing.
+    if !out.status.success() {
+        return; // refused: correct
+    }
+    // DuckDB, not the parquet crate rivet wrote with: a symmetric read/write
+    // fault cannot be seen by the reader that shares the writer's code.
+    let got = duckdb_total_parquet_rows(&rig.out_dir()) as i64;
+    assert_eq!(
+        got,
+        ROWS,
+        "range-chunked export of {ROWS} rows on a {} DECIMAL key reported SUCCESS but wrote \
+         {} row(s). The bounds could not be parsed as i64, so both collapsed to 0 and the plan \
+         became the single window `BETWEEN 0 AND 0`. A run that exits 0 having exported nothing \
+         is the worst of the three possible outcomes: refusing would be safe, exporting would be \
+         correct, and this is neither.\nstderr:\n{}",
+        match eng {
+            Eng::Pg => "PostgreSQL numeric",
+            Eng::My => "MySQL decimal",
+            Eng::Ms => "SQL Server decimal",
+        },
+        got,
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+#[ignore = "live: requires docker compose up -d postgres"]
+fn stand_unreadable_range_bounds_must_not_export_nothing_postgres() {
+    run_unreadable_range_bounds_must_not_export_nothing(Eng::Pg);
+}
+
+#[test]
+#[ignore = "live: requires docker compose up -d mysql"]
+fn stand_unreadable_range_bounds_must_not_export_nothing_mysql() {
+    run_unreadable_range_bounds_must_not_export_nothing(Eng::My);
+}
+
+#[test]
+#[ignore = "live: requires docker compose up -d mssql"]
+fn stand_unreadable_range_bounds_must_not_export_nothing_mssql() {
+    run_unreadable_range_bounds_must_not_export_nothing(Eng::Ms);
+}

--- a/tests/live/chunking_stand.rs
+++ b/tests/live/chunking_stand.rs
@@ -1108,9 +1108,24 @@ fn stand_time_window_mssql() {
 /// the columns actually land in a real export (previously unit-only).
 fn run_meta_columns(eng: Eng) {
     eng.require();
-    let (table, _guard) = seed_dense(eng, 200);
+    // The GOLDEN TYPE MATRIX, not `seed_dense`.
+    //
+    // This used to run over `seed_dense` — two columns, `BIGINT` and `INT` — so
+    // it proved the meta columns LAND and nothing about what they contain. The
+    // gap was not theoretical: `_rivet_row_hash` could not render a timestamp
+    // whose timezone is a NAME (`Some("UTC")` — what a MySQL `TIMESTAMP` maps
+    // to), and on a production config that cost 63 of 65 exports on 2026-08-05.
+    // The matrix has carried `created_at_ts TIMESTAMP(6)` the whole time; this
+    // test simply never looked at it, so four months of green meant only that
+    // two integers could be hashed.
+    //
+    // Measured on the type matrix's real output: `created_at_dt` is a naive
+    // TIMESTAMP and `created_at_ts` is TIMESTAMP WITH TIME ZONE — both forms in
+    // one export, which is the point.
+    let table = "rivet_type_matrix".to_string();
     let rig = eng
         .rig(&table)
+        .duckdb_oracle()
         .mode("full")
         .export_line("meta_columns:")
         .export_line("  exported_at: true")
@@ -1133,6 +1148,38 @@ fn run_meta_columns(eng: Eng) {
     assert!(
         cols.iter().any(|c| c == "_rivet_row_hash"),
         "output must carry _rivet_row_hash; got {cols:?}"
+    );
+    // PRESENCE is not content. The column landed for four months while the
+    // temporal cells contributed NOTHING to it — before 2026-08-04 an
+    // unrenderable value was swallowed (`.ok()` → skip), so two rows differing
+    // only in a timestamp hashed identically. Assert the matrix's own temporal
+    // columns are in the export AND that the hash actually varies across its
+    // rows, which it cannot do if the cells were dropped.
+    // Assert the PROPERTY, not a column name: the three engines name their
+    // temporal columns differently (`created_at_ts` on MySQL, `created_at_tz`
+    // on PostgreSQL), and a name list would pass on one engine and lie on the
+    // others. What must hold everywhere is that the export carries a
+    // TIMEZONE-AWARE timestamp — the exact shape `row_hash` could not render.
+    let dir = rig.oracle_dir();
+    let described = duckdb_run_sql_json(&format!(
+        "DESCRIBE SELECT * FROM read_parquet('{dir}/**/*.parquet')"
+    ));
+    let schema = duckdb_parse_describe(&described);
+    assert!(
+        schema.values().any(|t| t.contains("WITH TIME ZONE")),
+        "the type matrix must contribute a TIMEZONE-AWARE timestamp — that is the \
+         shape row_hash could not render, and hashing it is the point of this test; \
+         got {schema:?}"
+    );
+    // Read back with DuckDB — a decoder rivet does not share — so the claim is
+    // not rivet re-reading its own rendering.
+    let rows = duckdb_parquet_rows(dir);
+    let distinct = duckdb_parquet_distinct(dir, "_rivet_row_hash");
+    assert_eq!(
+        distinct, rows,
+        "{rows} matrix rows produced {distinct} distinct hashes — equal rows with fewer \
+         distinct hashes is exactly what a SWALLOWED cell looks like: the differing \
+         column contributed nothing"
     );
 }
 
@@ -1164,6 +1211,24 @@ fn run_csv(eng: Eng) {
 #[ignore = "live: requires docker compose up -d postgres"]
 fn stand_meta_columns_postgres() {
     run_meta_columns(Eng::Pg);
+}
+
+// Per ENGINE, not one standing in for three. `meta_columns` is engine-agnostic
+// enrichment, which is why this ran on PostgreSQL alone — but the TYPE it must
+// survive is not: a MySQL `TIMESTAMP` and a SQL Server `DATETIME2` resolve
+// through different mappings to reach `Some("UTC")`, and the production failure
+// that motivated this test was on MySQL, the one engine it did not cover.
+
+#[test]
+#[ignore = "live: requires docker compose up -d mysql"]
+fn stand_meta_columns_mysql() {
+    run_meta_columns(Eng::My);
+}
+
+#[test]
+#[ignore = "live: requires docker compose up -d mssql"]
+fn stand_meta_columns_mssql() {
+    run_meta_columns(Eng::Ms);
 }
 
 #[test]

--- a/tests/live/chunking_stand.rs
+++ b/tests/live/chunking_stand.rs
@@ -1852,3 +1852,165 @@ fn stand_unreadable_range_bounds_must_not_export_nothing_mysql() {
 fn stand_unreadable_range_bounds_must_not_export_nothing_mssql() {
     run_unreadable_range_bounds_must_not_export_nothing(Eng::Ms);
 }
+
+// ─── a PARTIAL unique index is not a unique key ──────────────────────────────
+
+/// Seed the soft-delete shape: a column carrying duplicates, plus a unique index
+/// that only covers the live rows.
+///
+/// `dups` rows share one key value and are all soft-deleted, so the partial index
+/// permits them; `live` rows have distinct keys and `deleted_at IS NULL`. On
+/// MySQL — which cannot express a partial index at all — the closest honest
+/// equivalent is a plain NON-unique index, which is the control this matrix
+/// needs: the probe must refuse that key.
+fn seed_partial_unique(eng: Eng, dups: i64, live: i64) -> (String, StandCleanup) {
+    let table = unique_name("stand_partuk");
+    let guard = StandCleanup(eng, table.clone());
+    match eng {
+        Eng::Pg => {
+            let mut c = pg_connect();
+            c.batch_execute(&format!(
+                "CREATE TABLE {table} (k TEXT NOT NULL, deleted_at TIMESTAMPTZ, v TEXT NOT NULL);
+                 INSERT INTO {table} SELECT 'dup', now(), 'd'||g FROM generate_series(1,{dups}) g;
+                 INSERT INTO {table} SELECT 'u'||lpad(g::text,4,'0'), NULL, 'l'||g
+                   FROM generate_series(1,{live}) g;
+                 CREATE UNIQUE INDEX {table}_live ON {table} (k) WHERE deleted_at IS NULL;
+                 ANALYZE {table};"
+            ))
+            .unwrap();
+        }
+        Eng::My => {
+            let mut c = mysql_connect();
+            c.query_drop(format!(
+                "CREATE TABLE {table} (k VARCHAR(64) NOT NULL, deleted_at DATETIME NULL, \
+                 v VARCHAR(32) NOT NULL, KEY {table}_k (k))"
+            ))
+            .unwrap();
+            c.query_drop(format!(
+                "SET SESSION cte_max_recursion_depth = {}",
+                dups + live + 10
+            ))
+            .unwrap();
+            c.query_drop(format!(
+                "INSERT INTO {table} (k, deleted_at, v) \
+                 WITH RECURSIVE s AS (SELECT 1 n UNION ALL SELECT n+1 FROM s WHERE n < {dups}) \
+                 SELECT 'dup', NOW(), CONCAT('d', n) FROM s"
+            ))
+            .unwrap();
+            c.query_drop(format!(
+                "INSERT INTO {table} (k, deleted_at, v) \
+                 WITH RECURSIVE s AS (SELECT 1 n UNION ALL SELECT n+1 FROM s WHERE n < {live}) \
+                 SELECT CONCAT('u', LPAD(n, 4, '0')), NULL, CONCAT('l', n) FROM s"
+            ))
+            .unwrap();
+        }
+        Eng::Ms => {
+            mssql_exec(&format!(
+                "CREATE TABLE {table} (k VARCHAR(64) NOT NULL, deleted_at DATETIME2 NULL, \
+                 v VARCHAR(32) NOT NULL)"
+            ));
+            mssql_exec(&format!(
+                "INSERT INTO {table} (k, deleted_at, v) SELECT 'dup', SYSDATETIME(), \
+                 CONCAT('d', value) FROM GENERATE_SERIES(CAST(1 AS BIGINT), CAST({dups} AS BIGINT))"
+            ));
+            mssql_exec(&format!(
+                "INSERT INTO {table} (k, deleted_at, v) \
+                 SELECT CONCAT('u', RIGHT('0000' + CAST(value AS VARCHAR(8)), 4)), NULL, \
+                 CONCAT('l', value) FROM GENERATE_SERIES(CAST(1 AS BIGINT), CAST({live} AS BIGINT))"
+            ));
+            // A FILTERED unique index — SQL Server's spelling of a partial index.
+            mssql_exec(&format!(
+                "CREATE UNIQUE INDEX {table}_live ON {table} (k) WHERE deleted_at IS NULL"
+            ));
+            mssql_exec(&format!("UPDATE STATISTICS {table}"));
+        }
+    }
+    (table, guard)
+}
+
+/// A keyset key backed only by a PARTIAL (filtered) unique index must not be
+/// accepted — the index does not make the key unique over the rows being read.
+///
+/// Keyset's entire correctness argument is that the key is GLOBALLY unique, so
+/// `WHERE k > <last> ORDER BY k LIMIT n` cannot skip a row sharing the boundary
+/// key. The introspection that is supposed to supply that guarantee asks
+/// `i.indisunique AND i.indnkeyatts = 1 AND a.attnotnull` on PostgreSQL
+/// (src/source/postgres/mod.rs:380) and `i.is_unique = 1 AND c.is_nullable = 0`
+/// on SQL Server (src/source/mssql/mod.rs:1132). Neither excludes a PARTIAL /
+/// FILTERED index — `i.indpred IS NOT NULL` on PG, `i.has_filter = 1` on MSSQL —
+/// and PG additionally never checks `i.indisvalid`.
+///
+/// The shape is not exotic; it is the standard soft-delete index:
+///   `CREATE UNIQUE INDEX ON users (email) WHERE deleted_at IS NULL`
+/// Duplicates are legal among the soft-deleted rows, so a run of them straddles
+/// a page boundary and everything past the first page is skipped.
+///
+/// Measured on this stand (postgres, 50 duplicate + 50 distinct, page size 10):
+///   `rivet check` → `Strategy: keyset(k, size=10)`, `Verdict: ACCEPTABLE`
+///   `rivet run`   → `status: success`, 60 of 100 rows
+/// and the reason the loss survives every ordinary check: the duplicate key
+/// contributes exactly ONE page (10 of its 50 rows), so all 51 DISTINCT key
+/// values are present. A `count(DISTINCT k)` comparison against the source
+/// matches perfectly while 40 rows are gone.
+///
+/// MySQL is the CONTROL arm, not padding: it cannot express a partial index, so
+/// its `NON_UNIQUE = 0` genuinely means globally unique and the equivalent seed
+/// (a plain non-unique index) must be REFUSED. The guard is real on the one
+/// engine that never needed it.
+// AUDIT-RED keyset-partial-unique: a partial/filtered unique index is accepted as a keyset key; duplicates past the first page are dropped, status success. Asserts CORRECT behavior; expected to FAIL until fixed.
+fn run_partial_unique_index_is_not_a_keyset_key(eng: Eng) {
+    eng.require();
+    const DUPS: i64 = 50;
+    const LIVE: i64 = 50;
+    let (table, _guard) = seed_partial_unique(eng, DUPS, LIVE);
+
+    let rig = eng
+        .rig(&table)
+        .mode("chunked")
+        .export_line("chunk_by_key: k")
+        .export_line("chunk_size: 10");
+    let cfg = rig.config_path();
+    let out = run_rivet_env(
+        &["run", "--config", cfg.to_str().unwrap()],
+        &[("RUST_LOG", "warn")],
+    );
+
+    // Refusing is the correct outcome — the key is not unique over the read set.
+    if !out.status.success() {
+        return;
+    }
+    // If it ran, it must have read EVERY row. DuckDB, not the parquet crate
+    // rivet wrote with.
+    let got = duckdb_total_parquet_rows(&rig.out_dir()) as i64;
+    assert_eq!(
+        got,
+        DUPS + LIVE,
+        "keyset over a key backed only by a PARTIAL/FILTERED unique index reported SUCCESS with \
+         {} of {} rows. {} duplicate rows share one key; the seek emits one page of them and then \
+         asks for `k > <that key>`, dropping the rest. The loss is invisible to a DISTINCT check \
+         — every distinct key value is still present — so counts of distinct values agree with \
+         the source while whole rows are gone.\nstderr:\n{}",
+        got,
+        DUPS + LIVE,
+        DUPS,
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+#[ignore = "live: requires docker compose up -d postgres"]
+fn stand_partial_unique_index_is_not_a_keyset_key_postgres() {
+    run_partial_unique_index_is_not_a_keyset_key(Eng::Pg);
+}
+
+#[test]
+#[ignore = "live: requires docker compose up -d mysql"]
+fn stand_partial_unique_index_is_not_a_keyset_key_mysql() {
+    run_partial_unique_index_is_not_a_keyset_key(Eng::My);
+}
+
+#[test]
+#[ignore = "live: requires docker compose up -d mssql"]
+fn stand_partial_unique_index_is_not_a_keyset_key_mssql() {
+    run_partial_unique_index_is_not_a_keyset_key(Eng::Ms);
+}

--- a/tests/live/chunking_stand.rs
+++ b/tests/live/chunking_stand.rs
@@ -75,6 +75,20 @@ impl Eng {
         }
     }
 
+    /// The matrix's TIMEZONE-AWARE timestamp column, per engine.
+    ///
+    /// The names genuinely differ (`created_at_ts` on MySQL, `created_at_tz` on
+    /// PostgreSQL and SQL Server), and the value-consumer guard needs to point
+    /// its uniqueness gate at THIS column rather than at `id`: an integer key
+    /// renders on every build, so a check over it cannot notice a rendering
+    /// failure — the guard's own uniqueness leg was inert until it aimed here.
+    fn tz_column(self) -> &'static str {
+        match self {
+            Eng::My => "created_at_ts",
+            Eng::Pg | Eng::Ms => "created_at_tz",
+        }
+    }
+
     fn rig(self, table: &str) -> Rig {
         match self {
             Eng::Pg => Rig::pg_batch(&format!("public.{table}")),
@@ -1205,6 +1219,99 @@ fn run_csv(eng: Eng) {
         lines > 100,
         "csv must have a header + rows; got {lines} lines"
     );
+}
+
+/// THE GUARD: every type the fixture carries must survive every mechanism that
+/// CONSUMES a cell value — in one export, so adding a column to the matrix
+/// exercises all of them at once and none can be forgotten.
+///
+/// Three consumers exist and each renders a value independently:
+///
+///   `enrich::row_hash_array`      the `_rivet_row_hash` meta column
+///   `ExportSink::track_checksum`  the per-column value checksum `validate` re-reads
+///   `quality::check_uniqueness`   the `unique_columns` gate
+///
+/// Every defect this guard exists for had the same shape: a type the product
+/// PRODUCES met a consumer nobody had run it through, and the consumer degraded
+/// to a value instead of refusing.
+///
+///   2026-03-28  `_rivet_row_hash` shipped hashing arrays by their rendered text,
+///               so `["a, b"]` and `["a","b"]` collided. Arrays landed six weeks
+///               later and nobody asked whether the hash could canonicalise one.
+///   2026-08-05  a timestamp with a NAMED timezone — 278 of 1184 columns in a real
+///               production database — could not be rendered at all. `row_hash`
+///               swallowed it (empty cell in the hash) until 0.24.0 and then
+///               refused, costing 63 of 65 exports. The type matrix had carried
+///               `created_at_ts TIMESTAMP(6)` the whole time; the row_hash test
+///               ran over a two-INTEGER table instead.
+///
+/// So the guard is not "does the fixture contain the type" — it did — but "does
+/// the type reach every consumer". Executable rather than declarative on
+/// purpose: a ledger of type × mechanism would need updating by the same person
+/// who forgot the mechanism.
+fn run_type_matrix_through_every_value_consumer(eng: Eng) {
+    eng.require();
+    let table = "rivet_type_matrix".to_string();
+    let rig = eng
+        .rig(&table)
+        .duckdb_oracle()
+        .mode("full")
+        // consumer 1: the row hash, over EVERY column (no declared subset)
+        .export_line("meta_columns:")
+        .export_line("  row_hash: true")
+        // consumer 3: the uniqueness gate, over the primary key
+        .export_line("quality:")
+        .export_line(&format!("  unique_columns: [{}]", eng.tz_column()))
+        .export_line("  unique_max_entries: 100000");
+    let cfg = rig.config_path();
+
+    // consumer 2: `--validate` re-reads the parts and re-checks the per-column
+    // value checksums the sink recorded while writing.
+    let out = run_rivet_env(
+        &["run", "--config", cfg.to_str().unwrap(), "--validate"],
+        &[("RUST_LOG", "warn")],
+    );
+    assert!(
+        out.status.success(),
+        "the type matrix must survive row_hash + value checksum + quality in ONE export. \
+         A failure here means a type the product can PRODUCE reached a consumer that \
+         cannot handle it.\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Not just "exit 0": the hash must actually DISTINGUISH the rows. A consumer
+    // that silently drops a cell still exits 0 — that is precisely how this class
+    // hides — so read the output back with a decoder rivet does not share.
+    let dir = rig.oracle_dir();
+    let rows = duckdb_parquet_rows(dir);
+    assert!(
+        rows > 1,
+        "the matrix must have >1 row to distinguish anything"
+    );
+    let distinct = duckdb_parquet_distinct(dir, "_rivet_row_hash");
+    assert_eq!(
+        distinct, rows,
+        "{rows} matrix rows hashed to {distinct} distinct values — a collision over \
+         distinct rows means a consumer swallowed the cells that differ"
+    );
+}
+
+#[test]
+#[ignore = "live: requires docker compose up -d postgres with the golden seed"]
+fn stand_type_matrix_every_consumer_postgres() {
+    run_type_matrix_through_every_value_consumer(Eng::Pg);
+}
+
+#[test]
+#[ignore = "live: requires docker compose up -d mysql with the golden seed"]
+fn stand_type_matrix_every_consumer_mysql() {
+    run_type_matrix_through_every_value_consumer(Eng::My);
+}
+
+#[test]
+#[ignore = "live: requires docker compose up -d mssql with the golden seed"]
+fn stand_type_matrix_every_consumer_mssql() {
+    run_type_matrix_through_every_value_consumer(Eng::Ms);
 }
 
 #[test]

--- a/tests/live/gremlin.rs
+++ b/tests/live/gremlin.rs
@@ -270,7 +270,7 @@ fn gremlin_auto_shrink_total_rows_correct_under_quality_gate() {
     // (which reads the same internal counter) would still pass while the
     // destination silently lost rows.
     assert_eq!(
-        total_parquet_rows(out.path()),
+        duckdb_total_parquet_rows(out.path()),
         2000,
         "auto_shrink must write all 2000 rows to the destination across its splits"
     );

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -1652,7 +1652,9 @@ exports:
     );
     assert_eq!(manifest_rows(&out), 0, "nothing to drain yet");
     assert_eq!(
-        dir_parquet_id_set(&snap).into_iter().collect::<Vec<i64>>(),
+        duckdb_dir_parquet_id_set(&snap)
+            .into_iter()
+            .collect::<Vec<i64>>(),
         vec![1, 2],
         "snapshot parquet must hold exactly the pre-existing ids (independent re-read)"
     );
@@ -2085,7 +2087,7 @@ exports:
     let _slot = Slot(slot.clone());
     assert_eq!(manifest_rows(&out.join("snapshot")), 2);
     assert_eq!(
-        dir_parquet_id_set(&out.join("snapshot"))
+        duckdb_dir_parquet_id_set(&out.join("snapshot"))
             .into_iter()
             .collect::<Vec<i64>>(),
         vec![1, 2],
@@ -2934,7 +2936,7 @@ fn roast_pg_cdc_crash_in_a_re_drain_pass_stays_at_least_once() {
     let rig2 = Rig::pg_cdc(&a, &slot).dest_path(out.clone());
     run_rivet_ok(&rig2.config_path());
 
-    let ids = dir_parquet_i64(&out, "id");
+    let ids = duckdb_dir_parquet_i64(&out, "id");
     let distinct: std::collections::BTreeSet<i64> = ids.iter().copied().collect();
     let want: std::collections::BTreeSet<i64> = (0..12).collect();
     assert_eq!(
@@ -3004,7 +3006,8 @@ fn roast_pg_cdc_large_transaction_is_atomic_across_a_mid_flush_crash() {
     let rig2 = Rig::pg_cdc(&tbl, &slot).dest_path(out.clone());
     run_rivet_ok(&rig2.config_path());
 
-    let got: std::collections::BTreeSet<i64> = dir_parquet_i64(&out, "id").into_iter().collect();
+    let got: std::collections::BTreeSet<i64> =
+        duckdb_dir_parquet_i64(&out, "id").into_iter().collect();
     let want: std::collections::BTreeSet<i64> = (0..12).collect();
     assert_eq!(
         got,
@@ -3064,7 +3067,8 @@ fn roast_mysql_cdc_large_transaction_is_atomic_across_a_mid_flush_crash() {
     // Run 2 resumes from the checkpoint the crash left behind.
     run_rivet_ok(&rig.config_path());
 
-    let got: std::collections::BTreeSet<i64> = dir_parquet_i64(&out, "id").into_iter().collect();
+    let got: std::collections::BTreeSet<i64> =
+        duckdb_dir_parquet_i64(&out, "id").into_iter().collect();
     let want: std::collections::BTreeSet<i64> = (0..12).collect();
     assert_eq!(
         got,
@@ -3267,7 +3271,7 @@ fn pg_cdc_column_added_mid_stream_is_captured() {
     std::fs::create_dir_all(&out1).unwrap();
     run_rivet_ok(&pg_cdc_config(&d, &tbl, &slot, &out1));
     assert!(
-        !dir_parquet_has_column(&out1, "w"),
+        !duckdb_dir_parquet_has_column(&out1, "w"),
         "run 1 predates the added column"
     );
 
@@ -3282,7 +3286,7 @@ fn pg_cdc_column_added_mid_stream_is_captured() {
     std::fs::create_dir_all(&out2).unwrap();
     run_rivet_ok(&pg_cdc_config(&d, &tbl, &slot, &out2));
     assert!(
-        dir_parquet_has_column(&out2, "w"),
+        duckdb_dir_parquet_has_column(&out2, "w"),
         "run 2 must re-resolve and pick up the column added between runs"
     );
     assert_eq!(parquet_one_string(&out2, "w"), "hello");
@@ -3346,7 +3350,8 @@ fn pg_cdc_until_current_terminates_under_sustained_writes() {
         "until_current must terminate under sustained writes (killed at the 30s ceiling)"
     );
     // Termination must NOT come from dropping the backlog.
-    let ids: std::collections::BTreeSet<i64> = dir_parquet_i64(&out, "id").into_iter().collect();
+    let ids: std::collections::BTreeSet<i64> =
+        duckdb_dir_parquet_i64(&out, "id").into_iter().collect();
     for i in 0..30 {
         assert!(
             ids.contains(&i),
@@ -3404,7 +3409,8 @@ fn cdc_until_current_terminates_under_sustained_writes() {
         elapsed.is_some(),
         "until_current must terminate under sustained writes (killed at the 30s ceiling)"
     );
-    let ids: std::collections::BTreeSet<i64> = dir_parquet_i64(&out, "id").into_iter().collect();
+    let ids: std::collections::BTreeSet<i64> =
+        duckdb_dir_parquet_i64(&out, "id").into_iter().collect();
     for i in 0..30 {
         assert!(
             ids.contains(&i),
@@ -3492,8 +3498,9 @@ fn roast_pg_until_current_open_bound_two_runs_lose_nothing() {
         "run 2 (no writers) must drain the tail and exit"
     );
 
-    let got: std::collections::BTreeSet<i64> =
-        dir_parquet_i64(&rig.out_dir(), "id").into_iter().collect();
+    let got: std::collections::BTreeSet<i64> = duckdb_dir_parquet_i64(&rig.out_dir(), "id")
+        .into_iter()
+        .collect();
     let want: std::collections::BTreeSet<i64> = c
         .query(&format!("SELECT id FROM {tbl}"), &[])
         .unwrap()
@@ -3565,8 +3572,9 @@ fn roast_mysql_until_current_open_bound_two_runs_lose_nothing() {
         "run 2 (no writers) must drain the tail and exit"
     );
 
-    let got: std::collections::BTreeSet<i64> =
-        dir_parquet_i64(&rig.out_dir(), "id").into_iter().collect();
+    let got: std::collections::BTreeSet<i64> = duckdb_dir_parquet_i64(&rig.out_dir(), "id")
+        .into_iter()
+        .collect();
     let want: std::collections::BTreeSet<i64> = c
         .query_map(format!("SELECT id FROM {tbl}"), |id: i64| id)
         .unwrap()
@@ -3684,7 +3692,8 @@ fn roast_pg_cdc_reaches_open_bound_past_a_large_empty_ddl_span() {
         .dest_path(out.clone());
     run_rivet_ok(&rig.config_path());
 
-    let got: std::collections::BTreeSet<i64> = dir_parquet_i64(&out, "id").into_iter().collect();
+    let got: std::collections::BTreeSet<i64> =
+        duckdb_dir_parquet_i64(&out, "id").into_iter().collect();
     let want: std::collections::BTreeSet<i64> = (0..12).collect();
     assert_eq!(
         got,
@@ -3894,8 +3903,9 @@ fn roast_pg_cdc_reaches_open_bound_past_a_large_uncaptured_transaction() {
         .cdc("rollover: 5");
     run_rivet_ok(&rig.config_path());
 
-    let got: std::collections::BTreeSet<i64> =
-        dir_parquet_i64(&rig.out_dir(), "id").into_iter().collect();
+    let got: std::collections::BTreeSet<i64> = duckdb_dir_parquet_i64(&rig.out_dir(), "id")
+        .into_iter()
+        .collect();
     let want: std::collections::BTreeSet<i64> = (0..30).collect();
     assert_eq!(
         got,
@@ -4064,7 +4074,7 @@ fn roast_pg_cdc_captures_a_silent_update_a_watermark_sync_would_miss() {
         vec![(1, "insert".to_string()), (1, "update".to_string())],
         "CDC must capture the insert AND the silent update the watermark missed — got {ops:?}"
     );
-    let vcs: Vec<i64> = dir_parquet_i64(&out, "v");
+    let vcs: Vec<i64> = duckdb_dir_parquet_i64(&out, "v");
     assert_eq!(
         vcs,
         vec![0, 42],
@@ -4638,6 +4648,25 @@ fn roast_pg_cdc_destination_placeholders_resolve_like_the_batch_path() {
         &[&slot],
     )
     .unwrap();
+    // Drop the slot even if an assertion below panics. The file's other tests
+    // use a TRAILING `pg_drop_replication_slot`, which leaks whenever the test
+    // fails before reaching it — and a leaked logical slot is not inert: it
+    // pins WAL and counts against `max_replication_slots` (32 here). Measured
+    // 2026-08-05: this test alone left 25 of 32 slots held after a day of runs,
+    // and the PG CDC tests then began failing in the parallel suite with
+    // symptoms that looked like anything but slot exhaustion.
+    struct SlotGuard(String);
+    impl Drop for SlotGuard {
+        fn drop(&mut self) {
+            if let Ok(mut c) = postgres::Client::connect(POSTGRES_CDC_URL, postgres::NoTls) {
+                let _ = c.execute(
+                    &format!("SELECT pg_drop_replication_slot('{}')", self.0),
+                    &[],
+                );
+            }
+        }
+    }
+    let _slot_guard = SlotGuard(slot.clone());
     c.batch_execute(&format!(
         "INSERT INTO {tbl} (id, v) VALUES (1, 'a'), (2, 'b'), (3, 'c');"
     ))

--- a/tests/live/live_cdc_mbt.rs
+++ b/tests/live/live_cdc_mbt.rs
@@ -51,6 +51,39 @@ struct OpCounts {
     deletes: i64,
 }
 
+/// Run one autocommit statement, retrying the two outcomes InnoDB is CONTRACTED
+/// to hand a concurrent writer, and return the rows it affected.
+///
+/// Four threads hammering 60 shared keys with UPDATE/DELETE in random order is
+/// exactly the shape that produces `ERROR 1213 Deadlock found` — InnoDB picks a
+/// victim, rolls its transaction back, and expects the client to reissue. The
+/// writers used to `.unwrap()`, so a deadlock panicked one thread, its `Table`
+/// guard dropped the fixture, and the other three then died on
+/// `ERROR 1146 doesn't exist` — a cascade that reads like a rivet bug and is
+/// four threads' worth of ordinary lock contention (CI, run 31139785655).
+///
+/// Retrying is exact rather than approximate here: the victim's statement is
+/// rolled back WHOLE (single statement == whole transaction under autocommit),
+/// so it affected nothing, and only the successful attempt is counted. The
+/// conservation identity the test checks downstream stays honest.
+///
+/// Anything that is NOT a lock outcome still panics — this must not become a
+/// blanket retry that hides a real error.
+fn exec_serializable(c: &mut mysql::PooledConn, sql: &str) -> i64 {
+    use mysql::prelude::Queryable;
+    for attempt in 0..8 {
+        match c.query_drop(sql) {
+            Ok(()) => return c.affected_rows() as i64,
+            Err(mysql::Error::MySqlError(e)) if e.code == 1213 || e.code == 1205 => {
+                // 1213 deadlock, 1205 lock wait timeout — both mean "reissue".
+                std::thread::sleep(std::time::Duration::from_millis(5 * (attempt + 1)));
+            }
+            Err(e) => panic!("writer statement failed: {sql}\n{e}"),
+        }
+    }
+    panic!("writer statement still deadlocking after 8 attempts: {sql}")
+}
+
 #[test]
 #[ignore = "live: requires docker compose --profile cdc mysql-cdc"]
 fn cdc_concurrent_writers_capture_converges_to_source_state() {
@@ -91,26 +124,29 @@ fn cdc_concurrent_writers_capture_converges_to_source_state() {
                         // 40%: upsert-style insert (fails silently on dup via
                         // IGNORE — affected==0 then, so conservation stays exact)
                         0..=3 => {
-                            c.query_drop(format!(
-                                "INSERT IGNORE INTO {tbl} VALUES ({id}, {val}, 'w{t}-{val}')"
-                            ))
-                            .unwrap();
-                            counts.inserts += c.affected_rows() as i64;
+                            counts.inserts += exec_serializable(
+                                &mut c,
+                                &format!(
+                                    "INSERT IGNORE INTO {tbl} VALUES ({id}, {val}, 'w{t}-{val}')"
+                                ),
+                            );
                         }
                         // 40%: update (affected==0 when the row is absent OR
                         // the values are unchanged — both excluded from counts)
                         4..=7 => {
-                            c.query_drop(format!(
-                                "UPDATE {tbl} SET v = {val}, w = 'u{t}-{val}' WHERE id = {id}"
-                            ))
-                            .unwrap();
-                            counts.updates += c.affected_rows() as i64;
+                            counts.updates += exec_serializable(
+                                &mut c,
+                                &format!(
+                                    "UPDATE {tbl} SET v = {val}, w = 'u{t}-{val}' WHERE id = {id}"
+                                ),
+                            );
                         }
                         // 20%: delete
                         _ => {
-                            c.query_drop(format!("DELETE FROM {tbl} WHERE id = {id}"))
-                                .unwrap();
-                            counts.deletes += c.affected_rows() as i64;
+                            counts.deletes += exec_serializable(
+                                &mut c,
+                                &format!("DELETE FROM {tbl} WHERE id = {id}"),
+                            );
                         }
                     }
                 }

--- a/tests/live/live_cdc_mongo.rs
+++ b/tests/live/live_cdc_mongo.rs
@@ -253,7 +253,7 @@ fn walkdir_parquet_ids(root: &std::path::Path, marker: &str) -> std::collections
             } else if p.extension().is_some_and(|x| x == "parquet")
                 && p.to_string_lossy().contains(marker)
             {
-                for id in dir_parquet_distinct_strings(p.parent().unwrap(), "_id") {
+                for id in duckdb_dir_parquet_distinct_strings(p.parent().unwrap(), "_id") {
                     ids.insert(id);
                 }
             }

--- a/tests/live/live_cdc_mssql.rs
+++ b/tests/live/live_cdc_mssql.rs
@@ -1463,3 +1463,104 @@ fn mssql_a_partial_capture_instance_is_refused_even_beside_a_complete_sibling() 
          instances; stderr:\n{stderr}"
     );
 }
+
+// ─── the config's table name is a label; the catalog is the truth ────────────
+
+/// A `table:` that differs from the catalog only in CASE must not silently
+/// capture nothing while the checkpoint advances past the changes.
+///
+/// `MssqlChangeStream::open` takes each event's `(schema, table)` from the
+/// catalog — `cdc.change_tables` / `OBJECT_NAME` — which is right. But the SINK
+/// routes with the raw config string through `table_matches`
+/// (src/source/cdc/sink.rs:220), a byte-exact Rust comparison. Nothing ever
+/// compares the two, and SQL Server's default collation is case-INSENSITIVE, so
+/// `table: dbo.casetest` against a real `dbo.CaseTest` resolves its schema
+/// perfectly (`SELECT * FROM dbo.casetest` returns a full, correct column list)
+/// while `table_matches("dbo.casetest", "dbo", "CaseTest")` is false for every
+/// event.
+///
+/// This is the `product_catalog` finding's sibling with the opposite ending. That
+/// one dropped 100% of events for six of eight tables and at-least-once saved it
+/// — flush → checkpoint → ack never ran for the unrouted tables, so one fixed
+/// run recovered everything. Here the commit boundary is recorded BEFORE the
+/// routing filter and the end-of-pass roll fires on `unacked_commit` alone, so
+/// the checkpoint advances over events that were never captured.
+///
+/// Measured on this stand — 6 rows in `cdc.dbo_CaseTest_CT`, config lowercase:
+///
+///   run                          0 rows, 0 files, status success
+///   checkpoint written           {"lsn":"0000006b000021a80005"}
+///   re-run, case FIXED           0 rows — the LSN is already past them
+///   re-run, case fixed + ckpt deleted   5 rows   ← they were there all along
+///
+/// The last two lines are the control pair, and they are what separates "lost"
+/// from "deferred": the change rows never left the change table, so the only
+/// thing that skipped them was the advanced checkpoint. Recovery costs deleting
+/// the checkpoint and re-reading from the retention floor; past retention there
+/// is nothing to re-read.
+// AUDIT-RED cdc-case-identity: a case-only `table:` mismatch routes ZERO events while the checkpoint advances past them — the changes are unrecoverable without discarding the checkpoint. Asserts CORRECT behavior; expected to FAIL until fixed.
+#[test]
+#[ignore = "live: requires docker compose mssql with SQL Server Agent + CDC"]
+fn mssql_cdc_case_only_table_mismatch_must_not_silently_drop_events() {
+    let _serial = CDC_SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+
+    // Mixed case ON PURPOSE — `unique_name` lowercases, and the whole mechanism
+    // is a catalog name the config spells differently.
+    let table = format!("CaseIdent{}", std::process::id() % 100_000);
+    let table = table.as_str();
+    let ci = &format!("dbo_{table}");
+    mssql_cdc_drop_table(&format!("dbo.{table}"));
+    mssql_cdc_exec(&format!(
+        "CREATE TABLE dbo.{table} (id int PRIMARY KEY, v nvarchar(50))"
+    ));
+    enable_cdc(table, ci);
+    let _guard = MssqlCdcTable {
+        table: table.to_string(),
+        ci: ci.clone(),
+    };
+
+    let d = tempfile::tempdir().unwrap();
+    let out = tempfile::tempdir().unwrap();
+    let ckpt = d.path().join("cdc.ckpt");
+    // The config names the table in a case the catalog does not use. SQL Server
+    // accepts it everywhere EXCEPT rivet's own byte-exact router.
+    let cfg = mssql_cdc_config(&d, &table.to_lowercase(), ci, &ckpt, out.path());
+
+    run_rivet_ok(&cfg); // anchor
+    mssql_cdc_exec(&format!(
+        "INSERT INTO dbo.{table} VALUES (1,'a'),(2,'b'),(3,'c'); \
+         UPDATE dbo.{table} SET v='B' WHERE id=2; \
+         DELETE FROM dbo.{table} WHERE id=3;"
+    ));
+    wait_for_capture(ci, 6);
+
+    let o = run_rivet_env(&["run", "--config", cfg.to_str().unwrap()], &[]);
+    // Refusing at open — a catalog cross-check — is the correct outcome.
+    if !o.status.success() {
+        return;
+    }
+
+    let captured = read_cdc_changes(out.path()).len();
+    if captured > 0 {
+        return; // routed correctly; nothing to guard
+    }
+
+    // Captured nothing. The only acceptable version of that is a checkpoint that
+    // did NOT move, leaving the events for the next run (at-least-once). Prove
+    // which happened: the change rows are still there, so a correctly-cased
+    // re-run against the SAME checkpoint must find them.
+    let still_in_ct = mssql_cdc_query_i64(&format!("SELECT COUNT(*) FROM cdc.{ci}_CT"));
+    let fixed = mssql_cdc_config(&d, &format!("dbo.{table}"), ci, &ckpt, out.path());
+    let _ = run_rivet_env(&["run", "--config", fixed.to_str().unwrap()], &[]);
+    let after_fix = read_cdc_changes(out.path()).len();
+
+    panic!(
+        "a case-only `table:` mismatch captured 0 of the {still_in_ct} change row(s) and exited 0. \
+         Re-running with the case FIXED against the same checkpoint recovered {after_fix} — the \
+         change rows never left the change table, so the checkpoint advanced past events that \
+         were never captured. `MssqlChangeStream::open` reads identity from the catalog; the sink \
+         routes with the raw config string through the byte-exact `table_matches` \
+         (src/source/cdc/sink.rs:220), and nothing compares the two. SQL Server's default \
+         collation is case-insensitive, so every other layer accepted the name."
+    );
+}

--- a/tests/live/live_cdc_mssql.rs
+++ b/tests/live/live_cdc_mssql.rs
@@ -519,7 +519,7 @@ fn mssql_cdc_initial_snapshot_covers_preexisting_rows_then_streams() {
     run_rivet_ok(&cfg);
     assert_eq!(manifest_rows(&out.join("snapshot")), 2);
     assert_eq!(
-        dir_parquet_id_set(&out.join("snapshot"))
+        duckdb_dir_parquet_id_set(&out.join("snapshot"))
             .into_iter()
             .collect::<Vec<i64>>(),
         vec![1, 2],
@@ -1057,7 +1057,7 @@ fn mssql_cdc_column_added_via_new_capture_instance_is_captured() {
     std::fs::create_dir_all(&out1).unwrap();
     run_rivet_ok(&mssql_cdc_config(&d, &table, &ci1, &ckpt1, &out1));
     assert!(
-        !dir_parquet_has_column(&out1, "w"),
+        !duckdb_dir_parquet_has_column(&out1, "w"),
         "ci1 predates the added column"
     );
 
@@ -1081,11 +1081,11 @@ fn mssql_cdc_column_added_via_new_capture_instance_is_captured() {
     std::fs::create_dir_all(&out2).unwrap();
     run_rivet_ok(&mssql_cdc_config(&d, &table, &ci2, &ckpt2, &out2));
     assert!(
-        dir_parquet_has_column(&out2, "w"),
+        duckdb_dir_parquet_has_column(&out2, "w"),
         "the new capture instance must expose the column added after ci1"
     );
     assert!(
-        dir_parquet_distinct_strings(&out2, "w").contains("hello"),
+        duckdb_dir_parquet_distinct_strings(&out2, "w").contains("hello"),
         "the added column's value must be captured, not nulled"
     );
 }
@@ -1146,7 +1146,8 @@ fn mssql_cdc_until_current_terminates_under_sustained_writes() {
         elapsed.is_some(),
         "until_current must terminate under sustained writes (killed at the 30s ceiling)"
     );
-    let ids: std::collections::BTreeSet<i64> = dir_parquet_i64(&out, "id").into_iter().collect();
+    let ids: std::collections::BTreeSet<i64> =
+        duckdb_dir_parquet_i64(&out, "id").into_iter().collect();
     for i in 0..30 {
         assert!(
             ids.contains(&i),
@@ -1225,8 +1226,9 @@ fn roast_mssql_until_current_open_bound_two_runs_lose_nothing() {
         "run 2 (no writers) must drain the tail and exit"
     );
 
-    let got: std::collections::BTreeSet<i64> =
-        dir_parquet_i64(&rig.out_dir(), "id").into_iter().collect();
+    let got: std::collections::BTreeSet<i64> = duckdb_dir_parquet_i64(&rig.out_dir(), "id")
+        .into_iter()
+        .collect();
     let sum: i64 = got.iter().sum();
     assert_eq!(
         got.len() as i64,
@@ -1313,7 +1315,8 @@ fn roast_mssql_cdc_large_transaction_is_atomic_across_a_mid_flush_crash() {
         .dest_path(out.clone());
     run_rivet_ok(&rig2.config_path());
 
-    let got: std::collections::BTreeSet<i64> = dir_parquet_i64(&out, "id").into_iter().collect();
+    let got: std::collections::BTreeSet<i64> =
+        duckdb_dir_parquet_i64(&out, "id").into_iter().collect();
     let want: std::collections::BTreeSet<i64> = (0..12).collect();
     assert_eq!(
         got,

--- a/tests/live/live_cdc_mssql.rs
+++ b/tests/live/live_cdc_mssql.rs
@@ -1526,7 +1526,18 @@ fn mssql_cdc_case_only_table_mismatch_must_not_silently_drop_events() {
     // accepts it everywhere EXCEPT rivet's own byte-exact router.
     let cfg = mssql_cdc_config(&d, &table.to_lowercase(), ci, &ckpt, out.path());
 
-    run_rivet_ok(&cfg); // anchor
+    // The anchor run is where a catalog cross-check would fire, so it must be
+    // allowed to REFUSE rather than asserted to succeed — refusing is the
+    // outcome this test wants.
+    let anchor = run_rivet_env(&["run", "--config", cfg.to_str().unwrap()], &[]);
+    if !anchor.status.success() {
+        let why = String::from_utf8_lossy(&anchor.stderr);
+        assert!(
+            why.contains("no configured table matches"),
+            "the anchor run failed for an unrelated reason:\n{why}"
+        );
+        return; // refused at open, before any checkpoint could advance — correct
+    }
     mssql_cdc_exec(&format!(
         "INSERT INTO dbo.{table} VALUES (1,'a'),(2,'b'),(3,'c'); \
          UPDATE dbo.{table} SET v='B' WHERE id=2; \

--- a/tests/live/live_chunked_dense.rs
+++ b/tests/live/live_chunked_dense.rs
@@ -60,7 +60,7 @@ const GRP_CASE: &str = "CASE WHEN n <= 200 THEN n WHEN n <= 800 THEN 5000 ELSE 5
 /// Parquet, not rivet's counters. Distinguishes LOSS (missing id) from
 /// DUPLICATION (count > ROWS) so the failure message names the actual fault.
 fn assert_each_id_exactly_once(dir: &std::path::Path, ctx: &str) {
-    let ids = dir_parquet_ids(dir);
+    let ids = duckdb_dir_parquet_ids(dir);
     let set: BTreeSet<i64> = ids.iter().copied().collect();
     let expected: BTreeSet<i64> = (1..=ROWS).collect();
 

--- a/tests/live/live_chunked_recovery.rs
+++ b/tests/live/live_chunked_recovery.rs
@@ -111,7 +111,7 @@ fn manifest_total_rows(cfg: &std::path::Path, export: &str) -> i64 {
 fn parquet_physical_and_distinct_ids(dir: &std::path::Path) -> (i64, i64) {
     (
         duckdb_total_parquet_rows(dir) as i64,
-        dir_parquet_id_set(dir).len() as i64,
+        duckdb_dir_parquet_id_set(dir).len() as i64,
     )
 }
 

--- a/tests/live/live_chunked_recovery.rs
+++ b/tests/live/live_chunked_recovery.rs
@@ -110,7 +110,7 @@ fn manifest_total_rows(cfg: &std::path::Path, export: &str) -> i64 {
 /// alone would wave through); `distinct` proves the de-duplicated logical total.
 fn parquet_physical_and_distinct_ids(dir: &std::path::Path) -> (i64, i64) {
     (
-        total_parquet_rows(dir) as i64,
+        duckdb_total_parquet_rows(dir) as i64,
         dir_parquet_id_set(dir).len() as i64,
     )
 }
@@ -1078,7 +1078,7 @@ fn a_failed_chunk_must_fail_the_run_not_ship_a_short_export() {
 
     // The fixture must not be inert: the OTHER chunks have to have run, or the
     // run failed for an unrelated reason and proves nothing about the guard.
-    let rows = total_parquet_rows(out.path());
+    let rows = duckdb_total_parquet_rows(out.path());
     assert!(
         rows > 0 && rows < 150,
         "fixture is inert — expected a PARTIAL export (some chunks written, one failed), \

--- a/tests/live/live_cli_flags.rs
+++ b/tests/live/live_cli_flags.rs
@@ -214,7 +214,7 @@ fn run_json_flag_prints_aggregate_summary_to_stdout() {
     );
     // Back the reported total_rows with an independent destination read.
     assert_eq!(
-        total_parquet_rows(out.path()),
+        duckdb_total_parquet_rows(out.path()),
         20,
         "destination must physically hold the 20 reported rows"
     );
@@ -264,7 +264,7 @@ fn run_summary_output_writes_json_to_file() {
     );
     // Back the "export succeeded" claim with an independent destination read.
     assert_eq!(
-        total_parquet_rows(out.path()),
+        duckdb_total_parquet_rows(out.path()),
         10,
         "destination must physically hold all 10 rows"
     );
@@ -331,7 +331,7 @@ exports:
     );
     // Back the reported count with an independent destination read.
     assert_eq!(
-        total_parquet_rows(out.path()),
+        duckdb_total_parquet_rows(out.path()),
         31,
         "destination must physically hold the 31 param-filtered rows"
     );
@@ -400,7 +400,7 @@ exports:
     );
     // Back the reported count with an independent destination read.
     assert_eq!(
-        total_parquet_rows(out.path()),
+        duckdb_total_parquet_rows(out.path()),
         11,
         "destination must physically hold the 11 param-filtered rows"
     );
@@ -454,7 +454,7 @@ fn run_reconcile_flag_exits_zero_when_counts_match() {
     );
     // Back the 25-row claim independently of rivet's reconcile/aggregate.
     assert_eq!(
-        total_parquet_rows(out.path()),
+        duckdb_total_parquet_rows(out.path()),
         25,
         "destination must physically hold all 25 rows"
     );
@@ -602,12 +602,12 @@ fn run_parallel_exports_flag_runs_both_exports() {
     // Back the success-count with independent destination reads of BOTH outputs —
     // separable destinations are the point of `also_export`.
     assert_eq!(
-        total_parquet_rows(&rig.out_dir_for(t1.name())),
+        duckdb_total_parquet_rows(&rig.out_dir_for(t1.name())),
         10,
         "export 1 destination must hold 10 rows"
     );
     assert_eq!(
-        total_parquet_rows(&rig.out_dir_for(t2.name())),
+        duckdb_total_parquet_rows(&rig.out_dir_for(t2.name())),
         10,
         "export 2 destination must hold 10 rows"
     );
@@ -684,12 +684,12 @@ exports:
     );
     // Back the success-count with independent destination reads of both outputs.
     assert_eq!(
-        total_parquet_rows(out1.path()),
+        duckdb_total_parquet_rows(out1.path()),
         10,
         "export 1 destination must hold 10 rows"
     );
     assert_eq!(
-        total_parquet_rows(out2.path()),
+        duckdb_total_parquet_rows(out2.path()),
         10,
         "export 2 destination must hold 10 rows"
     );
@@ -1371,7 +1371,7 @@ exports:
     // Back the chunked-completeness claim with an independent destination read:
     // both chunks' rows must physically land, not just be marked 'completed'.
     assert_eq!(
-        total_parquet_rows(out.path()),
+        duckdb_total_parquet_rows(out.path()),
         100,
         "both chunks' rows must reach the destination (100 total)"
     );

--- a/tests/live/live_crash_recovery.rs
+++ b/tests/live/live_crash_recovery.rs
@@ -25,7 +25,10 @@ use crate::common::*;
 /// destination — re-reads the files, NOT rivet's state DB. Lets a recovery test
 /// assert the no-row-loss superset invariant the state-DB assertions cannot see.
 fn parquet_ids_and_rows(dir: &std::path::Path) -> (std::collections::BTreeSet<i64>, i64) {
-    (dir_parquet_id_set(dir), total_parquet_rows(dir) as i64)
+    (
+        dir_parquet_id_set(dir),
+        duckdb_total_parquet_rows(dir) as i64,
+    )
 }
 
 /// RAII guard — drops a Postgres table on scope exit.

--- a/tests/live/live_crash_recovery.rs
+++ b/tests/live/live_crash_recovery.rs
@@ -26,7 +26,7 @@ use crate::common::*;
 /// assert the no-row-loss superset invariant the state-DB assertions cannot see.
 fn parquet_ids_and_rows(dir: &std::path::Path) -> (std::collections::BTreeSet<i64>, i64) {
     (
-        dir_parquet_id_set(dir),
+        duckdb_dir_parquet_id_set(dir),
         duckdb_total_parquet_rows(dir) as i64,
     )
 }

--- a/tests/live/live_crash_soak.rs
+++ b/tests/live/live_crash_soak.rs
@@ -97,7 +97,7 @@ exports:
     // The invariant: the destination, re-read independently, is a COMPLETE
     // superset of the source — every id present at least once (no loss), with
     // at-least-once duplication the only allowed surplus.
-    let ids = dir_parquet_id_set(out.path());
+    let ids = duckdb_dir_parquet_id_set(out.path());
     let expected: std::collections::BTreeSet<i64> = (0..N).collect();
     let missing: Vec<i64> = expected.difference(&ids).copied().collect();
     assert!(

--- a/tests/live/live_crash_soak.rs
+++ b/tests/live/live_crash_soak.rs
@@ -107,7 +107,7 @@ exports:
         missing.len(),
         &missing.iter().take(20).collect::<Vec<_>>()
     );
-    let physical = total_parquet_rows(out.path()) as i64;
+    let physical = duckdb_total_parquet_rows(out.path()) as i64;
     assert!(
         physical >= N,
         "[{fault}] at-least-once: physical destination rows ({physical}) must be >= source ({N})"

--- a/tests/live/live_governor.rs
+++ b/tests/live/live_governor.rs
@@ -33,7 +33,7 @@ use std::time::Duration;
 
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 
-fn total_parquet_rows(dir: &std::path::Path) -> usize {
+fn duckdb_total_parquet_rows(dir: &std::path::Path) -> usize {
     let mut n = 0;
     for path in files_with_extension(dir, "parquet") {
         let bytes = std::fs::read(&path).unwrap();
@@ -105,7 +105,7 @@ exports:
         "governor must activate for adaptive + parallel>1; stderr:\n{stderr}"
     );
     assert_eq!(
-        total_parquet_rows(out_dir.path()),
+        duckdb_total_parquet_rows(out_dir.path()),
         N,
         "every row must round-trip through the governed parallel run"
     );
@@ -254,7 +254,7 @@ exports:
          (a 'backed off' parallelism adjustment); stderr:\n{stderr}"
     );
     assert_eq!(
-        total_parquet_rows(out_dir.path()),
+        duckdb_total_parquet_rows(out_dir.path()),
         ROWS as usize,
         "every exported row must round-trip despite concurrent writes to the same rows"
     );

--- a/tests/live/live_mongo.rs
+++ b/tests/live/live_mongo.rs
@@ -321,7 +321,7 @@ fn mongo_run_reconcile_matches_source_count() {
     // Independent oracle: the verdict is rivet's own counter chain — also
     // physically re-read the destination (matrix audit: self-oracle class).
     assert_eq!(
-        total_parquet_rows(&rig.out_dir()),
+        duckdb_total_parquet_rows(&rig.out_dir()),
         3000,
         "destination parquet must physically hold every source document, independent of the reconcile verdict"
     );
@@ -400,7 +400,7 @@ fn mongo_batch_read_concern_snapshot_empty_first_run_then_populated() {
     // Empty first run: snapshot read of a 0-doc collection reads nothing, cleanly.
     rig.run_ok();
     assert_eq!(
-        total_parquet_rows(&rig.out_dir()),
+        duckdb_total_parquet_rows(&rig.out_dir()),
         0,
         "empty snapshot run must read 0, not hang or phantom-read"
     );
@@ -433,7 +433,7 @@ fn mongo_batch_no_cursor_timeout_false_empty_first_run_then_populated() {
 
     rig.run_ok();
     assert_eq!(
-        total_parquet_rows(&rig.out_dir()),
+        duckdb_total_parquet_rows(&rig.out_dir()),
         0,
         "empty first run reads 0 with no_cursor_timeout: false"
     );

--- a/tests/live/live_mongo.rs
+++ b/tests/live/live_mongo.rs
@@ -44,7 +44,7 @@ fn mongo_batch_keyset_no_loss_or_dup() {
     // fewer rows is loss, fewer distinct is duplication.
     rig.assert_complete("_id", 5000, "distinct _id must equal source (no loss)");
     assert!(
-        dir_parquet_has_column(&rig.out_dir(), "document"),
+        duckdb_dir_parquet_has_column(&rig.out_dir(), "document"),
         "blob document column present"
     );
 }
@@ -269,7 +269,7 @@ fn mongo_batch_type_fidelity_document_is_verbatim_extjson() {
     let rig = batch(&db, "t");
     rig.run_ok();
 
-    let docs = dir_parquet_distinct_strings(&rig.out_dir(), "document");
+    let docs = duckdb_dir_parquet_distinct_strings(&rig.out_dir(), "document");
     let doc_text = docs.iter().next().expect("one document");
     assert!(
         doc_text.contains("9007199254740993"),
@@ -343,7 +343,7 @@ fn mongo_batch_resume_reads_only_new_since_last_run() {
         .mongo("page_size: 500, resume: true");
     rig.run_ok();
     assert_eq!(
-        dir_parquet_distinct_strings(&rig.out_dir(), "_id").len(),
+        duckdb_dir_parquet_distinct_strings(&rig.out_dir(), "_id").len(),
         2000
     );
 
@@ -409,7 +409,7 @@ fn mongo_batch_read_concern_snapshot_empty_first_run_then_populated() {
     m.seed_int_id("t", 1500);
     rig.run_ok();
     assert_eq!(
-        dir_parquet_distinct_strings(&rig.out_dir(), "_id").len(),
+        duckdb_dir_parquet_distinct_strings(&rig.out_dir(), "_id").len(),
         1500,
         "snapshot read_concern must read the whole collection on the second run"
     );
@@ -441,7 +441,7 @@ fn mongo_batch_no_cursor_timeout_false_empty_first_run_then_populated() {
     m.seed_int_id("t", 1200);
     rig.run_ok();
     assert_eq!(
-        dir_parquet_distinct_strings(&rig.out_dir(), "_id").len(),
+        duckdb_dir_parquet_distinct_strings(&rig.out_dir(), "_id").len(),
         1200,
         "no_cursor_timeout: false must not truncate the paged scan on the populated run"
     );
@@ -477,7 +477,7 @@ fn mongo_keyset_on_heterogeneous_id_errors_loudly_full_scan_still_works() {
     let fs = batch(&db, "t");
     fs.run_ok();
     assert_eq!(
-        dir_parquet_distinct_strings(&fs.out_dir(), "_id").len(),
+        duckdb_dir_parquet_distinct_strings(&fs.out_dir(), "_id").len(),
         2000,
         "full scan must read every _id across both types"
     );
@@ -503,7 +503,7 @@ fn roast_resume_must_not_bypass_heterogeneous_id_guard() {
     let rig = batch(&db, "t").mongo("page_size: 40, resume: true");
     rig.run_ok();
     assert_eq!(
-        dir_parquet_distinct_strings(&rig.out_dir(), "_id").len(),
+        duckdb_dir_parquet_distinct_strings(&rig.out_dir(), "_id").len(),
         100
     );
 
@@ -556,7 +556,7 @@ fn roast_null_and_object_id_must_not_slip_past_the_bracket_guard() {
     let fs = batch(&db, "t");
     fs.run_ok();
     assert_eq!(
-        dir_parquet_distinct_strings(&fs.out_dir(), "_id").len(),
+        duckdb_dir_parquet_distinct_strings(&fs.out_dir(), "_id").len(),
         4,
         "full scan must read every doc across the null and object bands"
     );
@@ -614,7 +614,7 @@ fn roast_nan_id_refused_for_keyset_and_parallel_full_scan_complete() {
     let fs = batch(&db, "t");
     fs.run_ok();
     assert_eq!(
-        dir_parquet_distinct_strings(&fs.out_dir(), "_id").len(),
+        duckdb_dir_parquet_distinct_strings(&fs.out_dir(), "_id").len(),
         4,
         "full scan must read every doc including the NaN _id"
     );

--- a/tests/live/live_mongo_harm_permission.rs
+++ b/tests/live/live_mongo_harm_permission.rs
@@ -21,7 +21,7 @@ fn mongo_readonly_login_exports_despite_denied_harm_probe() {
     let rig = Rig::mongo_batch("t").source_url(&mongo_auth_reader_url());
     rig.run_ok();
     assert_eq!(
-        dir_parquet_distinct_strings(&rig.out_dir(), "_id").len(),
+        duckdb_dir_parquet_distinct_strings(&rig.out_dir(), "_id").len(),
         3,
         "the read-only export must still read every document"
     );

--- a/tests/live/live_mongo_retry_and_faults.rs
+++ b/tests/live/live_mongo_retry_and_faults.rs
@@ -55,7 +55,7 @@ fn mongo_export_survives_transient_latency_added_via_toxiproxy() {
     let rig = proxied(&db);
     rig.run_ok();
     assert_eq!(
-        dir_parquet_distinct_strings(&rig.out_dir(), "_id").len(),
+        duckdb_dir_parquet_distinct_strings(&rig.out_dir(), "_id").len(),
         8000,
         "latency must not lose rows"
     );
@@ -107,7 +107,7 @@ fn mongo_export_recovers_after_mid_stream_proxy_disable_then_enable_with_retries
     // at-least-once (committed parts + a full re-export can leave duplicate ROWS),
     // so assert on the DISTINCT _id set — the completeness oracle, dup-immune.
     assert_eq!(
-        dir_parquet_distinct_strings(&rig.out_dir(), "_id").len(),
+        duckdb_dir_parquet_distinct_strings(&rig.out_dir(), "_id").len(),
         100_000,
         "a mid-stream outage must never lose a row — recovered in place or safely re-run",
     );

--- a/tests/live/live_mssql_chunked_recovery.rs
+++ b/tests/live/live_mssql_chunked_recovery.rs
@@ -164,7 +164,7 @@ fn mssql_chunked_crash_after_first_chunk_complete_resume_finishes_export() {
         "destination must hold exactly 150 rows (no re-run, no dup)"
     );
     assert_eq!(
-        dir_parquet_id_set(&rig.out_dir()).len(),
+        duckdb_dir_parquet_id_set(&rig.out_dir()).len(),
         150,
         "150 distinct source ids must be present at the destination"
     );
@@ -246,7 +246,7 @@ fn mssql_chunked_crash_after_chunk_file_before_commit_resume_reruns_chunk_atleas
     // Destination re-read: every source id present (no loss) despite the
     // at-least-once chunk-0 re-run; physical rows >= source (the dup is surplus).
     assert_eq!(
-        dir_parquet_id_set(&rig.out_dir()).len(),
+        duckdb_dir_parquet_id_set(&rig.out_dir()).len(),
         150,
         "every seeded id must survive the at-least-once re-run (no loss)"
     );
@@ -356,7 +356,7 @@ fn mssql_parallel_chunked_crash_after_chunk_complete_resume_finishes_with_no_dup
         "destination must hold exactly ROW_COUNT rows — no parallel double-write"
     );
     assert_eq!(
-        dir_parquet_id_set(&rig.out_dir()).len() as i64,
+        duckdb_dir_parquet_id_set(&rig.out_dir()).len() as i64,
         ROW_COUNT,
         "ROW_COUNT distinct source ids must be present"
     );
@@ -461,7 +461,7 @@ fn mssql_parallel_chunked_crash_after_chunk_file_stuck_running_resume_reruns_chu
     // Destination re-read: every source id survives the stuck-running reset +
     // at-least-once re-run (no loss); physical rows >= source (dup is surplus).
     assert_eq!(
-        dir_parquet_id_set(&rig.out_dir()).len() as i64,
+        duckdb_dir_parquet_id_set(&rig.out_dir()).len() as i64,
         ROW_COUNT,
         "every seeded id must land after stuck-running reset + at-least-once re-run"
     );

--- a/tests/live/live_mssql_chunked_recovery.rs
+++ b/tests/live/live_mssql_chunked_recovery.rs
@@ -159,7 +159,7 @@ fn mssql_chunked_crash_after_first_chunk_complete_resume_finishes_export() {
     );
     // Destination re-read: chunk 0 not re-run → exactly 150 rows, 150 distinct ids.
     assert_eq!(
-        total_parquet_rows(&rig.out_dir()),
+        duckdb_total_parquet_rows(&rig.out_dir()),
         150,
         "destination must hold exactly 150 rows (no re-run, no dup)"
     );
@@ -251,7 +251,7 @@ fn mssql_chunked_crash_after_chunk_file_before_commit_resume_reruns_chunk_atleas
         "every seeded id must survive the at-least-once re-run (no loss)"
     );
     assert!(
-        total_parquet_rows(&rig.out_dir()) as i64 >= 150,
+        duckdb_total_parquet_rows(&rig.out_dir()) as i64 >= 150,
         "at-least-once: physical destination rows must be >= source (150)"
     );
 }
@@ -351,7 +351,7 @@ fn mssql_parallel_chunked_crash_after_chunk_complete_resume_finishes_with_no_dup
 
     // Destination re-read: no parallel double-write → exactly ROW_COUNT rows + distinct.
     assert_eq!(
-        total_parquet_rows(&rig.out_dir()) as i64,
+        duckdb_total_parquet_rows(&rig.out_dir()) as i64,
         ROW_COUNT,
         "destination must hold exactly ROW_COUNT rows — no parallel double-write"
     );
@@ -466,7 +466,7 @@ fn mssql_parallel_chunked_crash_after_chunk_file_stuck_running_resume_reruns_chu
         "every seeded id must land after stuck-running reset + at-least-once re-run"
     );
     assert!(
-        total_parquet_rows(&rig.out_dir()) as i64 >= ROW_COUNT,
+        duckdb_total_parquet_rows(&rig.out_dir()) as i64 >= ROW_COUNT,
         "at-least-once: physical destination rows must be >= ROW_COUNT"
     );
 

--- a/tests/live/live_mssql_crash_recovery.rs
+++ b/tests/live/live_mssql_crash_recovery.rs
@@ -219,7 +219,7 @@ fn mssql_crash_after_source_read_leaves_state_completely_clean() {
     assert!(cursor_value(&cfg, &export).is_some());
     // Re-read the destination (not the state DB): recovery file holds all 10 rows.
     assert_eq!(
-        total_parquet_rows(out.path()),
+        duckdb_total_parquet_rows(out.path()),
         10,
         "recovery file must hold all 10 rows"
     );
@@ -290,7 +290,7 @@ fn mssql_crash_after_file_write_leaves_file_but_no_manifest_or_cursor() {
         "recovery must leave every source id (1..=8) — a missing id is row LOSS"
     );
     assert!(
-        total_parquet_rows(out.path()) as i64 >= 8,
+        duckdb_total_parquet_rows(out.path()) as i64 >= 8,
         "at-least-once: physical destination rows must be >= source (8)"
     );
 }
@@ -343,7 +343,7 @@ fn mssql_crash_after_manifest_update_leaves_file_and_manifest_but_no_cursor() {
         "recovery must leave every source id (1..=7) — a missing id is row LOSS"
     );
     assert!(
-        total_parquet_rows(out.path()) as i64 >= 7,
+        duckdb_total_parquet_rows(out.path()) as i64 >= 7,
         "at-least-once: physical destination rows must be >= source (7)"
     );
 }
@@ -403,7 +403,7 @@ fn mssql_crash_after_cursor_commit_is_recoverable_with_full_state() {
     );
     // Destination re-read: committed file holds every source row exactly once.
     assert_eq!(
-        total_parquet_rows(out.path()),
+        duckdb_total_parquet_rows(out.path()),
         6,
         "committed file must hold all 6 rows once"
     );

--- a/tests/live/live_mssql_crash_recovery.rs
+++ b/tests/live/live_mssql_crash_recovery.rs
@@ -224,7 +224,7 @@ fn mssql_crash_after_source_read_leaves_state_completely_clean() {
         "recovery file must hold all 10 rows"
     );
     assert_eq!(
-        dir_parquet_id_set(out.path()),
+        duckdb_dir_parquet_id_set(out.path()),
         (1..=10).collect::<std::collections::BTreeSet<i64>>(),
         "recovery must surface every source id (1..=10)"
     );
@@ -285,7 +285,7 @@ fn mssql_crash_after_file_write_leaves_file_but_no_manifest_or_cursor() {
     );
     // Destination re-read: complete superset of the source (no loss), at-least-once surplus.
     assert_eq!(
-        dir_parquet_id_set(out.path()),
+        duckdb_dir_parquet_id_set(out.path()),
         (1..=8).collect::<std::collections::BTreeSet<i64>>(),
         "recovery must leave every source id (1..=8) — a missing id is row LOSS"
     );
@@ -338,7 +338,7 @@ fn mssql_crash_after_manifest_update_leaves_file_and_manifest_but_no_cursor() {
     assert!(cursor_value(&cfg, &export).is_some());
     // Destination re-read: complete superset of the source (no loss).
     assert_eq!(
-        dir_parquet_id_set(out.path()),
+        duckdb_dir_parquet_id_set(out.path()),
         (1..=7).collect::<std::collections::BTreeSet<i64>>(),
         "recovery must leave every source id (1..=7) — a missing id is row LOSS"
     );
@@ -408,7 +408,7 @@ fn mssql_crash_after_cursor_commit_is_recoverable_with_full_state() {
         "committed file must hold all 6 rows once"
     );
     assert_eq!(
-        dir_parquet_id_set(out.path()),
+        duckdb_dir_parquet_id_set(out.path()),
         (1..=6).collect::<std::collections::BTreeSet<i64>>(),
         "committed file must hold every source id (1..=6)"
     );

--- a/tests/live/live_mssql_reconcile_repair.rs
+++ b/tests/live/live_mssql_reconcile_repair.rs
@@ -77,7 +77,7 @@ fn mssql_reconcile_all_match_exits_zero_with_pretty_output() {
     // chain. Re-read the destination parquet and count physically (matrix
     // audit: self-oracle class) — the verdict and the physical rows must agree.
     assert_eq!(
-        total_parquet_rows(&rig.out_dir()),
+        duckdb_total_parquet_rows(&rig.out_dir()),
         100,
         "destination parquet must physically hold every source row, independent of the reconcile verdict"
     );

--- a/tests/live/live_mssql_resume.rs
+++ b/tests/live/live_mssql_resume.rs
@@ -161,7 +161,7 @@ fn mssql_roast_rapid_incremental_runs_into_same_prefix_must_not_clobber_prior_pa
     }
 
     assert_eq!(
-        dir_parquet_id_set(out.path()),
+        duckdb_dir_parquet_id_set(out.path()),
         (0..N).collect::<std::collections::BTreeSet<i64>>(),
         "every incremental delta must survive; a clobbered part is silent data loss"
     );

--- a/tests/live/live_mssql_resume.rs
+++ b/tests/live/live_mssql_resume.rs
@@ -107,7 +107,7 @@ fn mssql_full_mode_repeated_run_accumulates_manifest_entries() {
     // when the manifest sidecar clobbers; the copies' summed row_count is RED
     // pre-fix (one clobbered manifest.json held only the last run's rows).
     assert_eq!(
-        total_parquet_rows(out.path()),
+        duckdb_total_parquet_rows(out.path()),
         20,
         "two full runs of 10 rows must materialise 20 physical rows"
     );

--- a/tests/live/live_mysql_chunked_recovery.rs
+++ b/tests/live/live_mysql_chunked_recovery.rs
@@ -159,7 +159,7 @@ fn mysql_chunked_crash_after_first_chunk_complete_resume_finishes_export() {
     );
     // Destination re-read: chunk 0 not re-run → exactly 150 rows, 150 distinct ids.
     assert_eq!(
-        total_parquet_rows(&rig.out_dir()),
+        duckdb_total_parquet_rows(&rig.out_dir()),
         150,
         "destination must hold exactly 150 rows (no re-run, no dup)"
     );
@@ -251,7 +251,7 @@ fn mysql_chunked_crash_after_chunk_file_before_commit_resume_reruns_chunk_atleas
         "every seeded id must survive the at-least-once re-run (no loss)"
     );
     assert!(
-        total_parquet_rows(&rig.out_dir()) as i64 >= 150,
+        duckdb_total_parquet_rows(&rig.out_dir()) as i64 >= 150,
         "at-least-once: physical destination rows must be >= source (150)"
     );
 }
@@ -358,7 +358,7 @@ fn mysql_parallel_chunked_crash_after_chunk_complete_resume_finishes_with_no_dup
     // Destination re-read: no parallel double-write → exactly ROW_COUNT rows,
     // ROW_COUNT distinct ids.
     assert_eq!(
-        total_parquet_rows(&rig.out_dir()) as i64,
+        duckdb_total_parquet_rows(&rig.out_dir()) as i64,
         ROW_COUNT,
         "destination must hold exactly ROW_COUNT rows — no parallel double-write"
     );
@@ -473,7 +473,7 @@ fn mysql_parallel_chunked_crash_after_chunk_file_stuck_running_resume_reruns_chu
         "every seeded id must land after stuck-running reset + at-least-once re-run"
     );
     assert!(
-        total_parquet_rows(&rig.out_dir()) as i64 >= ROW_COUNT,
+        duckdb_total_parquet_rows(&rig.out_dir()) as i64 >= ROW_COUNT,
         "at-least-once: physical destination rows must be >= ROW_COUNT"
     );
 }

--- a/tests/live/live_mysql_chunked_recovery.rs
+++ b/tests/live/live_mysql_chunked_recovery.rs
@@ -164,7 +164,7 @@ fn mysql_chunked_crash_after_first_chunk_complete_resume_finishes_export() {
         "destination must hold exactly 150 rows (no re-run, no dup)"
     );
     assert_eq!(
-        dir_parquet_id_set(&rig.out_dir()).len(),
+        duckdb_dir_parquet_id_set(&rig.out_dir()).len(),
         150,
         "150 distinct source ids must be present at the destination"
     );
@@ -246,7 +246,7 @@ fn mysql_chunked_crash_after_chunk_file_before_commit_resume_reruns_chunk_atleas
     // Destination re-read: every source id present (no loss) despite the
     // at-least-once chunk-0 re-run; physical rows >= source (the dup is surplus).
     assert_eq!(
-        dir_parquet_id_set(&rig.out_dir()).len(),
+        duckdb_dir_parquet_id_set(&rig.out_dir()).len(),
         150,
         "every seeded id must survive the at-least-once re-run (no loss)"
     );
@@ -363,7 +363,7 @@ fn mysql_parallel_chunked_crash_after_chunk_complete_resume_finishes_with_no_dup
         "destination must hold exactly ROW_COUNT rows — no parallel double-write"
     );
     assert_eq!(
-        dir_parquet_id_set(&rig.out_dir()).len() as i64,
+        duckdb_dir_parquet_id_set(&rig.out_dir()).len() as i64,
         ROW_COUNT,
         "ROW_COUNT distinct source ids must be present"
     );
@@ -468,7 +468,7 @@ fn mysql_parallel_chunked_crash_after_chunk_file_stuck_running_resume_reruns_chu
     // Destination re-read: every source id survives the stuck-running reset +
     // at-least-once re-run (no loss); physical rows >= source (the dup is surplus).
     assert_eq!(
-        dir_parquet_id_set(&rig.out_dir()).len() as i64,
+        duckdb_dir_parquet_id_set(&rig.out_dir()).len() as i64,
         ROW_COUNT,
         "every seeded id must land after stuck-running reset + at-least-once re-run"
     );

--- a/tests/live/live_mysql_crash_recovery.rs
+++ b/tests/live/live_mysql_crash_recovery.rs
@@ -221,7 +221,7 @@ fn mysql_crash_after_source_read_leaves_state_completely_clean() {
         "recovery file must hold all 10 rows"
     );
     assert_eq!(
-        dir_parquet_id_set(out.path()),
+        duckdb_dir_parquet_id_set(out.path()),
         (1..=10).collect::<std::collections::BTreeSet<i64>>(),
         "recovery must surface every source id (1..=10)"
     );
@@ -284,7 +284,7 @@ fn mysql_crash_after_file_write_leaves_file_but_no_manifest_or_cursor() {
     // source (every id present — no loss across orphan+recovery), with
     // at-least-once duplication the only surplus.
     assert_eq!(
-        dir_parquet_id_set(out.path()),
+        duckdb_dir_parquet_id_set(out.path()),
         (1..=8).collect::<std::collections::BTreeSet<i64>>(),
         "recovery must leave every source id (1..=8) — a missing id is row LOSS"
     );
@@ -337,7 +337,7 @@ fn mysql_crash_after_manifest_update_leaves_file_and_manifest_but_no_cursor() {
     assert!(cursor_value(&cfg, &export).is_some());
     // Destination re-read: complete superset of the source (no loss).
     assert_eq!(
-        dir_parquet_id_set(out.path()),
+        duckdb_dir_parquet_id_set(out.path()),
         (1..=7).collect::<std::collections::BTreeSet<i64>>(),
         "recovery must leave every source id (1..=7) — a missing id is row LOSS"
     );
@@ -408,7 +408,7 @@ fn mysql_crash_after_cursor_commit_is_recoverable_with_full_state() {
         "committed file must hold all 6 rows once"
     );
     assert_eq!(
-        dir_parquet_id_set(out.path()),
+        duckdb_dir_parquet_id_set(out.path()),
         (1..=6).collect::<std::collections::BTreeSet<i64>>(),
         "committed file must hold every source id (1..=6)"
     );

--- a/tests/live/live_mysql_crash_recovery.rs
+++ b/tests/live/live_mysql_crash_recovery.rs
@@ -216,7 +216,7 @@ fn mysql_crash_after_source_read_leaves_state_completely_clean() {
     // Re-read the destination (not the state DB): the recovery file holds every
     // source row exactly once.
     assert_eq!(
-        total_parquet_rows(out.path()),
+        duckdb_total_parquet_rows(out.path()),
         10,
         "recovery file must hold all 10 rows"
     );
@@ -289,7 +289,7 @@ fn mysql_crash_after_file_write_leaves_file_but_no_manifest_or_cursor() {
         "recovery must leave every source id (1..=8) — a missing id is row LOSS"
     );
     assert!(
-        total_parquet_rows(out.path()) as i64 >= 8,
+        duckdb_total_parquet_rows(out.path()) as i64 >= 8,
         "at-least-once: physical destination rows must be >= source (8)"
     );
 }
@@ -342,7 +342,7 @@ fn mysql_crash_after_manifest_update_leaves_file_and_manifest_but_no_cursor() {
         "recovery must leave every source id (1..=7) — a missing id is row LOSS"
     );
     assert!(
-        total_parquet_rows(out.path()) as i64 >= 7,
+        duckdb_total_parquet_rows(out.path()) as i64 >= 7,
         "at-least-once: physical destination rows must be >= source (7)"
     );
 }
@@ -403,7 +403,7 @@ fn mysql_crash_after_cursor_commit_is_recoverable_with_full_state() {
     // Destination re-read: the durably-committed file holds every source row
     // exactly once (cursor committed before the crash → no re-export, no dup).
     assert_eq!(
-        total_parquet_rows(out.path()),
+        duckdb_total_parquet_rows(out.path()),
         6,
         "committed file must hold all 6 rows once"
     );

--- a/tests/live/live_mysql_reconcile_repair.rs
+++ b/tests/live/live_mysql_reconcile_repair.rs
@@ -76,7 +76,7 @@ fn mysql_reconcile_all_match_exits_zero_with_pretty_output() {
     // chain. Re-read the destination parquet and count physically (matrix
     // audit: self-oracle class) — the verdict and the physical rows must agree.
     assert_eq!(
-        total_parquet_rows(&rig.out_dir()),
+        duckdb_total_parquet_rows(&rig.out_dir()),
         100,
         "destination parquet must physically hold every source row, independent of the reconcile verdict"
     );

--- a/tests/live/live_mysql_resume.rs
+++ b/tests/live/live_mysql_resume.rs
@@ -166,7 +166,7 @@ fn mysql_roast_rapid_incremental_runs_into_same_prefix_must_not_clobber_prior_pa
     }
 
     assert_eq!(
-        dir_parquet_id_set(out.path()),
+        duckdb_dir_parquet_id_set(out.path()),
         (0..N).collect::<std::collections::BTreeSet<i64>>(),
         "every incremental delta must survive; a clobbered part is silent data loss"
     );

--- a/tests/live/live_mysql_resume.rs
+++ b/tests/live/live_mysql_resume.rs
@@ -110,7 +110,7 @@ fn mysql_full_mode_repeated_run_accumulates_manifest_entries() {
     // when the manifest sidecar clobbers; the copies' summed row_count is RED
     // pre-fix (one clobbered manifest.json held only the last run's rows).
     assert_eq!(
-        total_parquet_rows(out.path()),
+        duckdb_total_parquet_rows(out.path()),
         20,
         "two full runs of 10 rows must materialise 20 physical rows"
     );

--- a/tests/live/live_plan_apply.rs
+++ b/tests/live/live_plan_apply.rs
@@ -226,7 +226,7 @@ fn plan_and_apply_chunked_export_round_trip_uses_precomputed_ranges() {
         "3 chunks must land all 150 rows"
     );
     assert_eq!(
-        dir_parquet_id_set(&rig.out_dir()),
+        duckdb_dir_parquet_id_set(&rig.out_dir()),
         (0..150).collect::<std::collections::BTreeSet<i64>>(),
         "chunked round-trip must hold every source id 0..150"
     );
@@ -350,7 +350,7 @@ fn apply_replay_case(extra_mode_lines: &str) {
         "apply must move only the rows its plan covered"
     );
     assert_eq!(
-        dir_parquet_id_set(&rig.out_dir()),
+        duckdb_dir_parquet_id_set(&rig.out_dir()),
         (0..150).collect::<std::collections::BTreeSet<i64>>(),
         "the ids must be exactly the planned range — rows added after planning \
          belong to the next run, not this artifact"

--- a/tests/live/live_plan_apply.rs
+++ b/tests/live/live_plan_apply.rs
@@ -134,7 +134,7 @@ fn plan_and_apply_full_export_round_trip() {
     );
     // Back the round-trip claim with an independent destination read.
     assert_eq!(
-        total_parquet_rows(&rig.out_dir()),
+        duckdb_total_parquet_rows(&rig.out_dir()),
         30,
         "full plan+apply must land all 30 rows"
     );
@@ -221,7 +221,7 @@ fn plan_and_apply_chunked_export_round_trip_uses_precomputed_ranges() {
     // Back the chunked round-trip with an independent destination read: all 150
     // rows across the 3 chunks, distinct ids 0..150 (no drop/dup at boundaries).
     assert_eq!(
-        total_parquet_rows(&rig.out_dir()),
+        duckdb_total_parquet_rows(&rig.out_dir()),
         150,
         "3 chunks must land all 150 rows"
     );
@@ -345,7 +345,7 @@ fn apply_replay_case(extra_mode_lines: &str) {
          grown table; found: {parquet:?}"
     );
     assert_eq!(
-        total_parquet_rows(&rig.out_dir()),
+        duckdb_total_parquet_rows(&rig.out_dir()),
         150,
         "apply must move only the rows its plan covered"
     );
@@ -555,7 +555,7 @@ fn apply_force_flag_bypasses_expired_plan() {
     );
     // "Data must actually be exported" — back it with a destination read.
     assert_eq!(
-        total_parquet_rows(&rig.out_dir()),
+        duckdb_total_parquet_rows(&rig.out_dir()),
         10,
         "forced apply must still land all 10 rows"
     );
@@ -650,7 +650,7 @@ fn plan_param_flag_substitutes_in_query() {
     );
     // Back the export_metrics count with an independent destination read.
     assert_eq!(
-        total_parquet_rows(&rig.out_dir()),
+        duckdb_total_parquet_rows(&rig.out_dir()),
         20,
         "param max_id=19 must physically land exactly 20 rows at the destination"
     );

--- a/tests/live/live_reconcile_repair.rs
+++ b/tests/live/live_reconcile_repair.rs
@@ -73,7 +73,7 @@ fn reconcile_all_match_exits_zero_with_pretty_output() {
     // chain. Re-read the destination parquet and count physically (matrix
     // audit: self-oracle class) — the verdict and the physical rows must agree.
     assert_eq!(
-        total_parquet_rows(&rig.out_dir()),
+        duckdb_total_parquet_rows(&rig.out_dir()),
         100,
         "destination parquet must physically hold every source row, independent of the reconcile verdict"
     );

--- a/tests/live/live_resume.rs
+++ b/tests/live/live_resume.rs
@@ -200,7 +200,7 @@ fn roast_rapid_incremental_runs_into_same_prefix_must_not_clobber_prior_parts() 
 
     // The union of all deltas must be every id — no run's part was clobbered.
     assert_eq!(
-        dir_parquet_id_set(out.path()),
+        duckdb_dir_parquet_id_set(out.path()),
         (0..N).collect::<std::collections::BTreeSet<i64>>(),
         "every incremental delta must survive; a clobbered part is silent data loss"
     );
@@ -277,7 +277,7 @@ fn pg_incremental_cursor_survives_a_non_utc_session_timezone() {
     );
 
     assert_eq!(
-        dir_parquet_id_set(out.path()),
+        duckdb_dir_parquet_id_set(out.path()),
         (1..=4).collect::<std::collections::BTreeSet<i64>>(),
         "a non-UTC session must not skip the offset-window rows (3,4) — the incremental \
          cursor boundary must be parsed as UTC, not the session zone"

--- a/tests/live/live_resume.rs
+++ b/tests/live/live_resume.rs
@@ -719,12 +719,12 @@ fn incremental_manifest_ships_contiguous_cursor_range() {
 /// `if let Some(..)` with no else then swallow it, so nothing is recorded and
 /// nothing is committed.
 ///
-/// Measured on this stand — 20 dated rows plus ONE with `updated_at IS NULL`:
+/// Measured on this stand — 20 dated rows plus 25 with `updated_at IS NULL`:
 ///
-///   with the NULL row      21, 21, 21 rows   `export_state` EMPTY
-///   without it (control)   20,  0,  0 rows   `export_state` → 2026-…T19:44:23
+///   with the NULL rows     45, 45, 45 rows   `export_state` EMPTY
+///   without them (control) 20,  0,  0 rows   `export_state` → 2026-…T19:44:23
 ///
-/// Three runs put 63 rows at the destination for a 21-row table, every run
+/// Three runs put 135 rows at the destination for a 45-row table, every run
 /// reporting success with mode `incremental`. Unbounded: the stored cursor is
 /// never written, so the unfiltered branch is taken forever and the NULL row is
 /// re-included every time, re-arming the wipe.
@@ -751,7 +751,8 @@ fn roast_a_null_cursor_cell_must_not_freeze_the_incremental_cursor() {
         "CREATE TABLE {table} (id int PRIMARY KEY, updated_at timestamptz, v text);
          INSERT INTO {table} SELECT g, now() - (g||' min')::interval, 'v'||g
            FROM generate_series(1,20) g;
-         INSERT INTO {table} VALUES (99, NULL, 'null_cursor_row');"
+         INSERT INTO {table} SELECT 100 + g, NULL, 'null_'||g
+           FROM generate_series(1,25) g;"
     ))
     .unwrap();
     let _guard = PgTable::adopt(table.clone());
@@ -760,13 +761,13 @@ fn roast_a_null_cursor_cell_must_not_freeze_the_incremental_cursor() {
     // is the whole mechanism. Assert it rather than assume the collation.
     let last: i32 = c
         .query_one(
-            &format!("SELECT id FROM {table} ORDER BY updated_at ASC LIMIT 1 OFFSET 20"),
+            &format!("SELECT id FROM {table} ORDER BY updated_at ASC LIMIT 1 OFFSET 44"),
             &[],
         )
         .expect("order probe")
         .get(0);
-    assert_eq!(
-        last, 99,
+    assert!(
+        last > 100,
         "fixture is inert: the NULL-cursor row is not ASC-last on this server, so the wipe \
          cannot occur and a green result would mean nothing"
     );
@@ -775,6 +776,12 @@ fn roast_a_null_cursor_cell_must_not_freeze_the_incremental_cursor() {
     let rig = Rig::pg_batch(&format!("public.{table}"))
         .mode("incremental")
         .export_line("cursor_column: updated_at")
+        // A SMALL batch on purpose: 25 NULL-cursor rows at batch_size 10 means
+        // the final batches are ENTIRELY null, which is the case the backward
+        // scan cannot rescue and only the "never erase the mark" half covers.
+        // With a single NULL row the second half is belt-and-suspenders; this
+        // fixture makes it load-bearing, so both halves are proven.
+        .export_line("tuning: {batch_size: 10}")
         .dest_path(out.path().to_path_buf());
     let cfg = rig.config_path();
 
@@ -796,17 +803,21 @@ fn roast_a_null_cursor_cell_must_not_freeze_the_incremental_cursor() {
     // count is read from the destination by DuckDB, so a "0 new rows" claim by
     // rivet cannot satisfy it.
     assert_eq!(
-        per_run[0], 21,
-        "first run must export all 21 rows, got {}",
+        per_run[0], 45,
+        "first run must export all 45 rows, got {}",
         per_run[0]
     );
     assert_eq!(
-        per_run[2], 21,
-        "after three incremental runs the destination holds {} rows for a 21-row table \
-         ({:?} cumulative). One row has a NULL cursor cell and sorts ASC-LAST on PostgreSQL, so \
-         it overwrites the high-water mark with None; nothing is recorded, nothing is committed, \
-         and every run re-reads the whole table forever. The same fixture without that one row \
-         exports 20 then 0 then 0.",
+        per_run[2], 45,
+        "after three incremental runs the destination holds {} rows for a 45-row table \
+         ({:?} cumulative). 25 rows have a NULL cursor cell and sort ASC-LAST on PostgreSQL, so \
+         they overwrite the high-water mark with None; nothing is recorded, nothing is \
+         committed, and every run re-reads the whole table forever. The same fixture without \
+         them exports 20 then 0 then 0.\n\nThe fixture is sized for BOTH halves of the fix: 25 \
+         null rows at batch_size 10 means the final batches are ENTIRELY null, which the \
+         last-non-null scan cannot rescue and only the never-erase-the-mark guard covers. With a \
+         single null row the second half is belt-and-suspenders; here each half fails this test \
+         on its own.",
         per_run[2], per_run
     );
 }

--- a/tests/live/live_resume.rs
+++ b/tests/live/live_resume.rs
@@ -704,3 +704,109 @@ fn incremental_manifest_ships_contiguous_cursor_range() {
     );
     assert_eq!(e2["cursor_high"], "7", "run 2 covered up to id 7");
 }
+
+// ─── a NULL cursor cell must not disable incremental ─────────────────────────
+
+/// One row whose cursor cell is NULL must not stop the incremental cursor from
+/// advancing.
+///
+/// `ExportSink::on_batch` assigns the high-water mark UNCONDITIONALLY
+/// (src/pipeline/sink/mod.rs:730-732), and `extract_last_cursor_value` returns
+/// `None` when the LAST ROW's cursor cell is NULL — silently, with no log.
+/// Incremental queries always append `ORDER BY <cursor>` and PostgreSQL sorts
+/// NULLs LAST in ASC, so a single NULL-cursor row is the last row of the last
+/// batch and overwrites the good mark accumulated from every prior batch. Two
+/// `if let Some(..)` with no else then swallow it, so nothing is recorded and
+/// nothing is committed.
+///
+/// Measured on this stand — 20 dated rows plus ONE with `updated_at IS NULL`:
+///
+///   with the NULL row      21, 21, 21 rows   `export_state` EMPTY
+///   without it (control)   20,  0,  0 rows   `export_state` → 2026-…T19:44:23
+///
+/// Three runs put 63 rows at the destination for a 21-row table, every run
+/// reporting success with mode `incremental`. Unbounded: the stored cursor is
+/// never written, so the unfiltered branch is taken forever and the NULL row is
+/// re-included every time, re-arming the wipe.
+///
+/// The CONTROL arm is what makes this a causal claim rather than an observation:
+/// the same table, same config, same prefix shape, with only the NULL row
+/// removed, advances the cursor and exports 0 on the second run. Nothing else
+/// differs.
+///
+/// PostgreSQL-specific by collation of NULL ordering — MySQL and SQL Server sort
+/// NULLs FIRST in ASC, so the last row carries a real value there and the mark
+/// survives. `rivet init` discovers and emits nullable cursor candidates (it
+/// notes "Primary cursor candidate is nullable; consider coalesce" — a
+/// suggestion, not a requirement), so this config is one init away.
+// AUDIT-RED null-cursor-wipe: a NULL in the ASC-last row wipes the incremental high-water mark; the cursor is never written and every run re-exports the whole table. Asserts CORRECT behavior; expected to FAIL until fixed.
+#[test]
+#[ignore = "live: requires docker compose up -d postgres"]
+fn roast_a_null_cursor_cell_must_not_freeze_the_incremental_cursor() {
+    require_alive(LiveService::Postgres);
+
+    let table = unique_name("null_cursor");
+    let mut c = pg_connect();
+    c.batch_execute(&format!(
+        "CREATE TABLE {table} (id int PRIMARY KEY, updated_at timestamptz, v text);
+         INSERT INTO {table} SELECT g, now() - (g||' min')::interval, 'v'||g
+           FROM generate_series(1,20) g;
+         INSERT INTO {table} VALUES (99, NULL, 'null_cursor_row');"
+    ))
+    .unwrap();
+    let _guard = PgTable::adopt(table.clone());
+
+    // The fixture is only expressive if the NULL row really is ASC-LAST — that
+    // is the whole mechanism. Assert it rather than assume the collation.
+    let last: i32 = c
+        .query_one(
+            &format!("SELECT id FROM {table} ORDER BY updated_at ASC LIMIT 1 OFFSET 20"),
+            &[],
+        )
+        .expect("order probe")
+        .get(0);
+    assert_eq!(
+        last, 99,
+        "fixture is inert: the NULL-cursor row is not ASC-last on this server, so the wipe \
+         cannot occur and a green result would mean nothing"
+    );
+
+    let out = tempfile::tempdir().unwrap();
+    let rig = Rig::pg_batch(&format!("public.{table}"))
+        .mode("incremental")
+        .export_line("cursor_column: updated_at")
+        .dest_path(out.path().to_path_buf());
+    let cfg = rig.config_path();
+
+    let mut per_run = Vec::new();
+    for _ in 0..3 {
+        let o = run_rivet_env(
+            &["run", "--config", cfg.to_str().unwrap()],
+            &[("RUST_LOG", "warn")],
+        );
+        assert!(
+            o.status.success(),
+            "incremental run must succeed; stderr:\n{}",
+            String::from_utf8_lossy(&o.stderr)
+        );
+        per_run.push(duckdb_total_parquet_rows(out.path()));
+    }
+
+    // Run 1 reads everything; runs 2 and 3 must add nothing. The cumulative
+    // count is read from the destination by DuckDB, so a "0 new rows" claim by
+    // rivet cannot satisfy it.
+    assert_eq!(
+        per_run[0], 21,
+        "first run must export all 21 rows, got {}",
+        per_run[0]
+    );
+    assert_eq!(
+        per_run[2], 21,
+        "after three incremental runs the destination holds {} rows for a 21-row table \
+         ({:?} cumulative). One row has a NULL cursor cell and sorts ASC-LAST on PostgreSQL, so \
+         it overwrites the high-water mark with None; nothing is recorded, nothing is committed, \
+         and every run re-reads the whole table forever. The same fixture without that one row \
+         exports 20 then 0 then 0.",
+        per_run[2], per_run
+    );
+}

--- a/tests/offline/attestation_matrix_guard.rs
+++ b/tests/offline/attestation_matrix_guard.rs
@@ -138,3 +138,131 @@ fn unverified_claims_do_not_grow() {
         );
     }
 }
+
+/// Guard #5 — a value-consuming claim must say WHICH TYPES it saw.
+///
+/// The four guards above ask *who* verifies a number. This one asks *what they
+/// looked at*, and it exists because the first question can be answered
+/// perfectly while the second goes unasked.
+///
+/// `row_hash_column` carried `independence: independent`, named a real second
+/// implementation (`dev/release_oracle/rowhash.py`, a Python rebuild of the
+/// canonical image hashed with `xxhash`) and recorded `PASS on
+/// postgres/mysql/mssql 2026-08-02`. Every word true. It still missed
+/// `Timestamp(µs, Some("UTC"))` — 278 of 1184 columns in a real production
+/// database — because the probe it ran against did not carry that type. The
+/// failure cost 63 of 65 exports on 2026-08-05.
+///
+/// So: any claim about a number DERIVED FROM CELL VALUES must declare its type
+/// coverage. The consumer list is derived from the ledger itself (claims whose
+/// `what` names a per-value digest), not hand-written here, so a NEW value
+/// consumer added to the matrix inherits the requirement without anyone
+/// remembering to extend this test.
+#[test]
+fn a_value_derived_claim_declares_its_type_coverage() {
+    // A claim is value-derived if its own text says it is computed per row or
+    // per column from cell values. Derived from the row, not a literal list —
+    // a hand-written list grades only what its author already knew, which is
+    // the exact failure this guard was written for.
+    let value_derived: Vec<Value> = claims()
+        .into_iter()
+        .filter(|c| {
+            let what = field(c, "what").unwrap_or_default().to_lowercase();
+            (what.contains("per-row")
+                || what.contains("per-column")
+                || what.contains("value digest"))
+                && (what.contains("digest") || what.contains("hash") || what.contains("checksum"))
+        })
+        .collect();
+
+    assert!(
+        value_derived.len() >= 3,
+        "expected at least the three known value consumers (row_hash, Form A, Form B); \
+         found {} — has a `what:` been reworded so this guard no longer recognises it? \
+         The filter is deliberately on the CLAIM's own description, so rewording it \
+         silently drops the requirement.",
+        value_derived.len()
+    );
+
+    for c in &value_derived {
+        let cov = field(c, "type_coverage").unwrap_or_default();
+        assert!(
+            !cov.trim().is_empty(),
+            "claim '{}' is derived from CELL VALUES but declares no `type_coverage:`. \
+             Naming a verifier is not enough — `row_hash_column` named an INDEPENDENT one \
+             and still missed a type that is 23% of a real database, because nothing said \
+             which types the verifier had seen. Add `type_coverage:` naming the fixture and \
+             the test, or state the gap.",
+            id(c)
+        );
+        // A coverage claim that names no fixture is a sentence, not a check.
+        assert!(
+            cov.contains("rivet_type_matrix") || cov.to_lowercase().contains("gap"),
+            "claim '{}' declares type_coverage but names no fixture: {cov:?}. \
+             Point it at `rivet_type_matrix` (the golden fixture that spans the type \
+             surface) and the test that drives it, or say `gap:` and why.",
+            id(c)
+        );
+    }
+}
+
+/// Guard #6 — the fixture those claims point at must actually span the type
+/// surface, and the test that drives it must exist.
+///
+/// Guard #5 makes a claim NAME its coverage; this one makes the name true. The
+/// pair is deliberate: a declaration nobody checks is how
+/// `docs/scenario-artifact-matrix.yaml` came to list five tables as having "no
+/// export_name column" when three of them did.
+#[test]
+fn the_type_coverage_fixture_and_its_driver_exist() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+
+    // The driver: one export putting the fixture through every value consumer.
+    let stand = fs::read_to_string(root.join("tests/live/chunking_stand.rs"))
+        .expect("read tests/live/chunking_stand.rs");
+    assert!(
+        stand.contains("fn run_type_matrix_through_every_value_consumer"),
+        "the claims point at `stand_type_matrix_every_consumer_*`, but its driver is gone \
+         from tests/live/chunking_stand.rs — a renamed or deleted test leaves the ledger \
+         asserting coverage that nothing produces."
+    );
+    for eng in ["postgres", "mysql", "mssql"] {
+        assert!(
+            stand.contains(&format!("stand_type_matrix_every_consumer_{eng}")),
+            "engine `{eng}` has no value-consumer test. The production failure this guards \
+             was on MySQL while the only such test ran on PostgreSQL — one engine standing \
+             in for three is exactly how it was missed."
+        );
+    }
+
+    // The fixture: the golden type matrix must carry a TIMEZONE-AWARE timestamp,
+    // the shape that broke. Checked per engine because the seeds are separate
+    // files and can drift apart (they did: `dbo.orders` had two owners).
+    for (seed, needle) in [
+        ("seeds/common/mysql.sql", "TIMESTAMP"),
+        ("seeds/common/postgres.sql", "TIMESTAMPTZ"),
+        ("seeds/common/mssql.sql", "DATETIMEOFFSET"),
+    ] {
+        let text =
+            fs::read_to_string(root.join(seed)).unwrap_or_else(|e| panic!("read {seed}: {e}"));
+        // Slice from the CREATE TABLE to its closing paren. Splitting on the
+        // bare word picks up comments and INSERTs — the first draft did, and
+        // reported PostgreSQL as missing a column it has carried all along.
+        let upper = text.to_uppercase();
+        let create = upper
+            .find("CREATE TABLE")
+            .and_then(|i| upper[i..].find("TYPE_MATRIX").map(|j| i + j))
+            .unwrap_or_else(|| panic!("{seed} has no `CREATE TABLE ... type_matrix`"));
+        let end = upper[create..]
+            .find("\n);")
+            .map(|e| create + e)
+            .unwrap_or(upper.len());
+        let matrix_block = &upper[create..end];
+        assert!(
+            matrix_block.contains(needle),
+            "{seed}'s type_matrix carries no {needle} column. The type-coverage claims in \
+             {MATRIX} rest on this fixture spanning the type surface; a timezone-aware \
+             timestamp is the specific shape that cost 63 of 65 exports on 2026-08-05."
+        );
+    }
+}

--- a/tests/offline/destructive_delete_gate.rs
+++ b/tests/offline/destructive_delete_gate.rs
@@ -31,9 +31,18 @@
 
 use std::path::PathBuf;
 
+/// dispatch.rs up to its `#[cfg(test)]` module.
+///
+/// The test module builds `LoadSection` values and so mentions `cleanup_source`
+/// without deleting anything — it caught one on the first run. The subject here
+/// is production wiring; a fixture naming the flag is not a delete site.
 fn dispatch_src() -> String {
     let p = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/cli/dispatch.rs");
-    std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()))
+    let all = std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()));
+    match all.find("\n#[cfg(test)]") {
+        Some(i) => all[..i].to_string(),
+        None => all,
+    }
 }
 
 /// Split a Rust source into `fn` bodies keyed by name, by brace depth.
@@ -90,22 +99,10 @@ fn fn_bodies(src: &str) -> Vec<(String, String)> {
 /// or incremental export the source side has already advanced (slot acked,
 /// cursor committed), so those rows then exist in neither the source log, nor
 /// the destination, nor the warehouse.
-/// STATUS: RED against current code, and `#[ignore]`d for that reason rather
-/// than because it needs anything to be running.
-///
-/// The live suite has a convention for a guard that documents an open finding
-/// (`AUDIT-RED … expected to FAIL until fixed`) because that suite is run with
-/// `--ignored` and its reds are visible. The offline suite has no such
-/// convention: it is the green gate every commit is measured against, so a red
-/// test here would read as a broken build rather than as a recorded finding.
-///
-/// So it is opt-in: `cargo test --test offline_suite -- --ignored
-/// cleanup_source_must_consult`. Remove the `#[ignore]` in the same commit that
-/// gates the delete — at that point it becomes a real regression guard and
-/// belongs in the gate.
-// AUDIT-RED destructive-delete-gate: cleanup_source wipes the whole prefix with no live-run check, while the strictly gentler gc_orphans on the same prefix consults the ledger. Asserts CORRECT behavior; expected to FAIL until fixed.
+/// GREEN as of the commit that gated the delete; it was written RED and opt-in
+/// while the finding was open, and joins the gate now that it guards a fix
+/// rather than recording a gap.
 #[test]
-#[ignore = "AUDIT-RED: open finding — cleanup_source is ungated; run with --ignored"]
 fn cleanup_source_must_consult_the_active_run_ledger() {
     let src = dispatch_src();
     let bodies = fn_bodies(&src);
@@ -115,15 +112,19 @@ fn cleanup_source_must_consult_the_active_run_ledger() {
         bodies.len()
     );
 
-    // The sites that turn the flag into a delete target.
+    // Every function that reads the flag at all. Detection is on `cleanup_source`
+    // rather than on a particular expression shape: the first version keyed on
+    // `… .then_some(..)` and went blind the moment the construction was extracted
+    // into a helper — it said so loudly instead of passing, which is the only
+    // reason this is not a silently dead guard today.
     let deleters: Vec<&(String, String)> = bodies
         .iter()
-        .filter(|(_, b)| b.contains("cleanup_source") && b.contains("then_some"))
+        .filter(|(n, b)| b.contains("cleanup_source") && n != "cleanup_source")
         .collect();
     assert!(
         !deleters.is_empty(),
-        "no `cleanup_source … then_some(..)` site found in dispatch.rs — the wiring moved, and \
-         this guard now checks nothing. Re-point it at the new delete-target construction."
+        "no function in dispatch.rs reads `cleanup_source` — the wiring moved, and this guard \
+         now checks nothing. Re-point it at the new delete-target construction."
     );
 
     // The signal the gentler delete already uses, in the same file.
@@ -133,9 +134,23 @@ fn cleanup_source_must_consult_the_active_run_ledger() {
          gate is gone, which is a bigger problem than the one this guard was written for."
     );
 
+    // Reaching the ledger through ONE named helper counts. A guard that demanded
+    // the call be inline would forbid the obvious refactor — and the obvious
+    // refactor is what a fix looks like when three call sites share one rule.
+    let reaches_ledger = |body: &str| -> bool {
+        if body.contains("has_active_run_on_prefix") {
+            return true;
+        }
+        bodies.iter().any(|(callee, cbody)| {
+            !callee.is_empty()
+                && body.contains(&format!("{callee}("))
+                && cbody.contains("has_active_run_on_prefix")
+        })
+    };
+
     let ungated: Vec<&str> = deleters
         .iter()
-        .filter(|(_, b)| !b.contains("has_active_run_on_prefix"))
+        .filter(|(_, b)| !reaches_ledger(b))
         .map(|(n, _)| n.as_str())
         .collect();
 

--- a/tests/offline/destructive_delete_gate.rs
+++ b/tests/offline/destructive_delete_gate.rs
@@ -1,0 +1,155 @@
+//! Every delete under a shared export prefix must consult the run ledger.
+//!
+//! rivet has TWO deletes that target the same object-store prefix, and they are
+//! guarded in inverse proportion to what they destroy:
+//!
+//!   `gc_orphans`      removes only parts NO `Success` manifest references —
+//!                     crash leftovers. It asks the ledger
+//!                     (`has_active_run_on_prefix`) and spares everything when a
+//!                     run is live (`src/cli/dispatch.rs`, the `maybe_gc_orphans`
+//!                     path), failing conservative on a query error.
+//!
+//!   `cleanup_source`  recursively deletes the WHOLE prefix — every part, every
+//!                     manifest, `_SUCCESS` — via `maybe_cleanup` → `delete_under`
+//!                     → `store.remove_all`. It asks nothing.
+//!
+//! `src/load/plan.rs` states the relationship in its own words: gc_orphans is
+//! "strictly gentler than `cleanup_source`, which wipes the whole prefix". So the
+//! gentler delete honours a classification the total one skips.
+//!
+//! WHY THIS GUARD IS SOURCE-SHAPED AND NOT BEHAVIOURAL, said plainly: the signal
+//! is not plumbed. `maybe_cleanup` takes `Option<(&GcsStore, &str)>` — there is
+//! no ledger parameter to pass a live-run verdict through, so no behavioural test
+//! can drive the distinction that does not exist yet. What CAN be pinned is the
+//! wiring: `state: Option<&StateStore>` is already in scope at each site that
+//! builds the cleanup pair, so the ledger is reachable exactly where it is not
+//! consulted. This guard fails while that stays true.
+//!
+//! It is deliberately the same shape as `every_gate_function_has_a_call_site`
+//! (release_gate_matrix_guard) — a lint over the source, because the defect is a
+//! LOCAL omission at a call site rather than a wrong value anywhere.
+
+use std::path::PathBuf;
+
+fn dispatch_src() -> String {
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/cli/dispatch.rs");
+    std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()))
+}
+
+/// Split a Rust source into `fn` bodies keyed by name, by brace depth.
+///
+/// Crude on purpose: the question is only "does this function mention X", and a
+/// full parse would be a dependency and a second thing to be wrong about.
+fn fn_bodies(src: &str) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    let lines: Vec<&str> = src.lines().collect();
+    let mut i = 0;
+    while i < lines.len() {
+        let t = lines[i].trim_start();
+        let is_fn = t.starts_with("fn ") || t.starts_with("pub fn ") || t.starts_with("async fn ");
+        if !is_fn {
+            i += 1;
+            continue;
+        }
+        let name = t
+            .split("fn ")
+            .nth(1)
+            .and_then(|r| r.split(['(', '<']).next())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        let mut depth = 0i32;
+        let mut body = String::new();
+        let mut started = false;
+        while i < lines.len() {
+            let l = lines[i];
+            body.push_str(l);
+            body.push('\n');
+            depth += l.matches('{').count() as i32;
+            depth -= l.matches('}').count() as i32;
+            if l.contains('{') {
+                started = true;
+            }
+            i += 1;
+            if started && depth <= 0 {
+                break;
+            }
+        }
+        out.push((name, body));
+    }
+    out
+}
+
+/// The total-wipe delete must be gated on the same live-run signal the partial
+/// delete already honours.
+///
+/// A function that turns `cleanup_source` into a delete target without ever
+/// naming `has_active_run_on_prefix` will hand `maybe_cleanup` a prefix that a
+/// concurrent extract may be writing into — and `delete_under` is recursive over
+/// the whole prefix, so the concurrent run's committed parts go with it. On a CDC
+/// or incremental export the source side has already advanced (slot acked,
+/// cursor committed), so those rows then exist in neither the source log, nor
+/// the destination, nor the warehouse.
+/// STATUS: RED against current code, and `#[ignore]`d for that reason rather
+/// than because it needs anything to be running.
+///
+/// The live suite has a convention for a guard that documents an open finding
+/// (`AUDIT-RED … expected to FAIL until fixed`) because that suite is run with
+/// `--ignored` and its reds are visible. The offline suite has no such
+/// convention: it is the green gate every commit is measured against, so a red
+/// test here would read as a broken build rather than as a recorded finding.
+///
+/// So it is opt-in: `cargo test --test offline_suite -- --ignored
+/// cleanup_source_must_consult`. Remove the `#[ignore]` in the same commit that
+/// gates the delete — at that point it becomes a real regression guard and
+/// belongs in the gate.
+// AUDIT-RED destructive-delete-gate: cleanup_source wipes the whole prefix with no live-run check, while the strictly gentler gc_orphans on the same prefix consults the ledger. Asserts CORRECT behavior; expected to FAIL until fixed.
+#[test]
+#[ignore = "AUDIT-RED: open finding — cleanup_source is ungated; run with --ignored"]
+fn cleanup_source_must_consult_the_active_run_ledger() {
+    let src = dispatch_src();
+    let bodies = fn_bodies(&src);
+    assert!(
+        bodies.len() > 20,
+        "parsed only {} fn bodies from dispatch.rs — this guard is reading it wrong",
+        bodies.len()
+    );
+
+    // The sites that turn the flag into a delete target.
+    let deleters: Vec<&(String, String)> = bodies
+        .iter()
+        .filter(|(_, b)| b.contains("cleanup_source") && b.contains("then_some"))
+        .collect();
+    assert!(
+        !deleters.is_empty(),
+        "no `cleanup_source … then_some(..)` site found in dispatch.rs — the wiring moved, and \
+         this guard now checks nothing. Re-point it at the new delete-target construction."
+    );
+
+    // The signal the gentler delete already uses, in the same file.
+    assert!(
+        src.contains("has_active_run_on_prefix"),
+        "dispatch.rs no longer references `has_active_run_on_prefix` at all — gc_orphans' own \
+         gate is gone, which is a bigger problem than the one this guard was written for."
+    );
+
+    let ungated: Vec<&str> = deleters
+        .iter()
+        .filter(|(_, b)| !b.contains("has_active_run_on_prefix"))
+        .map(|(n, _)| n.as_str())
+        .collect();
+
+    assert!(
+        ungated.is_empty(),
+        "these function(s) turn `cleanup_source` into a RECURSIVE delete of the whole export \
+         prefix without asking whether a run is writing there: {}\n\n\
+         Its sibling on the same prefix — `gc_orphans`, which only removes parts no Success \
+         manifest references — does ask (`has_active_run_on_prefix`, failing conservative on a \
+         query error). src/load/plan.rs calls gc_orphans \"strictly gentler than cleanup_source, \
+         which wipes the whole prefix\", so the destructive path skips the classification the \
+         gentle one must honour.\n\
+         `state: Option<&StateStore>` is already in scope at each of these sites — the ledger is \
+         reachable exactly where it is not consulted.",
+        ungated.join(", ")
+    );
+}

--- a/tests/offline/release_gate_matrix_guard.rs
+++ b/tests/offline/release_gate_matrix_guard.rs
@@ -241,3 +241,70 @@ fn gaps_do_not_exceed_the_ratchet() {
          wire the check (flip gap -> test / gate the version) and LOWER the ratchet"
     );
 }
+
+/// A `test` cell must name a check the gate actually RUNS — not one it merely defines.
+///
+/// The sibling guard above asks whether every `def verify_*` has a matrix row.
+/// That is the weaker half of the question, and the gap between the two halves
+/// was live: `blessed_path.verify_blessed_path` was registered `test` for all
+/// four engines and had **no caller anywhere in the tree**. It was dead code
+/// wearing four green cells, and every signal a reader has — the matrix, the
+/// definition, the guard — agreed it was covered.
+///
+/// So this asks the other half: for every gate function, is there a CALL SITE?
+/// A call is an occurrence of `name(` that is not the `def`. Cross-module calls
+/// (`blessed_flow.verify_blessed_flow(...)`) and same-module ones both count;
+/// what does not count is the definition alone.
+#[test]
+fn every_gate_function_has_a_call_site() {
+    let sources: Vec<(String, String)> = gate_py()
+        .iter()
+        .map(|p| {
+            (
+                p.file_name().unwrap().to_string_lossy().to_string(),
+                fs::read_to_string(p).unwrap_or_else(|e| panic!("read {}: {e}", p.display())),
+            )
+        })
+        .collect();
+    let all: String = sources
+        .iter()
+        .map(|(_, s)| s.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let mut defined: Vec<String> = Vec::new();
+    for line in all.lines() {
+        for prefix in ["def sc_", "def verify_"] {
+            if let Some(rest) = line.strip_prefix(prefix)
+                && rest.contains('(')
+            {
+                let bare = rest.split('(').next().unwrap().trim();
+                defined.push(format!("{}{bare}", &prefix[4..]));
+            }
+        }
+    }
+    assert!(
+        defined.len() > 10,
+        "found only {} gate functions — this guard is reading the wrong files",
+        defined.len()
+    );
+
+    let mut orphans: Vec<String> = Vec::new();
+    for f in &defined {
+        let needle = format!("{f}(");
+        let called = all
+            .lines()
+            .filter(|l| l.contains(&needle))
+            .any(|l| !l.trim_start().starts_with("def "));
+        if !called {
+            orphans.push(f.clone());
+        }
+    }
+    assert!(
+        orphans.is_empty(),
+        "these gate checks are DEFINED but never called — the matrix may register them \
+         as `test` while nothing runs them (this is exactly how verify_blessed_path sat \
+         dead behind four green cells): {}",
+        orphans.join(", ")
+    );
+}

--- a/tests/offline_suite.rs
+++ b/tests/offline_suite.rs
@@ -30,6 +30,8 @@ mod config_fuzz;
 mod config_parse_errors;
 #[path = "offline/config_secrets.rs"]
 mod config_secrets;
+#[path = "offline/destructive_delete_gate.rs"]
+mod destructive_delete_gate;
 #[path = "offline/examples_parse.rs"]
 mod examples_parse;
 #[path = "offline/extension_seam.rs"]


### PR DESCRIPTION
Nine product defects, every one of them silent — the run reported success and
the data was wrong or gone. Plus the two layers that found them: an
**independent-oracle** attestation pass (DuckDB reads back what rivet claims)
and a **whole-journey gate matrix** (`plan → apply → run → validate → load`
across every axis, one cross-product instead of a pile of one-off scenarios).

Each fix ships as a **pair**: an `AUDIT-RED` commit that goes red against the
shipped product, then the fix that turns it green. The RED commit is the proof
the test can fail; reading it is how you check I did not write a test that
agrees with the bug.

---

## The nine

| # | Defect | Blast radius |
|---|--------|--------------|
| 1 | `_rivet_row_hash` could not hash a **named-timezone** timestamp | 63 of 65 exports in the field config lost the hash column |
| 2 | A uniqueness check **skipped every value it could not render** | the check passed by looking at nothing |
| 3 | A **deterministically failed** chunk was retried to the attempt cap | a permanent error burned N attempts and N round-trips |
| 4 | `cleanup_source` wiped a prefix **without asking the ledger** | a concurrent extract's in-flight parts deleted |
| 5 | An **unreadable range bound** exported ZERO rows as `success` | whole table silently missing |
| 6 | A **partial / filtered unique index** accepted as a keyset key | keyset pages only the indexed subset |
| 7 | `scale: 0` **skipped the lossy-down-scale guard** | money truncated to whole units, silently |
| 8 | A **NULL cursor cell froze the cursor** forever | incremental stopped advancing, no error |
| 9 | MSSQL CDC: a **case-only table mismatch** dropped events | 100% loss for that table, checkpoint still advanced |

Two more that are the same shape but sit one layer up:

- a **healthy no-op run invalidated its own prefix** — a run with nothing to do
  wrote a manifest that made the previous good data look unverifiable;
- `rivet apply` of a **chunked** plan ignored `on_schema_drift` — the gate was
  wired into `single` only, the runner-bypass class again.

Every one was found by a coverage hunt, verified by hand against a live stack,
and closed with a test that goes RED against the exact pre-fix code.

## The oracle layer

The old CDC/export tests re-read rivet's own manifest to decide whether rivet
was right. This branch adds a read-back through **DuckDB** — a decoder rivet
does not link — for row counts, ids, per-column claims and schema claims, plus
an attestation matrix that forces a value-derived claim to say **which types
its verifier actually saw**. That layer is what surfaced #1 and #2: both were
green under every count/sum assertion in the suite.

## The gate

`dev/release_oracle/blessed_flow.py` (new) states the journey as ONE declared
cross-product — `pipeline × lifecycle × store × state × engine` = 144 cells,
76 runnable, 68 `na` **each with a written reason**. It runs `plan → apply →
run → validate → load` with the flag surface rotated per cell, and
`--rerun-failed` re-runs only the cells that failed. `Makefile` targets
(`release-oracle-full`, `release-oracle-bless`) assemble the environment so the
gate is one command rather than 20 exported variables.

Gate fixes that came out of running it end to end for the first time: a
non-unique cloud prefix, a version tag shadowed in two functions (which made an
earlier prefix fix **inert** — the gate caught its own fix not working), a
shared dataset across engines, a missing Mongo collection and a missing
`mongosh` shim for 4.4. Final state: **✓5599 ✗0 ⊘493**, every skip declared.

## Also here

- `init` now records the **table shape a strategy was chosen from**
  (`strategy_snapshot`, state schema **v22**, both SQLite and Postgres ladders)
  so a strategy decision is reproducible and auditable after the fact.
- Field fixtures reproducing the slow `aa_import_*` cohort, and a probe for it.
- `CLAUDE.md`: the call-site rule and three sibling rules the blessed-flow
  build paid for.

## Verification

- `cargo test --tests`: **5087 passed, 0 failed** (offline suite 239 of them).
- `cargo fmt --check`, `cargo clippy --all-targets -D warnings`: clean.
- Live: the affected engine suites re-run against the local stack.
- Release gate: `✓5599 ✗0 ⊘493` — RELEASE-READY with every SKIP accounted for.

## Known, and stated rather than hidden

- `e344951` was committed **RED** on purpose and is now closed by the fix in
  this branch (`f8d3563`): `check` asks the planner's own rule
  (`plan::build::chunked_without_table_error`, one definition, both callers)
  instead of holding its own opinion. My earlier claim that the RED test kept
  CI green was wrong — the E2E job runs `--ignored`, so it ran and failed
  there; the run that proved it is 31133584958.
- Two MSSQL stand cells failed on a fresh CI stand because
  `dev/mssql/init.sql` never declared `dbo.rivet_type_matrix` (PG and MySQL
  have declared it all along) — they passed locally only against a
  hand-created table in a long-lived container. The fixture is now in the
  stand file.
- `init`'s scaffold comment still says keyset is sequential; it is not, and 53
  of the field config's 66 keyset exports run single-threaded because of it.
  Separate fix.
