### PR TITLE
refactor(config): impl Display for TlsMode (#162 item 4)

### DIFF
--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -616,10 +616,7 @@ fn resolve_init_tls(
             "--tls-ca is meaningless with `--tls {}`: that mode never verifies the server \
              certificate, so the CA would be silently ignored. Use `--tls verify-ca` or \
              `--tls verify-full` (or drop --tls-ca).",
-            match mode {
-                TlsMode::Disable => "disable",
-                _ => "require",
-            }
+            mode
         );
     }
     Ok(Some(crate::config::TlsConfig {

--- a/src/config/source.rs
+++ b/src/config/source.rs
@@ -236,6 +236,19 @@ pub enum TlsMode {
     VerifyFull,
 }
 
+/// The kebab-case name serde/clap already own — ONE rendering for every
+/// user-facing surface (#162: three hand matches drifted-in-waiting).
+impl std::fmt::Display for TlsMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            TlsMode::Disable => "disable",
+            TlsMode::Require => "require",
+            TlsMode::VerifyCa => "verify-ca",
+            TlsMode::VerifyFull => "verify-full",
+        })
+    }
+}
+
 impl TlsMode {
     pub fn is_enforced(self) -> bool {
         !matches!(self, TlsMode::Disable)

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -838,15 +838,7 @@ fn init_discovery_json(
         rivet_version: env!("CARGO_PKG_VERSION").to_string(),
         source_type: st.to_string(),
         scope,
-        tls_mode: tls.map(|t| {
-            match t.mode {
-                crate::config::TlsMode::Disable => "disable",
-                crate::config::TlsMode::Require => "require",
-                crate::config::TlsMode::VerifyCa => "verify-ca",
-                crate::config::TlsMode::VerifyFull => "verify-full",
-            }
-            .to_string()
-        }),
+        tls_mode: tls.map(|t| t.mode.to_string()),
         tables,
     };
     artifact.to_json_pretty()

--- a/src/init/yaml_scaffold.rs
+++ b/src/init/yaml_scaffold.rs
@@ -208,12 +208,7 @@ fn config_header_lines(
 
 /// Render `--tls` / `--tls-ca` as the scaffold's `source.tls:` block.
 fn tls_line(t: &crate::config::TlsConfig) -> String {
-    let mode = match t.mode {
-        crate::config::TlsMode::Disable => "disable",
-        crate::config::TlsMode::Require => "require",
-        crate::config::TlsMode::VerifyCa => "verify-ca",
-        crate::config::TlsMode::VerifyFull => "verify-full",
-    };
+    let mode = t.mode.to_string();
     match (&t.ca_file, t.mode) {
         (Some(ca), _) => format!(
             "  tls: {{ mode: {mode}, ca_file: {} }}",


### PR DESCRIPTION
One rendering for the four kebab-case mode names (three hand matches replaced; the dispatch error now names the exact mode). Part of #162 — items 1 (checkpoint at_ref twins via the row.rs seam), 2 (delete the record_metric shim; its callers are all cfg(test) — confirmed against the earlier mis-read), and 3 (RunRequest arg-tunnel collapse) remain, each a focused structural PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)