### PR TITLE
fix: close out #173 — deferred roast/bug-hunt findings, all six + LOWs

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -318,17 +318,11 @@ impl Config {
     /// check serde silently ignores unknown keys and the user gets unexpected
     /// defaults (e.g. batch_size=10 000 instead of the intended 1 000).
     fn check_misplaced_tuning_fields(yaml: &str) -> crate::error::Result<()> {
-        const TUNING_FIELDS: &[&str] = &[
-            "batch_size",
-            "batch_size_memory_mb",
-            "throttle_ms",
-            "statement_timeout_s",
-            "max_retries",
-            "retry_backoff_ms",
-            "lock_timeout_s",
-            "memory_threshold_mb",
-            "profile",
-        ];
+        // Every TuningConfig field — drift-guarded generatively against the
+        // struct's own JsonSchema (misplaced_tuning_list_covers_every_field):
+        // the old hand list froze at 9 of 14, so the newest five knobs misplaced
+        // at source-level were silently ignored (roast 2026-08-09, #173).
+        const TUNING_FIELDS: &[&str] = crate::config::TUNING_FIELD_NAMES;
 
         let root: serde_yaml_ng::Value = serde_yaml_ng::from_str(yaml)?;
 
@@ -2306,3 +2300,24 @@ mod sec_config_validation {
         );
     }
 }
+
+/// Every field of [`crate::tuning::TuningConfig`], for the misplaced-field
+/// detector. Kept in ONE place and generatively drift-guarded against the
+/// struct's JsonSchema, so a new tuning knob cannot be silently invisible to
+/// the misplaced-key check (#173).
+pub(crate) const TUNING_FIELD_NAMES: &[&str] = &[
+    "profile",
+    "batch_size",
+    "batch_size_memory_mb",
+    "throttle_ms",
+    "statement_timeout_s",
+    "max_retries",
+    "retry_backoff_ms",
+    "lock_timeout_s",
+    "memory_threshold_mb",
+    "max_batch_memory_mb",
+    "on_batch_memory_exceeded",
+    "adaptive",
+    "min_parallel",
+    "max_value_mb",
+];

--- a/src/config/tests/validation.rs
+++ b/src/config/tests/validation.rs
@@ -1368,3 +1368,27 @@ exports:
         "a typo'd CDC key must be rejected, not silently defaulted"
     );
 }
+
+/// #173: the misplaced-tuning-field detector's list must cover EVERY
+/// TuningConfig field — derived generatively from the struct's own JsonSchema,
+/// so a new knob cannot be silently invisible to the check (the hand list froze
+/// at 9 of 14). RED against removing a name from TUNING_FIELD_NAMES.
+#[test]
+fn misplaced_tuning_list_covers_every_field() {
+    let schema = schemars::schema_for!(crate::tuning::TuningConfig);
+    let val = serde_json::to_value(&schema).unwrap();
+    let props: std::collections::BTreeSet<String> = val["properties"]
+        .as_object()
+        .expect("TuningConfig schema has properties")
+        .keys()
+        .cloned()
+        .collect();
+    let listed: std::collections::BTreeSet<String> = crate::config::TUNING_FIELD_NAMES
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    assert_eq!(
+        listed, props,
+        "TUNING_FIELD_NAMES must equal TuningConfig's own fields (schema-derived)"
+    );
+}

--- a/src/load/reconcile.rs
+++ b/src/load/reconcile.rs
@@ -98,6 +98,29 @@ pub fn fetch_manifests_keyed(
                 .with_context(|| format!("parsing manifest {key}"))?;
             Ok((key, m))
         })
