### PR TITLE
refactor: five verdict/probe splits by the compression_refusal precedent (#161)

### DIFF
--- a/proptest-regressions/pipeline/keyset.txt
+++ b/proptest-regressions/pipeline/keyset.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc b499bf21ddae4ec1d51f4fa97f731dd97af2888e5e8b11e6fa238233302b6bec # shrinks to mut bounds = ["a"], floor = None, ceil = None

--- a/src/pipeline/keyset.rs
+++ b/src/pipeline/keyset.rs
@@ -253,10 +253,24 @@ fn sample_parallel_ranges(
     ceil: Option<&str>,
 ) -> Result<Vec<(usize, Option<String>, Option<String>, bool)>> {
     let bounds = sample_key_boundaries(src, plan, key, parallel, floor, ceil)?;
-    // The first range's floor + the last range's ceiling come from the incremental
-    // bounds (both None for a full pass): the first range seeks past `floor`, the
-    // last stops at `ceil` so a row arriving DURING the run is deferred, not
-    // double-counted (which keeps the anchor advance exact).
+    Ok(partition_ranges(&bounds, floor, ceil))
+}
+
+/// Pure partitioning half of [`sample_parallel_ranges`] (#161): fold N−1 sampled
+/// boundaries into N half-open `(lo_exclusive, hi_inclusive]` ranges whose union
+/// is exactly the `(floor, ceil]` key space — gap-free and overlap-free BY
+/// CONSTRUCTION (each range's `lo` IS the previous range's `hi`), which the
+/// property test asserts rather than trusts. The first range's floor + the last
+/// range's ceiling come from the incremental bounds (both None for a full pass):
+/// the first range seeks past `floor`, the last stops at `ceil` so a row
+/// arriving DURING the run is deferred, not double-counted (which keeps the
+/// anchor advance exact).
+#[allow(clippy::type_complexity)]
+fn partition_ranges(
+    bounds: &[String],
+    floor: Option<&str>,
+    ceil: Option<&str>,
+) -> Vec<(usize, Option<String>, Option<String>, bool)> {
     let mut ranges = Vec::with_capacity(bounds.len() + 1);
     let mut prev: Option<String> = floor.map(str::to_string);
     for (i, b) in bounds.iter().enumerate() {
@@ -265,7 +279,7 @@ fn sample_parallel_ranges(
     }
     let last = ranges.len();
     ranges.push((last, prev, ceil.map(str::to_string), false));
-    Ok(ranges)
+    ranges
 }
 
 /// Parallel keyset (feat/parallel-keyset). N ROW-percentile-range workers seek
@@ -1172,5 +1186,35 @@ mod tests {
                 (Some("k1000".to_string()), None),
             ]
         );
+    }
+
+    /// #161: the gap-free / overlap-free coverage property of the pure
+    /// partitioning fold, asserted rather than trusted — for ANY boundary set
+    /// and any floor/ceil, consecutive ranges CHAIN (each lo == previous hi),
+    /// the first lo == floor, the last hi == ceil, indices are dense.
+    #[test]
+    fn partition_ranges_cover_the_key_space_without_gaps_or_overlap() {
+        use proptest::prelude::*;
+        proptest!(|(
+            mut bounds in proptest::collection::vec("[0-9a-f]{1,8}", 0..12),
+            floor in proptest::option::of("[0-9a-f]{1,8}"),
+            ceil in proptest::option::of("[0-9a-f]{1,8}"),
+        )| {
+            bounds.sort();
+            bounds.dedup();
+            let ranges = partition_ranges(&bounds, floor.as_deref(), ceil.as_deref());
+            // N boundaries -> N+1 ranges, densely indexed.
+            prop_assert_eq!(ranges.len(), bounds.len() + 1);
+            for (i, r) in ranges.iter().enumerate() {
+                prop_assert_eq!(r.0, i, "dense range indices");
+                prop_assert!(!r.3, "ranges start not-done");
+            }
+            // Chain: first lo == floor, each next lo == previous hi, last hi == ceil.
+            prop_assert_eq!(ranges[0].1.as_deref(), floor.as_deref());
+            for w in ranges.windows(2) {
+                prop_assert_eq!(w[1].1.as_deref(), w[0].2.as_deref(), "no gap, no overlap");
+            }
+            prop_assert_eq!(ranges[ranges.len() - 1].2.as_deref(), ceil.as_deref());
+        });
     }
 }

--- a/src/source/mongo/cdc.rs
+++ b/src/source/mongo/cdc.rs
@@ -104,6 +104,34 @@ fn token_data(v: &serde_json::Value) -> Option<String> {
     v.get("_data").and_then(|d| d.as_str()).map(String::from)
 }
 
