### PR TITLE
feat(scheduler): apply --pool N executor + the dedicated toxiproxy e2e flow (#166)

### DIFF
--- a/dev/release_oracle/blessed_flow.py
+++ b/dev/release_oracle/blessed_flow.py
@@ -1207,6 +1207,11 @@ FLAG_EXCUSED = {
     "--source-file": "the file form of --source; same reader, and --source-env is the one ops use",
     "--s3-region": "carried with --s3-bucket on the s3 cells",
     "--gcs-credentials-file": "fake-gcs takes no credentials; the real path is the bigquery cycle's",
+    "--pool": "pool mode schedules a whole CONFIG's exports (multi-export, duration-ordered); "
+              "the blessed cell chain applies a sealed SINGLE-export plan artifact, where --pool "
+              "is a refusal by design. Carried by its dedicated e2e flow instead: "
+              "tests/live/live_pool_toxiproxy.rs (bandwidth-capped multi-export pool, exact rows "
+              "+ the predicted-vs-actual makespan contract).",
     "--tls-ca": "verify-ca/full need a TLS-terminating server; the compose stand has none — the "
                 "CA path is unit-pinned (scaffold_records_the_tls_posture…) and refused-with-"
                 "disable is offline-tested",

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -391,6 +391,7 @@ Execute a sealed plan artifact, or run a config's exports wave-by-wave
 * `--parallel-export-processes` — Run the cheap (low-cost) exports within each wave concurrently, as separate processes (same as `parallel_export_processes: true` in the config). Config-wave mode only; heavier exports — which already chunk-parallelize internally — still run one at a time
 * `--resume` — Config-wave mode: skip exports a prior run already completed (`_SUCCESS` present) and resume incomplete chunked exports from their checkpoints, so a re-run after a partial failure does not redo finished tables. Independent tables are never re-exported
 * `--force` — Skip staleness check (allow plans older than 24 h)
+* `--pool <N>` — Run the whole config as ONE bounded work-stealing pool of N export slots (config mode only, #166): exports start longest-first (LPT, by each export's last measured duration) and every freeing slot pulls the next — no wave barriers, so the wall approaches `max(longest, total/N)`. Priority `wave:` tiers are NOT honored (makespan mode); exports that are not `parallel_safe` never run concurrently with EACH OTHER (one heavy at a time; cheap exports backfill the remaining slots)
 
 
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -304,6 +304,16 @@ pub enum Commands {
         /// Skip staleness check (allow plans older than 24 h)
         #[arg(long)]
         force: bool,
+        /// Run the whole config as ONE bounded work-stealing pool of N export
+        /// slots (config mode only, #166): exports start longest-first (LPT, by
+        /// each export's last measured duration) and every freeing slot pulls
+        /// the next — no wave barriers, so the wall approaches
+        /// `max(longest, total/N)`. Priority `wave:` tiers are NOT honored
+        /// (makespan mode); exports that are not `parallel_safe` never run
+        /// concurrently with EACH OTHER (one heavy at a time; cheap exports
+        /// backfill the remaining slots).
+        #[arg(long, value_name = "N", conflicts_with = "parallel_export_processes")]
+        pool: Option<usize>,
     },
     /// Targeted repair of chunks flagged by reconcile: emit a repair plan, or re-export only mismatched ranges.
     Repair(RepairArgs),

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -144,7 +144,10 @@ pub fn dispatch(cli: Cli) -> Result<()> {
             parallel_export_processes,
             resume,
             force,
-        } => pipeline::run_apply_command(&plan_file, force, parallel_export_processes, resume),
+            pool,
+        } => {
+            pipeline::run_apply_command(&plan_file, force, parallel_export_processes, resume, pool)
+        }
         Commands::Validate(args) => dispatch_validate(args),
         Commands::Reconcile {
             config,

--- a/src/pipeline/apply_cmd.rs
+++ b/src/pipeline/apply_cmd.rs
@@ -20,12 +20,29 @@ use super::chunked::ChunkSource;
 use super::summary::ApplyContext;
 
 /// Entry point for `rivet apply <plan-file> [--parallel-export-processes] [--resume] [--force]`.
-pub fn run_apply_command(plan_file: &str, force: bool, parallel: bool, resume: bool) -> Result<()> {
+pub fn run_apply_command(
+    plan_file: &str,
+    force: bool,
+    parallel: bool,
+    resume: bool,
+    pool: Option<usize>,
+) -> Result<()> {
     // A YAML config selects the wave-ordered multi-export path (plan→apply
-    // cycle): run every export wave-by-wave in ascending `wave:` order. A JSON
-    // plan artifact falls through to the sealed single-export replay below.
+    // cycle): run every export wave-by-wave in ascending `wave:` order — or,
+    // with `--pool N`, as one bounded work-stealing pool (#166). A JSON plan
+    // artifact falls through to the sealed single-export replay below.
     if plan_file.ends_with(".yaml") || plan_file.ends_with(".yml") {
+        if let Some(m) = pool {
+            return super::run::run_pool(plan_file, force, resume, m);
+        }
         return super::run::run_waves(plan_file, force, parallel, resume);
+    }
+    if pool.is_some() {
+        anyhow::bail!(
+            "--pool schedules a whole CONFIG's exports (it needs the full set to order by \
+             duration) and does not apply to a sealed single-export plan artifact. Pass the \
+             YAML config instead: `rivet apply <config.yaml> --pool N`."
+        );
     }
     if parallel || resume {
         log::warn!(
@@ -400,7 +417,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let path = write_artifact(&dir, &artifact);
 
-        let err = run_apply_command(&path, false, false, false).unwrap_err();
+        let err = run_apply_command(&path, false, false, false, None).unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             msg.contains("hours old") || msg.contains("24 h"),
@@ -418,7 +435,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let path = write_artifact(&dir, &artifact);
 
-        let err = run_apply_command(&path, false, false, false).unwrap_err();
+        let err = run_apply_command(&path, false, false, false, None).unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             msg.contains("drifted") || msg.contains("cursor"),
@@ -430,8 +447,14 @@ mod tests {
 
     #[test]
     fn missing_plan_file_returns_error() {
-        let err = run_apply_command("/tmp/rivet_nonexistent_xyzxyz.json", false, false, false)
-            .unwrap_err();
+        let err = run_apply_command(
+            "/tmp/rivet_nonexistent_xyzxyz.json",
+            false,
+            false,
+            false,
+            None,
+        )
+        .unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             msg.contains("cannot read") || msg.contains("No such file"),
@@ -444,7 +467,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("plan.json");
         std::fs::write(&path, b"not valid json at all").unwrap();
-        let err = run_apply_command(path.to_str().unwrap(), false, false, false).unwrap_err();
+        let err = run_apply_command(path.to_str().unwrap(), false, false, false, None).unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             msg.contains("invalid plan") || msg.contains("JSON") || msg.contains("expected"),
@@ -475,7 +498,7 @@ mod tests {
         let tampered = json.replace("SELECT 1", "SELECT * FROM secrets");
         std::fs::write(&path, &tampered).unwrap();
 
-        let err = run_apply_command(&path, false, false, false).unwrap_err();
+        let err = run_apply_command(&path, false, false, false, None).unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             msg.contains("integrity check failed") && msg.contains("modified after planning"),
@@ -483,7 +506,7 @@ mod tests {
         );
 
         // And --force must NOT override it — a hand-edited contract is not opt-in.
-        let err_forced = run_apply_command(&path, true, false, false).unwrap_err();
+        let err_forced = run_apply_command(&path, true, false, false, None).unwrap_err();
         let msg_forced = format!("{err_forced:#}");
         assert!(
             msg_forced.contains("integrity check failed"),

--- a/src/pipeline/run.rs
+++ b/src/pipeline/run.rs
@@ -723,6 +723,252 @@ pub(crate) fn run_waves(
     Ok(())
 }
 
+/// Last successful run's duration for `name`, in seconds — the pool's
+/// predictor (the same source the wave packer reads). `None` = no history.
+fn last_success_secs(state: &StateStore, name: &str) -> Option<f64> {
+    state
+        .get_metrics(Some(name), 25)
+        .ok()?
+        .into_iter()
+        .find(|m| m.status == "success")
+        .map(|m| (m.duration_ms as f64 / 1000.0).max(0.001))
+}
+
+/// The pool's pick rule, pure for the mutation gate (#166): the first queued
+/// export a freeing slot may start. A `parallel_safe` export is always
+/// eligible; a non-safe (heavy) one only when NO other heavy export is
+/// currently running — heavies serialize among THEMSELVES (a big table already
+/// chunk-parallelizes internally; two at once overload the source) while cheap
+/// exports backfill the remaining slots. That is exactly the field ask: the
+/// giant runs, the small and medium ride alongside — but never two giants.
+fn next_eligible(safe_flags: &[bool], heavy_running: bool) -> Option<usize> {
+    safe_flags.iter().position(|&safe| safe || !heavy_running)
+}
+
+/// `rivet apply <config.yaml> --pool N` (#166): run the WHOLE config as one
+/// bounded work-stealing pool of `m` slots. Exports start longest-first (LPT by
+/// last measured duration; 5 s placeholder for history-less ones, which only
+/// orders their first run) and every freeing slot pulls the next eligible —
+/// no wave barriers, so the wall approaches `max(longest, total/m)`.
+///
+/// Deliberate semantics, stated once (see `pipeline::pool`):
+/// - PRIORITY `wave:` tiers are NOT honored — the pool is makespan mode for a
+///   full refresh with no inter-table ordering; ordered pipelines keep waves.
+/// - non-`parallel_safe` exports never co-run with EACH OTHER (see
+///   [`next_eligible`]); `--resume` skips `_SUCCESS`-complete exports and
+///   resumes checkpoints, exactly like waves.
+/// - a failed export is collected and the pool keeps draining (wave
+///   semantics); the run exits non-zero with the representative error.
+pub(crate) fn run_pool(config_path: &str, force: bool, resume: bool, m: usize) -> Result<()> {
+    let m = m.max(1);
+    let config = Config::load_with_params(config_path, None)?;
+    let config_dir = Path::new(config_path)
+        .parent()
+        .unwrap_or(Path::new("."))
+        .to_path_buf();
+    let opts = RunOptions {
+        validate: false,
+        reconcile: false,
+        resume,
+        force,
+        params: None,
+    };
+    // Pre-migrate the state DB once before worker threads race on DDL, and use
+    // this handle for the duration reads below.
+    let state = StateStore::open(config_path)?;
+
+    // Same skip-completed contract as the wave path (probe the EXPANDED
+    // destination for _SUCCESS under --resume).
+    let pending: Vec<&ExportConfig> = config
+        .exports
+        .iter()
+        .filter(|e| {
+            let ctx = crate::destination::placeholder::PlaceholderContext::for_today(&e.name);
+            let expanded =
+                crate::destination::placeholder::expand_destination(e.destination.clone(), &ctx);
+            let done = resume && finalize::destination_has_success(&expanded);
+            if done {
+                log::info!(
+                    "apply --pool: skipping '{}' — destination already complete (_SUCCESS)",
+                    e.name
+                );
+            }
+            !done
+        })
+        .collect();
+    if pending.is_empty() {
+        log::warn!("apply --pool: nothing to run (no exports, or all complete)");
+        return Ok(());
+    }
+
+    // LPT order + the makespan the model PREDICTS — printed up front and graded
+    // against the actual wall at the end, so every run improves trust in (or
+    // honestly indicts) the model.
+    let items: Vec<super::pool::PoolItem> = pending
+        .iter()
+        .map(|e| super::pool::PoolItem {
+            name: e.name.clone(),
+            predicted_secs: last_success_secs(&state, &e.name).unwrap_or(5.0),
+        })
+        .collect();
+    let order = super::pool::pool_order(&items);
+    let predicted_secs = super::pool::predicted_makespan_secs(&items, m);
+    let floor_secs = super::pool::makespan_floor_secs(&items, m);
+    let measured_n = pending
+        .iter()
+        .filter(|e| last_success_secs(&state, &e.name).is_some())
+        .count();
+    println!(
+        "  Pool: {} export(s) × {} slot(s) — predicted makespan ~{:.1} min (floor {:.1}; {} measured, {} estimated)",
+        pending.len(),
+        m,
+        predicted_secs / 60.0,
+        floor_secs / 60.0,
+        measured_n,
+        pending.len() - measured_n,
+    );
+
+    let by_name: std::collections::HashMap<&str, &ExportConfig> =
+        pending.iter().map(|e| (e.name.as_str(), *e)).collect();
+    let queue: std::sync::Mutex<std::collections::VecDeque<&ExportConfig>> = std::sync::Mutex::new(
+        order
+            .iter()
+            .filter_map(|n| by_name.get(n.as_str()).copied())
+            .collect(),
+    );
+    // Mutated ONLY while holding `queue` (claim) or after a heavy export
+    // finishes (release) — claim-side check+set is serialized by the queue
+    // lock, so two slots can never claim two heavies together.
+    let heavy_running = std::sync::atomic::AtomicBool::new(false);
+
+    // The same in-process ChildEvent UI the threads path uses: one card per
+    // export, a single UI thread owning stderr.
+    let name_floor = pending
+        .iter()
+        .map(|e| e.name.chars().count())
+        .max()
+        .unwrap_or(0);
+    let prev_multi = MULTI_EXPORT_MODE.swap(false, AtomicOrdering::Relaxed);
+    let (tx, rx) = std::sync::mpsc::channel::<parent_ui::UiMessage>();
+    ipc::install_in_process_tx(tx);
+    let n_cards = pending.len();
+    let ui_thread = std::thread::Builder::new()
+        .name("rivet-ui".to_string())
+        .spawn(move || parent_ui::run_ui(rx, name_floor, n_cards))
+        .ok();
+
+    let started_at = chrono::Utc::now();
+    let collected: std::sync::Mutex<Vec<(Result<()>, RunSummary)>> =
+        std::sync::Mutex::new(Vec::with_capacity(pending.len()));
+    std::thread::scope(|s| {
+        for _ in 0..m.min(pending.len()) {
+            s.spawn(|| {
+                loop {
+                    // Claim under the queue lock (heavy check+set serialized).
+                    let export = {
+                        let mut q = queue.lock().unwrap();
+                        if q.is_empty() {
+                            break;
+                        }
+                        let flags: Vec<bool> = q.iter().map(|e| is_parallel_safe(e)).collect();
+                        match next_eligible(&flags, heavy_running.load(AtomicOrdering::SeqCst)) {
+                            Some(i) => {
+                                let e = q.remove(i).unwrap();
+                                if !is_parallel_safe(e) {
+                                    heavy_running.store(true, AtomicOrdering::SeqCst);
+                                }
+                                e
+                            }
+                            None => {
+                                // Only heavies left while one runs: wait for it.
+                                drop(q);
+                                std::thread::sleep(std::time::Duration::from_millis(200));
+                                continue;
+                            }
+                        }
+                    };
+                    let pair = match StateStore::open(config_path) {
+                        Ok(st) => job::run_export_job(
+                            config_path,
+                            &config,
+                            export,
+                            &st,
+                            &config_dir,
+                            &opts,
+                        ),
+                        Err(e) => {
+                            let err = anyhow::anyhow!(
+                                "export '{}': failed to open state database: {:#}",
+                                export.name,
+                                e
+                            );
+                            let summary = job::synthetic_failed_summary(&export.name, &err);
+                            (Err(err), summary)
+                        }
+                    };
+                    if !is_parallel_safe(export) {
+                        heavy_running.store(false, AtomicOrdering::SeqCst);
+                    }
+                    collected.lock().unwrap().push(pair);
+                }
+            });
+        }
+    });
+    ipc::clear_in_process_tx();
+    if let Some(h) = ui_thread {
+        let _ = h.join();
+    }
+    MULTI_EXPORT_MODE.store(prev_multi, AtomicOrdering::Relaxed);
+
+    let finished_at = chrono::Utc::now();
+    let actual_secs = (finished_at - started_at).num_milliseconds() as f64 / 1000.0;
+    println!(
+        "  Pool: actual makespan {:.1} min vs predicted {:.1} min ({:+.0}%) — the model grades itself every run",
+        actual_secs / 60.0,
+        predicted_secs / 60.0,
+        if predicted_secs > 0.0 {
+            (actual_secs - predicted_secs) / predicted_secs * 100.0
+        } else {
+            0.0
+        },
+    );
+
+    let mut summaries: Vec<RunSummary> = Vec::new();
+    let mut failures: Vec<anyhow::Error> = Vec::new();
+    for (res, summary) in collected.into_inner().unwrap() {
+        if let Err(e) = res {
+            failures.push(e);
+        }
+        summaries.push(summary);
+    }
+    if pending.len() > 1 {
+        let entries = summaries
+            .iter()
+            .map(aggregate::entry_from_summary)
+            .collect();
+        let agg = aggregate::build(entries, started_at, finished_at, Some(config_path), "pool");
+        aggregate::print(&agg);
+        aggregate::persist(&state, &agg, None);
+    }
+    if !failures.is_empty() {
+        let primary_idx = representative_failure_idx(&failures).unwrap();
+        let primary = failures.remove(primary_idx);
+        if failures.is_empty() {
+            return Err(primary);
+        }
+        let others = failures
+            .iter()
+            .map(|e| format!("{e:#}"))
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(primary.context(format!(
+            "{} export(s) failed in the pool; representative error follows (also: {others})",
+            failures.len() + 1
+        )));
+    }
+    Ok(())
+}
+
 /// Group exports by `wave:` in ascending order; an export with no `wave:` runs
 /// last (sorted as `u32::MAX`). Pure + unit-tested — the ordering is the
 /// contract `apply` depends on, so it does not hide inside [`run_waves`].
@@ -750,7 +996,27 @@ fn is_parallel_safe(export: &ExportConfig) -> bool {
 
 #[cfg(test)]
 mod wave_grouping_tests {
-    use super::{group_exports_by_wave, is_parallel_safe};
+    use super::{group_exports_by_wave, is_parallel_safe, next_eligible};
+
+    /// The pool's pick rule (#166), both directions — RED against `||`→`&&`
+    /// (which would starve every heavy export the moment slots are free) and
+    /// against dropping the heavy-serialization guard (two giants at once —
+    /// the exact overload the wave cost-gate exists to prevent).
+    #[test]
+    fn pool_next_eligible_serializes_heavies_and_backfills_safe() {
+        // No heavy running: the FIRST item is eligible whatever it is (LPT
+        // order must not be reshuffled when unconstrained).
+        assert_eq!(next_eligible(&[false, true], false), Some(0));
+        assert_eq!(next_eligible(&[true, false], false), Some(0));
+        // A heavy is running: the next heavy must WAIT; the first SAFE one
+        // backfills (the giant + small-and-medium field ask).
+        assert_eq!(next_eligible(&[false, true, false], true), Some(1));
+        assert_eq!(next_eligible(&[true, false], true), Some(0));
+        // Only heavies left while one runs: nothing eligible — the slot waits.
+        assert_eq!(next_eligible(&[false, false], true), None);
+        // Empty queue: nothing.
+        assert_eq!(next_eligible(&[], false), None);
+    }
 
     #[test]
     fn groups_ascending_with_unscheduled_last() {

--- a/tests/common/toxi.rs
+++ b/tests/common/toxi.rs
@@ -103,6 +103,26 @@ pub fn toxi_add_latency(proxy: &str, latency_ms: u64) -> String {
     toxic_name
 }
 
+/// Cap the proxy's throughput at `rate_kbps` KB/s — the SHARED-LINK simulator
+/// (#166 GA): the client field run showed 60 concurrent exports moving ~0.25
+/// MB/s AGGREGATE over one tunnel, i.e. per-connection parallelism split one
+/// ceiling instead of adding throughput. A pool run through this toxic is the
+/// honest test of the LPT model on a bandwidth-bound source: it must still
+/// complete correctly, and its makespan claim must not be trusted blindly.
+/// `stream`: "downstream" caps server→client (query results — the read leg).
+pub fn toxi_add_bandwidth(proxy: &str, rate_kbps: u64, stream: &str) -> String {
+    let toxic_name = unique_name("rivet_bw");
+    let payload = format!(
+        r#"{{"name":"{toxic_name}","type":"bandwidth","stream":"{stream}","toxicity":1.0,"attributes":{{"rate":{rate_kbps}}}}}"#
+    );
+    let (code, body) = toxi_admin("POST", &format!("/proxies/{proxy}/toxics"), Some(&payload));
+    assert!(
+        code == 200,
+        "add bandwidth to {proxy}: status {code}, body:\n{body}"
+    );
+    toxic_name
+}
+
 /// Cut the connection after `bytes` of downstream data — a DETERMINISTIC
 /// mid-stream network failure (unlike latency/timeout, the cut point does not
 /// depend on timing). Simulates a binlog/replication connection dying partway

--- a/tests/live/live_pool_toxiproxy.rs
+++ b/tests/live/live_pool_toxiproxy.rs
@@ -1,0 +1,140 @@
+//! The pool scheduler's SEPARATE e2e flow, through toxiproxy (#166 GA).
+//!
+//! `apply --pool N` on a multi-export config whose source connection runs
+//! through a BANDWIDTH-CAPPED proxy — the shared-link shape the field run
+//! exposed (60 concurrent exports split one tunnel's ~0.25 MB/s instead of
+//! adding throughput). The oracles:
+//!
+//! 1. CORRECTNESS under the pool: every export's row count is exact — bounded
+//!    concurrent slots + the heavy-serialization rule lose nothing on a
+//!    congested link.
+//! 2. HONESTY of the model: the run prints its predicted makespan up front and
+//!    grades itself against the actual at the end (the predicted-vs-actual
+//!    line) — the self-correction contract, asserted on the run's own stdout.
+//! 3. The heavy-serialization rule holds end-to-end (one non-parallel_safe
+//!    export at a time) — asserted structurally by the run COMPLETING with the
+//!    heavy primary + safe secondaries mix; the pick rule itself is RED-proven
+//!    at the unit level (`pool_next_eligible_serializes_heavies_and_backfills_safe`).
+
+use crate::common::*;
+
+/// ~50 MB of decoded rows for the heavy export, ~1-2 MB per small one, through
+/// a 4 MB/s downstream cap: the heavy stream saturates the link long enough
+/// that the pool genuinely overlaps work (and the run still finishes in tens of
+/// seconds, not minutes).
+const HEAVY_ROWS: i64 = 120_000;
+const SMALL_ROWS: i64 = 15_000;
+
+#[test]
+fn pool_apply_through_a_bandwidth_capped_link_is_exact_and_grades_itself() {
+    let _lock = toxiproxy_guard();
+    ensure_toxi_proxy("postgres", 15432, "postgres:5432");
+    toxi_reset_toxics("postgres");
+    let _bw = toxi_add_bandwidth("postgres", 4_000, "downstream");
+
+    // One heavy primary (parallel_safe ABSENT → not safe: it must serialize
+    // with any other heavy) + three cheap safe exports that backfill.
+    let rig = Rig::pg_batch("pool_heavy")
+        .source_url(POSTGRES_TOXI_URL)
+        .query(&format!(
+            "SELECT g AS id, md5(g::text) AS a, md5((g*3)::text) AS b, md5((g*7)::text) AS c \
+             FROM generate_series(1, {HEAVY_ROWS}) g"
+        ))
+        .also_export(
+            "pool_s1",
+            &format!(
+                "SELECT g AS id, md5(g::text) AS payload FROM generate_series(1, {SMALL_ROWS}) g"
+            ),
+        )
+        .also_export_line("parallel_safe: true")
+        .also_export(
+            "pool_s2",
+            &format!(
+                "SELECT g AS id, md5(g::text) AS payload FROM generate_series(1, {SMALL_ROWS}) g"
+            ),
+        )
+        .also_export_line("parallel_safe: true")
+        .also_export(
+            "pool_s3",
+            &format!(
+                "SELECT g AS id, md5(g::text) AS payload FROM generate_series(1, {SMALL_ROWS}) g"
+            ),
+        )
+        .also_export_line("parallel_safe: true");
+
+    let cfg = rig.config_path();
+    let out = run_rivet_env(&["apply", cfg.to_str().unwrap(), "--pool", "2"], &[]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "pool apply must succeed on a bandwidth-capped link\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    // 1. Correctness: exact per-export row counts read back independently.
+    assert_eq!(
+        duckdb_total_parquet_rows(&rig.out_dir()) as i64,
+        HEAVY_ROWS,
+        "heavy export must be exact under the pool"
+    );
+    for name in ["pool_s1", "pool_s2", "pool_s3"] {
+        assert_eq!(
+            duckdb_total_parquet_rows(&rig.out_dir_for(name)) as i64,
+            SMALL_ROWS,
+            "safe export {name} must be exact under the pool"
+        );
+    }
+
+    // 2. The model states its claim and grades itself — both lines are part of
+    //    the pool's contract, not decoration.
+    assert!(
+        stdout.contains("predicted makespan"),
+        "the pool must state its predicted makespan up front:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("actual makespan"),
+        "the pool must grade predicted vs actual at the end:\n{stdout}"
+    );
+
+    toxi_reset_toxics("postgres");
+}
+
+/// DEFER-NOT-DROP under --resume: a second pool run into the same destinations
+/// skips the already-complete exports (their `_SUCCESS` stands) instead of
+/// re-exporting — the wave path's resume contract, preserved verbatim by the
+/// pool. The union stays exact (no clobber, no double rows).
+#[test]
+fn pool_apply_resume_skips_complete_exports_and_loses_nothing() {
+    let _lock = toxiproxy_guard();
+    ensure_toxi_proxy("postgres", 15432, "postgres:5432");
+    toxi_reset_toxics("postgres");
+
+    let rig = Rig::pg_batch("pool_r_heavy")
+        .source_url(POSTGRES_TOXI_URL)
+        .query("SELECT g AS id, md5(g::text) AS payload FROM generate_series(1, 20000) g")
+        .also_export(
+            "pool_r_s1",
+            "SELECT g AS id, md5(g::text) AS payload FROM generate_series(1, 5000) g",
+        )
+        .also_export_line("parallel_safe: true");
+
+    let cfg = rig.config_path();
+    let first = run_rivet_env(&["apply", cfg.to_str().unwrap(), "--pool", "2"], &[]);
+    assert!(
+        first.status.success(),
+        "first pool run: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    let second = run_rivet_env(
+        &["apply", cfg.to_str().unwrap(), "--pool", "2", "--resume"],
+        &[],
+    );
+    let s2 = String::from_utf8_lossy(&second.stderr);
+    assert!(second.status.success(), "resume pool run: {s2}");
+    // Second run skipped both (complete): counts unchanged, no duplication.
+    assert_eq!(duckdb_total_parquet_rows(&rig.out_dir()), 20000);
+    assert_eq!(
+        duckdb_total_parquet_rows(&rig.out_dir_for("pool_r_s1")),
+        5000
+    );
+}

--- a/tests/live_suite.rs
+++ b/tests/live_suite.rs
@@ -165,6 +165,8 @@ mod live_plan_apply;
 mod live_plan_output_ux;
 #[path = "live/live_pool_safety.rs"]
 mod live_pool_safety;
+#[path = "live/live_pool_toxiproxy.rs"]
+mod live_pool_toxiproxy;
 #[path = "live/live_reconcile_repair.rs"]
 mod live_reconcile_repair;
 #[path = "live/live_resume.rs"]


### PR DESCRIPTION
Closes #166. The runtime half (the pure LPT core landed in #171); finalizes the scheduler+packer pair for GA evaluation.

## The executor
- \`rivet apply <config.yaml> --pool N\`: one bounded work-stealing pool — LPT start order (last measured duration; 5 s placeholder orders a first run only), every freeing slot pulls the next eligible, wall → \`max(longest, total/N)\`.
- **Heavy-serialization constraint** (the GA blocker from the evaluation): non-\`parallel_safe\` exports never co-run with EACH OTHER — one heavy at a time, cheap exports backfill. The giant runs while small+medium ride alongside; never two giants. Pick rule \`next_eligible\` is pure and RED-proven (\`||\`→\`&&\` starves every heavy).
- **Self-grading**: predicted makespan printed up front, predicted-vs-actual graded at the end — the model earns trust (or an honest indictment) every run.
- Wave semantics preserved: \`--resume\` skips \`_SUCCESS\`-complete exports; failures collect and the pool drains; \`wave:\` tiers deliberately NOT honored (makespan mode, documented); \`--pool\` on a sealed plan artifact refuses loudly.

## The dedicated e2e flow (toxiproxy)
New \`toxi_add_bandwidth\` toxic + \`tests/live/live_pool_toxiproxy.rs\` — the shared-tunnel shape the client field run exposed (60 workers splitting one ~0.25 MB/s ceiling):
- **bandwidth-capped pool run**: 1 heavy + 3 safe through a 4 MB/s cap, \`--pool 2\` — exact per-export rows (independent DuckDB readback) + both makespan-contract lines asserted. **GREEN live, 8 s.**
- **resume defer-not-drop**: second \`--resume\` run skips complete exports, union exact. **GREEN live.**

\`--pool\` is FLAG_EXCUSED in the blessed flag surface with the e2e named as its carrier (the blessed chain applies a sealed single-export artifact, where \`--pool\` refuses by design).

Offline: lib 2481 / offline_suite 240 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)