### PR TITLE
fix: bug-hunt low/tooling batch — identity colon-fold, baseline selection, worktree footgun

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ GATE_ENV = \
   BQ_ORACLE_BUCKET='$(BQ_ORACLE_BUCKET)'
 
 release-oracle-prev-bin:  ## Download the PREVIOUS release binary (the regression + scale baseline). A downloaded asset, never a locally rebuilt parent.
-	@mkdir -p $(PREV_RELEASE_DIR)
+	@rm -rf $(PREV_RELEASE_DIR) && mkdir -p $(PREV_RELEASE_DIR)  # exactly one baseline: `ls | tail` below must not pick a lexicographically-wrong version from an accumulating dir (bug hunt 2026-08-08)
 	@tag=$$(gh release list --limit 1 --json tagName -q '.[0].tagName'); \
 	 arch=$$(uname -m); os=$$(uname -s | tr 'A-Z' 'a-z'); \
 	 [ "$$arch" = "arm64" ] && arch=aarch64; \
@@ -257,7 +257,9 @@ release-oracle-full: release-oracle-prev-bin  ## Release gate with the WHOLE env
 	@# `Fresh` on a binary that predates your edits — drop the snapshot first.
 	@rm -rf target/package
 	cargo build --release
-	@prev=$$(ls -d $(PREV_RELEASE_DIR)/rivet-v*/rivet 2>/dev/null | tail -1); \
+	@# newest by mtime, not lexical order (accumulating dir would mis-tail)
+	@prev=$$(ls -t -d $(PREV_RELEASE_DIR)/rivet-v*/rivet 2>/dev/null | head -1); \
+
 	 echo "  previous release: $${prev:-<none — the regression + scale legs will SKIP>}"; \
 	 env $(GATE_ENV) RIVET_PREV_RELEASE_BIN="$$prev" python3 -m dev.release_oracle $(ARGS)
 

--- a/dev/release_oracle/__main__.py
+++ b/dev/release_oracle/__main__.py
@@ -126,6 +126,14 @@ def start_stores(led: Ledger) -> None:
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     ap = argparse.ArgumentParser(prog="release-oracle", add_help=True)
     ap.add_argument("--engines", default="", help="comma-separated subset, e.g. postgres,mysql")