+/// Pure bound verdicts (#161): Mongo was the only engine whose `until_current`
+/// stop rules lived inline in the drain loop instead of a testable transition
+/// (its siblings: MySQL `commit_past_bound`, PG `tx_disposition`, MSSQL
+/// `fill_sql`). Two rules, both unit-tested in both directions:
+///
+/// An EMPTY poll's disposition: the stream's resume token has silently advanced
+/// past the open-time `_data` target → the backlog is drained, STOP; no target
+/// (unbounded shouldn't reach here, and an unparseable boundary fails OPEN) →
+/// STOP; otherwise the backlog is still coming → POLL again.
+fn idle_poll_stops(advanced: Option<&str>, target: Option<&str>) -> bool {
+    match (advanced, target) {
+        (Some(cur), Some(tgt)) => cur > tgt,
+        (_, None) => true,
+        _ => false,
+    }
+}
+
+/// The TIME bound: an event whose `cluster_time` is past the open-time cluster
+/// time arrived AFTER we opened — a bounded run stops there (without it,
+/// sustained writes keep `next_if_any` yielding and the run never terminates).
+fn past_time_bound(
+    until_current: bool,
+    cluster_time: Option<mongodb::bson::Timestamp>,
+    bound: Option<mongodb::bson::Timestamp>,
+) -> bool {
+    until_current && matches!((cluster_time, bound), (Some(ct), Some(b)) if ct > b)
+}
+
 /// Persist a resume token as a [`Position`] LOSSLESSLY. A token can carry a BSON
 /// binary `_typeBits` field (for typed sort keys — e.g. an integer `_id`), and a
 /// plain `serde_json` round-trip mangles that binary, so the server rejects it on
@@ -441,11 +469,10 @@ impl ChangeStream for MongoChangeStream {
                             .and_then(|t| serde_json::to_value(&t).ok())
                             .as_ref()
                             .and_then(token_data);
-                        match (&advanced, &target) {
-                            (Some(cur), Some(tgt)) if cur > tgt => return None,
-                            (_, None) => return None,
-                            _ => continue, // backlog still coming — poll again
+                        if idle_poll_stops(advanced.as_deref(), target.as_deref()) {
+                            return None;
                         }
+                        continue; // backlog still coming — poll again
                     }
                     Err(e) => return Some(Err(anyhow::Error::from(e))),
                 }
@@ -462,10 +489,7 @@ impl ChangeStream for MongoChangeStream {
             // Without it, sustained writes keep `next_if_any` returning events and
             // the run never terminates (the `_data` target only fires on an empty
             // poll, which never happens under continuous writes).
-            if until_current
-                && let (Some(ct), Some(bound)) = (cse.cluster_time, bound_ts)
-                && ct > bound
-            {
+            if past_time_bound(until_current, cse.cluster_time, bound_ts) {
                 return None;
             }
 
@@ -547,5 +571,35 @@ mod tests {
                 "malformed resume token must be a clean Err, not a panic: {bad}"
             );
         }
+    }
+
+    /// #161: Mongo's until_current stop rules as pure transitions, both
+    /// directions each — the one engine whose bound lived inline in the drain
+    /// loop (siblings: commit_past_bound / tx_disposition / fill_sql).
+    #[test]
+    fn idle_poll_stops_both_directions() {
+        // stop: token advanced past the open-time target — backlog drained.
+        assert!(idle_poll_stops(Some("82AB"), Some("8299")));
+        // stop: no target (fail OPEN on an unparseable boundary).
+        assert!(idle_poll_stops(None, None));
+        assert!(idle_poll_stops(Some("82AB"), None));
+        // poll: backlog still coming (at or below the target, or no token yet).
+        assert!(!idle_poll_stops(Some("8299"), Some("82AB")));
+        assert!(!idle_poll_stops(Some("82AB"), Some("82AB")));
+        assert!(!idle_poll_stops(None, Some("82AB")));
+    }
+
+    #[test]
+    fn past_time_bound_both_directions() {
+        use mongodb::bson::Timestamp;
+        let t = |time: u32| Some(Timestamp { time, increment: 0 });
+        // stop: bounded run, event after the open-time cluster time.
+        assert!(past_time_bound(true, t(101), t(100)));
+        // keep: at/before the bound, daemon mode, or no bound.
+        assert!(!past_time_bound(true, t(100), t(100)));
+        assert!(!past_time_bound(true, t(99), t(100)));
+        assert!(!past_time_bound(false, t(101), t(100)));
+        assert!(!past_time_bound(true, t(101), None));
+        assert!(!past_time_bound(true, None, t(100)));
     }
 }

