### PR TITLE
feat(seam): expose the ADC authorized_user token loader (ADR-0026)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **Extension seam (ADR-0026): `rivet::google_auth`** —
+  `AdcUserTokenLoader` and `try_authorized_user_loader()` are now `pub`.
+  `reqsign` resolves service account → impersonated → external account → VM
+  metadata and has NO `authorized_user` arm, so every native Google client
+  needs this loader or it authenticates in CI and fails on a developer
+  laptop. It was already implemented here for the GCS destination; exposing
+  it lets `rivet-pro`'s native BigQuery client delete its own copy — which
+  had surfaced the token endpoint's error body (Google echoes the submitted
+  `client_id`/`client_secret` back in some failure modes), kept the secrets
+  un-zeroed, and invented a lifetime when `expires_in` was absent. Additive:
+  nothing existing changed shape.
+
 ## 0.24.3 — 2026-08-07
 
 Nine silent-loss fixes, one loud refusal, and the layers that found them. Every

--- a/docs/adr/0026-first-party-extension-seam.md
+++ b/docs/adr/0026-first-party-extension-seam.md
@@ -22,6 +22,19 @@ The seam is the exact set of library items `rivet-pro` depends on. It stays `pub
 | `ExportTarget::resolve_table(&[TypeMapping]) -> Vec<TargetColumnSpec>` | `rivet::types::target` |
 | `ExportTarget::resolve_column(TargetInput) -> TargetColumnSpec` | `rivet::types::target` |
 | `TargetColumnSpec`, `TargetInput`, `TargetStatus` | `rivet::types::target` |
+| `AdcUserTokenLoader`, `try_authorized_user_loader()` | `rivet::google_auth` |
+
+The ADC loader is on the seam for a reason worth stating: `reqsign`'s token
+loader resolves service account → impersonated → external account → VM
+metadata and has **no `authorized_user` arm**, so any native Google client
+must supply one or it authenticates in CI and fails on a developer laptop.
+`rivet-pro` wrote a second copy of this exchange before the seam existed, and
+got three things wrong that this implementation had already learned — it
+surfaced the token endpoint's error body (Google echoes the submitted
+`client_id`/`client_secret` back in some failure modes), it kept the secrets
+in un-zeroed `String`s, and it pinned an invented lifetime when `expires_in`
+was absent. Exposing the loader is what makes "never hand-roll a second auth
+path" true across BOTH repos instead of only inside this one.
 
 Everything else in the library keeps the ADR-0002 posture: `pub` only for the test harness, no stability guarantee.
 

--- a/src/destination/gcs_auth.rs
+++ b/src/destination/gcs_auth.rs
@@ -14,7 +14,12 @@ const GOOGLE_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
 
 /// Scope stamped on minted tokens — opendal's default GCS scope (rivet never
 /// overrides the builder's scope). Informational to reqsign's signer; the
-/// refresh_token grant itself determines the actually granted scopes.
+/// refresh_token grant itself determines the actually granted scopes, which
+/// for an ADC `authorized_user` credential are whatever the user consented to
+/// at `gcloud auth application-default login` (cloud-platform in practice).
+/// That is why the SAME loader serves a BigQuery consumer without a
+/// BigQuery-specific scope: changing this string would not widen or narrow
+/// anything.
 const GCS_SCOPE: &str = "https://www.googleapis.com/auth/devstorage.read_write";
 
 /// Remaining validity below which a cached access token is treated as stale
@@ -49,7 +54,7 @@ struct TokenResponse {
 /// builder `.token()` is wrapped by opendal with a `usize::MAX` expiry —
 /// never refreshed — so exports longer than the ~1h TTL would die mid-run
 /// with 401s the RetryLayer cannot fix.)
-pub(crate) struct AdcUserTokenLoader {
+pub struct AdcUserTokenLoader {
     client_id: String,
     // SecOps: long-lived secrets; heap zeroed on drop, never logged.
     client_secret: Zeroizing<String>,
@@ -176,7 +181,7 @@ pub(crate) fn parse_token_response(data: &str) -> Result<(String, u64)> {
 /// `authorized_user` type (i.e. the caller should let OpenDAL handle
 /// credentials normally). No network I/O happens here — the first
 /// refresh_token grant runs on the first signed request.
-pub(crate) fn try_authorized_user_loader() -> Result<Option<AdcUserTokenLoader>> {
+pub fn try_authorized_user_loader() -> Result<Option<AdcUserTokenLoader>> {
     let path = match adc_path() {
         Some(p) if p.exists() => p,
         _ => return Ok(None),

--- a/src/destination/mod.rs
+++ b/src/destination/mod.rs
@@ -7,7 +7,7 @@
 pub mod azure;
 mod cloud;
 pub mod gcs;
-mod gcs_auth;
+pub(crate) mod gcs_auth;
 pub mod local;
 pub mod placeholder;
 pub mod s3;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,10 +70,13 @@ pub mod destination_for_tests {
 /// `reqsign`'s token loader resolves service account → impersonated →
 /// external account → VM metadata and has NO `authorized_user` arm, so
 /// anything that talks to a Google API natively — this crate's GCS
-/// destination, and `rivet-pro`'s BigQuery client — needs this loader or it
-/// authenticates in CI and fails on a developer laptop. Exposing it is what
-/// keeps "never hand-roll a second auth path" true across BOTH repos rather
-/// than only inside this one.
+/// destination, and the first-party extension consumer's BigQuery client —
+/// needs this loader or it authenticates in CI and fails on a developer
+/// laptop. Exposing it is what keeps "never hand-roll a second auth path"
+/// true across both sides of the seam rather than only inside this crate.
+///
+/// (The consumer is named in docs/adr/0026, not here: the dependency-direction
+/// guard keeps the paid tier out of MIT sources, manifest and comments alike.)
 pub mod google_auth {
     pub use crate::destination::gcs_auth::{AdcUserTokenLoader, try_authorized_user_loader};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,23 @@ pub mod destination_for_tests {
 // consumer side would be a second thing that can drift from the extractor —
 // which is exactly the failure §5h removes, and the reason there is only one
 // hash left to recompute.
+/// Google ADC `authorized_user` support — an ADR-0026 extension-seam item.
+///
+/// A NARROW re-export (two items), not `pub mod destination`: the seam's own
+/// principle is that every `pub` is a compatibility commitment, so the module
+/// that happens to host the implementation stays private.
+///
+/// `reqsign`'s token loader resolves service account → impersonated →
+/// external account → VM metadata and has NO `authorized_user` arm, so
+/// anything that talks to a Google API natively — this crate's GCS
+/// destination, and `rivet-pro`'s BigQuery client — needs this loader or it
+/// authenticates in CI and fails on a developer laptop. Exposing it is what
+/// keeps "never hand-roll a second auth path" true across BOTH repos rather
+/// than only inside this one.
+pub mod google_auth {
+    pub use crate::destination::gcs_auth::{AdcUserTokenLoader, try_authorized_user_loader};
+}
+
 pub mod enrich;
 pub(crate) mod notify;
 pub(crate) mod plan;

--- a/tests/offline/extension_seam.rs
+++ b/tests/offline/extension_seam.rs
@@ -8,6 +8,7 @@
 //!
 //! See docs/adr/0026-first-party-extension-seam.md for the full seam table.
 
+use rivet::google_auth::{AdcUserTokenLoader, try_authorized_user_loader};
 use rivet::types::TypeMapping;
 use rivet::types::target::{ExportTarget, TargetColumnSpec, TargetInput};
 
@@ -31,6 +32,19 @@ fn seam_variants() -> [ExportTarget; 4] {
     ]
 }
 
+/// The ADC loader's shape, compile-locked: a fallible probe returning an
+/// optional loader that implements reqsign's `GoogleTokenLoad` — the only
+/// property a consumer needs, since it is plugged into
+/// `GoogleTokenLoader::with_customized_token_loader`.
+fn seam_adc_loader() -> anyhow::Result<Option<AdcUserTokenLoader>> {
+    let loaded = try_authorized_user_loader()?;
+    fn assert_token_load<T: reqsign::GoogleTokenLoad>(_: &T) {}
+    if let Some(l) = &loaded {
+        assert_token_load(l);
+    }
+    Ok(loaded)
+}
+
 #[test]
 fn first_party_extension_seam_is_stable() {
     // Binding each item to an explicitly-typed function pointer double-locks
@@ -39,4 +53,8 @@ fn first_party_extension_seam_is_stable() {
     let _rt: fn(ExportTarget, &[TypeMapping]) -> Vec<TargetColumnSpec> = seam_resolve_table;
     let _rc: fn(ExportTarget, TargetInput<'_>) -> TargetColumnSpec = seam_resolve_column;
     assert_eq!(seam_variants().len(), 4);
+    // The ADC loader probe: it must COMPILE against the seam and must not
+    // panic on a machine with no ADC file (it returns Ok(None) there).
+    let _adc: fn() -> anyhow::Result<Option<AdcUserTokenLoader>> = seam_adc_loader;
+    assert!(seam_adc_loader().is_ok());
 }


### PR DESCRIPTION
## Why

`reqsign`'s token loader resolves customized → service account → impersonated → external account → VM metadata. There is **no `authorized_user` arm** — the refresh-token shape `gcloud auth application-default login` writes, which is what sits in `~/.config/gcloud` on essentially every developer and operator machine.

This crate already solved it for GCS: `AdcUserTokenLoader`, plugged into reqsign's intended `customized_token_loader` hook. `destination/gcs.rs` even states the aim — *"never hand-roll a second auth path"*.

`rivet-pro`'s new native BigQuery client hand-rolled one anyway, before this seam existed, and got three things wrong that this implementation had already learned:

- surfaced the token endpoint's **error body** — Google's OAuth failures echo the submitted `client_id`/`client_secret` back in some modes, straight into a report, a ledger row and a Slack message;
- kept the secrets in un-zeroed `String`s with a derived `Debug`;
- pinned an invented 3600 s lifetime when `expires_in` was absent.

Exposing the loader makes the "no second auth path" rule true across **both** repos instead of only inside this one, and lets Pro delete ~90 lines.

## Shape

A **narrow** re-export — `pub mod google_auth { pub use … }`, two items — not `pub mod destination`. The seam's own principle is that every `pub` is a compatibility commitment, so the module hosting the implementation stays private. Additive; nothing existing changed shape.

Registered where ADR-0026 requires: seam table, CHANGELOG, and the compile-lock canary — which now also asserts the probe returns `Ok(None)` rather than panicking on a machine with no ADC file.

Suite: 5109 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLuaVdLz5pT4gRw4kXKHkX