### PR TITLE
fix(cdc/validate): order MySQL positions by binlog ordinal, not lexical filename (#160)

### DIFF
--- a/src/source/cdc/validate.rs
+++ b/src/source/cdc/validate.rs
@@ -38,8 +38,17 @@ impl PositionCheck {
 /// `Ord`'s discriminant tie-break is irrelevant).
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum PosKey {
-    /// MySQL binlog `{file, pos}` — zero-padded filename sorts lexically, then pos.
-    Binlog(String, u64),
+    /// MySQL binlog: the file's numeric ORDINAL, then pos. Stored as the
+    /// ordinal (not the filename) because a lexical filename compare inverts at
+    /// the 999999 → 1000000 suffix-width rollover — the exact break the engine's
+    /// `commit_past_bound` parses the ordinal to avoid (bug hunt 2026-08-08).
+    /// A binlog name with no numeric suffix keeps its filename via `BinlogRaw`
+    /// so two such never compare equal by accident.
+    Binlog(u64, u64),
+    /// A binlog file whose name has no parseable ordinal — ordered by name,
+    /// then pos. Never mixed with `Binlog` in a real run (one server, one
+    /// basename), but kept distinct so the fallback is not silently equal.
+    BinlogRaw(String, u64),
     /// PostgreSQL LSN `hi/lo` (hex) → a single u64.
     PgLsn(u64),
     /// SQL Server LSN — fixed-width hex, lexically comparable.
@@ -52,7 +61,13 @@ fn parse_pos(s: &str) -> Option<PosKey> {
     let v: serde_json::Value = serde_json::from_str(s).ok()?;
     if let (Some(file), Some(pos)) = (v.get("file").and_then(|x| x.as_str()), v.get("pos")) {
         let pos = pos.as_u64()?;
-        return Some(PosKey::Binlog(file.to_string(), pos));
+        // Order by the numeric ordinal (shared parser with the engine's
+        // commit_past_bound), falling back to the raw name only when there is
+        // no suffix to parse.
+        return Some(match crate::source::mysql::cdc::binlog_file_ordinal(file) {
+            Some(ord) => PosKey::Binlog(ord, pos),
+            None => PosKey::BinlogRaw(file.to_string(), pos),
+        });
     }
     // MongoDB change-stream position `{"_data": <hex>, "rt": <hex>}`: `_data` is
     // the resume-token keystring, order-preserving under lexical compare (oplog
@@ -199,7 +214,7 @@ mod v016_checkpoint_compat {
         let raw = serde_json::to_string(&p.0).expect("serialize");
         assert_eq!(
             parse_pos(&raw),
-            Some(PosKey::Binlog("binlog.000004".into(), 150_838_422)),
+            Some(PosKey::Binlog(4, 150_838_422)),
             "the 0.16 MySQL checkpoint must still resume at the SAME file+pos;              a renamed or newly-required field re-anchors the stream instead"
         );
     }
@@ -240,6 +255,20 @@ mod tests {
         assert!(
             parse_pos(r#"{"file":"binlog.000046","pos":999}"#).unwrap()
                 < parse_pos(r#"{"file":"binlog.000047","pos":4}"#).unwrap()
+        );
+        // ROLLOVER (bug hunt 2026-08-08): binlog.1000000 comes AFTER
+        // binlog.999999 ordinally, though "1000000" < "999999" lexically. The
+        // old String-keyed PosKey ordered these backwards, so validate's
+        // monotonicity check misjudged a rotation across the width boundary.
+        assert!(
+            parse_pos(r#"{"file":"binlog.999999","pos":10}"#).unwrap()
+                < parse_pos(r#"{"file":"binlog.1000000","pos":1}"#).unwrap(),
+            "ordinal order: .1000000 is newer than .999999 despite lexical order"
+        );
+        // A no-suffix name falls back to BinlogRaw and never equals an ordinal key.
+        assert_ne!(
+            parse_pos(r#"{"file":"binlog","pos":1}"#).unwrap(),
+            parse_pos(r#"{"file":"binlog.000001","pos":1}"#).unwrap()
         );
         // PostgreSQL LSN: hi/lo hex parsed numerically (not string — "9" > "1A" as
         // strings would be wrong).

--- a/src/source/mysql/cdc.rs
+++ b/src/source/mysql/cdc.rs
@@ -486,7 +486,7 @@ fn commit_past_bound(file: &str, pos: u64, bound: Option<&(String, u64)>) -> boo
 }
 
 /// The numeric suffix of a binlog file name (`mysql-bin.000042` → 42).
-fn binlog_file_ordinal(name: &str) -> Option<u64> {
+pub(crate) fn binlog_file_ordinal(name: &str) -> Option<u64> {
     name.rsplit_once('.')?.1.parse().ok()
 }
 


### PR DESCRIPTION
Closes #160. `validate --depth full` compared MySQL positions by lexical filename, which inverts at the 999999→1000000 binlog rollover — misjudging a forward position as a backwards jump on healthy output. Now keyed on the numeric ordinal via the engine's own `binlog_file_ordinal` (one parser, two callers), with a `BinlogRaw` fallback for suffix-less names. RED-proven (`binlog.999999 < binlog.1000000` fails the old String key); validate suite green, clippy clean.