--- a/src/source/mssql/cdc.rs
+++ b/src/source/mssql/cdc.rs
@@ -128,6 +128,16 @@ pub(crate) fn row_image(
     let Ok(rows) = src.query_single_column(&sql) else {
         return RowImage::Whole;
     };
+    row_image_verdict(&rows)
+}
+
+/// Pure verdict half of [`row_image`] (#161, the compression_refusal split):
+/// each row is `name:got/all` (captured vs source column counts for the capture
+/// instance rivet reads); any instance with `got < all` is a PARTIAL capture —
+/// refuse. Malformed rows are skipped (best-effort, like the query itself).
+/// Unit-tested in both directions; the connect+query half stays live-guarded.
+pub(crate) fn row_image_verdict(rows: &[String]) -> crate::source::cdc::RowImage {
+    use crate::source::cdc::RowImage;
     let short: Vec<String> = rows
         .iter()
         .filter_map(|r| {
@@ -1251,5 +1261,28 @@ mod tests {
             vec![ChangeOp::Insert, ChangeOp::Update, ChangeOp::Delete],
             "CDC change table must yield insert(2), update-after(4), delete(1)"
         );
+    }
+
+    /// #161: both directions of the got/all capture-column verdict.
+    #[test]
+    fn row_image_verdict_both_directions() {
+        use crate::source::cdc::RowImage;
+        // keep: every instance captures every column; malformed rows skipped.
+        assert!(matches!(
+            row_image_verdict(&["orders_ci:5/5".into(), "garbage".into()]),
+            RowImage::Whole
+        ));
+        assert!(matches!(row_image_verdict(&[]), RowImage::Whole));
+        // refuse: any instance short of the source column count.
+        match row_image_verdict(&["orders_ci:3/5".into(), "items_ci:4/4".into()]) {
+            RowImage::Partial { why } => {
+                assert!(why.contains("orders_ci (3 of 5 columns)"), "{why}");
+                assert!(
+                    !why.contains("items_ci"),
+                    "complete instance must not be named: {why}"
+                );
+            }
+            other => panic!("partial capture must refuse, got {other:?}"),
+        }
     }
 }

--- a/src/source/mysql/cdc.rs
+++ b/src/source/mysql/cdc.rs
@@ -105,19 +105,13 @@ impl MysqlChangeStream {
     /// Hence a refusal rather than a warning: there is no partially-correct outcome
     /// to let the operator choose. The check is one query at open, on the connection
     /// that is about to dump.
-    pub(crate) fn row_image(url: &str, tls: Option<&TlsConfig>) -> super::super::cdc::RowImage {
+    /// Pure verdict half of [`Self::row_image`] (#161, the compression_refusal
+    /// split): `@@global.binlog_row_image` → keep or refuse. `None` (older
+    /// MySQL / MariaDB without the variable) is NOT evidence of a bad setting —
+    /// refusing on absence would lock out binlogs that are fine. Unit-tested in
+    /// both directions; the connect+query half stays live-guarded.
+    pub(crate) fn row_image_verdict(image: Option<&str>) -> super::super::cdc::RowImage {
         use super::super::cdc::RowImage;
-        use mysql::prelude::Queryable;
-
-        let Ok(mut conn) = connect_conn(url, tls) else {
-            return RowImage::Whole;
-        };
-        let image: Option<String> = conn
-            .query_first("SELECT @@global.binlog_row_image")
-            .unwrap_or(None);
-        // An older MySQL / a MariaDB does not expose the variable. Absence is not
-        // evidence of a bad setting, and refusing on it would lock out binlogs
-        // that are fine.
         let Some(image) = image else {
             return RowImage::Whole;
         };
@@ -133,6 +127,19 @@ impl MysqlChangeStream {
                  server default) and re-run"
             ),
         }
+    }
+
+    pub(crate) fn row_image(url: &str, tls: Option<&TlsConfig>) -> super::super::cdc::RowImage {
+        use super::super::cdc::RowImage;
+        use mysql::prelude::Queryable;
+
+        let Ok(mut conn) = connect_conn(url, tls) else {
+            return RowImage::Whole;
+        };
+        let image: Option<String> = conn
+            .query_first("SELECT @@global.binlog_row_image")
+            .unwrap_or(None);
+        Self::row_image_verdict(image.as_deref())
     }
 
     pub(crate) fn open(
@@ -828,5 +835,32 @@ mod tests {
             RivetValue::Int(2),
             "resumed stream must start after the checkpoint, not re-read A"
         );
+    }
+
+    /// #161: both directions of the pure row-image verdict, RED against an
+    /// inverted/`Ok(())`-style mutant (the compression_refusal precedent).
+    #[test]
+    fn row_image_verdict_both_directions() {
+        use crate::source::cdc::RowImage;
+        // keep: FULL (any case) and ABSENT (older MySQL / MariaDB).
+        assert!(matches!(
+            MysqlChangeStream::row_image_verdict(Some("FULL")),
+            RowImage::Whole
+        ));
+        assert!(matches!(
+            MysqlChangeStream::row_image_verdict(Some("full")),
+            RowImage::Whole
+        ));
+        assert!(matches!(
+            MysqlChangeStream::row_image_verdict(None),
+            RowImage::Whole
+        ));
+        // refuse: MINIMAL / NOBLOB write partial rows.
+        for bad in ["MINIMAL", "noblob"] {
+            match MysqlChangeStream::row_image_verdict(Some(bad)) {
+                RowImage::Partial { why } => assert!(why.contains(bad), "{why}"),
+                other => panic!("{bad} must refuse, got {other:?}"),
+            }
+        }
     }
 }