+    ap.add_argument(
+        "--latest-only",
+        action="store_true",
+        default=bool(os.environ.get("RIVET_ORACLE_LATEST_ONLY")),
+        help="run only the LAST version of each engine family (fast dev loop). "
+        "The full version matrix is for release tags; a single-version pass "
+        "still covers every scenario × store × state-backend cell.",
+    )
     ap.add_argument("--no-cloud", action="store_true", help="local stage only (skip BigQuery)")
     ap.add_argument("--keep", action="store_true", help="leave engine containers up (debug)")
     ap.add_argument("--no-clean", action="store_true",
@@ -384,10 +392,21 @@ def engine_loop(led: Ledger, ns: argparse.Namespace) -> None:
     for engine in matrix_cfg("engines").split():
         if wanted and engine not in wanted:
             continue
-        for line in matrix_cfg("versions", engine).splitlines():
+        version_lines = [
+            l for l in matrix_cfg("versions", engine).splitlines() if len(l.split()) >= 3
+        ]
+        # --latest-only: keep just the last version of the family (the newest,
+        # matrix.yaml lists them ascending). Cuts the dev-loop wall roughly in
+        # proportion to the version count (postgres 4→1, mongo 5→1) while every
+        # scenario × store × state cell still runs once.
+        if ns.latest_only and version_lines:
+            skipped = len(version_lines) - 1
+            version_lines = version_lines[-1:]
+            if skipped:
+                led.add(engine, "-", "older-versions", "-", Status.SKIP,
+                        f"--latest-only: {skipped} older {engine} version(s) not run")
+        for line in version_lines:
             parts = line.split()
-            if len(parts) < 3:
-                continue
             tag, image, port = parts[0], parts[1], int(parts[2])
             led.phase(f"{engine} {tag} ({image})")
             url = bring_up(led, engine, tag, image, port)

--- a/src/load/reconcile.rs
+++ b/src/load/reconcile.rs
@@ -498,9 +498,19 @@ fn ensure_single_source(keyed: &[(String, RunManifest)]) -> Result<()> {
         .map(|(_, m)| crate::manifest::identity_source(m))
         .filter(|s| !s.is_empty())
         .filter(|s| {
-            // Drop an identity that is a strict PREFIX (at a segment boundary)
-            // of some other identity present — it is the same source, recorded
-            // with less detail.
+            // Drop an identity that is the BARE ENGINE (no table recorded — the
+            // synthesized batch leg's `table: null`, #144) when a fuller
+            // identity for that engine is present: it is the same source with
+            // less detail. Only the colon-FREE engine folds — a `:`-bearing
+            // identity is a concrete engine:table and must never be treated as
+            // a coarser prefix of another, or two DIFFERENT tables/collections
+            // whose names share a `:` boundary (a Mongo collection literally
+            // named `orders:archive` vs `orders`) would silently fold into one
+            // source and the two-source guard would wrongly pass (bug hunt
+            // 2026-08-08).
+            if s.contains(':') {
+                return true; // concrete engine:table — never a coarsening
+            }
             !keyed.iter().any(|(_, other)| {
                 let o = crate::manifest::identity_source(other);
                 o.len() > s.len() && o.starts_with(s.as_str()) && o.as_bytes()[s.len()] == b':'
@@ -753,6 +763,38 @@ mod tests {
         assert!(
             ensure_single_export(&[keyed(pg), keyed(again)]).is_ok(),
             "repeated runs of one export must not be refused — that is the normal load"
+        );
+    }
+
+    /// A `:` in a collection/table name must not fold two DIFFERENT sources
+    /// into one (bug hunt 2026-08-08). Mongo collection `orders:archive` →
+    /// identity `mongo:orders:archive`; collection `orders` → `mongo:orders`.
+    /// The bare-engine fold used to treat `mongo:orders` as a coarsening of
+    /// `mongo:orders:archive` (both at a `:` boundary) and pass — two distinct
+    /// collections under one export name loading as one source.
+    #[test]
+    fn ensure_single_source_does_not_fold_two_colon_named_collections() {
+        let keyed = |m: RunManifest| ("gs://b/p/manifest-x.json".to_string(), m);
+        let mut a = manifest("r1", 10, None);
+        a.source.engine = "mongo".into();
+        a.source.table = Some("orders".into());
+        let mut b = manifest("r2", 10, None);
+        b.source.engine = "mongo".into();
+        b.source.table = Some("orders:archive".into());
+        b.export_name = a.export_name.clone();
+        assert!(
+            ensure_single_export(&[keyed(a.clone()), keyed(b.clone())]).is_err(),
+            "two collections whose names share a `:` boundary are TWO sources"
+        );
+        // …and the bare-engine fold it must NOT have broken still works:
+        // engine `mongo` (no table) folds into `mongo:orders`.
+        let mut bare = manifest("r3", 10, None);
+        bare.source.engine = "mongo".into();
+        bare.source.table = None;
+        bare.export_name = a.export_name.clone();
+        assert!(
+            ensure_single_export(&[keyed(a), keyed(bare)]).is_ok(),
+            "a bare engine is still the same source, less detail"
         );
     }
 

--- a/tests/common/env.rs
+++ b/tests/common/env.rs
@@ -111,9 +111,27 @@ pub const CLICKHOUSE_CONTAINER: &str = "rivet-clickhouse";
 /// and `rivet-clickhouse`. Tests write Parquet here from Rust, then read the
 /// same path from inside the container.
 pub fn live_shared_tmp_host() -> std::path::PathBuf {
-    let dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests")
-        .join(".live-tmp");
+    let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // LOUD worktree footgun (bug hunt 2026-08-08). `docker compose` bind-mounts
+    // `./tests/.live-tmp` of the checkout it was STARTED from. A git WORKTREE
+    // has a different CARGO_MANIFEST_DIR, so a test run from a worktree writes
+    // Parquet into the worktree's tests/.live-tmp while the containers read the
+    // MAIN checkout's — the DuckDB oracle then sees 0 rows or another run's
+    // stale data and "fails" a correct build. Cost an hour of forensics once;
+    // never again silently. A worktree's `.git` is a FILE ("gitdir: …"), a real
+    // checkout's is a DIR — that is the cheap, reliable tell.
+    let git = root.join(".git");
+    if git.is_file() && std::env::var_os("RIVET_ALLOW_WORKTREE_LIVE").is_none() {
+        panic!(
+            "live tests are running from a git WORKTREE ({}), but the duckdb/clickhouse \
+             containers bind-mount tests/.live-tmp of the checkout `docker compose up` was \
+             started from — the paths diverge and the oracle reads the wrong directory. \
+             Run live tests from the main checkout (where you started the stand); or, if you \
+             genuinely started the stand from THIS worktree, set RIVET_ALLOW_WORKTREE_LIVE=1.",
+            root.display()
+        );
+    }
+    let dir = root.join("tests").join(".live-tmp");
     std::fs::create_dir_all(&dir).expect("create tests/.live-tmp");
     dir
 }


### PR DESCRIPTION
The four low-severity findings from the 2026-08-08 adversarial bug hunt, batched (each 0/2 refutes).

1. **reconcile colon-fold** — a `:` in a collection/table name folded two different sources into one (a Mongo `orders:archive` vs `orders`), so the two-source guard wrongly passed. Fold now restricted to the colon-free bare engine; #144's `table: null` case preserved. RED-proven.
2. **Makefile baseline** — `ls | tail -1` picked the lexicographically-last prev-release (v0.24.3 over v0.24.10). Now cleans the dir + selects newest by mtime.
3. **worktree footgun** — `live_shared_tmp_host` returned the worktree's `tests/.live-tmp` while containers mount the stand-checkout's; the DuckDB oracle read the wrong dir and failed correct builds. Now panics loudly from a worktree with an `RIVET_ALLOW_WORKTREE_LIVE=1` escape. Proven: a live test from a worktree fails at the check, not 10 cells deep.

Left out with reason: `--bless-gifs` all-or-nothing is a usability gap that reshapes the bless workflow — its own change, not this batch.

Lenses: ponytail — no new abstractions, three targeted fixes; architectural — the colon-fold is the same identity-coarsening seam as #144, tightened; verification — reconcile tests RED-proven, worktree check proven to fire, lib green, clippy clean. Gate queued behind #157.