### PR TITLE
feat(load): add a ClickHouse target loader with CDC append + dedup view

### DIFF
--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -1295,7 +1295,7 @@ fn execute_load<R>(
     done: impl FnOnce(&LoadInputs, &R),
 ) -> Result<Option<R>> {
     let store = load::open_store(&job.plan.destination)?;
-    let loader = load::build_loader(job.plan, job.run_id);
+    let loader = load::build_loader(job.plan, job.run_id, &store);
     let target_fqtn = loader.fqtn(&job.plan.table);
     let mut ctx = LoadCtx {
         state: job.state,

--- a/src/destination/gcs.rs
+++ b/src/destination/gcs.rs
@@ -33,6 +33,11 @@ fn dir_boundary(path: &str) -> String {
 /// (source cleanup). Mirrors [`CloudDestination`]'s runtime + blocking wrap,
 /// but exposes the read/list/delete surface the streaming `Destination` trait
 /// does not. Holds the runtime the blocking operator drives.
+///
+/// `Clone` (a cheap Arc/operator clone) so a load can hand the same store to
+/// its reconcile, its cleanup, and a download-ing adapter (ClickHouse) without
+/// each building its own opendal client.
+#[derive(Debug, Clone)]
 pub(crate) struct GcsStore {
     _runtime: Arc<tokio::runtime::Runtime>,
     op: opendal::blocking::Operator,

--- a/src/load/cdc.rs
+++ b/src/load/cdc.rs
@@ -52,15 +52,17 @@ pub enum SourceEngine {
 pub enum Warehouse {
     BigQuery,
     Snowflake,
+    ClickHouse,
 }
 
 impl Warehouse {
-    /// The `SELECT *`-minus-columns keyword: BigQuery spells it `EXCEPT`,
-    /// Snowflake `EXCLUDE`.
+    /// The `SELECT *`-minus-columns keyword: BigQuery and ClickHouse spell it
+    /// `EXCEPT`, Snowflake `EXCLUDE`.
     fn except_keyword(self) -> &'static str {
         match self {
             Warehouse::BigQuery => "EXCEPT",
             Warehouse::Snowflake => "EXCLUDE",
+            Warehouse::ClickHouse => "EXCEPT",
         }
     }
 
@@ -68,23 +70,30 @@ impl Warehouse {
     /// warehouse. BigQuery back-ticks the whole path; Snowflake leaves it bare
     /// (matching the unquoted identifiers the Snowflake loader creates, so a
     /// lowercase name resolves to the same upper-cased object) — a back-tick
-    /// there is a syntax error.
-    fn quote_fqtn(self, fqtn: &str) -> String {
+    /// there is a syntax error. ClickHouse back-ticks **each dot-separated
+    /// segment** — a single `` `db.table` `` would parse as ONE identifier
+    /// named `db.table`, not a qualified name.
+    pub(crate) fn quote_fqtn(self, fqtn: &str) -> String {
         match self {
             Warehouse::BigQuery => format!("`{fqtn}`"),
             Warehouse::Snowflake => fqtn.to_string(),
+            Warehouse::ClickHouse => fqtn
+                .split('.')
+                .map(|p| format!("`{p}`"))
+                .collect::<Vec<_>>()
+                .join("."),
         }
     }
 
     /// Quote a single column identifier for the view's `PARTITION BY`/`ORDER BY`.
-    /// BigQuery back-ticks (case-preserving, so a reserved-word column like
-    /// `order`/`end` is safe). Snowflake is left BARE — the loader creates its
-    /// columns unquoted (upper-cased), and a case-sensitive `"col"` there would
-    /// miss them; a reserved-word column already fails at the Snowflake `__changes`
-    /// DDL, a narrower pre-existing limitation.
-    fn quote_ident(self, col: &str) -> String {
+    /// BigQuery and ClickHouse back-tick (case-preserving, so a reserved-word
+    /// column like `order`/`end` is safe). Snowflake is left BARE — the loader
+    /// creates its columns unquoted (upper-cased), and a case-sensitive `"col"`
+    /// there would miss them; a reserved-word column already fails at the
+    /// Snowflake `__changes` DDL, a narrower pre-existing limitation.
+    pub(crate) fn quote_ident(self, col: &str) -> String {
         match self {
-            Warehouse::BigQuery => format!("`{col}`"),
+            Warehouse::BigQuery | Warehouse::ClickHouse => format!("`{col}`"),
             Warehouse::Snowflake => col.to_string(),
         }
     }
@@ -126,6 +135,34 @@ impl SourceEngine {
             (Warehouse::Snowflake, SourceEngine::Mongo) => {
                 vec!["PARSE_JSON(__pos):_data::string".into()]
             }
+            // ── ClickHouse: JSONExtract* — the JSON functions a String-typed
+            // `__pos` exposes (CH has no JSON_VALUE / PARSE_JSON dialect).
+            // MySQL `pos` is numeric → JSONExtractInt keeps a numeric sort;
+            // Postgres `lsn` hex halves pad to fixed width so lexical == numeric.
+            //
+            // `__pos` is `Nullable(String)` (snapshot backfill rows carry NULL),
+            // so `splitByChar('/', …)` would type as an Array of a NULLABLE —
+            // which MergeTree 24.8 rejects in an ORDER BY ("Array cannot be
+            // inside Nullable", caught live). `ifNull(__pos, '')` makes the
+            // parse chain non-nullable (the `__pos IS NOT NULL DESC` rank guard
+            // already sorts NULL-__pos rows LAST, so their parse value never
+            // decides an ordering).
+            (Warehouse::ClickHouse, SourceEngine::MySql) => vec![
+                "JSONExtractString(__pos, 'file')".into(),
+                "JSONExtractInt(__pos, 'pos')".into(),
+            ],
+            (Warehouse::ClickHouse, SourceEngine::Postgres) => vec![
+                "leftPad(splitByChar('/', JSONExtractString(ifNull(__pos, ''), 'lsn'))[1], 8, '0')"
+                    .into(),
+                "leftPad(splitByChar('/', JSONExtractString(ifNull(__pos, ''), 'lsn'))[2], 8, '0')"
+                    .into(),
+            ],
+            (Warehouse::ClickHouse, SourceEngine::SqlServer) => {
+                vec!["JSONExtractString(__pos, 'lsn')".into()]
+            }
+            (Warehouse::ClickHouse, SourceEngine::Mongo) => {
+                vec!["JSONExtractString(__pos, '_data')".into()]
+            }
         };
         // `__seq` is always the final, least-significant tiebreak: it orders
         // changes that share a commit position (same transaction).
@@ -151,6 +188,7 @@ pub fn meta_column_specs(warehouse: Warehouse) -> Vec<TargetColumnSpec> {
     let (str_ty, int_ty) = match warehouse {
         Warehouse::BigQuery => ("STRING", "INT64"),
         Warehouse::Snowflake => ("VARCHAR", "INTEGER"),
+        Warehouse::ClickHouse => ("String", "Int64"),
     };
     ["__op", "__pos"]
         .into_iter()
@@ -308,7 +346,11 @@ pub fn inc_dedup_view_sql(
 mod tests {
     use super::*;
 
-    const WAREHOUSES: [Warehouse; 2] = [Warehouse::BigQuery, Warehouse::Snowflake];
+    const WAREHOUSES: [Warehouse; 3] = [
+        Warehouse::BigQuery,
+        Warehouse::Snowflake,
+        Warehouse::ClickHouse,
+    ];
     const ENGINES: [SourceEngine; 4] = [
         SourceEngine::MySql,
         SourceEngine::Postgres,
@@ -519,7 +561,7 @@ mod tests {
                 "{wh:?}: no CDC delete logic: {sql}"
             );
             let kw = match wh {
-                Warehouse::BigQuery => "EXCEPT",
+                Warehouse::BigQuery | Warehouse::ClickHouse => "EXCEPT",
                 Warehouse::Snowflake => "EXCLUDE",
             };
             assert!(
@@ -605,5 +647,70 @@ mod tests {
         let sf = meta_column_specs(Warehouse::Snowflake);
         assert_eq!(sf[1].target_type, "VARCHAR");
         assert_eq!(sf[2].target_type, "INTEGER");
+        let ch = meta_column_specs(Warehouse::ClickHouse);
+        assert_eq!(ch[1].target_type, "String");
+        assert_eq!(ch[2].target_type, "Int64");
+    }
+
+    #[test]
+    fn clickhouse_uses_json_extract_except_and_per_segment_backticks() {
+        let sql = dedup_view_sql(
+            Warehouse::ClickHouse,
+            "db.orders",
+            "db.orders__changes",
+            &["id"],
+            SourceEngine::MySql,
+        );
+        // ClickHouse JSON functions, not JSON_VALUE/PARSE_JSON.
+        assert!(sql.contains("JSONExtractString(__pos, 'file') DESC"));
+        assert!(sql.contains("JSONExtractInt(__pos, 'pos') DESC"));
+        // Same EXCEPT keyword as BigQuery.
+        assert!(sql.contains("EXCEPT (__op, __pos, __seq, __rn)"));
+        // Each dot-separated segment is back-ticked separately — a single
+        // `` `db.orders` `` would parse as one identifier named `db.orders`.
+        assert!(sql.contains("VIEW `db`.`orders` AS"));
+        assert!(sql.contains("FROM `db`.`orders__changes`"));
+        // NULL __pos ranked below real changes (guarded first), like the others.
+        assert!(sql.contains("__pos IS NOT NULL DESC, JSONExtractString"));
+    }
+
+    #[test]
+    fn clickhouse_postgres_lsn_zero_pads_with_left_pad() {
+        let sql = dedup_view_sql(
+            Warehouse::ClickHouse,
+            "db.orders",
+            "db.orders__changes",
+            &["id"],
+            SourceEngine::Postgres,
+        );
+        // The NULLable `__pos` is coerced with ifNull so `splitByChar` does not
+        // type as a NULLable Array (MergeTree 24.8 rejects that in ORDER BY).
+        assert!(sql.contains(
+            "leftPad(splitByChar('/', JSONExtractString(ifNull(__pos, ''), 'lsn'))[1], 8, '0')"
+        ));
+        assert!(sql.contains(
+            "leftPad(splitByChar('/', JSONExtractString(ifNull(__pos, ''), 'lsn'))[2], 8, '0')"
+        ));
+        assert!(
+            !sql.contains("splitByChar('/', JSONExtractString(__pos"),
+            "the parse must not split a NULLable __pos (nullable-Array ORDER BY): {sql}"
+        );
+    }
+
+    #[test]
+    fn clickhouse_dedup_view_quotes_identifiers() {
+        let sql = dedup_view_sql(
+            Warehouse::ClickHouse,
+            "v",
+            "c",
+            &["order"],
+            SourceEngine::MySql,
+        );
+        assert!(sql.contains("PARTITION BY `order`"), "{sql}");
+        let inc = inc_dedup_view_sql(Warehouse::ClickHouse, "v", "c", &["id"], "end");
+        assert!(
+            inc.contains("ORDER BY `end` IS NOT NULL DESC, `end` DESC"),
+            "{inc}"
+        );
     }
 }

--- a/src/load/clickhouse.rs
+++ b/src/load/clickhouse.rs
@@ -1,0 +1,527 @@
+//! ClickHouse loader.
+//!
+//! Loads Rivet Parquet from GCS into a native-typed ClickHouse table over the
+//! HTTP interface (default port 8123, `https://host:8443` for the secure one).
+//! ClickHouse has no `LOAD DATA` analogue and no external stage — so this
+//! adapter, unlike BigQuery/Snowflake, cannot point the warehouse at the staged
+//! Parquet. Instead it downloads each driver-selected object through the load
+//! layer's [`GcsStore`] and streams the bytes straight to ClickHouse as an
+//! `INSERT INTO <table> FORMAT Parquet` (the Parquet input format maps columns
+//! BY NAME, so the file's column order never matters).
+//!
+//! Row counting for the driver's count-integrity gate: ClickHouse's HTTP
+//! interface returns no row count for an `INSERT`, so the adapter reads
+//! `SELECT count()` after an overwrite / before-and-after an append — the same
+//! metadata-only COUNT seam the other adapters use.
+//!
+//! Transport is plain HTTP + basic auth (the CH native interface): no new
+//! dependency (reqwest is already in the tree). Inserted data rides the URL's
+//! `query` parameter with the bytes as the POST body — the one convention that
+//! switches the body to INSERT data on 24.8 (the `X-ClickHouse-Query` header
+//! does not; verified live).
+
+use super::GcsStore;
+use super::TargetLoader;
+use crate::types::target::TargetColumnSpec;
+use anyhow::{Context, Result, bail};
+use reqwest::header::CONTENT_TYPE;
+use std::time::Duration;
+
+/// HTTP timeout for a single ClickHouse call. The INSERT of a budget-sized
+/// Parquet object over localhost is seconds; over a WAN, tens of seconds.
+/// 20 minutes is a generous ceiling that still fails a hung server loud.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(20 * 60);
+
+/// Loads Rivet Parquet from GCS into ClickHouse over its HTTP interface.
+#[derive(Debug, Clone)]
+pub struct ClickhouseLoader {
+    /// ClickHouse HTTP endpoint — `http://localhost:8123` for the native HTTP
+    /// port, `https://host:8443` for the secure one.
+    pub url: String,
+    /// Database to load into. The loader never creates databases — it must
+    /// exist (the loader is run as a single SQL user, not an admin).
+    pub database: String,
+    /// HTTP basic-auth user (ClickHouse's default superuser is `default`).
+    pub user: String,
+    /// Name of an env var holding the password — secrets stay out of config.
+    pub password_env: String,
+    /// The load layer's GCS store — downloads the driver-selected Parquet
+    /// objects for the HTTP `INSERT`. Injected (not built here) so a test /
+    /// fs-backed store exercises the whole path offline. `pub(crate)` — the
+    /// store itself is crate-private.
+    pub(crate) store: GcsStore,
+    /// MergeTree sort key — the analog of BigQuery `CLUSTER BY` / the CDC
+    /// log's PK clustering. Applied only at table creation. Empty = `tuple()`
+    /// (insertion order, no re-sort).
+    pub cluster_by: Vec<String>,
+}
+
+impl ClickhouseLoader {
+    /// `password_env` is resolved per-request (a load may run hours after the
+    /// process starts; re-reading the env keeps the secret out of the struct).
+    pub(crate) fn new(
+        url: impl Into<String>,
+        database: impl Into<String>,
+        user: impl Into<String>,
+        password_env: impl Into<String>,
+        store: GcsStore,
+    ) -> Self {
+        Self {
+            url: url.into(),
+            database: database.into(),
+            user: user.into(),
+            password_env: password_env.into(),
+            store,
+            cluster_by: Vec::new(),
+        }
+    }
+
+    fn password(&self) -> Result<String> {
+        std::env::var(&self.password_env).with_context(|| {
+            format!(
+                "ClickHouse load: `password_env` names env var `{}`, which is not set",
+                self.password_env
+            )
+        })
+    }
+
+    /// The plain (unquoted) `db.table` — what the driver reads back in reports
+    /// and re-quotes per warehouse for the dedup view.
+    fn fqtn(&self, table: &str) -> String {
+        format!("{}.{}", self.database, table)
+    }
+
+    /// The `db.table` quoted per ClickHouse (each dot-separated segment
+    /// back-ticked — a single `` `db.table` `` would parse as ONE identifier).
+    fn quoted(&self, table: &str) -> String {
+        crate::load::cdc::Warehouse::ClickHouse.quote_fqtn(&self.fqtn(table))
+    }
+
+    /// Run `sql` via ClickHouse's HTTP interface, returning the response body.
+    /// A POST whose body is the query (no `query` URL param) is the CH-native
+    /// way to send statements too long for a URL.
+    fn query(&self, sql: &str) -> Result<String> {
+        let pass = self.password()?;
+        let resp = reqwest::blocking::Client::builder()
+            .timeout(HTTP_TIMEOUT)
+            .build()
+            .context("building the ClickHouse HTTP client")?
+            .post(self.url.trim_end_matches('/'))
+            .basic_auth(&self.user, Some(&pass))
+            .header(CONTENT_TYPE, "text/plain")
+            .body(sql.to_string())
+            .send()
+            .with_context(|| format!("ClickHouse HTTP request failed ({})", self.url))?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .with_context(|| format!("reading the ClickHouse HTTP response (HTTP {status})"))?;
+        if !status.is_success() {
+            bail!(
+                "ClickHouse query failed (HTTP {status}): {}",
+                trim_ch_error(&text)
+            );
+        }
+        Ok(text.trim().to_string())
+    }
+
+    /// Stream `data` (raw Parquet) as an `INSERT`. The query rides the URL's
+    /// `query` parameter (reqwest percent-encodes it); the request body is then
+    /// the DATA, per the CH HTTP interface convention. (The documented
+    /// `X-ClickHouse-Query` header was tried first — ClickHouse 24.8 ignores it
+    /// for INSERT-with-data and parses the body as SQL; the URL parameter is the
+    /// convention that actually switches the body to data. Verified live.)
+    fn insert(&self, sql: &str, data: &[u8]) -> Result<()> {
+        let pass = self.password()?;
+        let resp = reqwest::blocking::Client::builder()
+            .timeout(HTTP_TIMEOUT)
+            .build()
+            .context("building the ClickHouse HTTP client")?
+            .post(self.url.trim_end_matches('/'))
+            .basic_auth(&self.user, Some(&pass))
+            .query(&[("query", sql)])
+            .body(data.to_vec())
+            .send()
+            .with_context(|| format!("ClickHouse HTTP request failed ({})", self.url))?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .with_context(|| format!("reading the ClickHouse HTTP response (HTTP {status})"))?;
+        if !status.is_success() {
+            bail!(
+                "ClickHouse INSERT failed (HTTP {status}): {}",
+                trim_ch_error(&text)
+            );
+        }
+        Ok(())
+    }
+
+    /// Download each driver-selected `gs://…` object and INSERT it into
+    /// `target` (a quoted `db`.`table`). Each object is its own HTTP insert —
+    /// an at-least-once re-presentation reproduces the same rows, and a partial
+    /// failure fails the driver's count gate (overwrite cleans up next retry,
+    /// append is absorbed by the dedup view).
+    fn insert_uris(&self, target: &str, uris: &[String]) -> Result<()> {
+        for uri in uris {
+            let (_, key) = super::split_gs_uri(uri)?;
+            let bytes = self
+                .store
+                .read(key)
+                .with_context(|| format!("downloading {uri} for the ClickHouse load"))?;
+            self.insert(&format!("INSERT INTO {target} FORMAT Parquet"), &bytes)
+                .with_context(|| format!("ClickHouse INSERT of {uri} into {target} failed"))?;
+        }
+        Ok(())
+    }
+
+    /// `SELECT count()` — the metadata-only COUNT seam the other adapters use
+    /// for the driver's row-integrity gate.
+    fn count(&self, target: &str) -> Result<u64> {
+        let body = self.query(&format!(
+            "SELECT count() AS n FROM {target} FORMAT JSONEachRow"
+        ))?;
+        extract_count(&body)
+            .with_context(|| format!("reading the row count of {target} from ClickHouse"))
+    }
+}
+
+impl TargetLoader for ClickhouseLoader {
+    fn fqtn(&self, table: &str) -> String {
+        self.fqtn(table)
+    }
+
+    fn materialize(&self, table: &str, specs: &[TargetColumnSpec], uris: &[String]) -> Result<u64> {
+        // cluster_by splices into the MergeTree `ORDER BY` (an identifier list,
+        // no quoting) — the same is_safe_load_ident gate BigQuery applies to its
+        // CLUSTER BY. Config-derived (operator self-harm), but gated for
+        // consistency with the round-5/6 injection surface.
+        for c in &self.cluster_by {
+            if !super::is_safe_load_ident(c) {
+                bail!(
+                    "ClickHouse load: clustering column `{}` is not a plain SQL identifier \
+                     ([A-Za-z_][A-Za-z0-9_]*) — it splices into the MergeTree ORDER BY. Rename it.",
+                    c.escape_default()
+                );
+            }
+        }
+        let target = self.quoted(table);
+        // Overwrite: storage is the source of truth (the other loaders' `LOAD
+        // DATA OVERWRITE` / `CREATE OR REPLACE TABLE`). CREATE OR REPLACE is
+        // idempotent under retry — re-presenting the same Parquet reproduces
+        // the same table.
+        let create = create_table_sql(
+            &target,
+            &build_schema_ddl(specs),
+            &order_clause(&self.cluster_by),
+            true,
+        );
+        self.query(&create)
+            .with_context(|| format!("creating the ClickHouse table for `{table}`"))?;
+        self.insert_uris(&target, uris)?;
+        self.count(&target)
+    }
+
+    fn append_changelog(
+        &self,
+        table: &str,
+        specs: &[TargetColumnSpec],
+        uris: &[String],
+        pk: &[String],
+    ) -> Result<u64> {
+        use crate::load::cdc::Warehouse;
+        // Full change-log schema: rivet's `__op`/`__pos`/`__seq` meta columns
+        // (not reported by `rivet check`) ahead of the resolved data columns.
+        let mut full = crate::load::cdc::meta_column_specs(Warehouse::ClickHouse);
+        full.extend(
+            specs
+                .iter()
+                .filter(|s| !is_meta_column(&s.column_name))
+                .cloned(),
+        );
+
+        let changes = format!("{table}__changes");
+        let changes_q = self.quoted(&changes);
+        // Clustered on the PK so the dedup view prunes efficiently.
+        let create = create_table_sql(
+            &changes_q,
+            &build_schema_ddl(&full),
+            &order_clause(pk),
+            false,
+        );
+        self.query(&create)
+            .with_context(|| format!("creating the change log for `{table}`"))?;
+
+        // A log that ALREADY existed (rivet did not create it, or one that
+        // predates a new column) is reconciled by ADDING what the declared
+        // schema has — never replaced: the table may hold the customer's
+        // history. `CREATE TABLE IF NOT EXISTS` is a no-op on such a table, so
+        // without this the INSERT below names columns the table lacks and fails
+        // the load after the extract was paid for.
+        let alter = build_alter_add_columns_sql(&changes_q, &full);
+        if !alter.is_empty() {
+            self.query(&alter)
+                .with_context(|| format!("reconciling the change log for `{table}`"))?;
+        }
+
+        // Count before / append / count after — the delta is what THIS load
+        // added; the driver gates it against the manifest total.
+        let before = self.count(&changes_q)?;
+        self.insert_uris(&changes_q, uris)?;
+        let after = self.count(&changes_q)?;
+        Ok(after.saturating_sub(before))
+    }
+
+    fn warehouse(&self) -> crate::load::cdc::Warehouse {
+        crate::load::cdc::Warehouse::ClickHouse
+    }
+
+    fn create_view(&self, _table: &str, view_sql: &str) -> Result<()> {
+        self.query(view_sql)
+            .with_context(|| "creating the ClickHouse dedup view")?;
+        Ok(())
+    }
+}
+
+/// Whether a column name is one of rivet's CDC meta columns — filtered out of
+/// the data specs before the meta columns are prepended, so a schema can never
+/// declare `__op`/`__pos`/`__seq` twice.
+fn is_meta_column(name: &str) -> bool {
+    crate::load::cdc::is_meta_column(name)
+}
+
+/// `CREATE OR REPLACE TABLE` / `CREATE TABLE IF NOT EXISTS` with the MergeTree
+/// engine — the loaders create their own tables (BigQuery/Snowflake do the
+/// same). `replace` is the full-snapshot overwrite verb; the append path uses
+/// the idempotent IF NOT EXISTS so a pre-existing log is never dropped.
+///
+/// The loader declares every column `Nullable(…)` (see [`build_schema_ddl`]), so
+/// a column-bearing sort key (`ORDER BY (id)` on the change log) is a NULLABLE
+/// key — which MergeTree rejects by default (`allow_nullable_key=0`, caught
+/// live on 24.8). The table-level `SETTINGS allow_nullable_key = 1` permits it
+/// (the key columns are non-NULL in practice — a PK / cluster column). An
+/// `ORDER BY tuple()` key has no columns and needs no setting.
+fn create_table_sql(fqtn: &str, ddl: &str, order: &str, replace: bool) -> String {
+    let kw = if replace {
+        "CREATE OR REPLACE TABLE"
+    } else {
+        "CREATE TABLE IF NOT EXISTS"
+    };
+    let settings = if order == "tuple()" {
+        ""
+    } else {
+        " SETTINGS allow_nullable_key = 1"
+    };
+    format!("{kw} {fqtn} (\n{ddl}\n) ENGINE = MergeTree ORDER BY {order}{settings}")
+}
+
+/// `  `id` Nullable(Int64),\n  `tags` Array(Nullable(String))` — the native
+/// column DDL. Rivet's resolver emits the NON-nullable native type
+/// (`Int64`, `DateTime64(6, 'UTC')`, …), but the exported Parquet fields are
+/// all `Nullable(T)` — so the loader declares `Nullable(…)` to preserve NULLs
+/// (the cloud warehouses' columns are nullable too; a non-Nullable CH column
+/// would silently coerce NULLs to defaults). `Array(Nullable(…))` already
+/// carries its own inner Nullable and is NOT wrapped again, matching the
+/// Parquet autoload shape exactly.
+fn build_schema_ddl(specs: &[TargetColumnSpec]) -> String {
+    specs
+        .iter()
+        .map(|s| format!("  `{}` {}", s.column_name, ddl_type(s)))
+        .collect::<Vec<_>>()
+        .join(",\n")
+}
+
+/// The physical ClickHouse column type for a resolved spec (see
+/// [`build_schema_ddl`] for the Nullable rationale).
+fn ddl_type(spec: &TargetColumnSpec) -> String {
+    let t = &spec.target_type;
+    if t.starts_with("Array(") || t.starts_with("LowCardinality(") {
+        t.clone()
+    } else {
+        format!("Nullable({t})")
+    }
+}
+
+/// ` (a, b)` / `tuple()` — the MergeTree sort key (the analog of BigQuery's
+/// CLUSTER BY), or insertion order when unset.
+fn order_clause(cluster_by: &[String]) -> String {
+    if cluster_by.is_empty() {
+        "tuple()".to_string()
+    } else {
+        format!("({})", cluster_by.join(", "))
+    }
+}
+
+/// Bring an EXISTING change log's schema up to the declared one by ADDING what
+/// is missing — never by replacing the table, which would impose rivet's schema
+/// on history rivet does not own. `ADD COLUMN IF NOT EXISTS` is the only safe
+/// verb: additive, idempotent, metadata-only. Trailing newline-free (the caller
+/// checks `is_empty`) so an empty spec list yields no statement at all.
+fn build_alter_add_columns_sql(fqtn: &str, specs: &[TargetColumnSpec]) -> String {
+    if specs.is_empty() {
+        return String::new();
+    }
+    let adds = specs
+        .iter()
+        .map(|s| {
+            format!(
+                "ADD COLUMN IF NOT EXISTS `{}` {}",
+                s.column_name,
+                ddl_type(s)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",\n  ");
+    format!("ALTER TABLE {fqtn}\n  {adds}")
+}
+
+/// Pull the `n` column out of a `FORMAT JSONEachRow` body. ClickHouse serializes
+/// 64-bit integers as JSON *strings* by default (`output_format_json_quote_64bit_integers`),
+/// so both the number and string forms are accepted.
+fn extract_count(body: &str) -> Result<u64> {
+    let v: serde_json::Value = serde_json::from_str(body)
+        .with_context(|| format!("parsing the ClickHouse count response: {body}"))?;
+    let n = v
+        .get("n")
+        .with_context(|| format!("ClickHouse count response lacks `n`: {body}"))?;
+    n.as_u64()
+        .or_else(|| n.as_str().and_then(|s| s.parse().ok()))
+        .with_context(|| format!("reading the count from the ClickHouse response: {body}"))
+}
+
+/// ClickHouse errors carry a `Code: N. DB::Exception: …` head and can trail a
+/// long stack trace; keep the head so logs stay readable.
+fn trim_ch_error(text: &str) -> String {
+    let head = text.lines().take(6).collect::<Vec<_>>().join("\n");
+    head.chars().take(4000).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::target::TargetStatus;
+
+    fn spec(name: &str, ty: &str) -> TargetColumnSpec {
+        TargetColumnSpec {
+            column_name: name.to_string(),
+            target_type: ty.to_string(),
+            autoload_type: String::new(),
+            status: TargetStatus::Ok,
+            note: None,
+            cast_sql: None,
+        }
+    }
+
+    #[test]
+    fn schema_ddl_uses_nullable_scalars_and_backticked_names() {
+        let specs = [
+            spec("id", "Int64"),
+            spec("amount", "Decimal(18, 2)"),
+            spec("tags", "Array(Nullable(String))"),
+            spec("at", "DateTime64(6, 'UTC')"),
+        ];
+        let ddl = build_schema_ddl(&specs);
+        assert_eq!(
+            ddl,
+            "  `id` Nullable(Int64),\n  `amount` Nullable(Decimal(18, 2)),\n  \
+             `tags` Array(Nullable(String)),\n  `at` Nullable(DateTime64(6, 'UTC'))"
+        );
+    }
+
+    #[test]
+    fn order_clause_is_tuple_or_the_cluster_columns() {
+        assert_eq!(order_clause(&[]), "tuple()");
+        assert_eq!(
+            order_clause(&["created".to_string(), "customer".to_string()]),
+            "(created, customer)"
+        );
+    }
+
+    #[test]
+    fn create_table_sql_spells_replace_verb_per_mode() {
+        let replace = create_table_sql("`db`.`t`", "  `id` Nullable(Int64)", "tuple()", true);
+        assert!(
+            replace.starts_with("CREATE OR REPLACE TABLE `db`.`t`"),
+            "{replace}"
+        );
+        assert!(replace.ends_with("ENGINE = MergeTree ORDER BY tuple()"));
+        let if_not = create_table_sql("`db`.`t__changes`", "  `id` Nullable(Int64)", "(id)", false);
+        assert!(
+            if_not.starts_with("CREATE TABLE IF NOT EXISTS `db`.`t__changes`"),
+            "{if_not}"
+        );
+        assert!(
+            if_not.contains("ENGINE = MergeTree ORDER BY (id)"),
+            "order clause must precede the table setting: {if_not}"
+        );
+        // A column-bearing (Nullable) sort key needs the table setting MergeTree
+        // otherwise refuses (caught live on 24.8).
+        assert!(
+            if_not.contains("SETTINGS allow_nullable_key = 1"),
+            "nullable sort key must carry the table setting: {if_not}"
+        );
+        assert!(
+            !replace.contains("SETTINGS"),
+            "tuple() sort key needs no setting: {replace}"
+        );
+    }
+
+    #[test]
+    fn alter_add_columns_reconciles_an_existing_log_and_never_replaces_it() {
+        let specs = vec![
+            spec("__op", "String"),
+            spec("id", "Int64"),
+            spec(crate::enrich::COL_ROW_HASH, "String"),
+        ];
+        let sql = build_alter_add_columns_sql("`db`.`t__changes`", &specs);
+        assert!(
+            sql.starts_with("ALTER TABLE `db`.`t__changes`"),
+            "must ALTER the log in place; got: {sql}"
+        );
+        assert!(
+            sql.contains("ADD COLUMN IF NOT EXISTS `__op` Nullable(String)")
+                && sql.contains("ADD COLUMN IF NOT EXISTS `id` Nullable(Int64)"),
+            "every declared column is added idempotently; got: {sql}"
+        );
+        assert!(
+            !sql.to_uppercase().contains("REPLACE") && !sql.to_uppercase().contains("DROP"),
+            "reconciliation must never replace or drop — the log holds history \
+             rivet does not own; got: {sql}"
+        );
+        assert_eq!(build_alter_add_columns_sql("`db`.`t`", &[]), "");
+    }
+
+    #[test]
+    fn fqtn_is_db_table_and_quoted_backticks_each_segment() {
+        let l = ClickhouseLoader {
+            url: "http://localhost:8123".into(),
+            database: "rivet".into(),
+            user: "rivet".into(),
+            password_env: "RIVET_CLICKHOUSE_PASSWORD".into(),
+            store: crate::load::GcsStore::open_fs("/tmp/opencode").unwrap(),
+            cluster_by: Vec::new(),
+        };
+        assert_eq!(l.fqtn("orders"), "rivet.orders");
+        assert_eq!(l.quoted("orders"), "`rivet`.`orders`");
+        assert_eq!(l.quoted("public_orders"), "`rivet`.`public_orders`");
+    }
+
+    #[test]
+    fn count_is_extracted_from_json_each_row_both_number_and_string() {
+        assert_eq!(extract_count("{\"n\":42}").unwrap(), 42);
+        assert_eq!(
+            extract_count("{\"n\":\"18446744073709551615\"}").unwrap(),
+            u64::MAX
+        );
+        assert!(extract_count("{\"m\":1}").is_err());
+        assert!(extract_count("not json").is_err());
+    }
+
+    #[test]
+    fn is_meta_column_matches_only_cdc_meta() {
+        assert!(is_meta_column("__op"));
+        assert!(is_meta_column("__pos"));
+        assert!(is_meta_column("__seq"));
+        assert!(!is_meta_column("id"));
+        assert!(!is_meta_column("__other"));
+    }
+}

--- a/src/load/mod.rs
+++ b/src/load/mod.rs
@@ -4,10 +4,12 @@
 //! OSS decides *what* a column becomes in the warehouse (`TargetColumnSpec` via
 //! `ExportTarget::resolve_table`). A [`TargetLoader`] **adapter** runs the
 //! warehouse-specific load ([`bigquery`] — free `LOAD DATA`; [`snowflake`] —
-//! `COPY` off a GCS external stage). The **driver** ([`run_load`] /
-//! [`run_load_cdc`]) owns the invariant orchestration — spec validation, the
-//! count-integrity gate, the dedup-view wiring, and cleanup ordering — so those
-//! invariants are exercised once through a fake adapter, not per warehouse.
+//! `COPY` off a GCS external stage; [`clickhouse`] — HTTP `INSERT … FORMAT
+//! Parquet`, downloading the staged objects through [`GcsStore`]). The
+//! **driver** ([`run_load`] / [`run_load_cdc`]) owns the invariant
+//! orchestration — spec validation, the count-integrity gate, the dedup-view
+//! wiring, and cleanup ordering — so those invariants are exercised once through
+//! a fake adapter, not per warehouse.
 
 use crate::destination::gcs::GcsStore;
 use crate::types::target::{TargetColumnSpec, TargetStatus};
@@ -15,11 +17,13 @@ use anyhow::{Context, Result, bail};
 
 mod bigquery;
 pub mod cdc;
+mod clickhouse;
 pub mod plan;
 pub mod reconcile;
 mod snowflake;
 
 pub use bigquery::BigQueryLoader;
+pub use clickhouse::ClickhouseLoader;
 pub use snowflake::SnowflakeLoader;
 
 /// Outcome of a successful batch load.
@@ -467,7 +471,18 @@ pub fn open_store(dest: &crate::config::DestinationConfig) -> Result<GcsStore> {
 /// concrete [`TargetLoader`] adapter — wiring partition / cluster / connection /
 /// run-id from the config. The count gate and cleanup are the driver's, so the
 /// adapter carries no `expected_rows`.
-pub fn build_loader(plan: &plan::LoadPlan, run_id: &str) -> Box<dyn TargetLoader> {
+///
+/// The load layer's [`GcsStore`] is injected: the ClickHouse adapter downloads
+/// the staged Parquet through it (there is no external-stage path for CH), and
+/// every adapter's driver-side cleanup deletes through it. Taking it as an
+/// argument (rather than each adapter building one from a config) is what lets
+/// an fs-backed store exercise the whole load offline.
+#[allow(private_interfaces)]
+pub fn build_loader(
+    plan: &plan::LoadPlan,
+    run_id: &str,
+    store: &GcsStore,
+) -> Box<dyn TargetLoader> {
     use plan::LoadTarget;
     let load = &plan.load;
     match &load.target {
@@ -496,6 +511,22 @@ pub fn build_loader(plan: &plan::LoadPlan, run_id: &str) -> Box<dyn TargetLoader
             l.gcs_url = plan.gcs_prefix.replacen("gs://", "gcs://", 1);
             // The `snow` CLI does not expand `~`; pass an absolute key path.
             l.private_key_path = std::env::var("RIVET_SNOWFLAKE_KEY").ok();
+            Box::new(l)
+        }
+        LoadTarget::Clickhouse {
+            url,
+            database,
+            user,
+            password_env,
+        } => {
+            let mut l = ClickhouseLoader::new(
+                url.clone(),
+                database.clone(),
+                user.clone(),
+                password_env.clone(),
+                store.clone(),
+            );
+            l.cluster_by = load.cluster_by.clone();
             Box::new(l)
         }
     }

--- a/src/load/plan.rs
+++ b/src/load/plan.rs
@@ -120,6 +120,18 @@ pub enum LoadTarget {
         schema: String,
         storage_integration: String,
     },
+    Clickhouse {
+        /// ClickHouse HTTP endpoint — `http://localhost:8123` for the native
+        /// HTTP port, `https://host:8443` for the secure one.
+        url: String,
+        /// Database to load into. The loader never creates databases — it must
+        /// exist (the loader is run as a single SQL user, not an admin).
+        database: String,
+        /// HTTP basic-auth user (ClickHouse's default superuser is `default`).
+        user: String,
+        /// Name of an env var holding the password — secrets stay out of config.
+        password_env: String,
+    },
 }
 
 impl LoadTarget {
@@ -128,6 +140,7 @@ impl LoadTarget {
         match self {
             LoadTarget::Bigquery { .. } => "bigquery",
             LoadTarget::Snowflake { .. } => "snowflake",
+            LoadTarget::Clickhouse { .. } => "clickhouse",
         }
     }
 }
@@ -247,7 +260,7 @@ const LOAD_KEYS: &[&str] = &[
     "allow_source_drift",
     "gc_orphans",
     "cluster_by",
-    // LoadTarget::{Bigquery, Snowflake} variant fields (flattened in).
+    // LoadTarget::{Bigquery, Snowflake, Clickhouse} variant fields (flattened in).
     "project",
     "dataset",
     "connection",
@@ -255,6 +268,9 @@ const LOAD_KEYS: &[&str] = &[
     "database",
     "schema",
     "storage_integration",
+    "url",
+    "user",
+    "password_env",
 ];
 
 /// Reject any key in a `load:` block that isn't in [`LOAD_KEYS`] — turns a
@@ -273,34 +289,53 @@ fn check_load_keys(value: &serde_json::Value, whose: &str) -> Result<()> {
     Ok(())
 }
 
-/// Warehouse fields that belong to exactly ONE target.
-const BIGQUERY_ONLY: &[&str] = &["project", "dataset"];
-const SNOWFLAKE_ONLY: &[&str] = &[
-    "connection",
-    "warehouse",
-    "database",
-    "schema",
-    "storage_integration",
-];
-
 /// Reject fields that belong to a DIFFERENT warehouse than the resolved
 /// `target`. `#[serde(flatten)]` on the target enum can't `deny_unknown_fields`,
 /// so `LOAD_KEYS` (the union of all warehouses' fields) let a `target: snowflake`
 /// block silently carry — and ignore — BigQuery's `project:`/`dataset:` (and
 /// vice versa) (dogfood LOW). Name the offending key and its warehouse.
+///
+/// `database` is notably shared by Snowflake and ClickHouse, so it is never
+/// foreign between the two — only to BigQuery.
 fn reject_foreign_target_fields(
     value: &serde_json::Value,
     target: &str,
     whose: &str,
 ) -> Result<()> {
-    let (foreign, other) = match target {
-        "bigquery" => (SNOWFLAKE_ONLY, "snowflake"),
-        "snowflake" => (BIGQUERY_ONLY, "bigquery"),
+    // (foreign field, the warehouse it belongs to) — the field list per target
+    // is every OTHER warehouse's exclusive fields, with `database` excluded from
+    // the ClickHouse foreign set because Snowflake and ClickHouse share it.
+    let foreign: &[(&str, &str)] = match target {
+        "bigquery" => &[
+            ("connection", "snowflake"),
+            ("warehouse", "snowflake"),
+            ("database", "snowflake"),
+            ("schema", "snowflake"),
+            ("storage_integration", "snowflake"),
+            ("url", "clickhouse"),
+            ("user", "clickhouse"),
+            ("password_env", "clickhouse"),
+        ],
+        "snowflake" => &[
+            ("project", "bigquery"),
+            ("dataset", "bigquery"),
+            ("url", "clickhouse"),
+            ("user", "clickhouse"),
+            ("password_env", "clickhouse"),
+        ],
+        "clickhouse" => &[
+            ("project", "bigquery"),
+            ("dataset", "bigquery"),
+            ("connection", "snowflake"),
+            ("warehouse", "snowflake"),
+            ("schema", "snowflake"),
+            ("storage_integration", "snowflake"),
+        ],
         _ => return Ok(()),
     };
     if let Some(obj) = value.as_object() {
         for k in obj.keys() {
-            if foreign.contains(&k.as_str()) {
+            if let Some((_, other)) = foreign.iter().find(|(f, _)| f == k) {
                 bail!(
                     "the {whose} `load:` block targets `{target}` but carries `{k}`, a `{other}` \
                      field — remove it (it would be silently ignored, masking a mis-configured load)"


### PR DESCRIPTION
Add a ClickHouse target to the load layer, alongside BigQuery and Snowflake.

## What

- `src/load/clickhouse.rs`: a `ClickhouseLoader` implementing the `TargetLoader` seam (materialize / append_changelog / warehouse / create_view / fqtn), driven over the existing HTTP `:8123` transport with `INSERT … FORMAT Parquet` from the export parquet files.
  - `CREATE OR REPLACE TABLE` for batch/full, `CREATE TABLE IF NOT EXISTS` for the accumulating change log.
  - `Nullable(…)` wrapping for scalar columns, `Array(…)` left unwrapped.
  - `ALTER TABLE … ADD COLUMN IF NOT EXISTS` to reconcile a pre-existing change log with a drifted schema.
  - JSONEachRow `SELECT count(*)` gate, `trim_ch_error` for readable failures.
- `LoadTarget::Clickhouse` in the plan with strict foreign-key validation; `build_loader` injects the export store (same shape as the BQ/SF setup paths).
- CDC path: `Warehouse::ClickHouse` in `src/load/cdc.rs` — backtick quoting per dot-segment, `EXCEPT` meta-column stripping, `JSONExtract*` position cursors, and zero-padded LSN halves via `leftPad` for Postgres.

## Live-caught during validation on a docker ClickHouse 24.8

1. **`SETTINGS allow_nullable_key = 1`** — the change log sorts by a nullable key column (`ORDER BY (id)`), which MergeTree 24.8 refuses by default (`ILLEGAL_COLUMN`, allow_nullable_key=0). Added the table setting when `order != "tuple()"`.
2. **`ifNull(__pos, '')` in the Postgres dedup view ordering** — `splitByChar('/', JSONExtractString(__pos, 'lsn'))` over a `Nullable(String)` `__pos` typed as a nullable `Array`, which MergeTree 24.8 rejects in an ORDER BY (`Nested type Array cannot be inside Nullable`). The snapshot-backfill rows that carry NULL `__pos` rank last via `__pos IS NOT NULL DESC`, so the coercion never changes an ordering decision.

## Validation

Verified live against docker ClickHouse 24.8 + fake-gcs:

- Batch load of a Postgres table: `LOAD OK`, 4 rows, `DESCRIBE` shows `Nullable(…)` column types with values/NULLs preserved; repeat load is idempotent.
- CDC round-trip: `__changes` append (snapshot backfill with NULL meta + change rows with `__op`/`__pos`/`__seq`), then the dedup view reports the correct current state (updated row wins, delete renders as `__is_deleted = 1`); an incremental `UPDATE` flows through `rivet run` → `rivet load` → view.
- CI contract: `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all-targets` all green.
