### PR TITLE
fix: roast + bug-hunt findings on the 7-PR merge (TLS-CDC plaintext, cursor-picker traps)

### DIFF
--- a/src/init/catalog_replay.rs
+++ b/src/init/catalog_replay.rs
@@ -61,7 +61,14 @@ pub(crate) fn scaffold_strategy(info: &TableInfo) -> String {
         },
         "incremental" => format!(
             "incremental({})",
-            info.best_cursor_column().unwrap_or("updated_at")
+            // Mirror yaml_scaffold::export_block_lines EXACTLY: it renders the
+            // cursor via chosen_cursor_column() (the scored picker), not
+            // best_cursor_column() (name-only) — and emits a REVIEW marker,
+            // never a phantom `updated_at`, when there is no candidate. Using
+            // best_ here re-implemented the product with a DIFFERENT picker,
+            // the exact self-oracle this golden exists to prevent (roast
+            // 2026-08-09; superseded fully by the #159 deletion).
+            info.chosen_cursor_column().as_deref().unwrap_or("?")
         ),
         other => other.to_string(), // "full"
     }
@@ -103,7 +110,14 @@ pub(crate) fn scaffold_full(info: &TableInfo, engine: &str) -> String {
         }
         "incremental" => format!(
             "incremental({})",
-            info.best_cursor_column().unwrap_or("updated_at")
+            // Mirror yaml_scaffold::export_block_lines EXACTLY: it renders the
+            // cursor via chosen_cursor_column() (the scored picker), not
+            // best_cursor_column() (name-only) — and emits a REVIEW marker,
+            // never a phantom `updated_at`, when there is no candidate. Using
+            // best_ here re-implemented the product with a DIFFERENT picker,
+            // the exact self-oracle this golden exists to prevent (roast
+            // 2026-08-09; superseded fully by the #159 deletion).
+            info.chosen_cursor_column().as_deref().unwrap_or("?")
         ),
         other => other.to_string(),
     }

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -96,6 +96,23 @@ impl TableInfo {
             .map(|c| c.column.clone())
     }
 