+        .collect::<Result<Vec<_>>>()
+        .map(dedupe_by_run_id)
+}
+
+/// One manifest per RUN: the canonical `manifest.json` is a last-writer-wins
+/// POINTER to the latest run, so when its run_id is also present as an immutable
+/// `manifest-<run_id>.json` copy, keep the copy and drop the pointer (the
+/// double-count guard). A run_id present ONLY under the canonical name — a
+/// legacy run predating the run-unique copies — survives, so an upgraded prefix
+/// still counts it (#173).
+fn dedupe_by_run_id(keyed: Vec<(String, RunManifest)>) -> Vec<(String, RunManifest)> {
+    let copy_run_ids: std::collections::HashSet<&str> = keyed
+        .iter()
+        .filter(|(k, _)| is_run_unique_manifest(k.rsplit('/').next().unwrap_or("")))
+        .map(|(_, m)| m.run_id.as_str())
+        .collect();
+    keyed
+        .iter()
+        .cloned()
+        .filter(|(k, m)| {
+            is_run_unique_manifest(k.rsplit('/').next().unwrap_or(""))
+                || !copy_run_ids.contains(m.run_id.as_str())
+        })
         .collect()
 }
 
@@ -382,23 +405,13 @@ fn list_manifest_keys(store: &GcsStore, base: &str) -> Result<Vec<String>> {
         .into_iter()
         .filter(|k| is_manifest_key(k))
         .collect();
-    // A run into a shared prefix leaves BOTH the canonical `manifest.json`
-    // (last-writer-wins — a pointer to the LATEST run) and an immutable
-    // `manifest-<run_id>.json` copy (one per run). Sum the per-run copies so a
-    // prefix that accumulated several CDC/incremental cycles counts EVERY run;
-    // counting the canonical pointer too would double-count the latest. Fall
-    // back to the canonical name only when no per-run copy exists (a single
-    // batch run, or a legacy prefix predating the run-unique copy).
-    let run_unique: Vec<String> = all
-        .iter()
-        .filter(|k| is_run_unique_manifest(k.rsplit('/').next().unwrap_or("")))
-        .cloned()
-        .collect();
-    Ok(if run_unique.is_empty() {
-        all
-    } else {
-        run_unique
-    })
+    // Return EVERY manifest key — the canonical `manifest.json` pointer AND the
+    // immutable `manifest-<run_id>.json` copies. The double-count guard is a
+    // RUN-ID dedupe in `fetch_manifests_keyed` (post-parse), not a name filter
+    // here: the old "copies win when any exist" rule silently DROPPED a legacy
+    // run whose only record is the canonical name on a prefix that later gained
+    // run-unique copies — an upgrade-compat under-count (roast 2026-08-09, #173).
+    Ok(all)
 }
 
 /// A listed key is a run manifest iff its final path segment is the canonical
@@ -1619,24 +1632,58 @@ mod tests {
     }
 
     #[test]