--- a/src/source/postgres/cdc.rs
+++ b/src/source/postgres/cdc.rs
@@ -172,10 +172,20 @@ impl PgChangeStream {
         ) else {
             return RowImage::Whole;
         };
-        if rows.is_empty() {
+        let named: Vec<String> = rows.iter().map(|r| r.get::<_, String>(0)).collect();
+        Self::row_image_verdict(&named)
+    }
+
+    /// Pure verdict half of [`Self::row_image`] (#161, the compression_refusal
+    /// split): the captured tables whose REPLICA IDENTITY is not FULL — empty
+    /// means every table carries whole rows (keep); any named table downgrades
+    /// DELETEs to key-only (warn). Unit-tested in both directions; the
+    /// connect+query half stays live-guarded.
+    pub(crate) fn row_image_verdict(named: &[String]) -> crate::source::cdc::RowImage {
+        use crate::source::cdc::RowImage;
+        if named.is_empty() {
             return RowImage::Whole;
         }
-        let named: Vec<String> = rows.iter().map(|r| r.get::<_, String>(0)).collect();
         RowImage::KeyOnlyDeletes {
             why: format!(
                 "{} of the captured table(s) ({}) have REPLICA IDENTITY other than FULL, so a \
@@ -1668,6 +1678,7 @@ mod tests {
 
 #[cfg(test)]
 mod slot_creation_warning_tests {
+    use super::PgChangeStream;
     use super::slot_created_warning;
 
     /// A created slot means capture starts at the CURRENT WAL position, so
@@ -1698,5 +1709,22 @@ mod slot_creation_warning_tests {
             w.contains("cdc.checkpoint"),
             "must name the setting that upgrades this to a hard error: {w}"
         );
+    }
+
+    /// #161: both directions of the replica-identity verdict.
+    #[test]
+    fn row_image_verdict_both_directions() {
+        use crate::source::cdc::RowImage;
+        assert!(matches!(
+            PgChangeStream::row_image_verdict(&[]),
+            RowImage::Whole
+        ));
+        match PgChangeStream::row_image_verdict(&["orders".into(), "items".into()]) {
+            RowImage::KeyOnlyDeletes { why } => {
+                assert!(why.contains("2 of the captured table(s)"), "{why}");
+                assert!(why.contains("orders, items"), "{why}");
+            }
+            other => panic!("non-FULL identity must warn, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
Closes #161. Every probe's decision extracted into a pure, both-directions-tested function; all five RED-proven against inverted-guard mutants (each mutant fails its new test — and nothing else in the suite catches it, the blindness the precedent documented):

1. **mysql** \`row_image_verdict\` — FULL/absent keep; MINIMAL/NOBLOB refuse.
2. **postgres** \`row_image_verdict\` — empty keep; named tables → KeyOnlyDeletes. (The probe's TLS-gate fix from this issue is already on main.)
3. **mssql** \`row_image_verdict\` — the \`name:got/all\` parse; short instance refuses.
4. **mongo** \`idle_poll_stops\` + \`past_time_bound\` — the until_current stop rules as pure transitions (fail-OPEN no-target arm included), mirroring commit_past_bound / tx_disposition / fill_sql.
5. **keyset** \`partition_ranges\` — pure fold + proptest: ranges chain (no gap, no overlap), first==floor, last==ceil, dense indices.

Offline: lib 2352 / bins 2477 / offline_suite 240 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)