+    /// [`chosen_cursor_column`] RESTRICTED to a timestamp column — for
+    /// `time_window`, whose `time_column` MUST be a timestamp. An integer
+    /// surrogate PK is a valid INCREMENTAL cursor (monotonic ids) and
+    /// `cursor_candidates` scores it as one, so `chosen_cursor_column` can return
+    /// `id` on a timestamp-less table; scaffolding that as a `time_column`
+    /// compares a bigint against a timestamp window at run time — an error on
+    /// PostgreSQL, a silently-empty export on MySQL (bug hunt 2026-08-09). Same
+    /// scoring/order as `chosen_cursor_column` among the timestamp candidates, so
+    /// a table WITH a timestamp gets the same column both modes would; `None`
+    /// (no timestamp) drives the honest REVIEW marker instead of a wrong column.
+    pub(crate) fn chosen_time_column(&self) -> Option<String> {
+        crate::init::candidates::cursor_candidates(self)
+            .into_iter()
+            .find(|c| is_timestamp_type(&c.data_type))
+            .map(|c| c.column)
+    }
+
     pub(crate) fn best_cursor_column(&self) -> Option<&str> {
         let ts_cols: Vec<&ColumnInfo> = self
             .columns
@@ -163,6 +180,13 @@ impl TableInfo {
                 // exists, point operators at incremental for scheduled re-runs —
                 // the pilot showed a 655k-row table re-dumped 4× in 2 days under
                 // chunked, re-reading ~570k unchanged rows each time.
+                // Gate the incremental SUGGESTION on best_cursor_column
+                // (timestamp-only): incremental on an integer surrogate PK
+                // catches inserts but MISSES updates, so "pulls only changed
+                // rows" would be false advice — only suggest it when a real
+                // timestamp cursor exists (roast 2026-08-09: the incremental
+                // ARM below names chosen_, but this SUGGESTION must stay
+                // timestamp-gated, unlike an actual incremental export).
                 match self.best_cursor_column() {
                     Some(cursor) => format!(
                         "{base}. NOTE: chunked re-reads the whole table each run — for scheduled \
@@ -171,11 +195,21 @@ impl TableInfo {
                     None => base,
                 }
             }
-            "incremental" => format!(
-                "auto: ~{} rows ≥ 100K threshold; chunk column missing, falling back to incremental on '{}'",
-                fmt_row_estimate(self.row_estimate),
-                self.best_cursor_column().unwrap_or("updated_at"),
-            ),
+            "incremental" => match self.chosen_cursor_column() {
+                Some(cursor) => format!(
+                    "auto: ~{} rows ≥ 100K threshold; chunk column missing, falling back to \
+                     incremental on '{cursor}'",
+                    fmt_row_estimate(self.row_estimate),
+                ),
+                // No timestamp candidate: do NOT name a phantom `updated_at` —
+                // the scaffold emits a REVIEW marker here, so the rationale must
+                // agree (roast 2026-08-09).
+                None => format!(
+                    "auto: ~{} rows ≥ 100K threshold; chunk column missing — set cursor_column \
+                     manually (no timestamp column detected)",
+                    fmt_row_estimate(self.row_estimate),
+                ),
+            },
             "full" => {
                 // full is reached TWO ways: below the 100K threshold, OR above it
                 // with no usable chunk key / cursor column (e.g. a keyless table, or
@@ -1035,6 +1069,45 @@ mod tests {
             total_bytes: None,
             columns: cols,
         }
+    }
+
+    /// A3/A2 (roast 2026-08-09): where best_cursor_column (name-preference) and
+    /// chosen_cursor_column (scored) DIVERGE, every user-facing surface that
+    /// names the cursor must name the CHOSEN one — the column actually written as
+    /// cursor_column — not the name-preferred phantom. Fixture: `updated_at` is
+    /// nullable (name-preferred but -10) and `modified_at` is not-null (scores
+    /// higher). RED against `mode_rationale` reading `best_cursor_column`.
+    #[test]
+    fn mode_rationale_names_the_chosen_cursor_not_the_name_preferred_one() {
+        let nullable_ts = |name: &str| ColumnInfo {
+            name: name.into(),
+            data_type: "timestamp".into(),
+            is_primary_key: false,
+            is_nullable: true,
+            numeric_precision: None,
+            numeric_scale: None,
+        };
+        let info = make_table(
+            500_000,
+            vec![
+                col("payload", "text", false),
+                nullable_ts("updated_at"),
+                col("modified_at", "timestamp", false),
+            ],
+        );
+        // the divergence this test rests on (fixture is not inert)
+        assert_eq!(info.best_cursor_column(), Some("updated_at"));
+        assert_eq!(info.chosen_cursor_column().as_deref(), Some("modified_at"));
+        // the incremental rationale is printed next to `cursor_column: modified_at`
+        let r = info.mode_rationale("incremental");
+        assert!(
+            r.contains("modified_at"),
+            "must name the chosen cursor: {r}"
+        );
+        assert!(
+            !r.contains("updated_at"),
+            "must NOT name the name-preferred phantom: {r}"
+        );
     }
 
     #[test]

--- a/src/init/yaml_scaffold.rs
+++ b/src/init/yaml_scaffold.rs
@@ -588,9 +588,12 @@ fn export_block_lines(
         "time_window" => {
             // time_window REQUIRES time_column (+ days_window) — omitting them
             // scaffolds a config that immediately fails `rivet check`
-            // ("time_window mode requires time_column"). Seed from the best
-            // timestamp column (same resolution as incremental's cursor).
-            match info.chosen_cursor_column() {
+            // ("time_window mode requires time_column"). Seed from a TIMESTAMP
+            // column (chosen_time_column, NOT chosen_cursor_column): the latter
+            // scores an integer surrogate PK as an incremental cursor, so on a
+            // timestamp-less table it would name `time_column: id` — a bigint
+            // compared to a timestamp window at run time (bug hunt 2026-08-09).
+            match info.chosen_time_column() {
                 Some(ts) => lines.push(format!("    time_column: {}", yaml_quote_if_needed(&ts))),
                 None => lines.push(
                     "    # REVIEW: no timestamp column detected — set time_column: <col> manually"
@@ -1119,6 +1122,56 @@ mod tests {
             numeric_precision: None,
             numeric_scale: None,
         }
+    }
+
+    /// Bug hunt 2026-08-09: `time_window`'s `time_column` MUST be a timestamp.
+    /// `chosen_cursor_column` scores an integer surrogate PK as an incremental
+    /// cursor, so on a timestamp-less table it returns the PK — reusing it here
+    /// scaffolded `time_column: id` (a bigint compared to a timestamp window at
+    /// run time). The timestamp-only `chosen_time_column` must yield None → the
+    /// honest REVIEW marker. RED against the `chosen_cursor_column` version.
+    #[test]
+    fn time_window_never_scaffolds_an_integer_pk_as_time_column() {
+        let id_pk = ColumnInfo {
+            name: "id".into(),
+            data_type: "bigint".into(),
+            is_primary_key: true,
+            is_nullable: false,
+            numeric_precision: None,
+            numeric_scale: None,
+        };
+        let info = TableInfo {
+            schema: "public".into(),
+            table: "orders".into(),
+            row_estimate: 1_000_000,
+            total_bytes: Some(1 << 30),
+            columns: vec![
+                id_pk,
+                col("customer_name", "text"),
+                col("amount", "numeric"),
+            ],
+        };
+        // the fixture actually exercises the surrogate-PK trap...
+        assert_eq!(info.chosen_cursor_column().as_deref(), Some("id"));
+        // ...and the timestamp-only picker refuses it.
+        assert_eq!(info.chosen_time_column(), None);
+        let yaml = generate_config(
+            &info,
+            "postgresql://localhost/db",
+            &crate::init::SourceProvenance::Inline,
+            &Default::default(),
+            Some("time_window"),
+            None,
+        )
+        .expect("scaffold");
+        assert!(
+            !yaml.contains("time_column: id"),
+            "must NOT scaffold the integer PK as a time_column:\n{yaml}"
+        );
+        assert!(
+            yaml.contains("REVIEW: no timestamp column detected"),
+            "must emit the honest REVIEW marker:\n{yaml}"
+        );
     }
 
     /// #159 (correctness): the cursor the YAML renders and the cursor the

--- a/src/pipeline/frame.rs
+++ b/src/pipeline/frame.rs
@@ -39,18 +39,13 @@ impl RunnerFrame {
     /// must never clobber a CDC export's audit trail — finding #44), and
     /// derive the part-file extension. Fails BEFORE the first part.
     pub(crate) fn open(plan: &ResolvedRunPlan) -> Result<Self> {
-        let dest = destination::create_destination(&plan.destination)?;
-        crate::manifest::guard_manifest_mode(dest.as_ref(), "batch")?;
-
-        let ext = crate::format::create_format(
-            plan.format,
-            plan.compression,
-            plan.compression_level,
-            None,
-        )
-        .file_extension()
-        .to_string();
-        Ok(Self { dest, ext })
+        // open == open_unguarded + the run-start cross-shape guard; sharing the
+        // body keeps the two from drifting (roast 2026-08-09). The guard runs
+        // before the first part either way — nothing happens between build and
+        // guard that a manifest read could observe.
+        let frame = Self::open_unguarded(plan)?;
+        crate::manifest::guard_manifest_mode(frame.dest.as_ref(), "batch")?;
+        Ok(frame)
     }
 
     /// [`RunnerFrame::open`] for runners that share one destination across

--- a/src/pipeline/plan_cmd.rs
+++ b/src/pipeline/plan_cmd.rs
@@ -546,9 +546,21 @@ fn print_pool_estimate(artifacts: &[PlanArtifact], state: &StateStore) {
         return;
     };
     let total: f64 = items.iter().map(|i| i.predicted_secs).sum();
+    // Honesty: the estimate covers only exports with run history — a config with
+    // newly-added tables schedules more work than this, so an operator comparing
+    // the pool number against the (all-inclusive) wave plan must see the gap
+    // (roast 2026-08-09).
+    let excluded = per_export.len().saturating_sub(items.len());
+    let excluded_note = if excluded > 0 {
+        format!("; {excluded} without history excluded — real makespan is higher")
+    } else {
+        String::new()
+    };
     println!(
-        "\n  Pool scheduler (measured, {} export(s) with history):",
-        items.len()
+        "\n  Pool scheduler (measured, {} of {} export(s) with history{}):",
+        items.len(),
+        per_export.len(),
+        excluded_note
     );
     println!("    sequential: {:.0} min", total / 60.0);
     for m in [2usize, 4, 6] {

--- a/src/source/postgres/cdc.rs
+++ b/src/source/postgres/cdc.rs
@@ -140,7 +140,12 @@ impl PgChangeStream {
         let Ok(mut client) = (match tls {
             Some(cfg) if cfg.mode.is_enforced() => crate::source::tls::build_native_tls(cfg)
                 .and_then(|c| {
-                    Client::connect(conn_str, postgres_native_tls::MakeTlsConnector::new(c))
+                    // Force ssl_mode(Require) so the connector is honored — the
+                    // same enforcement the batch path and open() use; without it
+                    // this catalog probe carries credentials in cleartext under
+                    // an enforced verify-full posture (roast 2026-08-09).
+                    super::pg_config_ssl_forced(conn_str)?
+                        .connect(postgres_native_tls::MakeTlsConnector::new(c))
                         .map_err(Into::into)
                 }),
             _ => Client::connect(conn_str, NoTls).map_err(Into::into),
@@ -189,10 +194,14 @@ impl PgChangeStream {
         let mut client = match tls {
             Some(cfg) if cfg.mode.is_enforced() => {
                 let connector = crate::source::tls::build_native_tls(cfg)?;
-                Client::connect(
-                    conn_str,
-                    postgres_native_tls::MakeTlsConnector::new(connector),
-                )?
+                // Force ssl_mode(Require) like the batch path — otherwise
+                // tokio-postgres picks TLS from the URL's sslmode and a
+                // `?sslmode=disable` (or a `prefer` downgrade) ships the CDC
+                // stream in cleartext, ignoring the connector we just built
+                // (roast 2026-08-09: the batch leg was fixed, the CDC leg was
+                // not — the exact posture verify-full is asked to forbid).
+                super::pg_config_ssl_forced(conn_str)?
+                    .connect(postgres_native_tls::MakeTlsConnector::new(connector))?
             }
             _ => Client::connect(conn_str, NoTls)?,
         };


### PR DESCRIPTION
Review-pipeline pass over the 7-PR merge (\`cefcc35..bc890d4\`): architectural lens + ponytail lens + adversarial bug hunt. Every finding was verified by reading the site before acting; the two RED-proven regressions are named below.

## Architectural (HIGH)
- **PostgreSQL CDC shipped plaintext under enforced verify-full.** The TLS-honesty fix forced \`ssl_mode(Require)\` on the batch connection paths but left the CDC \`open\`/\`row_image\` connects on a raw \`Client::connect\`, so \`?sslmode=disable\` (or a \`prefer\` downgrade) sent credentials and captured changes in cleartext under exit 0 — the batch export of a table was protected, its CDC stream was not. Both now route through the same \`pg_config_ssl_forced\` seam.
- **Golden harness re-implemented the product with a different picker.** The offline scaffold golden kept the name-preference cursor picker after the real scaffold moved to the scored one — the exact divergence the golden exists to prevent, now aligned.

## Architectural (MED/LOW)
- Mode rationale named the name-preferred cursor while the config writes the scored one (now aligned; the chunked→incremental *suggestion* stays timestamp-gated on purpose — incremental on an integer surrogate PK misses updates).
- The plan pool estimate covered only exports with run history; it now prints the excluded count so it is not misread against the all-inclusive wave plan.

## Bug hunt (MED)
- \`time_window\` scaffolded an integer PK as \`time_column\` on a timestamp-less table (the scored picker scores an integer PK as an incremental surrogate) — a bigint compared to a timestamp window at run time. A new timestamp-only picker drives the honest REVIEW marker instead.

## Ponytail
- \`RunnerFrame::open\` now == \`open_unguarded\` + the guard, sharing one body.

## Tests (RED-proven against the pre-fix pickers)
- \`mode_rationale_names_the_chosen_cursor_not_the_name_preferred_one\`
- \`time_window_never_scaffolds_an_integer_pk_as_time_column\`

Offline suite green: lib 2333, bins 2457, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)