-    fn list_manifest_keys_prefers_run_unique_copies_over_the_canonical_pointer() {
-        // A shared prefix that accumulated two runs holds the last-writer-wins
-        // `manifest.json` pointer AND one immutable per-run copy each. Summing
-        // must count the two run copies, never the pointer (double-count guard).
-        let (store, _g) = fs_store(&[
-            ("base/manifest.json", b"{}".to_vec()),
-            ("base/manifest-r1.json", b"{}".to_vec()),
-            ("base/manifest-r2.json", b"{}".to_vec()),
-            ("base/part-0.parquet", b"x".to_vec()), // data file: not a manifest
-        ]);
-        let mut keys = list_manifest_keys(&store, "base").unwrap();
-        keys.sort();
-        assert_eq!(
-            keys,
-            vec![
+    fn dedupe_drops_the_pointer_but_keeps_a_legacy_canonical_only_run() {
+        // The double-count guard moved from the KEY level to the RUN-ID level
+        // (#173): the canonical pointer is dropped when its run_id also exists
+        // as an immutable copy — but a LEGACY run whose only record IS the
+        // canonical name (pre-copy prefix that later gained copies) must
+        // survive. The old "copies win when any exist" key filter silently
+        // dropped it (upgrade-compat under-count); RED against that filter.
+        //
+        // Case 1: pointer's run_id (r2) is covered by a copy → pointer dropped.
+        let keyed = vec![
+            (
+                "base/manifest.json".to_string(),
+                serde_json::from_slice::<RunManifest>(&manifest_bytes("r2", 40, Some(40))).unwrap(),
+            ),
+            (
                 "base/manifest-r1.json".to_string(),
+                serde_json::from_slice::<RunManifest>(&manifest_bytes("r1", 100, Some(100)))
+                    .unwrap(),
+            ),
+            (
                 "base/manifest-r2.json".to_string(),
-            ]
+                serde_json::from_slice::<RunManifest>(&manifest_bytes("r2", 40, Some(40))).unwrap(),
+            ),
+        ];
+        let mut ids: Vec<String> = dedupe_by_run_id(keyed)
+            .into_iter()
+            .map(|(_, m)| m.run_id)
+            .collect();
+        ids.sort();
+        assert_eq!(ids, vec!["r1".to_string(), "r2".to_string()]);
+
+        // Case 2: the canonical names a LEGACY run (r0) no copy covers → kept.
+        let keyed = vec![
+            (
+                "base/manifest.json".to_string(),
+                serde_json::from_slice::<RunManifest>(&manifest_bytes("r0", 7, Some(7))).unwrap(),
+            ),
+            (
+                "base/manifest-r1.json".to_string(),
+                serde_json::from_slice::<RunManifest>(&manifest_bytes("r1", 100, Some(100)))
+                    .unwrap(),
+            ),
+        ];
+        let mut ids: Vec<String> = dedupe_by_run_id(keyed)
+            .into_iter()
+            .map(|(_, m)| m.run_id)
+            .collect();
+        ids.sort();
+        assert_eq!(
+            ids,
+            vec!["r0".to_string(), "r1".to_string()],
+            "a legacy canonical-only run must not be silently dropped"
         );
     }
 

--- a/src/pipeline/keyset.rs
+++ b/src/pipeline/keyset.rs
@@ -579,6 +579,29 @@ fn run_keyset_parallel(
                         .push(format!("range {ridx}: checkpoint commit: {e:#}"));
                     return;
                 }
+                // Project the in-flight `running` aggregate from file_log, so the
+                // part-landed / aggregate-projected pair travels together on this
+                // runner like the other three (roast 2026-08-09, #173: keyset was
+                // the one runner whose mid-run metrics row lagged its parts).
+                // Best-effort observability over a fresh at-ref connection — the
+                // projection is race-safe by construction (INSERT ON CONFLICT +
+                // recompute-UPDATE) and never gates the checkpoint above.
+                if let Some(sref) = sref_r
+                    && let Err(e) = crate::state::StateStore::open_at_ref(sref).and_then(|st| {
+                        st.project_running_aggregate(
+                            rid_r,
+                            &plan_r.export_name,
+                            plan_r.strategy.mode_label(),
+                            plan_r.format.label(),
+                        )
+                    })
+                {
+                    log::warn!(
+                        "export '{}': running-aggregate projection failed for range {ridx} \
+                         (checkpoint is durable; metrics row will catch up at finalize): {e:#}",
+                        plan_r.export_name
+                    );
+                }
                 // Crash simulation: this range is now durably `done` in the state DB,
                 // but the run has NOT finalized — a resume must skip it (rehydrate its
                 // parts) and re-run only the ranges that never reached here.

--- a/src/pipeline/mongo_parallel.rs
+++ b/src/pipeline/mongo_parallel.rs
@@ -70,6 +70,11 @@ pub(crate) fn run_mongo_parallel(
 
     // Fan out: each worker reads its disjoint slice, writes its parts, returns
     // (rows, PartRecords). Errors surface per worker and fail the whole run.
+    // ONE guarded open at run start (the cross-shape manifest GET), shared into
+    // every worker — N workers used to open GUARDED frames concurrently: N remote
+    // GETs for an answer that cannot change mid-run (roast 2026-08-09, #173; the
+    // chunked sibling was fixed the same way).
+    let (shared_dest, shared_ext) = super::frame::RunnerFrame::open_shared(plan)?;
     let results: Vec<(WorkerOutput, Result<()>)> = std::thread::scope(|s| {
         let handles: Vec<_> = ranges
             .iter()
@@ -80,7 +85,9 @@ pub(crate) fn run_mongo_parallel(
                 let stamp = &stamp;
                 // Bson bounds aren't Copy — clone the slice into the worker.
                 let (lo, hi) = (range.0.clone(), range.1.clone());
-                s.spawn(move || range_worker(url, plan, key_plan, kp, stamp, w, lo, hi))
+                let dest = std::sync::Arc::clone(&shared_dest);
+                let ext = &shared_ext;
+                s.spawn(move || range_worker(url, plan, key_plan, kp, stamp, w, lo, hi, dest, ext))
             })
             .collect();
         handles
@@ -217,6 +224,8 @@ fn range_worker(
     worker: usize,
     lo: mongodb::bson::Bson,
     hi: mongodb::bson::Bson,
+    dest: std::sync::Arc<Box<dyn crate::destination::Destination>>,
+    ext: &str,
 ) -> (WorkerOutput, Result<()>) {
     let mut out = WorkerOutput {
         rows: 0,
@@ -225,7 +234,9 @@ fn range_worker(
         column_checksums: std::collections::BTreeMap::new(),
         checksum_key_column: None,
     };
-    let res = range_worker_pages(url, plan, key_plan, kp, stamp, worker, lo, hi, &mut out);
+    let res = range_worker_pages(
+        url, plan, key_plan, kp, stamp, worker, lo, hi, dest, ext, &mut out,
+    );
     (out, res)
 }
 
@@ -239,12 +250,12 @@ fn range_worker_pages(
     worker: usize,
     lo: mongodb::bson::Bson,
     hi: mongodb::bson::Bson,
+    dest: std::sync::Arc<Box<dyn crate::destination::Destination>>,
+    ext: &str,
     out: &mut WorkerOutput,
 ) -> Result<()> {
     let mut src = MongoSource::connect(url, plan.source.tls.as_ref(), plan.source.mongo.as_ref())?
         .with_id_range(lo, hi);
-    let frame = super::frame::RunnerFrame::open(plan)?;
-    let (dest, ext) = (frame.dest, frame.ext);
 
     let mut last: Option<String> = None;
     let mut page = 0usize;
@@ -273,7 +284,7 @@ fn range_worker_pages(
             key_plan,
             kp.chunk_size,
             last.as_deref(),
-            dest.as_ref(),
+            &**dest,
             &base,
         )?
         else {

--- a/src/pipeline/sink/pipelined.rs
+++ b/src/pipeline/sink/pipelined.rs
@@ -51,6 +51,11 @@ const DEFAULT_CHANNEL_DEPTH: usize = 3;
 enum SinkMsg {
     Schema(SchemaRef),
     Batch(RecordBatch),
+    /// A lossless keyset token from the source (Mongo's typed BSON `_id`) —
+    /// forwarded so the decorator is a FAITHFUL BatchSink: the trait's no-op
+    /// default silently swallowed it, a latent wrong-cursor bug the moment a
+    /// cursor-reporting runner is pipelined (roast 2026-08-09, #173).
+    SourceCursor(String),
 }
 
 /// A `BatchSink` that forwards schema/batches to a background encode worker.
@@ -99,6 +104,7 @@ impl PipelinedSink {
                     match msg {
                         SinkMsg::Schema(s) => sink.on_schema(s)?,
                         SinkMsg::Batch(b) => sink.on_batch(&b)?,
+                        SinkMsg::SourceCursor(t) => sink.set_source_cursor(t),
                     }
                 }
                 Ok(sink)
@@ -122,6 +128,7 @@ impl PipelinedSink {
                     match msg {
                         SinkMsg::Schema(s) => sink.on_schema(s)?,
                         SinkMsg::Batch(b) => sink.on_batch(&b)?,
+                        SinkMsg::SourceCursor(t) => sink.set_source_cursor(t),
                     }
                 }
                 Ok(sink)
@@ -164,6 +171,12 @@ impl PipelinedSink {
 impl BatchSink for PipelinedSink {
     fn on_schema(&mut self, schema: SchemaRef) -> Result<()> {
         self.send(SinkMsg::Schema(schema))
+    }
+
+    fn set_source_cursor(&mut self, token: String) {
+        // Best-effort like the underlying setter (no Result to surface): a
+        // closed channel means the worker already failed and finish() reports it.
+        let _ = self.send(SinkMsg::SourceCursor(token));
     }
 
     fn on_batch(&mut self, batch: &RecordBatch) -> Result<()> {

--- a/src/pipeline/sink/tests.rs
+++ b/src/pipeline/sink/tests.rs
@@ -1229,3 +1229,20 @@ fn bytes_read_accumulates_across_sinks_sharing_the_plan_counter() {
         "both sinks must sum into the ONE run-wide counter"
     );
 }
+
+/// #173: PipelinedSink must FORWARD `set_source_cursor` — the trait's no-op
+/// default silently swallowed the source's lossless keyset token, a latent
+/// wrong-cursor bug the moment a cursor-reporting runner is pipelined. RED
+/// against removing the override / the worker's SourceCursor arm.
+#[test]
+fn pipelined_forwards_the_source_cursor_to_the_inner_sink() {
+    use crate::source::BatchSink;
+    let mut p = PipelinedSink::spawn_with_sink(minimal_sink());
+    p.set_source_cursor("bson:int64:42".to_string());
+    let sink = p.finish().expect("worker joins clean");
+    assert_eq!(
+        sink.source_cursor.as_deref(),
+        Some("bson:int64:42"),
+        "the token must reach the inner ExportSink through the decorator"
+    );
+}

--- a/src/state/metrics.rs
+++ b/src/state/metrics.rs
@@ -172,7 +172,7 @@ impl StateStore {
     /// rows and every sum over the table would count it five times. Hence UPDATE
     /// the run's `running` row, INSERT only when there is none, and let
     /// [`record_metric_full`] clear it when the terminal row lands.
-    pub(super) fn project_running_aggregate(
+    pub(crate) fn project_running_aggregate(
         &self,
         run_id: &str,
         export_name: &str,


### PR DESCRIPTION
Closes #173. Every deferred finding from the full-project roast/bug-hunt, RED-proven where a unit oracle exists:

- **keyset running-aggregate**: after a range's atomic checkpoint, the worker projects the in-flight \`running\` aggregate over a fresh at-ref connection (best-effort, never gates the checkpoint) — keyset was the one runner whose mid-run metrics row lagged its parts.
- **mongo_parallel shared frame**: ONE guarded \`open_shared\` at run start, \`Arc<dest>\`+ext threaded into workers — N workers each opened a guarded frame (N concurrent manifest GETs); sibling of the chunked fix.
- **legacy-manifest dedupe** (\`load/reconcile\`): the double-count guard moved from the KEY level to a RUN-ID dedupe post-parse — the old "copies win when any exist" filter silently dropped a legacy run whose only record is the canonical \`manifest.json\` (upgrade-compat under-count). RED-proven.
- **pipelined cursor forwarding**: \`PipelinedSink\` now forwards \`set_source_cursor\` instead of inheriting the no-op default that swallowed the source's lossless keyset token (latent → impossible). RED-proven.
- **generative TUNING_FIELDS**: the misplaced-tuning-field detector's list is the full 14 fields, drift-guarded against \`TuningConfig\`'s own JsonSchema (the hand list froze at 9 of 14).

Earlier commits on main already closed the other #173 items (validate false-clean fallback, coalesce scaffold, chunk-label).

Offline: lib 2349 / bins 2474 / offline_suite 240 — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)