### PR TITLE
fix(tls): honesty cluster — enforced posture must not be silently downgraded (bug hunt + init --tls in the blessed matrix)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -58,4 +58,12 @@ exclude_re = [
     # not depend on which arm renders it.
     "delete match arm .* in hash_value",
     "replace refuse_compressed_binlog -> Result<\\(\\)> with Ok\\(\\(\\)\\)",
+    # The DECISION whether an MSSQL TLS posture trusts an unverified cert lives
+    # in `mssql_trusts_cert_without_verify`, unit-tested in both directions and
+    # RED-proven (Require/VerifyFull/accept_invalid combos). The match GUARD at
+    # its call site (`connect_with_tls`) takes a live `tiberius::Config` and only
+    # matters against a real TLS handshake — there is no offline caller, so the
+    # `guard -> true`/`-> false` mutant is unkillable HERE by construction. It is
+    # live-guarded by the blessed-path `init --tls` + MSSQL connect scenarios.
+    "replace match guard mssql_trusts_cert_without_verify\\(cfg\\) with (true|false) in MssqlSource::connect_with_tls",
 ]

--- a/dev/release_oracle/blessed_path.py
+++ b/dev/release_oracle/blessed_path.py
@@ -336,18 +336,29 @@ def sc_blessed_path(
 
     # ── init ──────────────────────────────────────────────────────────────────
     cfg = work / "rivet.yaml"
+    # init WITH the TLS flag (#146), exercised end to end — not just "init exits
+    # 0". mssql's stand encrypts the login packet with a self-signed cert, so
+    # `require` (= TLS + accept-any after the 2026-08-08 fix) is its honest
+    # posture; the loopback SQL/Mongo stands serve plaintext, so `disable` is
+    # theirs. Either way the flag must REACH the scaffold's source.tls block.
+    init_tls = "require" if engine == "mssql" else "disable"
     p = rivet(
-        "init", "--source-env", "ORACLE_URL", "-o", str(cfg),
+        "init", "--source-env", "ORACLE_URL", "--tls", init_tls, "-o", str(cfg),
         env=env, timeout=scenarios.NO_TIMEOUT,
     )
     body = cfg.read_text() if cfg.is_file() else ""
+    # The posture init was ASKED for must be IN the generated config — the
+    # finding this closes: --tls cells that proved only "init exits 0" while the
+    # posture never entered the chain config.
+    tls_reflected = f"mode: {init_tls}" in body
     # Deliberately NOT parsed with a YAML library here. "Does the file parse"
     # is answered by feeding it to rivet's own parser — `check`, two stages
     # down, whose failure is a real failure of the chain. A private parse would
     # grade this module's YAML knowledge against init's, holding both sides of
     # the comparison; the repo has paid for that shape twice.
-    ok = bool(p.ok and body.strip() and "exports:" in body)
-    detail = f"config {cfg.name}, {len(body.splitlines())} lines" if ok else f"exit={p.returncode} file={cfg.is_file()}"
+    ok = bool(p.ok and body.strip() and "exports:" in body and tls_reflected)
+    detail = (f"config {cfg.name}, {len(body.splitlines())} lines, tls={init_tls}" if ok
+              else f"exit={p.returncode} file={cfg.is_file()} tls_reflected={tls_reflected}")
     if not _stage(led, engine, tag, store, "init", ok, detail):
         _downstream_unreached(led, engine, tag, store, "init")
         return
@@ -376,7 +387,9 @@ def sc_blessed_path(
         # correctly; the chain surfaced it as a doctor FAIL, which is the
         # handoff working exactly as intended.
         dest_block = "    destination:\n" + raw.rstrip("\n")
-    tls = "\n  tls: {accept_invalid_certs: true}" if engine == "mssql" else ""
+    # Carry init's OWN tls posture into the narrowed config (do not hand-write
+    # one) — the whole point is the chain runs over what init generated.
+    tls = f"\n  tls: {{ mode: {init_tls} }}"
     cfg.write_text(
         f"source:\n"
         f"  type: {engine}\n"

--- a/src/init/mongo.rs
+++ b/src/init/mongo.rs
@@ -19,7 +19,12 @@ use crate::source::mongo::MongoSession;
 /// Connect once (ungated) so one session serves the whole `list_tables` +
 /// per-collection `introspect` scan.
 pub(super) fn connect(url: &str, tls: Option<&crate::config::TlsConfig>) -> Result<MongoSession> {
-    MongoSession::connect(url, tls, false)
+    // gate=true, matching PG init (connect_client) and MySQL init (connect_pool),
+    // both of which refuse remote plaintext. The old `false` + "like the SQL
+    // init helpers" comment was doubly wrong: the SQL helpers DO gate, and
+    // skipping it let `rivet init` dial a remote Mongo in cleartext with no
+    // refusal (bug hunt 2026-08-08).
+    MongoSession::connect(url, tls)
 }
 
 /// List the user collections in the URL's database, skipping the internal

--- a/src/source/mongo/cdc.rs
+++ b/src/source/mongo/cdc.rs
@@ -168,7 +168,7 @@ impl MongoChangeStream {
         mode: DrainMode,
     ) -> Result<Self> {
         let until_current = mode.is_bounded();
-        let session = MongoSession::connect(url, tls, true)?;
+        let session = MongoSession::connect(url, tls)?;
         let db_name = session.db().to_string();
         // The resume token persisted by a prior run (opaque JSON → driver token).
         // A corrupt / unreadable checkpoint is a LOUD error, never silently
@@ -345,7 +345,7 @@ fn probe_capability_on(session: &MongoSession) -> MongoCdcCapability {
 
 /// Connect + probe (for `rivet doctor` — a fresh connection).
 pub(crate) fn probe_capability(url: &str, tls: Option<&TlsConfig>) -> Result<MongoCdcCapability> {
-    let session = MongoSession::connect(url, tls, true)?;
+    let session = MongoSession::connect(url, tls)?;
     Ok(probe_capability_on(&session))
 }
 

--- a/src/source/mongo/mod.rs
+++ b/src/source/mongo/mod.rs
@@ -110,12 +110,12 @@ pub struct MongoSession {
 
 impl MongoSession {
     /// Connect + `ping`. `gate` applies the shared remote-plaintext TLS refusal
-    /// (`require_tls_or_loopback`, CWE-319); `rivet init` passes `false` (dev
-    /// convenience, like the SQL init helpers), every other caller `true`.
-    pub fn connect(url: &str, tls: Option<&TlsConfig>, gate: bool) -> Result<Self> {
-        if gate {
-            crate::source::require_tls_or_loopback(url, tls)?;
-        }
+    /// (`require_tls_or_loopback`, CWE-319); every caller passes `true` — the SQL init helpers gate too, so init
+    /// is not an exception (bug hunt 2026-08-08 corrected the old `false`).
+    pub fn connect(url: &str, tls: Option<&TlsConfig>) -> Result<Self> {
+        // Always refuse remote plaintext (CWE-319) — the old `gate: bool` let
+        // init opt out, which was the bug hunt 2026-08-08 find. No opt-out now.
+        crate::source::require_tls_or_loopback(url, tls)?;
         // Small multi-thread runtime (not current-thread): the driver spawns
         // background SDAM/heartbeat tasks that must make progress independently
         // of our `block_on` calls, or connection monitoring starves.
@@ -190,7 +190,7 @@ impl MongoSource {
     /// `create_source` (with the config block) and the `doctor` / type-report
     /// probes (with `None`).
     pub fn connect(url: &str, tls: Option<&TlsConfig>, cfg: Option<&MongoConfig>) -> Result<Self> {
-        let session = MongoSession::connect(url, tls, true)?;
+        let session = MongoSession::connect(url, tls)?;
         let (canonical_json, snapshot, no_cursor_timeout) = match cfg {
             None => (false, false, true),
             Some(c) => (
@@ -874,7 +874,7 @@ pub(crate) fn sample_harm_counters(
     url: &str,
     tls: Option<&TlsConfig>,
 ) -> Option<Vec<(String, i64)>> {
-    let session = MongoSession::connect(url, tls, true).ok()?;
+    let session = MongoSession::connect(url, tls).ok()?;
     session.block_on(async {
         let status = session
             .client()
@@ -892,7 +892,7 @@ pub(crate) fn sample_harm_counters(
 /// collection. `None` on any failure — the diagnostic then shows an unknown
 /// row count, exactly as MySQL does when its estimate is untrustworthy.
 pub(crate) fn estimated_count(url: &str, tls: Option<&TlsConfig>, collection: &str) -> Option<i64> {
-    let session = MongoSession::connect(url, tls, true).ok()?;
+    let session = MongoSession::connect(url, tls).ok()?;
     session.block_on(async {
         let n = session
             .client()

--- a/src/source/mssql/cdc.rs
+++ b/src/source/mssql/cdc.rs
@@ -30,7 +30,7 @@ use tiberius::{AuthMethod, Client, ColumnData, Config, EncryptionLevel, Row};
 use tokio::net::TcpStream;
 use tokio_util::compat::{Compat, TokioAsyncWriteCompatExt};
 
-use crate::config::{TlsConfig, TlsMode};
+use crate::config::TlsConfig;
 use crate::error::Result;
 use crate::source::cdc::value::RivetValue;
 use crate::source::cdc::{ChangeEvent, ChangeOp, ChangeStream, DrainMode, Position};
@@ -833,7 +833,7 @@ async fn connect(
     // an explicit disable / accept-invalid, or for loopback (None — the
     // require_tls_or_loopback gate already ensured a remote host carries a tls block).
     match tls {
-        Some(c) if c.mode == TlsMode::Disable || c.accept_invalid_certs => config.trust_cert(),
+        Some(c) if crate::source::mssql::mssql_trusts_cert_without_verify(c) => config.trust_cert(),
         Some(c) => {
             if let Some(ca) = &c.ca_file {
                 config.trust_cert_ca(ca);

--- a/src/source/mssql/mod.rs
+++ b/src/source/mssql/mod.rs
@@ -106,6 +106,20 @@ fn pct_decode(s: &str) -> String {
         .into_owned()
 }
 
+/// Does this TLS posture mean "encrypt, but do NOT verify the certificate"?
+///
+/// `Disable`, `Require`, and `accept_invalid_certs` all do — SQL Server always
+/// encrypts the login packet, so "disable" is really trust-any, and `Require`'s
+/// documented contract (config/source.rs) is "TLS, accept any cert", the SAME
+/// as PG/MySQL/Mongo implement it. Treating `Require` as strict verify (bug
+/// hunt 2026-08-08) made `--tls require` fail against SQL Server's default
+/// self-signed cert while the identical flag connected on the other three
+/// engines. Only `verify-ca`/`verify-full` (without accept_invalid_certs) fall
+/// through to real chain validation.
+pub(crate) fn mssql_trusts_cert_without_verify(cfg: &TlsConfig) -> bool {
+    cfg.mode == TlsMode::Disable || cfg.mode == TlsMode::Require || cfg.accept_invalid_certs
+}
+
 pub(crate) fn parse_mssql_url(url: &str) -> Result<MssqlUrl> {
     let rest = url
         .strip_prefix("sqlserver://")
@@ -197,9 +211,7 @@ impl MssqlSource {
             // analogue of PG/MySQL remote plaintext. It is the documented way
             // to keep trust-cert against a remote host the gate above would
             // otherwise have refused.
-            Some(cfg) if cfg.mode == TlsMode::Disable || cfg.accept_invalid_certs => {
-                config.trust_cert()
-            }
+            Some(cfg) if mssql_trusts_cert_without_verify(cfg) => config.trust_cert(),
             Some(cfg) => {
                 // Strict cert validation is ON here (mode verify-ca/verify-full,
                 // no accept_invalid_certs). The TLS backend is OpenSSL
@@ -1203,6 +1215,48 @@ pub(crate) fn introspect_mssql_table_for_chunking(
         avg_row_bytes: None,
         int_columns,
     })
+}
+
+#[cfg(test)]
+mod tls_posture_tests {
+    use super::mssql_trusts_cert_without_verify;
+    use crate::config::{TlsConfig, TlsMode};
+
+    fn cfg(mode: TlsMode, accept: bool) -> TlsConfig {
+        TlsConfig {
+            mode,
+            ca_file: None,
+            accept_invalid_certs: accept,
+            ..Default::default()
+        }
+    }
+
+    /// Require must trust-without-verify, matching its documented contract and
+    /// the three sibling engines — the bug hunt find was mssql treating it as
+    /// strict verify. verify-ca/full must NOT trust (real validation).
+    #[test]
+    fn require_trusts_like_its_siblings_verify_modes_do_not() {
+        assert!(
+            mssql_trusts_cert_without_verify(&cfg(TlsMode::Require, false)),
+            "Require = encrypt+accept-any, same as PG/MySQL/Mongo"
+        );
+        assert!(mssql_trusts_cert_without_verify(&cfg(
+            TlsMode::Disable,
+            false
+        )));
+        assert!(
+            mssql_trusts_cert_without_verify(&cfg(TlsMode::VerifyFull, true)),
+            "accept_invalid_certs forces trust regardless of mode"
+        );
+        assert!(!mssql_trusts_cert_without_verify(&cfg(
+            TlsMode::VerifyCa,
+            false
+        )));
+        assert!(!mssql_trusts_cert_without_verify(&cfg(
+            TlsMode::VerifyFull,
+            false
+        )));
+    }
 }
 
 #[cfg(test)]

--- a/src/source/postgres/mod.rs
+++ b/src/source/postgres/mod.rs
@@ -95,7 +95,8 @@ impl PostgresSource {
             Some(cfg) if cfg.mode.is_enforced() => {
                 let connector = build_native_tls(cfg)?;
                 let make_tls = postgres_native_tls::MakeTlsConnector::new(connector);
-                let mut client = Client::connect(url, make_tls)?;
+                // Forced ssl_mode overrides the URL's sslmode; see connect_client.
+                let mut client = pg_config_ssl_forced(url)?.connect(make_tls)?;
                 let transaction_pooler = detect_pg_transaction_pooler(&mut client);
                 if transaction_pooler {
                     log::warn!(
@@ -438,6 +439,30 @@ pub(crate) fn introspect_pg_table_for_chunking(
 /// `crate::init::postgres::connect`). `tls = None` or `mode: disable` falls
 /// back to the insecure `NoTls` transport — a warning is logged from
 /// `create_source` so operators know TLS is off.
+/// Parse `url` into a `postgres::Config` and FORCE `ssl_mode(Require)`.
+///
+/// The bug this closes: `Client::connect(url, connector)` lets tokio-postgres
+/// decide TLS from the URL's own `sslmode` — so `?sslmode=disable`, or the
+/// driver's DEFAULT `prefer` against a server that declines TLS, returns a raw
+/// PLAINTEXT stream and never touches the connector we built. An operator who
+/// wrote `tls: { mode: verify-full }` (or `--tls verify-full`) then ships
+/// credentials and every row in cleartext under exit 0. Mongo fixed the
+/// identical class by overriding `opts.tls`; this is Postgres's override.
+///
+/// `ssl_mode(Require)` only forces TLS to be USED; the CONNECTOR
+/// (`build_native_tls`) still decides how strictly the cert is checked
+/// (require = accept-invalid, verify-ca = chain, verify-full = chain+host), so
+/// the four modes keep their meanings — this just stops `disable`/`prefer` in
+/// the URL from silently winning over an enforced `tls:` block.
+fn pg_config_ssl_forced(url: &str) -> Result<postgres::Config> {
+    use std::str::FromStr;
+    let mut config = postgres::Config::from_str(url).map_err(|e| {
+        anyhow::anyhow!("postgres: cannot parse source URL for TLS enforcement: {e}")
+    })?;
+    config.ssl_mode(postgres::config::SslMode::Require);
+    Ok(config)
+}
+
 pub(crate) fn connect_client(url: &str, tls: Option<&TlsConfig>) -> Result<Client> {
     // Refuse remote plaintext (no `tls:` block) before any dial (CWE-319).
     crate::source::require_tls_or_loopback(url, tls)?;
@@ -445,7 +470,10 @@ pub(crate) fn connect_client(url: &str, tls: Option<&TlsConfig>) -> Result<Clien
         Some(cfg) if cfg.mode.is_enforced() => {
             let connector = build_native_tls(cfg)?;
             let make_tls = postgres_native_tls::MakeTlsConnector::new(connector);
-            Ok(Client::connect(url, make_tls)?)
+            // Config::connect, NOT Client::connect(url, …): the forced
+            // ssl_mode(Require) overrides the URL's sslmode so the connector is
+            // actually used (see pg_config_ssl_forced).
+            Ok(pg_config_ssl_forced(url)?.connect(make_tls)?)
         }
         _ => Ok(Client::connect(url, NoTls)?),
     }
@@ -887,6 +915,35 @@ fn catalog_numeric_to_decimal_params(precision: i32, scale: i32) -> Option<(u8, 
 #[cfg(test)]
 mod tests {
     use super::catalog_numeric_to_decimal_params;
+
+    /// The TLS-honesty fix (bug hunt 2026-08-08): under an enforced `tls:`
+    /// block the connection's ssl_mode must be forced to Require REGARDLESS of
+    /// what the URL's own `sslmode` says — otherwise `?sslmode=disable` (or the
+    /// driver's default `prefer` against a TLS-declining server) silently wins
+    /// and the connector we built is never used, shipping cleartext under a
+    /// `verify-full` claim.
+    #[test]
+    fn enforced_tls_forces_ssl_mode_require_over_the_urls_sslmode() {
+        use postgres::config::SslMode;
+        // Every URL sslmode an operator might write — all must come out Require.
+        for url in [
+            "postgresql://u:p@h/db?sslmode=disable",
+            "postgresql://u:p@h/db?sslmode=prefer",
+            "postgresql://u:p@h/db", // no param → driver default is `prefer`
+            "postgresql://u:p@h/db?sslmode=require",
+        ] {
+            let cfg =
+                super::pg_config_ssl_forced(url).unwrap_or_else(|e| panic!("parse {url}: {e}"));
+            assert_eq!(
+                cfg.get_ssl_mode(),
+                SslMode::Require,
+                "enforced TLS must force Require, but {url} yielded {:?}",
+                cfg.get_ssl_mode()
+            );
+        }
+        // A malformed URL is a loud parse error, not a silent plaintext fallback.
+        assert!(super::pg_config_ssl_forced("not a url").is_err());
+    }
 
     // FROM-clause parser tests live in `from_parse.rs` alongside the parser.
 

--- a/src/source/postgres/mod.rs
+++ b/src/source/postgres/mod.rs
@@ -456,11 +456,39 @@ pub(crate) fn introspect_pg_table_for_chunking(
 /// the URL from silently winning over an enforced `tls:` block.
 fn pg_config_ssl_forced(url: &str) -> Result<postgres::Config> {
     use std::str::FromStr;
-    let mut config = postgres::Config::from_str(url).map_err(|e| {
+    // Strip the URL's own `sslmode` before parsing: we force Require below, so
+    // its value is irrelevant — AND tokio-postgres only accepts disable/prefer/
+    // require, rejecting the libpq-valid `verify-ca`/`verify-full` with a parse
+    // error (bug hunt 2026-08-08: init derived verify-full from such a URL and
+    // then failed to parse it, erroring every time). Dropping it makes any
+    // sslmode the operator wrote parseable; the connector decides verification.
+    let cleaned = strip_url_query_key(url, "sslmode");
+    let mut config = postgres::Config::from_str(&cleaned).map_err(|e| {
         anyhow::anyhow!("postgres: cannot parse source URL for TLS enforcement: {e}")
     })?;
     config.ssl_mode(postgres::config::SslMode::Require);
     Ok(config)
+}
+
+/// Remove a single query parameter (case-insensitive key) from a URL, leaving
+/// the rest of the query intact. Used to drop `sslmode` before handing the URL
+/// to a parser that would reject some of its values.
+fn strip_url_query_key(url: &str, key: &str) -> String {
+    let Some((base, query)) = url.split_once('?') else {
+        return url.to_string();
+    };
+    let kept: Vec<&str> = query
+        .split('&')
+        .filter(|pair| {
+            let k = pair.split('=').next().unwrap_or(pair);
+            !k.eq_ignore_ascii_case(key)
+        })
+        .collect();
+    if kept.is_empty() {
+        base.to_string()
+    } else {
+        format!("{base}?{}", kept.join("&"))
+    }
 }
 
 pub(crate) fn connect_client(url: &str, tls: Option<&TlsConfig>) -> Result<Client> {
@@ -931,6 +959,11 @@ mod tests {
             "postgresql://u:p@h/db?sslmode=prefer",
             "postgresql://u:p@h/db", // no param → driver default is `prefer`
             "postgresql://u:p@h/db?sslmode=require",
+            // libpq-valid but tokio-postgres-REJECTED values: stripped, not fatal
+            "postgresql://u:p@h/db?sslmode=verify-ca",
+            "postgresql://u:p@h/db?sslmode=verify-full",
+            // sslmode alongside another param — only sslmode is dropped
+            "postgresql://u:p@h/db?application_name=x&sslmode=verify-full&connect_timeout=5",
         ] {
             let cfg =
                 super::pg_config_ssl_forced(url).unwrap_or_else(|e| panic!("parse {url}: {e}"));

--- a/tests/live/sec_tls_defaults.rs
+++ b/tests/live/sec_tls_defaults.rs
@@ -188,3 +188,67 @@ fn sec_loopback_plaintext_pg_is_allowed() {
         "loopback plaintext must NOT trigger a TLS-required refusal; stderr:\n{stderr}"
     );
 }
+
+/// TLS-honesty (bug hunt 2026-08-08): an enforced `tls:` block must not be
+/// silently overridden by the URL's own `sslmode`.
+///
+/// The local stand runs Postgres with `ssl = off`, so `verify-full` is
+/// genuinely unsatisfiable here — which is the point. With `?sslmode=disable`
+/// in the URL, tokio-postgres used to hand back a raw PLAINTEXT stream and
+/// never touch the connector, so the export SUCCEEDED in cleartext under a
+/// `verify-full` claim. After the fix (`pg_config_ssl_forced` forces
+/// `ssl_mode(Require)`), TLS is attempted, the ssl-off server declines, and the
+/// run REFUSES. The assertion is "does not silently succeed in plaintext".
+///
+/// RED against `main`: there the run exits 0 with a written CSV part.
+fn pg_tls_config(
+    tmp: &tempfile::TempDir,
+    url: &str,
+    out_dir: &str,
+    mode: &str,
+) -> std::path::PathBuf {
+    let yaml = format!(
+        r#"source:
+  type: postgres
+  url: "{url}"
+  tls: {{ mode: {mode} }}
+exports:
+  - name: sec_tls_honesty
+    query: "SELECT 1"
+    mode: full
+    format: csv
+    destination:
+      type: local
+      path: "{out_dir}"
+"#
+    );
+    write_config(tmp, &yaml)
+}
+
+#[test]
+#[ignore = "live: requires the local ssl-off Postgres stand"]
+fn sec_enforced_tls_is_not_overridden_by_url_sslmode_disable() {
+    require_alive(LiveService::Postgres);
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("out");
+    // Loopback host + an EXPLICIT sslmode=disable in the URL, plus an enforced
+    // tls block. The host is loopback so the require_tls_or_loopback gate does
+    // NOT fire — the ONLY thing that can refuse plaintext here is the driver
+    // actually honoring the enforced mode, which is what this pins.
+    let url = format!("{POSTGRES_URL}?sslmode=disable");
+    let cfg = pg_tls_config(&tmp, &url, out.to_str().unwrap(), "verify-full");
+
+    let r = run_rivet(&["run", "--config", cfg.to_str().unwrap()]);
+    let stderr = String::from_utf8_lossy(&r.stderr);
+    assert!(
+        !r.status.success(),
+        "verify-full over an ssl-off server must REFUSE, not export in plaintext; \
+         the URL's sslmode=disable must not win. stderr:\n{stderr}"
+    );
+    // And it must fail for a TLS/connection reason, not some unrelated error.
+    let low = stderr.to_lowercase();
+    assert!(
+        low.contains("tls") || low.contains("ssl") || looks_like_connection_error(&low),
+        "refusal must be TLS/connection-shaped, not an unrelated failure; stderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
Four TLS findings from the 2026-08-08 adversarial bug hunt (each 0/2 refutes), one class: an enforced `tls:` posture some path silently fails to honor. Plus the user's ask — init's `--tls` flag exercised end to end in the blessed matrix.

## Findings fixed
- **🔴 PG: URL `sslmode=disable`/`prefer` overrode `--tls verify-full`** → plaintext, exit 0, under a verify-full claim. tokio-postgres decided TLS from the raw URL; the built connector was never used. `pg_config_ssl_forced` forces `ssl_mode(Require)` (connector still decides verification). Mongo had fixed this class; PG hadn't.
- **MSSQL treated `Require` as strict verify** → `--tls require` failed on the default self-signed cert while connecting on the other three engines. Extracted `mssql_trusts_cert_without_verify` (batch+CDC), unit-tested all modes.
- **Mongo init skipped the remote-plaintext gate** (`gate: bool` = `false`, "like the SQL init helpers" — which actually gate). Removed the param; the opt-out was the bug.
- **PG init derived verify-* from URL sslmode**, which tokio-postgres rejects → init always errored. Strip `sslmode` before parse.

## init --tls in the blessed matrix (the ask)
`blessed_path` now runs `init --tls disable|require`, **asserts the generated config carries `mode: <posture>`**, and carries init's own tls block into the chain config — closing the finding that `--tls` cells proved only "init exits 0" while the posture never entered the chain.

## Lenses
- **Ponytail**: removed the `gate` param (dead after the fix) and the mssql accept_invalid_certs hand-hack; net simpler.
- **Architectural**: verdicts extracted to pure functions (mssql_trusts_cert_without_verify, pg_config_ssl_forced) per the compression_refusal precedent — testable offline.
- **Verification**: unit RED-proven (forced Require; require-trusts); live RED-proven against the real run path (`sec_enforced_tls_is_not_overridden_by_url_sslmode_disable` — main exits 0 with a plaintext CSV part; fixed branch refuses). lib 2311, clippy clean, init+tls live green. Pre-release gate queued.