### PR TITLE
feat(metrics): bytes_read — source-read bytes, shared-seam by construction (#175)

### DIFF
--- a/docs/runner-coverage-matrix.yaml
+++ b/docs/runner-coverage-matrix.yaml
@@ -162,3 +162,10 @@ scenarios:
     chunked:        { na: "shared seam (run_export_job pre-dispatch)" }
     keyset:         { test: keyset_export_persists_v18_forensics_columns }
     mongo_parallel: { na: "shared seam (run_export_job pre-dispatch); the one distinct entry point is APPLY (run_export_job_with_chunk_source), which re-calls capture_open_forensics — job.rs, guarding the runner-bypass class this ledger exists for" }
+
+  - id: bytes_read_metric
+    what: "the v23 bytes_read metric (decoded Arrow bytes read from the source) must count EVERY runner's reads — a per-runner harvest would be the exact bypass class (a runner that forgets it reports 0). Wired shared-seam instead: the counter is an Arc on the PLAN (plan.bytes_read), every ExportSink::on_batch increments it (per-chunk sinks and plan-cloning workers share the Arc by construction), and run_export_job harvests it ONCE after the runner returns. No runner-specific code exists to forget (#175, 2026-08-09)."
+    single:         { na: "shared-seam: the sink increments plan.bytes_read; harvest is the single post-run read in run_export_job — proven once by bytes_read_accumulates_across_sinks_sharing_the_plan_counter (RED against dropping the fetch_add) + build_metric_row_maps_every_summary_and_plan_field (RED against dropping the mapping)" }
+    chunked:        { na: "shared-seam (per-chunk sinks share the plan Arc — the two-sink case the unit test exercises)" }
+    keyset:         { na: "shared-seam (worker plan clones share the Arc)" }
+    mongo_parallel: { na: "shared-seam (worker plan clones share the Arc)" }

--- a/src/pipeline/apply_cmd.rs
+++ b/src/pipeline/apply_cmd.rs
@@ -262,6 +262,7 @@ mod tests {
 
     fn unreachable_plan() -> ResolvedRunPlan {
         ResolvedRunPlan {
+            bytes_read: Default::default(),
             export_name: "orders".into(),
             source_table: None,
             base_query: "SELECT 1".into(),

--- a/src/pipeline/chunked/exec.rs
+++ b/src/pipeline/chunked/exec.rs
@@ -609,6 +609,7 @@ mod tests {
 
     fn chunked_plan_struct() -> ResolvedRunPlan {
         ResolvedRunPlan {
+            bytes_read: Default::default(),
             export_name: "orders".into(),
             source_table: None,
             base_query: "SELECT id FROM orders".into(),

--- a/src/pipeline/chunked/mod.rs
+++ b/src/pipeline/chunked/mod.rs
@@ -492,6 +492,7 @@ mod tests {
 
     fn make_plan(export_name: &str) -> ResolvedRunPlan {
         ResolvedRunPlan {
+            bytes_read: Default::default(),
             export_name: export_name.into(),
             source_table: None,
             base_query: "SELECT id FROM orders".into(),

--- a/src/pipeline/chunked/resume_m8.rs
+++ b/src/pipeline/chunked/resume_m8.rs
@@ -666,6 +666,7 @@ mod tests {
         use crate::config::{DestinationConfig, DestinationType, SourceConfig, SourceType};
         use crate::tuning::SourceTuning;
         crate::plan::ResolvedRunPlan {
+            bytes_read: Default::default(),
             export_name: "orders".into(),
             source_table: None,
             base_query: "SELECT 1".into(),

--- a/src/pipeline/commit.rs
+++ b/src/pipeline/commit.rs
@@ -368,6 +368,7 @@ mod tests {
 
     fn test_plan() -> ResolvedRunPlan {
         ResolvedRunPlan {
+            bytes_read: Default::default(),
             export_name: "orders".into(),
             source_table: None,
             base_query: "SELECT 1".into(),

--- a/src/pipeline/finalize.rs
+++ b/src/pipeline/finalize.rs
@@ -927,6 +927,7 @@ mod tests {
     fn fin_plan(dest: &std::path::Path) -> crate::plan::ResolvedRunPlan {
         use crate::config::{SourceConfig, SourceType};
         crate::plan::ResolvedRunPlan {
+            bytes_read: Default::default(),
             export_name: "public.orders".into(),
             source_table: None,
             base_query: "SELECT 1".into(),

--- a/src/pipeline/frame.rs
+++ b/src/pipeline/frame.rs
@@ -94,6 +94,7 @@ mod tests {
     fn local_plan(dir: &std::path::Path) -> ResolvedRunPlan {
         use crate::config::{DestinationConfig, DestinationType, SourceConfig, SourceType};
         ResolvedRunPlan {
+            bytes_read: Default::default(),
             export_name: "frame_probe".into(),
             source_table: None,
             base_query: "SELECT 1".into(),

--- a/src/pipeline/job.rs
+++ b/src/pipeline/job.rs
@@ -205,6 +205,7 @@ fn build_metric_row(
         mode: Some(summary.mode.clone()),
         files_produced: summary.files_produced as i64,
         bytes_written: summary.bytes_written as i64,
+        bytes_read: summary.bytes_read as i64,
         retries: summary.retries as i64,
         validated: summary.validated,
         schema_changed: summary.schema_changed,
@@ -580,6 +581,7 @@ pub(crate) fn synthetic_failed_summary(export_name: &str, err: &anyhow::Error) -
     );
     let journal = crate::journal::RunJournal::new(&run_id, export_name);
     RunSummary {
+        bytes_read: 0,
         cursor_column: None,
         cursor_low: None,
         cursor_high: None,
@@ -932,6 +934,10 @@ pub(super) fn run_export_job(
 
     let rss_peak = rss_sampler.stop();
     let rss_after = crate::resource::get_rss_mb();
+    // Harvest the run's bytes-read counter ONCE — every sink (per chunk, per
+    // worker) incremented plan.bytes_read, so this single read covers every
+    // runner by construction (#175).
+    summary.bytes_read = plan.bytes_read.load(std::sync::atomic::Ordering::Relaxed);
     summary.duration_ms = start.elapsed().as_millis() as i64;
     summary.peak_rss_mb = rss_peak.max(rss_after).max(rss_before) as i64;
 
@@ -1190,6 +1196,10 @@ pub(crate) fn run_export_job_with_chunk_source(
 
     let rss_peak = rss_sampler.stop();
     let rss_after = crate::resource::get_rss_mb();
+    // Harvest the run's bytes-read counter ONCE — every sink (per chunk, per
+    // worker) incremented plan.bytes_read, so this single read covers every
+    // runner by construction (#175).
+    summary.bytes_read = plan.bytes_read.load(std::sync::atomic::Ordering::Relaxed);
     summary.duration_ms = start.elapsed().as_millis() as i64;
     summary.peak_rss_mb = rss_peak.max(rss_after).max(rss_before) as i64;
 
@@ -1577,6 +1587,7 @@ mod tests {
 
     fn chunked_plan_with_quality(quality: Option<QualityConfig>) -> ResolvedRunPlan {
         ResolvedRunPlan {
+            bytes_read: Default::default(),
             export_name: "orders".into(),
             source_table: None,
             base_query: "SELECT id FROM orders".into(),
@@ -1822,6 +1833,7 @@ mod tests {
         summary.mode = "chunked".into();
         summary.files_produced = 7;
         summary.bytes_written = 4096;
+        summary.bytes_read = 65536;
         summary.retries = 2;
         summary.validated = Some(true);
         summary.schema_changed = Some(false);
@@ -1872,6 +1884,7 @@ mod tests {
             mode,
             files_produced,
             bytes_written,
+            bytes_read,
             retries,
             validated,
             schema_changed,
@@ -1915,6 +1928,7 @@ mod tests {
         assert_eq!(mode.as_deref(), Some("chunked"));
         assert_eq!(files_produced, 7);
         assert_eq!(bytes_written, 4096);
+        assert_eq!(bytes_read, 65536);
         assert_eq!(retries, 2);
         assert_eq!(validated, Some(true));
         assert_eq!(schema_changed, Some(false));

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -273,6 +273,7 @@ mod tests {
 
     fn minimal_plan() -> ResolvedRunPlan {
         ResolvedRunPlan {
+            bytes_read: Default::default(),
             export_name: "test_export".into(),
             source_table: None,
             base_query: "SELECT 1".into(),

--- a/src/pipeline/reconcile_cmd.rs
+++ b/src/pipeline/reconcile_cmd.rs
@@ -320,6 +320,7 @@ mod tests {
 
     fn chunked_plan() -> ResolvedRunPlan {
         ResolvedRunPlan {
+            bytes_read: Default::default(),
             export_name: "orders".into(),
             source_table: None,
             base_query: "SELECT * FROM orders".into(),

--- a/src/pipeline/run_store.rs
+++ b/src/pipeline/run_store.rs
@@ -163,6 +163,7 @@ mod tests {
 
     fn test_plan(export_name: &str) -> ResolvedRunPlan {
         ResolvedRunPlan {
+            bytes_read: Default::default(),
             export_name: export_name.into(),
             source_table: None,
             base_query: "SELECT 1".into(),

--- a/src/pipeline/single.rs
+++ b/src/pipeline/single.rs
@@ -672,6 +672,7 @@ mod tests {
 
     fn minimal_plan() -> ResolvedRunPlan {
         ResolvedRunPlan {
+            bytes_read: Default::default(),
             export_name: "test_export".into(),
             source_table: None,
             base_query: "SELECT 1".into(),

--- a/src/pipeline/sink/mod.rs
+++ b/src/pipeline/sink/mod.rs
@@ -38,6 +38,10 @@ pub(crate) struct ExportSink {
     pub(in crate::pipeline) compression_level: Option<u32>,
     pub(in crate::pipeline) tmp: tempfile::NamedTempFile,
     pub(in crate::pipeline) total_rows: usize,
+    /// The RUN-wide bytes-read counter, shared from `plan.bytes_read` (every
+    /// sink this run creates — per chunk, per worker — increments the same
+    /// `Arc`, so accumulation is runner-agnostic by construction; see #175).
+    pub(in crate::pipeline) bytes_read: std::sync::Arc<std::sync::atomic::AtomicU64>,
     pub(in crate::pipeline) part_rows: usize,
     /// Cursor column name (with internal columns), set from plan at construction.
     /// When `Some`, `on_batch` extracts the last cursor value inline so we never
@@ -136,6 +140,7 @@ impl ExportSink {
             compression_level: plan.compression_level,
             tmp,
             total_rows: 0,
+            bytes_read: std::sync::Arc::clone(&plan.bytes_read),
             part_rows: 0,
             cursor_column: plan.strategy.cursor_extract_column().map(str::to_string),
             last_cursor_value: None,
@@ -703,6 +708,14 @@ impl BatchSink for ExportSink {
     }
 
     fn on_batch(&mut self, batch: &RecordBatch) -> Result<()> {
+        // Bytes READ from the source: the in-memory Arrow size of the batch as
+        // received, BEFORE any internal-column strip. Incremented on the RUN's
+        // shared counter (plan.bytes_read), so every sink — per chunk, per
+        // worker — feeds one total with no per-runner harvest to forget (#175).
+        self.bytes_read.fetch_add(
+            batch.get_array_memory_size() as u64,
+            std::sync::atomic::Ordering::Relaxed,
+        );
         // Avoid cloning the batch when no internal column needs to be stripped.
         let stripped: Option<RecordBatch> = match &self.strip_internal_column {
             Some(strip) if batch.schema().index_of(strip).is_ok() => {

--- a/src/pipeline/sink/tests.rs
+++ b/src/pipeline/sink/tests.rs
@@ -377,6 +377,7 @@ fn value_ceiling_ignores_null_cells() {
 
 fn minimal_sink() -> ExportSink {
     ExportSink {
+        bytes_read: Default::default(),
         writer: None,
         format_type: crate::config::FormatType::Csv,
         compression: crate::config::CompressionType::None,
@@ -1185,5 +1186,46 @@ fn unique_cap_exact_boundary_trailing_nulls_do_not_trip_cap() {
             .iter()
             .map(|i| i.message.as_str())
             .collect::<Vec<_>>()
+    );
+}
+
+/// #175: bytes_read accumulates on the RUN-wide shared counter — two sinks
+/// sharing one `Arc` (the per-chunk / per-worker shape every runner produces)
+/// must SUM into it, and the count is the batch's in-memory Arrow size as
+/// received. RED against dropping the `fetch_add` in `on_batch`.
+#[test]
+fn bytes_read_accumulates_across_sinks_sharing_the_plan_counter() {
+    use crate::source::BatchSink;
+    use arrow::array::StringArray;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    let counter = Arc::new(AtomicU64::new(0));
+    let schema = Arc::new(Schema::new(vec![Field::new("name", DataType::Utf8, false)]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(StringArray::from(vec!["alice", "bob"]))],
+    )
+    .unwrap();
+    let expect_one = batch.get_array_memory_size() as u64;
+    assert!(expect_one > 0, "fixture batch must have a non-zero size");
+
+    // Two sinks share the counter — the per-chunk shape (chunked builds a fresh
+    // sink per chunk; workers clone the plan, sharing the Arc).
+    for _ in 0..2 {
+        let mut sink = minimal_sink();
+        sink.bytes_read = Arc::clone(&counter);
+        sink.on_schema(schema.clone()).unwrap();
+        sink.on_batch(&batch).unwrap();
+        if let Some(w) = sink.writer.take() {
+            w.finish().unwrap();
+        }
+    }
+    assert_eq!(
+        counter.load(Ordering::Relaxed),
+        expect_one * 2,
+        "both sinks must sum into the ONE run-wide counter"
     );
 }

--- a/src/pipeline/summary.rs
+++ b/src/pipeline/summary.rs
@@ -77,6 +77,9 @@ pub struct RunSummary {
     pub total_rows: i64,
     pub files_produced: usize,
     pub bytes_written: u64,
+    /// Decoded bytes READ from the source this run (harvested once from the
+    /// plan's shared counter by `run_export_job` after the runner returns; v23).
+    pub bytes_read: u64,
     /// Incremented after each successful `dest.write()`. Non-zero means a previous
     /// attempt already committed data — retrying from the same cursor would duplicate rows.
     pub files_committed: usize,
@@ -248,6 +251,7 @@ impl RunSummary {
             total_rows: 0,
             files_produced: 0,
             bytes_written: 0,
+            bytes_read: 0,
             files_committed: 0,
             duration_ms: 0,
             peak_rss_mb: 0,
@@ -325,6 +329,7 @@ impl RunSummary {
             total_rows: 0,
             files_produced: 0,
             bytes_written: 0,
+            bytes_read: 0,
             files_committed: 0,
             duration_ms: 0,
             peak_rss_mb: 0,
@@ -1133,6 +1138,7 @@ mod tests {
         };
         use crate::tuning::SourceTuning;
         let plan = ResolvedRunPlan {
+            bytes_read: Default::default(),
             export_name: "orders".into(),
             source_table: None,
             base_query: "SELECT 1".into(),
@@ -1268,6 +1274,7 @@ mod tests {
         };
         use crate::tuning::SourceTuning;
         let plan = ResolvedRunPlan {
+            bytes_read: Default::default(),
             export_name: "events".into(),
             source_table: None,
             base_query: "SELECT 1".into(),
@@ -1342,6 +1349,7 @@ mod tests {
         };
         use crate::tuning::SourceTuning;
         ResolvedRunPlan {
+            bytes_read: Default::default(),
             export_name: export_name.into(),
             source_table: None,
             base_query: "SELECT 1".into(),

--- a/src/plan/artifact.rs
+++ b/src/plan/artifact.rs
@@ -695,6 +695,7 @@ mod tests {
 
     fn minimal_plan() -> ResolvedRunPlan {
         ResolvedRunPlan {
+            bytes_read: Default::default(),
             export_name: "orders".into(),
             source_table: None,
             base_query: "SELECT * FROM orders".into(),

--- a/src/plan/build.rs
+++ b/src/plan/build.rs
@@ -114,6 +114,7 @@ pub fn build_plan(
     let (compression, compression_level) = export.effective_compression();
     Ok(ResolvedRunPlan {
         export_name: export.name.clone(),
+        bytes_read: Default::default(),
         source_table: export.table.clone(),
         base_query,
         strategy,

--- a/src/plan/contract.rs
+++ b/src/plan/contract.rs
@@ -67,6 +67,19 @@ pub struct KeysetPlan {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResolvedRunPlan {
     pub export_name: String,
+    /// Run-wide counter of decoded bytes READ from the source (in-memory Arrow
+    /// batch size, summed by every `ExportSink::on_batch` this run creates).
+    ///
+    /// Lives on the PLAN — the one value every runner, worker thread, and
+    /// per-chunk sink already receives — so accumulation is runner-agnostic BY
+    /// CONSTRUCTION (`Clone` shares the `Arc`, so a worker's plan clone feeds the
+    /// same counter): no per-runner harvest to forget, the exact runner-bypass
+    /// trap a per-sink field had (#175). Harvested ONCE into
+    /// `summary.bytes_read` by `run_export_job` after the runner returns.
+    /// `serde(skip)`: a runtime counter, not part of the serialized plan; a
+    /// deserialized plan starts a fresh one.
+    #[serde(skip, default)]
+    pub bytes_read: std::sync::Arc<std::sync::atomic::AtomicU64>,
     /// The export's declared source table (`table:`), carried VERBATIM.
     ///
     /// The manifest's source identity is built from this. It used to be derived

--- a/src/plan/inputs.rs
+++ b/src/plan/inputs.rs
@@ -134,6 +134,7 @@ mod tests {
 
     fn minimal_plan(strategy: ExtractionStrategy) -> ResolvedRunPlan {
         ResolvedRunPlan {
+            bytes_read: Default::default(),
             export_name: "test".into(),
             source_table: None,
             base_query: "SELECT 1".into(),

--- a/src/plan/validate.rs
+++ b/src/plan/validate.rs
@@ -227,6 +227,7 @@ mod tests {
 
     fn base_plan() -> ResolvedRunPlan {
         ResolvedRunPlan {
+            bytes_read: Default::default(),
             export_name: "test".into(),
             source_table: None,
             base_query: "SELECT 1".into(),

--- a/src/state/metrics.rs
+++ b/src/state/metrics.rs
@@ -45,6 +45,8 @@ pub struct MetricRow {
     pub mode: Option<String>,
     pub files_produced: i64,
     pub bytes_written: i64,
+    /// Decoded bytes READ from the source (plan-shared counter; v23).
+    pub bytes_read: i64,
     pub retries: i64,
     pub validated: Option<bool>,
     pub schema_changed: Option<bool>,
@@ -238,10 +240,10 @@ impl StateStore {
              chunk_size, parallel, source_type, destination_type, rivet_version,
              longest_chunk_ms, chunk_key,
              error_class, cursor_min, cursor_max, key_descriptor_json, offending_value,
-             server_context_json)
+             server_context_json, bytes_read)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16,
              ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31,
-             ?32, ?33, ?34, ?35, ?36, ?37, ?38)";
+             ?32, ?33, ?34, ?35, ?36, ?37, ?38, ?39)";
         match &self.conn {
             StateConn::Sqlite(c) => {
                 c.execute(
@@ -284,7 +286,8 @@ impl StateStore {
                         m.cursor_max,
                         m.key_descriptor_json,
                         m.offending_value,
-                        m.server_context_json
+                        m.server_context_json,
+                        m.bytes_read
                     ],
                 )?;
             }
@@ -331,6 +334,7 @@ impl StateStore {
                         &m.key_descriptor_json,
                         &m.offending_value,
                         &m.server_context_json,
+                        &m.bytes_read,
                     ],
                 )?;
             }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -441,6 +441,13 @@ const MIGRATIONS: &[(i64, &str)] = &[
          CREATE INDEX IF NOT EXISTS idx_strategy_snapshot_export
              ON strategy_snapshot(export_name, id DESC);",
     ),
+    // v23: decoded bytes READ from the source per run (in-memory Arrow batch
+    // size summed on the plan's shared counter by every sink) — the read-leg
+    // counterpart to bytes_written, so read-vs-write throughput is visible (#175).
+    (
+        23,
+        "ALTER TABLE export_metrics ADD COLUMN bytes_read INTEGER;",
+    ),
 ];
 
 /// PostgreSQL-compatible DDL.  Column types differ from SQLite (BIGSERIAL,
@@ -794,6 +801,10 @@ const PG_MIGRATIONS: &[(i64, &str)] = &[
          );
          CREATE INDEX IF NOT EXISTS idx_strategy_snapshot_export
              ON strategy_snapshot(export_name, id DESC);",
+    ),
+    (
+        23,
+        "ALTER TABLE export_metrics ADD COLUMN bytes_read BIGINT;",
     ),
 ];
 


### PR DESCRIPTION
Closes #175. The read-leg counterpart to \`bytes_written\`: decoded (in-memory Arrow) bytes a run READ from the source.

**Design** (after two reverted per-runner attempts documented in #175): the counter is an \`Arc<AtomicU64>\` on \`ResolvedRunPlan\` (serde-skipped) — the one value every runner/worker/per-chunk sink already receives; \`plan.clone()\` shares the Arc, so accumulation is runner-agnostic **by construction**. Every \`ExportSink::on_batch\` does \`fetch_add(batch.get_array_memory_size())\`; \`run_export_job\` harvests once after the runner returns (export + apply paths). v23 migration on both ladders; \`MetricRow\` + appended \`?39\`.

**Proof:** shared-counter accumulation test (RED vs dropping the fetch_add), exhaustive-destructure mapping test (compiler-enforced, RED vs zeroing), runner-coverage-matrix row \`bytes_read_metric\` = na(shared-seam)×4, drift-guard green.

Offline: lib 2347 / bins 2472 / offline_suite 240 green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)