### PR TITLE
feat(init): first-run density probe — sample the key, not the catalog (#148)

### DIFF
--- a/src/init/candidates.rs
+++ b/src/init/candidates.rs
@@ -123,6 +123,7 @@ mod tests {
 
     fn table(cols: Vec<ColumnInfo>) -> TableInfo {
         TableInfo {
+            density: None,
             schema: "public".into(),
             table: "t".into(),
             row_estimate: 1_000,

--- a/src/init/catalog_replay.rs
+++ b/src/init/catalog_replay.rs
@@ -152,6 +152,7 @@ mod tests {
     }
     fn tbl(rows: i64, bytes: i64, cols: Vec<ColumnInfo>) -> TableInfo {
         TableInfo {
+            density: None,
             schema: "s".into(),
             table: "t".into(),
             row_estimate: rows,

--- a/src/init/density.rs
+++ b/src/init/density.rs
@@ -1,0 +1,212 @@
+//! First-run density probe (#148): sample the chunk key instead of believing
+//! the catalog's row estimate.
+//!
+//! The lie, measured in the field (2026-08-07): a ~300M-row versioned table's
+//! `TABLE_ROWS` said ~332M; the run had read 835.7M rows by chunk 2853/3320 —
+//! the catalog under-counted ~2.5×, and every decision init makes (the 100K
+//! full→chunked threshold, parallel scaling, sparsity, duration prediction)
+//! stood on that number. This module is the pure math half; the per-engine
+//! probes live beside each engine's introspection (the connection is theirs).
+//!
+//! Method: `MIN(k)`/`MAX(k)` (two index-boundary seeks), then K windows of
+//! width W **evenly spaced across the span** — stratified, not random, because
+//! versioned tables densify toward fresh ids and a uniform grid averages that
+//! honestly. `rows ≈ span × Σcount/(K×W)`; `density = Σcount/(K×W)` falls out
+//! free and answers keyset-vs-range + rows-per-key questions the catalog
+//! structurally cannot.
+
+/// How a snapshot's row figure was obtained — recorded so the decision is
+/// auditable and the next `plan` can see how far the catalog was off.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EstimateMethod {
+    /// Below the triage line — the catalog figure is accepted as-is (no
+    /// strategy boundary is near; a catalog error changes nothing).
+    CatalogTriaged,
+    /// The engine's catalog figure is near-exact by construction
+    /// (MSSQL `dm_db_partition_stats`).
+    CatalogExact,
+    /// The stratified index probe ran; the snapshot's rows are sampled.
+    Probed,
+    /// Small table with no usable integer key — an honest `COUNT(*)`.
+    Counted,
+    /// Large table with no usable key/index: the catalog figure is kept but
+    /// the snapshot says so — never silently trusted.
+    Unverified,
+}
+
+impl EstimateMethod {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            EstimateMethod::CatalogTriaged => "catalog-triaged",
+            EstimateMethod::CatalogExact => "catalog-exact",
+            EstimateMethod::Probed => "probed",
+            EstimateMethod::Counted => "counted",
+            EstimateMethod::Unverified => "unverified",
+        }
+    }
+}
+
+/// One probe's outcome, carried on `TableInfo` and recorded in the snapshot.
+#[derive(Debug, Clone)]
+pub(crate) struct DensityProbe {
+    /// The estimate init's decisions now stand on.
+    pub rows: i64,
+    /// Rows per key-unit across the sampled windows (1.0 = perfectly dense
+    /// autoincrement; >1 = versioned key (N rows per key value); <1 = gappy).
+    pub density: f64,
+    pub method: EstimateMethod,
+    /// The catalog's original figure, kept for the audit trail.
+    pub catalog_rows: i64,
+    pub k: usize,
+    pub w: i64,
+}
+
+/// Tables claimed below this are candidates for tier-0 trust — but the claim
+/// must also survive the SPAN check (see [`span_agrees_with_claim`]).
+pub(crate) const TRIAGE_ROWS: i64 = 50_000;
+
+/// Tier-0's honesty gate, pure for the mutation gate. `TABLE_ROWS` and even
+/// `DATA_LENGTH` come from the SAME frozen statistics (this feature's own live
+/// fixture proved both lie together: stats frozen at 1 000 rows on a 148 000-
+/// row table). The one cheap signal that is NOT statistics is the key's
+/// MIN/MAX span — two index-boundary seeks. A genuinely small dense-ish table
+/// has span ≈ claim; a span far past the claim (×4, floored at 1 000 so tiny
+/// tables with a few gaps don't false-probe) means the claim cannot be
+/// trusted and the full probe runs. Probing a truly-small table is harmless
+/// (the window grid clamps), so false positives cost milliseconds.
+pub(crate) fn span_agrees_with_claim(catalog_rows: i64, span: i64) -> bool {
+    span <= catalog_rows.saturating_mul(4).max(1_000)
+}
+/// Default probe shape: ~1–2 s per table on a real index at any size.
+pub(crate) const PROBE_K: usize = 50;
+pub(crate) const PROBE_W: i64 = 10_000;
+
+/// The K stratified window starts over `[min, max]`, each window `w` wide —
+/// evenly spaced so the grid covers the WHOLE span (first at `min`, last
+/// ending at/near `max`). Returns fewer (possibly one) windows when the span
+/// is smaller than `k × w`; `w` is never widened (the caller's COUNT cost
+/// bound is `k × w` rows, kept honest).
+pub(crate) fn stratified_offsets(min: i64, max: i64, k: usize, w: i64) -> Vec<i64> {
+    let span = max.saturating_sub(min).saturating_add(1);
+    if span <= 0 || k == 0 || w <= 0 {
+        return Vec::new();
+    }
+    if span <= w.saturating_mul(k as i64) {
+        // Tiny span: contiguous windows cover it exactly — no gaps, no overlap.
+        let n = ((span + w - 1) / w).max(1);
+        return (0..n).map(|i| min + i * w).collect();
+    }
+    // Even spacing: window i starts at min + round(i × (span − w) / (k − 1)),
+    // so the first window starts at min and the last ENDS at max.
+    let k_i = k as i64;
+    (0..k_i)
+        .map(|i| {
+            if k_i == 1 {
+                min
+            } else {
+                min + ((span - w) as f64 * i as f64 / (k_i - 1) as f64).round() as i64
+            }
+        })
+        .collect()
+}
+
+/// `rows ≈ span × Σcount/(sampled key-units)`; density = mean rows per
+/// key-unit. `counts[i]` is `COUNT(*) WHERE k BETWEEN off[i] AND off[i]+w-1`.
+/// Empty windows are DATA (a gappy key), not absence — they stay in the mean.
+pub(crate) fn estimate_from_windows(min: i64, max: i64, counts: &[i64], w: i64) -> (i64, f64) {
+    let span = max.saturating_sub(min).saturating_add(1);
+    if counts.is_empty() || w <= 0 || span <= 0 {
+        return (0, 0.0);
+    }
+    let sampled_units = (counts.len() as i64).saturating_mul(w).min(span);
+    let total: i64 = counts.iter().sum();
+    let density = total as f64 / sampled_units as f64;
+    ((span as f64 * density).round() as i64, density)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The grid covers the WHOLE span: first window at min, last window's end
+    /// reaches max — a grid that stops short would systematically miss the
+    /// fresh-id end where versioned tables densify (the field bias). RED
+    /// against `span` instead of `span − w` in the spacing.
+    #[test]
+    fn stratified_offsets_cover_the_whole_span() {
+        let (min, max, k, w) = (1_000i64, 1_000_000i64, 50usize, 10_000i64);
+        let offs = stratified_offsets(min, max, k, w);
+        assert_eq!(offs.len(), k);
+        assert_eq!(offs[0], min, "first window starts at MIN");
+        assert_eq!(
+            offs[k - 1] + w - 1,
+            max,
+            "last window must END at MAX (fresh-id end sampled)"
+        );
+        // Monotonic, no window past the span.
+        for pair in offs.windows(2) {
+            assert!(pair[0] < pair[1], "offsets strictly increase");
+        }
+    }
+
+    /// A span smaller than K×W degrades to contiguous FULL coverage, never a
+    /// widened W (the COUNT cost bound stays k×w rows).
+    #[test]
+    fn stratified_offsets_clamp_on_a_tiny_span() {
+        let offs = stratified_offsets(10, 109, 50, 25); // span 100, k*w = 1250
+        assert_eq!(offs, vec![10, 35, 60, 85], "contiguous cover, no widening");
+        assert!(stratified_offsets(5, 5, 3, 10).len() == 1);
+        assert!(stratified_offsets(9, 5, 3, 10).is_empty(), "inverted span");
+    }
+
+    /// The estimator: dense key → density ~1.0, rows ≈ span; versioned key
+    /// (3 rows per key) → density ~3; gappy (10% occupancy) → ~0.1. RED
+    /// against dropping empty windows from the mean (which would inflate a
+    /// gappy key's estimate ~10×) and against Σ/K instead of Σ/(K×W).
+    #[test]
+    fn estimate_from_windows_dense_versioned_and_gappy() {
+        let w = 1_000i64;
+        // dense: every window full
+        let (rows, d) = estimate_from_windows(1, 1_000_000, &[w; 50], w);
+        assert!((d - 1.0).abs() < 1e-9);
+        assert_eq!(rows, 1_000_000);
+        // versioned: 3 rows per key value
+        let (rows, d) = estimate_from_windows(1, 1_000_000, &[3 * w; 50], w);
+        assert!((d - 3.0).abs() < 1e-9);
+        assert_eq!(rows, 3_000_000);
+        // gappy: 10% of keys exist — EMPTY windows count in the mean
+        let mut counts = vec![0i64; 45];
+        counts.extend(vec![w; 5]);
+        let (rows, d) = estimate_from_windows(1, 1_000_000, &counts, w);
+        assert!((d - 0.1).abs() < 1e-9, "empty windows are data: {d}");
+        assert_eq!(rows, 100_000);
+    }
+
+    /// The span gate (RED against rows-only triage — the live fixture's exact
+    /// escape: 1 000 claimed rows over a 51 000-wide key span → must probe;
+    /// and RED against dropping the ×4 slack or the 1 000 floor).
+    #[test]
+    fn span_gate_catches_a_small_claim_over_a_wide_span() {
+        assert!(span_agrees_with_claim(1_000, 1_000), "dense small table");
+        assert!(
+            span_agrees_with_claim(1_000, 3_999),
+            "modest gaps tolerated"
+        );
+        assert!(
+            !span_agrees_with_claim(1_000, 51_000),
+            "the frozen-stats fixture shape MUST probe"
+        );
+        assert!(
+            span_agrees_with_claim(100, 900),
+            "the 1 000 floor for tiny tables"
+        );
+        assert!(!span_agrees_with_claim(100, 1_500));
+    }
+
+    #[test]
+    fn estimate_degenerate_inputs_are_zero_not_panic() {
+        assert_eq!(estimate_from_windows(1, 100, &[], 10), (0, 0.0));
+        assert_eq!(estimate_from_windows(1, 100, &[5], 0), (0, 0.0));
+        assert_eq!(estimate_from_windows(100, 1, &[5], 10), (0, 0.0));
+    }
+}

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -3,6 +3,7 @@ mod candidates;
 /// Offline strategy-decision replay harness — test-only (no runtime caller).
 #[cfg(test)]
 mod catalog_replay;
+mod density;
 mod mongo;
 mod mssql;
 mod mysql;
@@ -49,6 +50,13 @@ pub(crate) struct TableInfo {
     /// Approximate physical size in bytes (heap + indexes), if available.
     pub total_bytes: Option<i64>,
     pub columns: Vec<ColumnInfo>,
+    /// First-run density probe (#148): when present, `row_estimate` above HAS
+    /// BEEN REPLACED by the sampled figure (the catalog's original lives in
+    /// `probe.catalog_rows`), so every downstream decision stands on the
+    /// measured number automatically. `serde(skip)`: a runtime measurement,
+    /// not part of the replayable catalog shape.
+    #[serde(skip, default)]
+    pub density: Option<crate::init::density::DensityProbe>,
 }
 
 impl TableInfo {
@@ -664,11 +672,13 @@ fn introspect_single_table(
     Ok(match source_type(source_url)? {
         "postgres" => {
             let mut client = postgres::connect(source_url, tls)?;
-            postgres::introspect(
+            let mut info = postgres::introspect(
                 &mut client,
                 eff_schema.as_deref().unwrap_or("public"),
                 table_name,
-            )?
+            )?;
+            postgres::density_probe(&mut client, &mut info);
+            info
         }
         "mysql" => {
             let mut conn = mysql::connect(source_url, tls)?;
@@ -698,15 +708,19 @@ fn introspect_single_table(
                 }
                 mysql::use_database(&mut conn, db)?;
             }
-            mysql::introspect(&mut conn, table_name)?
+            let mut info = mysql::introspect(&mut conn, table_name)?;
+            mysql::density_probe(&mut conn, &mut info);
+            info
         }
         "mssql" => {
             let mut conn = mssql::connect(source_url, tls)?;
-            mssql::introspect(
+            let mut info = mssql::introspect(
                 &mut conn,
                 &mssql_table_schema(eff_schema.as_deref().unwrap_or("public")),
                 table_name,
-            )?
+            )?;
+            mark_mssql_catalog_exact(&mut info);
+            info
         }
         "mongo" => {
             // #12 bughunt: --schema was silently ignored for Mongo (the cross-db
@@ -789,19 +803,45 @@ fn init_yaml(
 ///
 /// Every field here is something `init` already read from the catalog to make
 /// the choice; before this they were discarded the moment the YAML was written.
+/// MSSQL's `dm_db_partition_stats` row counts are near-exact by construction —
+/// no probe needed; the snapshot still SAYS where the number came from (#148).
+fn mark_mssql_catalog_exact(info: &mut TableInfo) {
+    info.density = Some(crate::init::density::DensityProbe {
+        rows: info.row_estimate,
+        density: 0.0,
+        method: crate::init::density::EstimateMethod::CatalogExact,
+        catalog_rows: info.row_estimate,
+        k: 0,
+        w: 0,
+    });
+}
+
 fn snapshot_of(info: &TableInfo, mode_override: Option<&str>) -> crate::state::StrategySnapshot {
     let d = yaml_scaffold::decided_strategy(info, mode_override);
     crate::state::StrategySnapshot {
         export_name: info.table.clone(),
         source_schema: (!info.schema.is_empty()).then(|| info.schema.clone()),
         source_table: info.table.clone(),
-        row_estimate: (info.row_estimate > 0).then_some(info.row_estimate),
+        row_estimate: info
+            .density
+            .as_ref()
+            .map(|p| p.rows)
+            .or((info.row_estimate > 0).then_some(info.row_estimate)),
         total_bytes: info.total_bytes,
         avg_row_bytes: info.avg_row_bytes(),
         chosen_mode: d.mode,
         strategy_kind: Some(d.kind.to_string()),
         key_column: d.key_column,
         chunk_size: d.chunk_size,
+        catalog_rows: info.density.as_ref().map(|p| p.catalog_rows),
+        density: info.density.as_ref().filter(|p| p.k > 0).map(|p| p.density),
+        estimate_method: info.density.as_ref().map(|p| p.method.label().to_string()),
+        probe_k: info
+            .density
+            .as_ref()
+            .filter(|p| p.k > 0)
+            .map(|p| p.k as i64),
+        probe_w: info.density.as_ref().filter(|p| p.w > 0).map(|p| p.w),
     }
 }
 
@@ -893,7 +933,10 @@ fn introspect_all(
             let mut out = Vec::with_capacity(names.len());
             for n in names {
                 match postgres::introspect(&mut client, sch, &n) {
-                    Ok(info) => out.push(info),
+                    Ok(mut info) => {
+                        postgres::density_probe(&mut client, &mut info);
+                        out.push(info)
+                    }
                     // Table may have been dropped between list_tables and introspect.
                     // Skip it rather than aborting the whole schema scan.
                     Err(e) if e.to_string().contains("not found or has no columns") => {}
@@ -929,7 +972,9 @@ fn introspect_all(
             let names = retain_filtered(mysql::list_tables(&mut conn, &db)?, filter);
             let mut out = Vec::with_capacity(names.len());
             for n in names {
-                out.push(mysql::introspect(&mut conn, &n)?);
+                let mut info = mysql::introspect(&mut conn, &n)?;
+                mysql::density_probe(&mut conn, &mut info);
+                out.push(info);
             }
             Ok(out)
         }
@@ -945,7 +990,10 @@ fn introspect_all(
             let mut out = Vec::with_capacity(names.len());
             for n in names {
                 match mssql::introspect(&mut conn, sch, &n) {
-                    Ok(info) => out.push(info),
+                    Ok(mut info) => {
+                        mark_mssql_catalog_exact(&mut info);
+                        out.push(info)
+                    }
                     // Dropped between list and introspect — skip, don't abort.
                     Err(e) if e.to_string().contains("not found or has no columns") => {}
                     Err(e) => return Err(e),
@@ -1060,6 +1108,7 @@ mod tests {
 
     fn make_table(rows: i64, cols: Vec<ColumnInfo>) -> TableInfo {
         TableInfo {
+            density: None,
             schema: "public".to_string(),
             table: "orders".to_string(),
             row_estimate: rows,
@@ -1474,6 +1523,7 @@ mod tests {
     #[test]
     fn generate_schema_config_emits_multiple_exports() {
         let a = TableInfo {
+            density: None,
             schema: "public".to_string(),
             table: "users".to_string(),
             row_estimate: 100,
@@ -1481,6 +1531,7 @@ mod tests {
             columns: vec![col("id", "bigint", true)],
         };
         let b = TableInfo {
+            density: None,
             schema: "public".to_string(),
             table: "orders".to_string(),
             row_estimate: 200,

--- a/src/init/mongo.rs
+++ b/src/init/mongo.rs
@@ -57,6 +57,7 @@ pub(super) fn introspect(session: &MongoSession, collection: &str) -> Result<Tab
         })
         .unwrap_or(0);
     Ok(TableInfo {
+        density: None,
         schema: session.db().to_string(),
         table: collection.to_string(),
         row_estimate: i64::try_from(count).unwrap_or(0),

--- a/src/init/mssql.rs
+++ b/src/init/mssql.rs
@@ -124,6 +124,7 @@ pub(super) fn introspect(conn: &mut MssqlSource, schema: &str, table: &str) -> R
     }
 
     Ok(TableInfo {
+        density: None,
         schema: schema.to_string(),
         table: table.to_string(),
         row_estimate,

--- a/src/init/mysql.rs
+++ b/src/init/mysql.rs
@@ -117,12 +117,122 @@ pub(super) fn introspect(conn: &mut mysql::PooledConn, table: &str) -> Result<Ta
         .collect();
 
     Ok(TableInfo {
+        density: None,
         schema: String::new(),
         table: table.to_string(),
         row_estimate,
         total_bytes,
         columns,
     })
+}
+
+/// First-run density probe (#148) — MySQL is the primary target: `TABLE_ROWS`
+/// is the least trustworthy of the four engines (field: a versioned table
+/// under-counted ~2.5×, flipping every threshold decision). Refines
+/// `info.row_estimate` IN PLACE (the catalog figure moves to
+/// `probe.catalog_rows`) so every downstream decision stands on the sample.
+/// Best-effort: any probe error keeps the catalog figure, marked `unverified`.
+pub(super) fn density_probe(conn: &mut mysql::PooledConn, info: &mut super::TableInfo) {
+    use super::density::*;
+    use mysql::prelude::Queryable;
+
+    let catalog = info.row_estimate;
+    let Some(key) = info.best_chunk_column().map(str::to_string) else {
+        // No integer key to stratify on: small → honest COUNT(*); large → keep
+        // the estimate but SAY so (never silently trust it).
+        let method = if catalog < 1_000_000 {
+            let tbl = info.table.replace('`', "``");
+            match conn.query_first::<i64, _>(format!("SELECT COUNT(*) FROM `{tbl}`")) {
+                Ok(Some(n)) => {
+                    info.row_estimate = n;
+                    info.density = Some(DensityProbe {
+                        rows: n,
+                        density: 0.0,
+                        method: EstimateMethod::Counted,
+                        catalog_rows: catalog,
+                        k: 0,
+                        w: 0,
+                    });
+                    return;
+                }
+                _ => EstimateMethod::Unverified,
+            }
+        } else {
+            EstimateMethod::Unverified
+        };
+        info.density = Some(DensityProbe {
+            rows: catalog,
+            density: 0.0,
+            method,
+            catalog_rows: catalog,
+            k: 0,
+            w: 0,
+        });
+        return;
+    };
+    let tbl = info.table.replace('`', "``");
+    let k_q = key.replace('`', "``");
+    let Ok(Some((Some(min), Some(max)))) = conn.query_first::<(Option<i64>, Option<i64>), _>(
+        format!("SELECT MIN(`{k_q}`), MAX(`{k_q}`) FROM `{tbl}`"),
+    ) else {
+        info.density = Some(DensityProbe {
+            rows: catalog,
+            density: 0.0,
+            method: EstimateMethod::Unverified,
+            catalog_rows: catalog,
+            k: 0,
+            w: 0,
+        });
+        return;
+    };
+    // Tier 0 AFTER the two boundary seeks: a small claim is trusted only when
+    // the span agrees (TABLE_ROWS and DATA_LENGTH freeze TOGETHER — the span
+    // is the one cheap signal that is not statistics; live-proven here).
+    if catalog < TRIAGE_ROWS && span_agrees_with_claim(catalog, max.saturating_sub(min) + 1) {
+        info.density = Some(DensityProbe {
+            rows: catalog,
+            density: 0.0,
+            method: EstimateMethod::CatalogTriaged,
+            catalog_rows: catalog,
+            k: 0,
+            w: 0,
+        });
+        return;
+    }
+    let offsets = stratified_offsets(min, max, PROBE_K, PROBE_W);
+    if offsets.is_empty() {
+        return;
+    }
+    let mut counts = Vec::with_capacity(offsets.len());
+    for off in &offsets {
+        let hi = off.saturating_add(PROBE_W - 1);
+        match conn.query_first::<i64, _>(format!(
+            "SELECT COUNT(*) FROM `{tbl}` WHERE `{k_q}` BETWEEN {off} AND {hi}"
+        )) {
+            Ok(Some(n)) => counts.push(n),
+            _ => {
+                info.density = Some(DensityProbe {
+                    rows: catalog,
+                    density: 0.0,
+                    method: EstimateMethod::Unverified,
+                    catalog_rows: catalog,
+                    k: 0,
+                    w: 0,
+                });
+                return;
+            }
+        }
+    }
+    let (rows, density) = estimate_from_windows(min, max, &counts, PROBE_W);
+    info.row_estimate = rows;
+    info.density = Some(DensityProbe {
+        rows,
+        density,
+        method: EstimateMethod::Probed,
+        catalog_rows: catalog,
+        k: offsets.len(),
+        w: PROBE_W,
+    });
 }
 
 #[cfg(test)]

--- a/src/init/postgres.rs
+++ b/src/init/postgres.rs
@@ -157,12 +157,78 @@ pub(super) fn introspect(client: &mut Client, schema: &str, table: &str) -> Resu
         .collect();
 
     Ok(TableInfo {
+        density: None,
         schema: schema.to_string(),
         table: table.to_string(),
         row_estimate,
         total_bytes,
         columns,
     })
+}
+
+/// First-run density probe (#148), PostgreSQL leg: `reltuples` after
+/// autovacuum is usually within a few %, so the probe runs only on LARGE
+/// tables (> 5M estimated), where a % error still moves absolute decisions
+/// (parallel scaling, duration prediction). Same stratified method as MySQL;
+/// best-effort (any error keeps the catalog figure, marked unverified only
+/// when we attempted and failed — an un-probed small table keeps density=None,
+/// i.e. "the catalog is trusted here by policy").
+pub(super) fn density_probe(client: &mut Client, info: &mut super::TableInfo) {
+    use super::density::*;
+
+    const PG_PROBE_LINE: i64 = 5_000_000;
+    let catalog = info.row_estimate;
+    if catalog < PG_PROBE_LINE {
+        return; // policy: reltuples trusted below the line (density stays None)
+    }
+    let Some(key) = info.best_chunk_column().map(str::to_string) else {
+        info.density = Some(DensityProbe {
+            rows: catalog,
+            density: 0.0,
+            method: EstimateMethod::Unverified,
+            catalog_rows: catalog,
+            k: 0,
+            w: 0,
+        });
+        return;
+    };
+    let q_ident = |s: &str| format!("\"{}\"", s.replace('"', "\"\""));
+    let rel = format!("{}.{}", q_ident(&info.schema), q_ident(&info.table));
+    let kq = q_ident(&key);
+    let Ok(row) = client.query_one(
+        &format!("SELECT MIN({kq})::bigint, MAX({kq})::bigint FROM {rel}"),
+        &[],
+    ) else {
+        return;
+    };
+    let (Some(min), Some(max)): (Option<i64>, Option<i64>) = (row.get(0), row.get(1)) else {
+        return;
+    };
+    let offsets = stratified_offsets(min, max, PROBE_K, PROBE_W);
+    if offsets.is_empty() {
+        return;
+    }
+    let mut counts = Vec::with_capacity(offsets.len());
+    for off in &offsets {
+        let hi = off.saturating_add(PROBE_W - 1);
+        match client.query_one(
+            &format!("SELECT COUNT(*) FROM {rel} WHERE {kq} BETWEEN {off} AND {hi}"),
+            &[],
+        ) {
+            Ok(r) => counts.push(r.get::<_, i64>(0)),
+            Err(_) => return,
+        }
+    }
+    let (rows, density) = estimate_from_windows(min, max, &counts, PROBE_W);
+    info.row_estimate = rows;
+    info.density = Some(DensityProbe {
+        rows,
+        density,
+        method: EstimateMethod::Probed,
+        catalog_rows: catalog,
+        k: offsets.len(),
+        w: PROBE_W,
+    });
 }
 
 #[cfg(test)]

--- a/src/init/yaml_scaffold.rs
+++ b/src/init/yaml_scaffold.rs
@@ -1113,6 +1113,7 @@ mod tests {
 
     fn make_table(cols: Vec<ColumnInfo>) -> TableInfo {
         TableInfo {
+            density: None,
             schema: "public".into(),
             table: "payments".into(),
             row_estimate: 100,
@@ -1149,6 +1150,7 @@ mod tests {
             numeric_scale: None,
         };
         let info = TableInfo {
+            density: None,
             schema: "public".into(),
             table: "orders".into(),
             row_estimate: 1_000_000,
@@ -1202,6 +1204,7 @@ mod tests {
             numeric_scale: None,
         };
         let info = TableInfo {
+            density: None,
             schema: "public".into(),
             table: "events".into(),
             row_estimate: 500_000,
@@ -1430,6 +1433,7 @@ mod tests {
         // decimal overrides as QUALIFIED `table.column` keys (never a bare key
         // that would apply to every table).
         let orders = TableInfo {
+            density: None,
             schema: "app".into(),
             table: "orders".into(),
             row_estimate: 100,
@@ -1437,6 +1441,7 @@ mod tests {
             columns: vec![col("id", "bigint"), decimal_col("amount", 18, 2)],
         };
         let invoices = TableInfo {
+            density: None,
             schema: "app".into(),
             table: "invoices".into(),
             row_estimate: 100,
@@ -1549,6 +1554,7 @@ mod tests {
 
     fn chunked_table(rows: i64, cols: Vec<ColumnInfo>) -> TableInfo {
         TableInfo {
+            density: None,
             schema: "public".into(),
             table: "events".into(),
             row_estimate: rows,
@@ -1672,6 +1678,7 @@ mod tests {
     #[test]
     fn full_mode_pg_non_public_schema_emits_qualified_table() {
         let info = TableInfo {
+            density: None,
             schema: "billing".into(),
             table: "invoices".into(),
             row_estimate: 100,

--- a/src/state/checkpoint.rs
+++ b/src/state/checkpoint.rs
@@ -736,6 +736,16 @@ pub struct StrategySnapshot {
     pub strategy_kind: Option<String>,
     pub key_column: Option<String>,
     pub chunk_size: Option<i64>,
+    // ── v24: density-probe audit (#148) ──
+    /// The catalog's ORIGINAL row claim when a probe replaced it (None = the
+    /// snapshot's row_estimate IS the catalog figure).
+    pub catalog_rows: Option<i64>,
+    /// Rows per key-unit from the stratified sample (None = not probed).
+    pub density: Option<f64>,
+    /// probed / counted / catalog-exact / catalog-triaged / unverified.
+    pub estimate_method: Option<String>,
+    pub probe_k: Option<i64>,
+    pub probe_w: Option<i64>,
 }
 
 impl StateStore {
@@ -748,8 +758,10 @@ impl StateStore {
         let sql = "INSERT INTO strategy_snapshot (
                  export_name, source_schema, source_table, row_estimate, total_bytes,
                  avg_row_bytes, chosen_mode, strategy_kind, key_column, chunk_size,
-                 rivet_version, captured_at
-             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)";
+                 rivet_version, captured_at,
+                 catalog_rows, density, estimate_method, probe_k, probe_w
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
+                 ?13, ?14, ?15, ?16, ?17)";
         match &self.conn {
             StateConn::Sqlite(c) => {
                 c.execute(
@@ -767,6 +779,11 @@ impl StateStore {
                         s.chunk_size,
                         ver,
                         now,
+                        s.catalog_rows,
+                        s.density,
+                        s.estimate_method,
+                        s.probe_k,
+                        s.probe_w,
                     ],
                 )?;
             }
@@ -787,6 +804,11 @@ impl StateStore {
                         &s.chunk_size,
                         &ver,
                         &now,
+                        &s.catalog_rows,
+                        &s.density,
+                        &s.estimate_method,
+                        &s.probe_k,
+                        &s.probe_w,
                     ],
                 )?;
             }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -448,6 +448,17 @@ const MIGRATIONS: &[(i64, &str)] = &[
         23,
         "ALTER TABLE export_metrics ADD COLUMN bytes_read INTEGER;",
     ),
+    // v24: the first-run density probe's audit trail (#148) — where the
+    // snapshot's row figure CAME from (probed/counted/catalog-*/unverified),
+    // the catalog's original claim, and the probe shape.
+    (
+        24,
+        "ALTER TABLE strategy_snapshot ADD COLUMN catalog_rows INTEGER;
+        ALTER TABLE strategy_snapshot ADD COLUMN density REAL;
+        ALTER TABLE strategy_snapshot ADD COLUMN estimate_method TEXT;
+        ALTER TABLE strategy_snapshot ADD COLUMN probe_k INTEGER;
+        ALTER TABLE strategy_snapshot ADD COLUMN probe_w INTEGER;",
+    ),
 ];
 
 /// PostgreSQL-compatible DDL.  Column types differ from SQLite (BIGSERIAL,
@@ -805,6 +816,14 @@ const PG_MIGRATIONS: &[(i64, &str)] = &[
     (
         23,
         "ALTER TABLE export_metrics ADD COLUMN bytes_read BIGINT;",
+    ),
+    (
+        24,
+        "ALTER TABLE strategy_snapshot ADD COLUMN catalog_rows BIGINT;
+        ALTER TABLE strategy_snapshot ADD COLUMN density DOUBLE PRECISION;
+        ALTER TABLE strategy_snapshot ADD COLUMN estimate_method TEXT;
+        ALTER TABLE strategy_snapshot ADD COLUMN probe_k BIGINT;
+        ALTER TABLE strategy_snapshot ADD COLUMN probe_w BIGINT;",
     ),
 ];
 

--- a/tests/live/live_density_probe.rs
+++ b/tests/live/live_density_probe.rs
@@ -1,0 +1,92 @@
+//! #148 live proof: init's row figure must come from the SAMPLE, not the
+//! catalog, when `TABLE_ROWS` lies — the field bite was a versioned table
+//! under-counted ~2.5×, flipping every threshold decision on the first run.
+//!
+//! Fixture: stats FROZEN small (`STATS_AUTO_RECALC=0` + `ANALYZE` at 1 000
+//! rows), then bulk-grown to 150 000 rows (3 rows per key value — the
+//! versioned shape). `TABLE_ROWS` keeps claiming ~1 000; believing it scaffolds
+//! `mode: full` (below the 100 K threshold). The probe must see ~150 K and
+//! scaffold `mode: chunked` — the RED direction is exactly "trust the catalog".
+
+use crate::common::*;
+use mysql::prelude::Queryable;
+
+#[test]
+fn init_probe_overrules_a_stale_table_rows_on_a_versioned_table() {
+    let mut c = mysql_connect();
+    c.query_drop("SET SESSION cte_max_recursion_depth = 60000")
+        .unwrap();
+    let name = unique_name("probe_versioned");
+    // No PK: the chunk candidate is the versioned key itself (`ref_id`), whose
+    // density (~3 rows per key unit) is what TABLE_ROWS structurally cannot see.
+    c.query_drop(format!(
+        "CREATE TABLE {name} (ref_id BIGINT NOT NULL, v INT NOT NULL, KEY(ref_id)) \
+         STATS_AUTO_RECALC=0, STATS_PERSISTENT=1"
+    ))
+    .unwrap();
+    let _guard = MysqlTable::adopt(name.clone());
+
+    // Freeze the stats while the table is TINY.
+    c.query_drop(format!(
+        "INSERT INTO {name} (ref_id, v) \
+         SELECT seq, 0 FROM (WITH RECURSIVE s(seq) AS \
+           (SELECT 1 UNION ALL SELECT seq+1 FROM s WHERE seq < 1000) SELECT seq FROM s) t"
+    ))
+    .unwrap();
+    c.query_drop(format!("ANALYZE TABLE {name}")).unwrap();
+
+    // Grow to 150 000 rows = 50 000 keys × 3 versions, stats stay frozen.
+    for round in 0..3 {
+        c.query_drop(format!(
+            "INSERT INTO {name} (ref_id, v) \
+             SELECT seq, {round} FROM (WITH RECURSIVE s(seq) AS \
+               (SELECT 1001 UNION ALL SELECT seq+1 FROM s WHERE seq < 50000) SELECT seq FROM s) t"
+        ))
+        .unwrap();
+    }
+    let true_rows: i64 = c
+        .query_first(format!("SELECT COUNT(*) FROM {name}"))
+        .unwrap()
+        .unwrap();
+    assert!(true_rows > 140_000, "fixture grew: {true_rows}");
+    let catalog: Option<i64> = c
+        .query_first(format!(
+            "SELECT TABLE_ROWS FROM information_schema.TABLES \
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '{name}'"
+        ))
+        .unwrap();
+    let catalog = catalog.unwrap_or(0);
+    // The fixture is only meaningful when the catalog genuinely LIES ≥2×.
+    assert!(
+        catalog * 2 < true_rows,
+        "fixture inert: TABLE_ROWS {catalog} vs true {true_rows} — stats not frozen"
+    );
+
+    // rivet init on that table: the probe must overrule the catalog.
+    let dir = tempfile::tempdir().unwrap();
+    let out_yaml = dir.path().join("probe.yaml");
+    let out = run_rivet_env(
+        &[
+            "init",
+            "--source",
+            MYSQL_URL,
+            "--table",
+            &name,
+            "-o",
+            out_yaml.to_str().unwrap(),
+        ],
+        &[],
+    );
+    assert!(
+        out.status.success(),
+        "init: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let yaml = std::fs::read_to_string(&out_yaml).unwrap();
+    // Believing TABLE_ROWS (~1k) scaffolds `mode: full`; the probe (~150k > the
+    // 100k threshold) must scaffold chunked. THE assertion of #148.
+    assert!(
+        yaml.contains("mode: chunked"),
+        "probe must overrule the stale catalog (catalog={catalog}, true={true_rows}):\n{yaml}"
+    );
+}

--- a/tests/live_suite.rs
+++ b/tests/live_suite.rs
@@ -97,6 +97,8 @@ mod live_crash_recovery;
 mod live_crash_soak;
 #[path = "live/live_cross_db_parity.rs"]
 mod live_cross_db_parity;
+#[path = "live/live_density_probe.rs"]
+mod live_density_probe;
 #[path = "live/live_destination_parity.rs"]
 mod live_destination_parity;
 #[path = "live/live_governor.rs"]


### PR DESCRIPTION
Closes #148. Stratified index probe replaces a lying `TABLE_ROWS` on the first run; SPAN-gated tier-0 (the live fixture caught the spec's rows-only-triage hole — `DATA_LENGTH` freezes together with `TABLE_ROWS`; the key's MIN/MAX span is the one cheap non-statistics signal, RED-proven); v24 snapshot audit columns (both ladders); PG large-only probe, MSSQL catalog-exact. **Live proof green:** frozen-stats 148K-row versioned fixture claiming 1K rows scaffolds `chunked`, not `full`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)