### PR TITLE
feat(metrics): bytes_read in every final summary + automatic parity participation

### DIFF
--- a/src/pipeline/aggregate.rs
+++ b/src/pipeline/aggregate.rs
@@ -106,6 +106,7 @@ pub(super) fn entry_from_summary(s: &RunSummary) -> RunAggregateEntry {
         rows: s.total_rows,
         files: s.files_produced as i64,
         bytes: s.bytes_written,
+        bytes_read: s.bytes_read,
         duration_ms: s.duration_ms,
         mode: s.mode.clone(),
         error_message: s.error_message.clone(),
@@ -133,6 +134,7 @@ pub(super) fn build(
     let total_rows = entries.iter().map(|e| e.rows).sum();
     let total_files = entries.iter().map(|e| e.files).sum();
     let total_bytes = entries.iter().map(|e| e.bytes).sum();
+    let total_bytes_read = entries.iter().map(|e| e.bytes_read).sum();
 
     let id = format!("agg_{}", started_at.format("%Y%m%dT%H%M%S%3f"));
 
@@ -150,6 +152,7 @@ pub(super) fn build(
         total_rows,
         total_files,
         total_bytes,
+        total_bytes_read,
         per_export: entries,
     }
 }
@@ -171,8 +174,11 @@ pub(super) fn print(agg: &RunAggregate) {
     eprintln!("  status:      {}", status_line);
     eprintln!("  rows:        {}", agg.total_rows);
     eprintln!("  files:       {}", agg.total_files);
+    if agg.total_bytes_read > 0 {
+        eprintln!("  bytes read:  {}", format_bytes(agg.total_bytes_read));
+    }
     if agg.total_bytes > 0 {
-        eprintln!("  bytes:       {}", format_bytes(agg.total_bytes));
+        eprintln!("  bytes writ:  {}", format_bytes(agg.total_bytes));
     }
     eprintln!(
         "  duration:    {} (wall clock)",
@@ -360,6 +366,7 @@ pub(super) fn collect_child_entries(
                         rows: m.total_rows,
                         files: m.files_produced,
                         bytes: m.bytes_written.max(0) as u64,
+                        bytes_read: m.bytes_read.max(0) as u64,
                         duration_ms: m.duration_ms,
                         mode: m.mode.unwrap_or_default(),
                         error_message: m.error_message,
@@ -383,6 +390,7 @@ pub(super) fn collect_child_entries(
                 rows: 0,
                 files: 0,
                 bytes: 0,
+                bytes_read: 0,
                 duration_ms: 0,
                 mode: String::new(),
                 error_message: Some(
@@ -482,6 +490,7 @@ mod tests {
 
     fn entry(name: &str, status: &str, rows: i64, files: i64, bytes: u64) -> RunAggregateEntry {
         RunAggregateEntry {
+            bytes_read: 0,
             export_name: name.into(),
             status: status.into(),
             run_id: format!("{name}_run"),
@@ -585,6 +594,7 @@ mod tests {
 
     fn metric(name: &str, status: &str) -> ExportMetric {
         ExportMetric {
+            bytes_read: 0,
             export_name: name.into(),
             run_id: Some(format!("{name}_run")),
             run_at: "2026-06-09T12:00:00+00:00".into(),

--- a/src/pipeline/summary.rs
+++ b/src/pipeline/summary.rs
@@ -557,6 +557,7 @@ impl RunSummary {
         rows.push(("files", fmt_thousands(self.files_produced as i64)));
         rows.extend(self.output_row());
         rows.extend(self.position_row());
+        rows.extend(self.bytes_read_row());
         rows.extend(self.bytes_row());
         rows.push(("duration", fmt_duration_ms(self.duration_ms)));
         rows.extend(self.peak_rss_row());
@@ -621,10 +622,20 @@ impl RunSummary {
         }
     }
 
-    /// `bytes` — only when something was written.
+    /// `bytes read` / `bytes written` — SEPARATE rows (read is the source
+    /// leg's decoded volume, written the parquet leg's; the pair is the
+    /// read-vs-write-bound signal the field 163-min run had neither of).
     fn bytes_row(&self) -> Option<Row> {
         if self.bytes_written > 0 {
-            Some(("bytes", format_bytes(self.bytes_written)))
+            Some(("bytes written", format_bytes(self.bytes_written)))
+        } else {
+            None
+        }
+    }
+
+    fn bytes_read_row(&self) -> Option<Row> {
+        if self.bytes_read > 0 {
+            Some(("bytes read", format_bytes(self.bytes_read)))
         } else {
             None
         }

--- a/src/plan/history.rs
+++ b/src/plan/history.rs
@@ -95,6 +95,7 @@ mod tests {
 
     fn metric(status: &str, duration_ms: i64, retries: i64) -> ExportMetric {
         ExportMetric {
+            bytes_read: 0,
             export_name: "orders".into(),
             run_id: Some("r".into()),
             run_at: "2026-04-18T00:00:00Z".into(),

--- a/src/state/metrics.rs
+++ b/src/state/metrics.rs
@@ -22,6 +22,8 @@ pub struct ExportMetric {
     pub retries: i64,
     pub validated: Option<bool>,
     pub schema_changed: Option<bool>,
+    /// v23 — decoded bytes READ from the source (0 for pre-v23 rows).
+    pub bytes_read: i64,
 }
 
 /// Every column written to one `export_metrics` row.
@@ -390,10 +392,12 @@ impl StateStore {
             retries: r.opt_i64(13).unwrap_or(0),
             validated: r.opt_bool(14),
             schema_changed: r.opt_bool(15),
+            bytes_read: r.opt_i64(16).unwrap_or(0),
         };
         let cols = "export_name, run_id, run_at, duration_ms, total_rows, peak_rss_mb, \
                     status, error_message, tuning_profile, format, mode, \
-                    files_produced, bytes_written, retries, validated, schema_changed";
+                    files_produced, bytes_written, retries, validated, schema_changed, \
+                    bytes_read";
         match export_name {
             Some(name) => self.query(
                 &format!(

--- a/src/state/run_aggregate.rs
+++ b/src/state/run_aggregate.rs
@@ -30,6 +30,10 @@ pub struct RunAggregate {
     pub total_rows: i64,
     pub total_files: i64,
     pub total_bytes: u64,
+    /// Decoded bytes READ (v23) — display/JSON only; recomputed from
+    /// `per_export` on load (no DB column, entries carry it in details_json).
+    #[serde(default)]
+    pub total_bytes_read: u64,
     pub per_export: Vec<RunAggregateEntry>,
 }
 
@@ -42,6 +46,9 @@ pub struct RunAggregateEntry {
     pub rows: i64,
     pub files: i64,
     pub bytes: u64,
+    /// Decoded bytes READ from the source (v23); 0 in pre-v23 details_json.
+    #[serde(default)]
+    pub bytes_read: u64,
     pub duration_ms: i64,
     pub mode: String,
     pub error_message: Option<String>,
@@ -94,6 +101,9 @@ impl StateStore {
         self.query(sql, &[(limit as i64).into()], |r| {
             let per_export: Vec<RunAggregateEntry> =
                 serde_json::from_str(&r.text(13)).unwrap_or_default();
+            // total_bytes_read has no DB column: recompute from the entries so
+            // a read-back never shows a false 0 beside real per-export figures.
+            let total_bytes_read = per_export.iter().map(|e| e.bytes_read).sum();
             RunAggregate {
                 run_aggregate_id: r.text(0),
                 started_at: r.text(1),
@@ -108,6 +118,7 @@ impl StateStore {
                 total_rows: r.i64(10),
                 total_files: r.i64(11),
                 total_bytes: r.i64(12) as u64,
+                total_bytes_read,
                 per_export,
             }
         })
@@ -120,6 +131,7 @@ mod tests {
 
     fn sample(id: &str) -> RunAggregate {
         RunAggregate {
+            total_bytes_read: 0,
             run_aggregate_id: id.into(),
             started_at: "2026-04-27T10:00:00Z".into(),
             finished_at: "2026-04-27T10:11:30Z".into(),
@@ -135,6 +147,7 @@ mod tests {
             total_bytes: 750 * 1024 * 1024,
             per_export: vec![
                 RunAggregateEntry {
+                    bytes_read: 0,
                     export_name: "orders".into(),
                     status: "success".into(),
                     run_id: "orders_20260427T100000".into(),
@@ -146,6 +159,7 @@ mod tests {
                     error_message: None,
                 },
                 RunAggregateEntry {
+                    bytes_read: 0,
                     export_name: "users".into(),
                     status: "failed".into(),
                     run_id: "users_20260427T100000".into(),


### PR DESCRIPTION
Per-export table gains separate 'bytes read'/'bytes written' rows; the run aggregate sums and prints both; entries carry bytes_read in details_json (serde-default legacy), recomputed on load. State parity needs nothing: the DuckDB oracle digests the dynamic shared-column set and v23 exists in both ladders — bytes_read participates in SQLite==Postgres automatically. Live smoke: 'bytes read: 196.2 KB / bytes writ: 114.2 KB'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)