### PR TITLE
feat(gate): pool scheduler e2e as a release-gate stage (#166 GA)

### DIFF
--- a/dev/release_oracle/__main__.py
+++ b/dev/release_oracle/__main__.py
@@ -211,6 +211,7 @@ def preflight(led: Ledger, *, bless_gifs: bool = False) -> None:
     # early, and it is not fixable by re-rendering (the tape has to change).
     gifs.verify_gif_currency(led, bless=bless_gifs)
     scenarios.verify_replica_read(led)
+    scenarios.verify_pool_e2e(led)
     cdc.verify_cdc_e2e(led)
     regression.verify_release_regression(led)
     regression.verify_scale_memory(led)

--- a/dev/release_oracle/blessed_flow.py
+++ b/dev/release_oracle/blessed_flow.py
@@ -1209,9 +1209,10 @@ FLAG_EXCUSED = {
     "--gcs-credentials-file": "fake-gcs takes no credentials; the real path is the bigquery cycle's",
     "--pool": "pool mode schedules a whole CONFIG's exports (multi-export, duration-ordered); "
               "the blessed cell chain applies a sealed SINGLE-export plan artifact, where --pool "
-              "is a refusal by design. Carried by its dedicated e2e flow instead: "
-              "tests/live/live_pool_toxiproxy.rs (bandwidth-capped multi-export pool, exact rows "
-              "+ the predicted-vs-actual makespan contract).",
+              "is a refusal by design. Carried INSIDE the gate by its own stage instead: "
+              "scenarios.verify_pool_e2e drives tests/live/live_pool_toxiproxy.rs (bandwidth-"
+              "capped multi-export pool, exact rows + the predicted-vs-actual makespan "
+              "contract + resume defer-not-drop).",
     "--tls-ca": "verify-ca/full need a TLS-terminating server; the compose stand has none — the "
                 "CA path is unit-pinned (scaffold_records_the_tls_posture…) and refused-with-"
                 "disable is offline-tested",

--- a/dev/release_oracle/scenarios.py
+++ b/dev/release_oracle/scenarios.py
@@ -69,6 +69,7 @@ __all__ = [
     "store_readback",
     "store_up",
     "verify_coverage_matrices",
+    "verify_pool_e2e",
     "verify_replica_read",
     "verify_state_migrations",
 ]
@@ -1126,6 +1127,53 @@ def verify_replica_read(led: Ledger) -> None:
         _failed(
             led, "replica", "read", "-", "-",
             f"replica read FAILED — rivet could not read from the replica (see {log_path})",
+            _first_match(p.out, r"FAILED|panic|assert|error"),
+        )
+
+
+def verify_pool_e2e(led: Ledger) -> None:
+    """The pool scheduler's e2e flow AS A GATE STAGE (#166 GA): drives the
+    dedicated toxiproxy scenario — `apply --pool 2` on a multi-export config
+    (one heavy + three parallel_safe) through a BANDWIDTH-CAPPED source link,
+    exact per-export rows via independent DuckDB readback, plus the
+    predicted-vs-actual makespan contract on stdout, and the --resume
+    defer-not-drop twin. The shared-link cap is the field pathology (60 workers
+    splitting one ~0.25 MB/s tunnel), so this is the honest shape to gate the
+    LPT model in — not an uncontended localhost.
+
+    Needs toxiproxy (:8474) and the main postgres (:5432); SKIP when down.
+    """
+    if not have("cargo"):
+        _skipped(led, "pool", "e2e", "-", "-", "pool e2e: cargo absent", "no cargo")
+        return
+    if not _tcp_open("127.0.0.1", 8474):
+        _skipped(
+            led, "pool", "e2e", "-", "-",
+            "pool e2e: no toxiproxy :8474 (docker compose up -d toxiproxy)",
+            "no toxiproxy",
+        )
+        return
+    led.phase(
+        "Pool scheduler e2e (apply --pool through a bandwidth-capped link — "
+        "exact rows + the predicted-vs-actual makespan contract)"
+    )
+    log_path = work_dir() / "pool_e2e.log"
+    p = run(
+        ["cargo", "test", "--manifest-path", str(ROOT / "Cargo.toml"), "--test", "live_suite",
+         "--", "--test-threads=1", "live_pool_toxiproxy"],
+        env={"RIVET_BIN": str(rivet_bin())},
+        timeout=NO_TIMEOUT,
+    )
+    log_path.write_text(p.out)
+    if p.ok and "test result: ok. 2 passed" in p.out:
+        _passed(
+            led, "pool", "e2e", "-", "-",
+            "pool e2e: bandwidth-capped --pool run exact + self-grading; resume defers, drops nothing",
+        )
+    else:
+        _failed(
+            led, "pool", "e2e", "-", "-",
+            f"pool e2e FAILED (see {log_path})",
             _first_match(p.out, r"FAILED|panic|assert|error"),
         )
 

--- a/docs/release-gate-matrix.yaml
+++ b/docs/release-gate-matrix.yaml
@@ -140,6 +140,10 @@ preflights:
     what: "prod topology — rivet reads a read-REPLICA, not the master (the 'we were handed a product, no master access' case). Drives tests/live/live_cdc_replica.rs: the mysql-replica re-logs the primary's replicated changes into its OWN binlog (log_replica_updates) and rivet captures from that. Needs the `replica` compose profile (mysql-primary :3308 → mysql-replica :3309); SKIP when down."
     infra: [mysql-replica]
     status: test        # verify_replica_read — drives cdc_reads_changes_from_a_replica
+  - id: pool_e2e
+    what: "the pool scheduler's e2e flow (#166): `apply --pool 2` on a multi-export config (one heavy + three parallel_safe) through a toxiproxy BANDWIDTH-CAPPED source — the shared-tunnel field pathology. Oracles: exact per-export rows (independent DuckDB readback), the predicted-vs-actual makespan contract on stdout (the model grades itself), and --resume defer-not-drop. Drives tests/live/live_pool_toxiproxy.rs; SKIP when toxiproxy :8474 is down."
+    backends: [postgres]
+    status: test        # verify_pool_e2e — drives live_pool_toxiproxy (both tests)
   - id: release_regression
     what: "regression vs the PREVIOUS RELEASE (not a golden, not the gate itself). B-format: the new binary must READ what the prev release WROTE — prev exports a 100K keyset+zstd fixture, cur `validate` re-reads its manifest+parts (PASSED) + DuckDB row-count == source (a format bump that can't read old artifacts silently breaks every existing user on upgrade). B-perf: cur wall <= the DOWNLOADED prev-release binary's wall × tol (default 1.5×; a 3× slowdown / RSS blow-up ships green through every correctness check), benchmarked against the artifact users actually run, never a rebuilt parent. Env: RIVET_PREV_RELEASE_BIN + RIVET_REGRESSION_SOURCE_URL; SKIP-if-absent."
     backends: [postgres]


### PR DESCRIPTION
The pool's toxiproxy e2e flow is now a gate preflight stage (verify_pool_e2e, replica-read pattern): bandwidth-capped `apply --pool 2`, exact rows, the self-grading makespan contract, resume defer-not-drop. Matrix row + drift-guard green; FLAG_EXCUSED points at the gate stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)