### PR TITLE
refactor: the #162 deepenings — shim deletion, at_ref twins, one-Args dispatch

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -66,48 +66,7 @@ pub fn parse_cli() -> Cli {
 #[derive(Subcommand)]
 pub enum Commands {
     /// Run export jobs defined in config
-    Run {
-        /// Path to YAML config file
-        #[arg(short, long)]
-        config: String,
-        /// Run only a specific export by name
-        #[arg(short, long)]
-        export: Option<String>,
-        /// Validate output files after writing
-        #[arg(long)]
-        validate: bool,
-        /// Row-count audit: run COUNT(*) on the source and compare with the
-        /// exported row count; a mismatch fails the run. Implies `--validate`
-        /// (also verifies the output file manifest).
-        #[arg(long)]
-        reconcile: bool,
-        /// Resume a chunked export with `chunk_checkpoint: true` (same query/chunk_column/chunk_size)
-        #[arg(long)]
-        resume: bool,
-        /// Override safety gates that would otherwise refuse the run.
-        ///
-        /// Today: with `--resume`, allows starting against a destination prefix
-        /// whose `_SUCCESS` marker is already present.  Without `--force`,
-        /// resume against an already-complete run refuses, so an operator
-        /// cannot accidentally re-export over a verified dataset.
-        #[arg(long)]
-        force: bool,
-        /// Run all exports from the config concurrently (ignored with `--export`; needs 2+ exports)
-        #[arg(long)]
-        parallel_exports: bool,
-        /// Run each export as a separate `rivet` child process (parallel; true per-export peak RSS; more overhead than threads)
-        #[arg(long)]
-        parallel_export_processes: bool,
-        /// Write the run aggregate summary as JSON to this file (in addition to .rivet_state.db)
-        #[arg(long, value_name = "PATH")]
-        summary_output: Option<String>,
-        /// Print the run aggregate summary as JSON to stdout at the end of the run
-        #[arg(long)]
-        json: bool,
-        /// Query parameter: key=value (repeatable, substitutes ${key} in queries)
-        #[arg(short, long = "param", value_name = "KEY=VALUE")]
-        params: Vec<String>,
-    },
+    Run(RunArgs),
     /// Column-type & schema report for each export (needs a working connection;
     /// run `doctor` first if it can't connect)
     Check {
@@ -322,30 +281,7 @@ pub enum Commands {
         tls_ca: Option<String>,
     },
     /// Generate an execution plan artifact (no data exported)
-    Plan {
-        /// Path to YAML config file
-        #[arg(short, long)]
-        config: String,
-        /// Plan only a specific export by name
-        #[arg(short, long)]
-        export: Option<String>,
-        /// Query parameter: key=value (repeatable)
-        #[arg(short, long = "param", value_name = "KEY=VALUE")]
-        params: Vec<String>,
-        /// Write plan JSON to this file (default: print summary to stdout)
-        #[arg(short, long)]
-        output: Option<String>,
-        /// Overwrite `wave:` / `parallel_safe:` values the config ALREADY has
-        /// with this plan's recommendations. Without this flag, plan only fills
-        /// in ABSENT fields — an operator's hand-tuned schedule is never
-        /// silently replaced (it was, before 0.24.4: a 5-per-wave split became
-        /// one 76-export wave after a read-only-looking `rivet plan`).
-        #[arg(long)]
-        annotate_waves: bool,
-        /// Output format: "pretty" (human summary) or "json" (machine-readable)
-        #[arg(long, default_value = "pretty")]
-        format: PlanFormat,
-    },
+    Plan(PlanArgs),
     /// Execute a sealed plan artifact, or run a config's exports wave-by-wave
     Apply {
         /// A plan JSON artifact from `rivet plan` (sealed single-export replay),
@@ -370,30 +306,7 @@ pub enum Commands {
         force: bool,
     },
     /// Targeted repair of chunks flagged by reconcile: emit a repair plan, or re-export only mismatched ranges.
-    Repair {
-        /// Path to YAML config file
-        #[arg(short, long)]
-        config: String,
-        /// Export name to repair (must be `mode: chunked`)
-        #[arg(short, long)]
-        export: String,
-        /// Path to a reconcile JSON report produced by `rivet reconcile --format json`.
-        /// Omit to run reconcile in-process against the latest chunk run.
-        #[arg(long)]
-        report: Option<String>,
-        /// Actually re-export the affected chunks. Without this flag, the plan is printed and nothing is executed.
-        #[arg(long)]
-        execute: bool,
-        /// Output format for plan / report
-        #[arg(long, default_value = "pretty")]
-        format: ReconcileFormat,
-        /// Write plan / report JSON to this file (with `--format json`)
-        #[arg(short, long)]
-        output: Option<String>,
-        /// Query parameter: key=value (repeatable)
-        #[arg(short, long = "param", value_name = "KEY=VALUE")]
-        params: Vec<String>,
-    },
+    Repair(RepairArgs),
     /// Re-run manifest-aware verification against an existing destination, no extraction.
     ///
     /// The same file-manifest checks `rivet run --validate` performs at
@@ -405,51 +318,7 @@ pub enum Commands {
     /// By default `validate` resolves the destination prefix the same way
     /// `run` does — `{date}` becomes today's UTC date.  Use `--date`,
     /// `--run-id`, or `--prefix` to point at a prior run instead of today.
-    Validate {
-        /// Path to YAML config file
-        #[arg(short, long)]
-        config: String,
-        /// Validate only this export (default: every export in the config)
-        #[arg(short, long)]
-        export: Option<String>,
-        /// Output format: "pretty" (human summary) or "json" (machine-readable)
-        #[arg(long, default_value = "pretty")]
-        format: ValidateFormat,
-        /// How deep to verify: "light" (manifest + _SUCCESS only, no prefix
-        /// listing), "sample" (light + part reconcile + untracked surplus), or
-        /// "full" (sample + the value-checksum re-read of every part).
-        ///
-        /// `full` is the default and matches the pre-graded behaviour. Use
-        /// `light` for a fast "is this a complete, marked run?" poll, or
-        /// `sample` for full structural verification without downloading parts.
-        #[arg(long, default_value = "full")]
-        depth: ValidateDepth,
-        /// Write JSON report to this file (only with `--format json`)
-        #[arg(short, long)]
-        output: Option<String>,
-        /// Resolve `{date}` to this ISO-8601 day (e.g. `2026-05-21`) instead of today.
-        ///
-        /// Use when a run that landed on a prior day's prefix needs to be
-        /// re-verified — without this flag `validate` looks at today's
-        /// resolved prefix and reports "no manifest" for yesterday's data.
-        #[arg(long, value_name = "YYYY-MM-DD", conflicts_with = "prefix")]
-        date: Option<String>,
-        /// Substitute `{run_id}` in the destination template with this value.
-        ///
-        /// Composes with `--date`.  Has no effect if the template does not
-        /// contain `{run_id}`.
-        #[arg(long, value_name = "RUN_ID", conflicts_with = "prefix")]
-        run_id: Option<String>,
-        /// Skip placeholder resolution entirely and verify exactly this prefix.
-        ///
-        /// Use when the resolved template no longer matches the physical
-        /// layout (e.g. data was relocated, or the template changed since
-        /// the run landed).  The destination *type* still comes from
-        /// config (`local`, `s3`, `gcs`, `azure`); only the resolved
-        /// `path`/`prefix` string is overridden.
-        #[arg(long, value_name = "PREFIX")]
-        prefix: Option<String>,
-    },
+    Validate(ValidateArgs),
     /// Partition/window reconciliation: re-count per-partition on source and report mismatches.
     /// Requires a chunked export previously run with `chunk_checkpoint: true`.
     /// Exits non-zero when a mismatch is detected, so CI / orchestrators can gate on it
@@ -941,7 +810,7 @@ mod tests {
             Err(e) => panic!("validate should parse, got: {e}"),
         };
         match cli.command {
-            Commands::Validate { depth, .. } => depth,
+            Commands::Validate(a) => a.depth,
             _ => panic!("expected the Validate subcommand"),
         }
     }
@@ -975,4 +844,159 @@ mod tests {
             "an unknown depth must be rejected by clap"
         );
     }
+}
+
+/// Arguments of `rivet validate` — one struct instead of an N-arg
+/// tunnel (#162 item 3): the variant flattens it, dispatch takes it whole, and a
+/// new flag is a field, not another positional parameter at every layer.
+#[derive(clap::Args)]
+pub struct ValidateArgs {
+    /// Path to YAML config file
+    #[arg(short, long)]
+    pub config: String,
+    /// Validate only this export (default: every export in the config)
+    #[arg(short, long)]
+    pub export: Option<String>,
+    /// Output format: "pretty" (human summary) or "json" (machine-readable)
+    #[arg(long, default_value = "pretty")]
+    pub format: ValidateFormat,
+    /// How deep to verify: "light" (manifest + _SUCCESS only, no prefix
+    /// listing), "sample" (light + part reconcile + untracked surplus), or
+    /// "full" (sample + the value-checksum re-read of every part).
+    ///
+    /// `full` is the default and matches the pre-graded behaviour. Use
+    /// `light` for a fast "is this a complete, marked run?" poll, or
+    /// `sample` for full structural verification without downloading parts.
+    #[arg(long, default_value = "full")]
+    pub depth: ValidateDepth,
+    /// Write JSON report to this file (only with `--format json`)
+    #[arg(short, long)]
+    pub output: Option<String>,
+    /// Resolve `{date}` to this ISO-8601 day (e.g. `2026-05-21`) instead of today.
+    ///
+    /// Use when a run that landed on a prior day's prefix needs to be
+    /// re-verified — without this flag `validate` looks at today's
+    /// resolved prefix and reports "no manifest" for yesterday's data.
+    #[arg(long, value_name = "YYYY-MM-DD", conflicts_with = "prefix")]
+    pub date: Option<String>,
+    /// Substitute `{run_id}` in the destination template with this value.
+    ///
+    /// Composes with `--date`.  Has no effect if the template does not
+    /// contain `{run_id}`.
+    #[arg(long, value_name = "RUN_ID", conflicts_with = "prefix")]
+    pub run_id: Option<String>,
+    /// Skip placeholder resolution entirely and verify exactly this prefix.
+    ///
+    /// Use when the resolved template no longer matches the physical
+    /// layout (e.g. data was relocated, or the template changed since
+    /// the run landed).  The destination *type* still comes from
+    /// config (`local`, `s3`, `gcs`, `azure`); only the resolved
+    /// `path`/`prefix` string is overridden.
+    #[arg(long, value_name = "PREFIX")]
+    pub prefix: Option<String>,
+}
+
+/// Arguments of `rivet repair` — one struct instead of an N-arg
+/// tunnel (#162 item 3): the variant flattens it, dispatch takes it whole, and a
+/// new flag is a field, not another positional parameter at every layer.
+#[derive(clap::Args)]
+pub struct RepairArgs {
+    /// Path to YAML config file
+    #[arg(short, long)]
+    pub config: String,
+    /// Export name to repair (must be `mode: chunked`)
+    #[arg(short, long)]
+    pub export: String,
+    /// Path to a reconcile JSON report produced by `rivet reconcile --format json`.
+    /// Omit to run reconcile in-process against the latest chunk run.
+    #[arg(long)]
+    pub report: Option<String>,
+    /// Actually re-export the affected chunks. Without this flag, the plan is printed and nothing is executed.
+    #[arg(long)]
+    pub execute: bool,
+    /// Output format for plan / report
+    #[arg(long, default_value = "pretty")]
+    pub format: ReconcileFormat,
+    /// Write plan / report JSON to this file (with `--format json`)
+    #[arg(short, long)]
+    pub output: Option<String>,
+    /// Query parameter: key=value (repeatable)
+    #[arg(short, long = "param", value_name = "KEY=VALUE")]
+    pub params: Vec<String>,
+}
+
+/// Arguments of `rivet plan` — one struct instead of an N-arg
+/// tunnel (#162 item 3): the variant flattens it, dispatch takes it whole, and a
+/// new flag is a field, not another positional parameter at every layer.
+#[derive(clap::Args)]
+pub struct PlanArgs {
+    /// Path to YAML config file
+    #[arg(short, long)]
+    pub config: String,
+    /// Plan only a specific export by name
+    #[arg(short, long)]
+    pub export: Option<String>,
+    /// Query parameter: key=value (repeatable)
+    #[arg(short, long = "param", value_name = "KEY=VALUE")]
+    pub params: Vec<String>,
+    /// Write plan JSON to this file (default: print summary to stdout)
+    #[arg(short, long)]
+    pub output: Option<String>,
+    /// Overwrite `wave:` / `parallel_safe:` values the config ALREADY has
+    /// with this plan's recommendations. Without this flag, plan only fills
+    /// in ABSENT fields — an operator's hand-tuned schedule is never
+    /// silently replaced (it was, before 0.24.4: a 5-per-wave split became
+    /// one 76-export wave after a read-only-looking `rivet plan`).
+    #[arg(long)]
+    pub annotate_waves: bool,
+    /// Output format: "pretty" (human summary) or "json" (machine-readable)
+    #[arg(long, default_value = "pretty")]
+    pub format: PlanFormat,
+}
+
+/// Arguments of `rivet run` — one struct instead of an 11-arg
+/// tunnel (#162 item 3): the variant flattens it, dispatch takes it whole, and a
+/// new flag is a field, not another positional parameter at every layer.
+#[derive(clap::Args)]
+pub struct RunArgs {
+    /// Path to YAML config file
+    #[arg(short, long)]
+    pub config: String,
+    /// Run only a specific export by name
+    #[arg(short, long)]
+    pub export: Option<String>,
+    /// Validate output files after writing
+    #[arg(long)]
+    pub validate: bool,
+    /// Row-count audit: run COUNT(*) on the source and compare with the
+    /// exported row count; a mismatch fails the run. Implies `--validate`
+    /// (also verifies the output file manifest).
+    #[arg(long)]
+    pub reconcile: bool,
+    /// Resume a chunked export with `chunk_checkpoint: true` (same query/chunk_column/chunk_size)
+    #[arg(long)]
+    pub resume: bool,
+    /// Override safety gates that would otherwise refuse the run.
+    ///
+    /// Today: with `--resume`, allows starting against a destination prefix
+    /// whose `_SUCCESS` marker is already present.  Without `--force`,
+    /// resume against an already-complete run refuses, so an operator
+    /// cannot accidentally re-export over a verified dataset.
+    #[arg(long)]
+    pub force: bool,
+    /// Run all exports from the config concurrently (ignored with `--export`; needs 2+ exports)
+    #[arg(long)]
+    pub parallel_exports: bool,
+    /// Run each export as a separate `rivet` child process (parallel; true per-export peak RSS; more overhead than threads)
+    #[arg(long)]
+    pub parallel_export_processes: bool,
+    /// Write the run aggregate summary as JSON to this file (in addition to .rivet_state.db)
+    #[arg(long, value_name = "PATH")]
+    pub summary_output: Option<String>,
+    /// Print the run aggregate summary as JSON to stdout at the end of the run
+    #[arg(long)]
+    pub json: bool,
+    /// Query parameter: key=value (repeatable, substitutes ${key} in queries)
+    #[arg(short, long = "param", value_name = "KEY=VALUE")]
+    pub params: Vec<String>,
 }

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -9,8 +9,7 @@
 use clap::CommandFactory;
 
 use super::args::{
-    Cli, Commands, PlanFormat, ReconcileFormat, SchemaKind, StateAction, ValidateDepth,
-    ValidateFormat,
+    Cli, Commands, PlanFormat, ReconcileFormat, SchemaKind, StateAction, ValidateFormat,
 };
 use super::params::{parse_params, resolve_init_source};
 use super::validate::validate_cli;
@@ -55,31 +54,7 @@ fn check_export_selection(config: &Config, export: Option<&str>) -> Result<()> {
 pub fn dispatch(cli: Cli) -> Result<()> {
     validate_cli(&cli.command)?;
     match cli.command {
-        Commands::Run {
-            config,
-            export,
-            validate,
-            reconcile,
-            resume,
-            force,
-            parallel_exports,
-            parallel_export_processes,
-            summary_output,
-            json,
-            params,
-        } => dispatch_run(
-            config,
-            export,
-            validate,
-            reconcile,
-            resume,
-            force,
-            parallel_exports,
-            parallel_export_processes,
-            summary_output,
-            json,
-            params,
-        ),
+        Commands::Run(args) => dispatch_run(args),
         Commands::Check {
             config,
             export,
@@ -163,30 +138,14 @@ pub fn dispatch(cli: Cli) -> Result<()> {
             tls,
             tls_ca,
         ),
-        Commands::Plan {
-            config,
-            export,
-            params,
-            output,
-            format,
-            annotate_waves,
-        } => dispatch_plan(config, export, params, output, format, annotate_waves),
+        Commands::Plan(args) => dispatch_plan(args),
         Commands::Apply {
             plan_file,
             parallel_export_processes,
             resume,
             force,
         } => pipeline::run_apply_command(&plan_file, force, parallel_export_processes, resume),
-        Commands::Validate {
-            config,
-            export,
-            format,
-            depth,
-            output,
-            date,
-            run_id,
-            prefix,
-        } => dispatch_validate(config, export, format, depth, output, date, run_id, prefix),
+        Commands::Validate(args) => dispatch_validate(args),
         Commands::Reconcile {
             config,
             export,
@@ -194,15 +153,7 @@ pub fn dispatch(cli: Cli) -> Result<()> {
             output,
             params,
         } => dispatch_reconcile(config, export, format, output, params),
-        Commands::Repair {
-            config,
-            export,
-            report,
-            execute,
-            format,
-            output,
-            params,
-        } => dispatch_repair(config, export, report, execute, format, output, params),
+        Commands::Repair(args) => dispatch_repair(args),
         Commands::Completions { shell } => {
             clap_complete::generate(shell, &mut Cli::command(), "rivet", &mut std::io::stdout());
             Ok(())
@@ -367,19 +318,20 @@ fn dispatch_cdc(a: CdcArgs) -> Result<()> {
 }
 
 #[allow(clippy::too_many_arguments)]
-fn dispatch_run(
-    config: String,
-    export: Option<String>,
-    validate: bool,
-    reconcile: bool,
-    resume: bool,
-    force: bool,
-    parallel_exports: bool,
-    parallel_export_processes: bool,
-    summary_output: Option<String>,
-    json: bool,
-    params: Vec<String>,
-) -> Result<()> {
+fn dispatch_run(args: crate::cli::args::RunArgs) -> Result<()> {
+    let crate::cli::args::RunArgs {
+        config,
+        export,
+        validate,
+        reconcile,
+        resume,
+        force,
+        parallel_exports,
+        parallel_export_processes,
+        summary_output,
+        json,
+        params,
+    } = args;
     let p = parse_params(&params)?;
     let p = if p.is_empty() { None } else { Some(p) };
     if let Some(name) = export.as_deref() {
@@ -626,14 +578,15 @@ fn resolve_init_tls(
     }))
 }
 
-fn dispatch_plan(
-    config: String,
-    export: Option<String>,
-    params: Vec<String>,
-    output: Option<String>,
-    format: PlanFormat,
-    annotate_waves: bool,
-) -> Result<()> {
+fn dispatch_plan(args: crate::cli::args::PlanArgs) -> Result<()> {
+    let crate::cli::args::PlanArgs {
+        config,
+        export,
+        params,
+        output,
+        annotate_waves,
+        format,
+    } = args;
     let p = parse_params(&params)?;
     let p = if p.is_empty() { None } else { Some(p) };
     if let Some(name) = export.as_deref() {
@@ -647,16 +600,17 @@ fn dispatch_plan(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn dispatch_validate(
-    config: String,
-    export: Option<String>,
-    format: ValidateFormat,
-    depth: ValidateDepth,
-    output: Option<String>,
-    date: Option<String>,
-    run_id: Option<String>,
-    prefix: Option<String>,
-) -> Result<()> {
+fn dispatch_validate(args: crate::cli::args::ValidateArgs) -> Result<()> {
+    let crate::cli::args::ValidateArgs {
+        config,
+        export,
+        format,
+        depth,
+        output,
+        date,
+        run_id,
+        prefix,
+    } = args;
     if let Some(name) = export.as_deref() {
         check_export_selection(&Config::load(&config)?, Some(name))?;
     }
@@ -706,15 +660,16 @@ fn dispatch_reconcile(
     pipeline::run_reconcile_command(&config, &export, p.as_ref(), fmt)
 }
 
-fn dispatch_repair(
-    config: String,
-    export: String,
-    report: Option<String>,
-    execute: bool,
-    format: ReconcileFormat,
-    output: Option<String>,
-    params: Vec<String>,
-) -> Result<()> {
+fn dispatch_repair(args: crate::cli::args::RepairArgs) -> Result<()> {
+    let crate::cli::args::RepairArgs {
+        config,
+        export,
+        report,
+        execute,
+        format,
+        output,
+        params,
+    } = args;
     let p = parse_params(&params)?;
     let p = if p.is_empty() { None } else { Some(p) };
     check_export_selection(

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -13,23 +13,15 @@ use crate::error::Result;
 /// JSON depending on `--json-errors`.
 pub(super) fn validate_cli(cmd: &Commands) -> Result<()> {
     match cmd {
-        Commands::Run {
-            parallel_exports,
-            parallel_export_processes,
-            ..
-        } => {
-            if *parallel_exports && *parallel_export_processes {
+        Commands::Run(a) => {
+            if a.parallel_exports && a.parallel_export_processes {
                 anyhow::bail!(
                     "--parallel-exports and --parallel-export-processes are mutually exclusive; \
                      choose one parallelism mode"
                 );
             }
         }
-        Commands::Plan {
-            format: PlanFormat::Pretty,
-            output: Some(_),
-            ..
-        } => {
+        Commands::Plan(a) if matches!(a.format, PlanFormat::Pretty) && a.output.is_some() => {
             anyhow::bail!("--output requires --format json (output is ignored in pretty mode)");
         }
         Commands::Reconcile {
@@ -39,18 +31,14 @@ pub(super) fn validate_cli(cmd: &Commands) -> Result<()> {
         } => {
             anyhow::bail!("--output requires --format json (output is ignored in pretty mode)");
         }
-        Commands::Validate {
-            format: ValidateFormat::Pretty,
-            output: Some(_),
-            ..
-        } => {
+        Commands::Validate(a)
+            if matches!(a.format, ValidateFormat::Pretty) && a.output.is_some() =>
+        {
             anyhow::bail!("--output requires --format json (output is ignored in pretty mode)");
         }
-        Commands::Repair {
-            format: ReconcileFormat::Pretty,
-            output: Some(_),
-            ..
-        } => {
+        Commands::Repair(a)
+            if matches!(a.format, ReconcileFormat::Pretty) && a.output.is_some() =>
+        {
             anyhow::bail!("--output requires --format json (output is ignored in pretty mode)");
         }
         _ => {}
@@ -63,7 +51,7 @@ mod tests {
     use super::*;
 
     fn make_run(parallel_exports: bool, parallel_export_processes: bool) -> Commands {
-        Commands::Run {
+        Commands::Run(crate::cli::args::RunArgs {
             config: "c.yaml".into(),
             export: None,
             validate: false,
@@ -75,7 +63,7 @@ mod tests {
             summary_output: None,
             json: false,
             params: vec![],
-        }
+        })
     }
 
     #[test]
@@ -93,27 +81,27 @@ mod tests {
 
     #[test]
     fn validate_plan_rejects_output_with_pretty() {
-        let cmd = Commands::Plan {
+        let cmd = Commands::Plan(crate::cli::args::PlanArgs {
             config: "c.yaml".into(),
             export: None,
             params: vec![],
             output: Some("out.json".into()),
             format: PlanFormat::Pretty,
             annotate_waves: false,
-        };
+        });
         assert!(validate_cli(&cmd).is_err());
     }
 
     #[test]
     fn validate_plan_accepts_output_with_json() {
-        let cmd = Commands::Plan {
+        let cmd = Commands::Plan(crate::cli::args::PlanArgs {
             config: "c.yaml".into(),
             export: None,
             params: vec![],
             output: Some("out.json".into()),
             format: PlanFormat::Json,
             annotate_waves: false,
-        };
+        });
         assert!(validate_cli(&cmd).is_ok());
     }
 
@@ -143,7 +131,7 @@ mod tests {
 
     #[test]
     fn validate_repair_rejects_output_with_pretty() {
-        let cmd = Commands::Repair {
+        let cmd = Commands::Repair(crate::cli::args::RepairArgs {
             config: "c.yaml".into(),
             export: "e".into(),
             report: None,
@@ -151,13 +139,13 @@ mod tests {
             format: ReconcileFormat::Pretty,
             output: Some("out.json".into()),
             params: vec![],
-        };
+        });
         assert!(validate_cli(&cmd).is_err());
     }
 
     #[test]
     fn validate_repair_accepts_output_with_json() {
-        let cmd = Commands::Repair {
+        let cmd = Commands::Repair(crate::cli::args::RepairArgs {
             config: "c.yaml".into(),
             export: "e".into(),
             report: None,
@@ -165,7 +153,7 @@ mod tests {
             format: ReconcileFormat::Json,
             output: Some("out.json".into()),
             params: vec![],
-        };
+        });
         assert!(validate_cli(&cmd).is_ok());
     }
 }

--- a/src/load/reconcile.rs
+++ b/src/load/reconcile.rs
@@ -116,11 +116,11 @@ fn dedupe_by_run_id(keyed: Vec<(String, RunManifest)>) -> Vec<(String, RunManife
         .collect();
     keyed
         .iter()
-        .cloned()
         .filter(|(k, m)| {
             is_run_unique_manifest(k.rsplit('/').next().unwrap_or(""))
                 || !copy_run_ids.contains(m.run_id.as_str())
         })
+        .cloned()
         .collect()
 }
 

--- a/src/pipeline/chunked/parallel_checkpoint.rs
+++ b/src/pipeline/chunked/parallel_checkpoint.rs
@@ -205,26 +205,28 @@ pub(crate) fn run_chunked_parallel_checkpoint(
                     let start: i64 = match sk.parse() {
                         Ok(v) => v,
                         Err(_) => {
-                            let _ = StateStore::fail_chunk_task_at_ref(
-                                &state_ref,
-                                run_id_arc.as_str(),
-                                chunk_index,
-                                "invalid start_key",
-                                false, // a malformed key parses the same way every time
-                            );
+                            let _ = StateStore::open_at_ref(&state_ref).and_then(|st| {
+                                st.fail_chunk_task(
+                                    run_id_arc.as_str(),
+                                    chunk_index,
+                                    "invalid start_key",
+                                    false, // a malformed key parses the same way every time
+                                )
+                            });
                             continue;
                         }
                     };
                     let end: i64 = match ek.parse() {
                         Ok(v) => v,
                         Err(_) => {
-                            let _ = StateStore::fail_chunk_task_at_ref(
-                                &state_ref,
-                                run_id_arc.as_str(),
-                                chunk_index,
-                                "invalid end_key",
-                                false, // a malformed key parses the same way every time
-                            );
+                            let _ = StateStore::open_at_ref(&state_ref).and_then(|st| {
+                                st.fail_chunk_task(
+                                    run_id_arc.as_str(),
+                                    chunk_index,
+                                    "invalid end_key",
+                                    false, // a malformed key parses the same way every time
+                                )
+                            });
                             continue;
                         }
                     };
@@ -468,13 +470,14 @@ pub(crate) fn run_chunked_parallel_checkpoint(
                             // crashing the process and leaving any in-flight workers'
                             // chunk_task rows as 'running' for the resume path to reset.
                             crate::test_hook::maybe_panic_at_chunk("after_chunk_file", chunk_index);
-                            let _ = StateStore::complete_chunk_task_at_ref(
-                                &state_ref,
-                                run_id_arc.as_str(),
-                                chunk_index,
-                                rows as i64,
-                                fname_for_state.as_deref(),
-                            );
+                            let _ = StateStore::open_at_ref(&state_ref).and_then(|st| {
+                                st.complete_chunk_task(
+                                    run_id_arc.as_str(),
+                                    chunk_index,
+                                    rows as i64,
+                                    fname_for_state.as_deref(),
+                                )
+                            });
                             crate::test_hook::maybe_panic_at_chunk(
                                 "after_chunk_complete",
                                 chunk_index,
@@ -483,13 +486,14 @@ pub(crate) fn run_chunked_parallel_checkpoint(
                         }
                         Err(e) => {
                             let msg = crate::redact::redact_error(&e);
-                            let _ = StateStore::fail_chunk_task_at_ref(
-                                &state_ref,
-                                run_id_arc.as_str(),
-                                chunk_index,
-                                &msg,
-                                crate::pipeline::retry::is_transient(&e),
-                            );
+                            let _ = StateStore::open_at_ref(&state_ref).and_then(|st| {
+                                st.fail_chunk_task(
+                                    run_id_arc.as_str(),
+                                    chunk_index,
+                                    &msg,
+                                    crate::pipeline::retry::is_transient(&e),
+                                )
+                            });
                             poison::lock_recover(errors)
                                 .push(format!("chunk {}: {}", chunk_index, msg));
                         }

--- a/src/pipeline/cli.rs
+++ b/src/pipeline/cli.rs
@@ -1116,43 +1116,45 @@ exports:
         let state = open_state(&dir);
         // ≥1000 ms → "X.Xs" branch; retries + validated + schema_changed flags
         state
-            .record_metric(
-                "orders",
-                "r1",
-                1_500,
-                50_000,
-                Some(42),
-                "success",
-                None,
-                Some("balanced"),
-                Some("parquet"),
-                Some("full"),
-                1,
-                4096,
-                3,
-                Some(true),
-                Some(true),
-            )
+            .record_metric_full(&crate::state::MetricRow {
+                export_name: "orders".to_string(),
+                run_id: "r1".to_string(),
+                duration_ms: 1_500,
+                total_rows: 50_000,
+                peak_rss_mb: Some(42),
+                status: "success".to_string(),
+                error_message: None,
+                tuning_profile: Some("balanced".to_string()),
+                format: Some("parquet".to_string()),
+                mode: Some("full".to_string()),
+                files_produced: 1,
+                bytes_written: 4096,
+                retries: 3,
+                validated: Some(true),
+                schema_changed: Some(true),
+                ..Default::default()
+            })
             .unwrap();
         // <1000 ms → "Xms" branch; error_message line
         state
-            .record_metric(
-                "orders",
-                "r2",
-                800,
-                0,
-                None,
-                "failed",
-                Some("timeout"),
-                None,
-                None,
-                None,
-                0,
-                0,
-                0,
-                Some(false),
-                None,
-            )
+            .record_metric_full(&crate::state::MetricRow {
+                export_name: "orders".to_string(),
+                run_id: "r2".to_string(),
+                duration_ms: 800,
+                total_rows: 0,
+                peak_rss_mb: None,
+                status: "failed".to_string(),
+                error_message: Some("timeout".to_string()),
+                tuning_profile: None,
+                format: None,
+                mode: None,
+                files_produced: 0,
+                bytes_written: 0,
+                retries: 0,
+                validated: Some(false),
+                schema_changed: None,
+                ..Default::default()
+            })
             .unwrap();
         drop(state);
         assert!(show_metrics(&config_path, Some("orders"), 10, false).is_ok());
@@ -1165,23 +1167,24 @@ exports:
         let (dir, config_path) = setup_dir(); // declares orders + transactions
         let state = open_state(&dir);
         let seed = |s: &StateStore, export: &str, run: &str| {
-            s.record_metric(
-                export,
-                run,
-                100,
-                10,
-                None,
-                "success",
-                None,
-                None,
-                Some("parquet"),
-                Some("full"),
-                1,
-                0,
-                0,
-                None,
-                None,
-            )
+            s.record_metric_full(&crate::state::MetricRow {
+                export_name: export.to_string(),
+                run_id: run.to_string(),
+                duration_ms: 100,
+                total_rows: 10,
+                peak_rss_mb: None,
+                status: "success".to_string(),
+                error_message: None,
+                tuning_profile: None,
+                format: Some("parquet".to_string()),
+                mode: Some("full".to_string()),
+                files_produced: 1,
+                bytes_written: 0,
+                retries: 0,
+                validated: None,
+                schema_changed: None,
+                ..Default::default()
+            })
             .unwrap();
         };
         seed(&state, "orders", "r1"); // declared in this config

--- a/src/pipeline/plan_cmd.rs
+++ b/src/pipeline/plan_cmd.rs
@@ -943,45 +943,47 @@ mod tests {
         let state = crate::state::StateStore::open_in_memory().expect("state");
         for (name, ms) in [("slowpoke", 90_000i64), ("quickie", 1_000i64)] {
             state
-                .record_metric(
-                    name,
-                    &format!("{name}_run"),
-                    ms,
-                    10,
-                    Some(120),
-                    "success",
-                    None,
-                    None,
-                    None,
-                    None,
-                    1,
-                    100,
-                    0,
-                    None,
-                    None,
-                )
+                .record_metric_full(&crate::state::MetricRow {
+                    export_name: name.to_string(),
+                    run_id: format!("{name}_run"),
+                    duration_ms: ms,
+                    total_rows: 10,
+                    peak_rss_mb: Some(120),
+                    status: "success".to_string(),
+                    error_message: None,
+                    tuning_profile: None,
+                    format: None,
+                    mode: None,
+                    files_produced: 1,
+                    bytes_written: 100,
+                    retries: 0,
+                    validated: None,
+                    schema_changed: None,
+                    ..Default::default()
+                })
                 .expect("record");
         }
         // …and a failed newer run for slowpoke, which must be IGNORED — only a
         // successful run predicts anything.
         state
-            .record_metric(
-                "slowpoke",
-                "slowpoke_failed",
-                5,
-                0,
-                Some(50),
-                "failed",
-                Some("boom"),
-                None,
-                None,
-                None,
-                0,
-                0,
-                0,
-                None,
-                None,
-            )
+            .record_metric_full(&crate::state::MetricRow {
+                export_name: "slowpoke".to_string(),
+                run_id: "slowpoke_failed".to_string(),
+                duration_ms: 5,
+                total_rows: 0,
+                peak_rss_mb: Some(50),
+                status: "failed".to_string(),
+                error_message: Some("boom".to_string()),
+                tuning_profile: None,
+                format: None,
+                mode: None,
+                files_produced: 0,
+                bytes_written: 0,
+                retries: 0,
+                validated: None,
+                schema_changed: None,
+                ..Default::default()
+            })
             .expect("record failed");
 
         let recs = vec![
@@ -1026,23 +1028,24 @@ mod tests {
         let state = crate::state::StateStore::open_in_memory().expect("state");
         for n in ["lonely", "buddy"] {
             state
-                .record_metric(
-                    n,
-                    &format!("{n}_r"),
-                    1000,
-                    10,
-                    Some(100),
-                    "success",
-                    None,
-                    None,
-                    None,
-                    None,
-                    1,
-                    100,
-                    0,
-                    None,
-                    None,
-                )
+                .record_metric_full(&crate::state::MetricRow {
+                    export_name: n.to_string(),
+                    run_id: format!("{n}_r"),
+                    duration_ms: 1000,
+                    total_rows: 10,
+                    peak_rss_mb: Some(100),
+                    status: "success".to_string(),
+                    error_message: None,
+                    tuning_profile: None,
+                    format: None,
+                    mode: None,
+                    files_produced: 1,
+                    bytes_written: 100,
+                    retries: 0,
+                    validated: None,
+                    schema_changed: None,
+                    ..Default::default()
+                })
                 .expect("rec");
         }
         let recs = vec![

--- a/src/state/checkpoint.rs
+++ b/src/state/checkpoint.rs
@@ -332,67 +332,6 @@ impl StateStore {
         Ok(())
     }
 
-    /// The parallel workers' twin of [`Self::fail_chunk_task`] — same contract,
-    /// including `retryable`.
-    pub fn fail_chunk_task_at_ref(
-        state_ref: &StateRef,
-        run_id: &str,
-        chunk_index: i64,
-        err: &str,
-        retryable: bool,
-    ) -> Result<()> {
-        let now = chrono::Utc::now().to_rfc3339();
-        let sql = if retryable {
-            "UPDATE chunk_task SET status = 'failed', last_error = ?1, updated_at = ?2
-             WHERE run_id = ?3 AND chunk_index = ?4"
-        } else {
-            "UPDATE chunk_task SET status = 'failed', last_error = ?1, updated_at = ?2,
-                    attempts = (SELECT max_chunk_attempts FROM chunk_run WHERE run_id = ?3)
-             WHERE run_id = ?3 AND chunk_index = ?4"
-        };
-        match state_ref {
-            StateRef::Sqlite(db_path) => {
-                let conn = open_connection(db_path)?;
-                conn.execute(sql, rusqlite::params![err, now, run_id, chunk_index])?;
-            }
-            StateRef::Postgres(url) => {
-                let mut client = super::connect_pg(url)?;
-                client.execute(&pg_sql(sql), &[&err, &now, &run_id, &chunk_index])?;
-            }
-        }
-        Ok(())
-    }
-
-    pub fn complete_chunk_task_at_ref(
-        state_ref: &StateRef,
-        run_id: &str,
-        chunk_index: i64,
-        rows_written: i64,
-        file_name: Option<&str>,
-    ) -> Result<()> {
-        let now = chrono::Utc::now().to_rfc3339();
-        let sql = "UPDATE chunk_task
-             SET status = 'completed', rows_written = ?1, file_name = ?2, last_error = NULL, updated_at = ?3
-             WHERE run_id = ?4 AND chunk_index = ?5";
-        match state_ref {
-            StateRef::Sqlite(db_path) => {
-                let conn = open_connection(db_path)?;
-                conn.execute(
-                    sql,
-                    rusqlite::params![rows_written, file_name, now, run_id, chunk_index],
-                )?;
-            }
-            StateRef::Postgres(url) => {
-                let mut client = super::connect_pg(url)?;
-                client.execute(
-                    &pg_sql(sql),
-                    &[&rows_written, &file_name, &now, &run_id, &chunk_index],
-                )?;
-            }
-        }
-        Ok(())
-    }
-
     pub fn count_chunk_tasks_total(&self, run_id: &str) -> Result<usize> {
         let sql = "SELECT COUNT(*) FROM chunk_task WHERE run_id = ?1";
         match &self.conn {

--- a/src/state/metrics.rs
+++ b/src/state/metrics.rs
@@ -97,53 +97,6 @@ pub struct MetricRow {
 /// Invariant I4 (Metric After Verdict) governs when `record_metric` is called:
 /// only after the terminal run outcome is determined.
 impl StateStore {
-    /// Back-compat shim: the original 15-field metric. Fills the v9 columns with
-    /// defaults (NULL) and delegates to [`record_metric_full`]. The production
-    /// run/apply path now builds a full [`MetricRow`]; this shim remains for the
-    /// unit + integration tests that only assert the core signals.
-    ///
-    /// `#[allow(dead_code)]`: the only non-test caller migrated to
-    /// `record_metric_full`, and the bin/lib dead-code pass can't see the uses
-    /// in `tests/*` (same reason `RunSummary::stub_for_testing` carries it).
-    #[allow(clippy::too_many_arguments, dead_code)]
-    pub fn record_metric(
-        &self,
-        export_name: &str,
-        run_id: &str,
-        duration_ms: i64,
-        total_rows: i64,
-        peak_rss_mb: Option<i64>,
-        status: &str,
-        error_message: Option<&str>,
-        tuning_profile: Option<&str>,
-        format: Option<&str>,
-        mode: Option<&str>,
-        files_produced: i64,
-        bytes_written: i64,
-        retries: i64,
-        validated: Option<bool>,
-        schema_changed: Option<bool>,
-    ) -> Result<()> {
-        self.record_metric_full(&MetricRow {
-            export_name: export_name.to_string(),
-            run_id: run_id.to_string(),
-            duration_ms,
-            total_rows,
-            peak_rss_mb,
-            status: status.to_string(),
-            error_message: error_message.map(str::to_string),
-            tuning_profile: tuning_profile.map(str::to_string),
-            format: format.map(str::to_string),
-            mode: mode.map(str::to_string),
-            files_produced,
-            bytes_written,
-            retries,
-            validated,
-            schema_changed,
-            ..Default::default()
-        })
-    }
-
     /// Drop a run's in-flight `running` aggregate. Only ever called by
     /// [`record_metric_full`], immediately before the terminal row replaces it.
     fn clear_running_metric(&self, run_id: &str) -> Result<()> {
@@ -542,41 +495,43 @@ mod tests {
     #[test]
     fn record_and_query_metrics() {
         let s = store();
-        s.record_metric(
-            "orders",
-            "run_001",
-            1200,
-            50000,
-            Some(142),
-            "success",
-            None,
-            Some("safe"),
-            Some("parquet"),
-            Some("full"),
-            1,
-            4096,
-            0,
-            Some(true),
-            Some(false),
-        )
+        s.record_metric_full(&crate::state::MetricRow {
+            export_name: "orders".to_string(),
+            run_id: "run_001".to_string(),
+            duration_ms: 1200,
+            total_rows: 50000,
+            peak_rss_mb: Some(142),
+            status: "success".to_string(),
+            error_message: None,
+            tuning_profile: Some("safe".to_string()),
+            format: Some("parquet".to_string()),
+            mode: Some("full".to_string()),
+            files_produced: 1,
+            bytes_written: 4096,
+            retries: 0,
+            validated: Some(true),
+            schema_changed: Some(false),
+            ..Default::default()
+        })
         .unwrap();
-        s.record_metric(
-            "orders",
-            "run_002",
-            300,
-            0,
-            Some(30),
-            "failed",
-            Some("timeout"),
-            Some("safe"),
-            Some("parquet"),
-            Some("full"),
-            0,
-            0,
-            2,
-            None,
-            None,
-        )
+        s.record_metric_full(&crate::state::MetricRow {
+            export_name: "orders".to_string(),
+            run_id: "run_002".to_string(),
+            duration_ms: 300,
+            total_rows: 0,
+            peak_rss_mb: Some(30),
+            status: "failed".to_string(),
+            error_message: Some("timeout".to_string()),
+            tuning_profile: Some("safe".to_string()),
+            format: Some("parquet".to_string()),
+            mode: Some("full".to_string()),
+            files_produced: 0,
+            bytes_written: 0,
+            retries: 2,
+            validated: None,
+            schema_changed: None,
+            ..Default::default()
+        })
         .unwrap();
 
         let metrics = s.get_metrics(Some("orders"), 10).unwrap();
@@ -667,15 +622,43 @@ mod tests {
     #[test]
     fn query_metrics_all_exports() {
         let s = store();
-        s.record_metric(
-            "orders", "r1", 100, 1000, None, "success", None, None, None, None, 1, 500, 0, None,
-            None,
-        )
+        s.record_metric_full(&crate::state::MetricRow {
+            export_name: "orders".to_string(),
+            run_id: "r1".to_string(),
+            duration_ms: 100,
+            total_rows: 1000,
+            peak_rss_mb: None,
+            status: "success".to_string(),
+            error_message: None,
+            tuning_profile: None,
+            format: None,
+            mode: None,
+            files_produced: 1,
+            bytes_written: 500,
+            retries: 0,
+            validated: None,
+            schema_changed: None,
+            ..Default::default()
+        })
         .unwrap();
-        s.record_metric(
-            "users", "r2", 200, 2000, None, "success", None, None, None, None, 1, 800, 0, None,
-            None,
-        )
+        s.record_metric_full(&crate::state::MetricRow {
+            export_name: "users".to_string(),
+            run_id: "r2".to_string(),
+            duration_ms: 200,
+            total_rows: 2000,
+            peak_rss_mb: None,
+            status: "success".to_string(),
+            error_message: None,
+            tuning_profile: None,
+            format: None,
+            mode: None,
+            files_produced: 1,
+            bytes_written: 800,
+            retries: 0,
+            validated: None,
+            schema_changed: None,
+            ..Default::default()
+        })
         .unwrap();
 
         let metrics = s.get_metrics(None, 10).unwrap();
@@ -686,23 +669,24 @@ mod tests {
     fn metrics_limit_works() {
         let s = store();
         for i in 0..10 {
-            s.record_metric(
-                "t",
-                &format!("r{}", i),
-                i * 100,
-                i,
-                None,
-                "success",
-                None,
-                None,
-                None,
-                None,
-                0,
-                0,
-                0,
-                None,
-                None,
-            )
+            s.record_metric_full(&crate::state::MetricRow {
+                export_name: "t".to_string(),
+                run_id: format!("r{}", i),
+                duration_ms: i * 100,
+                total_rows: i,
+                peak_rss_mb: None,
+                status: "success".to_string(),
+                error_message: None,
+                tuning_profile: None,
+                format: None,
+                mode: None,
+                files_produced: 0,
+                bytes_written: 0,
+                retries: 0,
+                validated: None,
+                schema_changed: None,
+                ..Default::default()
+            })
             .unwrap();
         }
         let metrics = s.get_metrics(Some("t"), 3).unwrap();

--- a/tests/invariants.rs
+++ b/tests/invariants.rs
@@ -233,23 +233,24 @@ fn i3_state_store_does_not_enforce_cursor_monotonicity() {
 fn i4_metric_records_terminal_status_success() {
     let state = StateStore::open_in_memory().unwrap();
     state
-        .record_metric(
-            "exp",
-            "run-a",
-            1000,
-            500,
-            None,
-            "success",
-            None,
-            None,
-            Some("parquet"),
-            Some("full"),
-            1,
-            4096,
-            0,
-            None,
-            None,
-        )
+        .record_metric_full(&rivet::state::MetricRow {
+            export_name: "exp".to_string(),
+            run_id: "run-a".to_string(),
+            duration_ms: 1000,
+            total_rows: 500,
+            peak_rss_mb: None,
+            status: "success".to_string(),
+            error_message: None,
+            tuning_profile: None,
+            format: Some("parquet".to_string()),
+            mode: Some("full".to_string()),
+            files_produced: 1,
+            bytes_written: 4096,
+            retries: 0,
+            validated: None,
+            schema_changed: None,
+            ..Default::default()
+        })
         .unwrap();
 
     let m = &state.get_metrics(Some("exp"), 1).unwrap()[0];
@@ -266,23 +267,24 @@ fn i4_metric_records_terminal_status_success() {
 fn i4_metric_records_terminal_status_failed() {
     let state = StateStore::open_in_memory().unwrap();
     state
-        .record_metric(
-            "exp",
-            "run-b",
-            200,
-            0,
-            None,
-            "failed",
-            Some("connection refused"),
-            None,
-            Some("parquet"),
-            Some("full"),
-            0,
-            0,
-            2,
-            None,
-            None,
-        )
+        .record_metric_full(&rivet::state::MetricRow {
+            export_name: "exp".to_string(),
+            run_id: "run-b".to_string(),
+            duration_ms: 200,
+            total_rows: 0,
+            peak_rss_mb: None,
+            status: "failed".to_string(),
+            error_message: Some("connection refused".to_string()),
+            tuning_profile: None,
+            format: Some("parquet".to_string()),
+            mode: Some("full".to_string()),
+            files_produced: 0,
+            bytes_written: 0,
+            retries: 2,
+            validated: None,
+            schema_changed: None,
+            ..Default::default()
+        })
         .unwrap();
 
     let m = &state.get_metrics(Some("exp"), 1).unwrap()[0];

--- a/tests/live/live_pg_state.rs
+++ b/tests/live/live_pg_state.rs
@@ -142,23 +142,24 @@ fn pg_schema_drift_detection() {
 fn pg_metrics_record_and_query() {
     let Some(s) = pg_store() else { return };
 
-    s.record_metric(
-        "pg_metrics_export",
-        "run_pg_001",
-        1500,
-        100_000,
-        Some(256),
-        "success",
-        None,
-        Some("balanced"),
-        Some("parquet"),
-        Some("full"),
-        3,
-        1_048_576,
-        0,
-        Some(true),
-        Some(false),
-    )
+    s.record_metric_full(&rivet::state::MetricRow {
+        export_name: "pg_metrics_export".to_string(),
+        run_id: "run_pg_001".to_string(),
+        duration_ms: 1500,
+        total_rows: 100_000,
+        peak_rss_mb: Some(256),
+        status: "success".to_string(),
+        error_message: None,
+        tuning_profile: Some("balanced".to_string()),
+        format: Some("parquet".to_string()),
+        mode: Some("full".to_string()),
+        files_produced: 3,
+        bytes_written: 1_048_576,
+        retries: 0,
+        validated: Some(true),
+        schema_changed: Some(false),
+        ..Default::default()
+    })
     .unwrap();
 
     let metrics = s.get_metrics(Some("pg_metrics_export"), 10).unwrap();

--- a/tests/recovery.rs
+++ b/tests/recovery.rs
@@ -259,23 +259,24 @@ fn f4_retry_count_captured_in_metric() {
     let state = StateStore::open_in_memory().unwrap();
 
     state
-        .record_metric(
-            "sales",
-            "run-f",
-            8_500,  // duration_ms (across 3 attempts)
-            10_000, // total_rows
-            None,   // peak_rss_mb
-            "success",
-            None, // error_message
-            None, // tuning_profile
-            Some("parquet"),
-            Some("incremental"),
-            1,       // files_produced
-            409_600, // bytes_written
-            2,       // retries = 2 failed attempts before success
-            None,
-            None,
-        )
+        .record_metric_full(&rivet::state::MetricRow {
+            export_name: "sales".to_string(),
+            run_id: "run-f".to_string(),
+            duration_ms: 8_500, // across 3 attempts
+            total_rows: 10_000,
+            peak_rss_mb: None,
+            status: "success".to_string(),
+            error_message: None,
+            tuning_profile: None,
+            format: Some("parquet".to_string()),
+            mode: Some("incremental".to_string()),
+            files_produced: 1,
+            bytes_written: 409_600,
+            retries: 2, // 2 failed attempts before success
+            validated: None,
+            schema_changed: None,
+            ..Default::default()
+        })
         .unwrap();
 
     let metrics = state.get_metrics(Some("sales"), 1).unwrap();


### PR DESCRIPTION
Closes #162 (item 4 landed earlier as #179). Three structural deepenings, all compiler-guided:

- **item 2** — the \`record_metric\` shim (15 positional args, all 15 call sites in cfg(test)/integration tests) is deleted; every caller builds \`MetricRow { named fields, ..Default::default() }\`. The integration-target callers were caught by clippy --all-targets after the lib-side deletion — the full pre-commit doing its job.
- **item 1** — \`fail_chunk_task_at_ref\` / \`complete_chunk_task_at_ref\` were VERBATIM SQL duplicates of their \`&self\` siblings; deleted, workers \`open_at_ref(...)?.fail/complete_chunk_task(...)\`. \`claim_next_chunk_task_at_ref\` deliberately stays the single real body (IMMEDIATE-tx sqlite arm + FOR UPDATE SKIP LOCKED pg arm — a distinct contract, not a duplicate).
- **item 3** — Run/Plan/Validate/Repair variants each carry one \`clap::Args\` struct; the 11/6/8/7-arg dispatch tunnels collapse to \`dispatch_x(args)\`. Flag surface unchanged (flatten; \`run --help\` lists the same 13 flags).

Offline: lib 2355 / bins 2480 / offline_suite 240 / recovery 13 / invariants 10 — green; clippy --all-targets clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)