### PR TITLE
feat(metrics): keyset records parallel + cursor bounds + bytes_read (#151)

### DIFF
--- a/src/pipeline/job.rs
+++ b/src/pipeline/job.rs
@@ -190,6 +190,11 @@ fn build_metric_row(
         crate::plan::ExtractionStrategy::Chunked(cp) => {
             (Some(cp.chunk_size as i64), Some(cp.parallel as i64))
         }
+        // #151: keyset runs demonstrably fanned N workers while the metric
+        // stayed NULL — the runner-bypass class, in a metrics field.
+        crate::plan::ExtractionStrategy::Keyset(kp) => {
+            (Some(kp.chunk_size as i64), Some(kp.parallel.max(1) as i64))
+        }
         _ => (None, None),
     };
     crate::state::MetricRow {

--- a/src/pipeline/keyset.rs
+++ b/src/pipeline/keyset.rs
@@ -47,6 +47,9 @@ pub(crate) struct KeysetPage {
     pub(crate) rows: usize,
     pub(crate) schema: Option<arrow::datatypes::Schema>,
     pub(crate) next_cursor: Option<String>,
+    /// First observed key of this page (the run floor when it is page 1 of
+    /// range 0) — recorded so cursor_min lands in the metrics (#151).
+    pub(crate) first_cursor: Option<String>,
     /// This page's sink's per-column Form B value checksums — XOR-combined
     /// run-wide by `run_keyset` so the finalize manifest records Form B (previously
     /// dropped here, making `rivet validate`'s re-read a no-op on keyset exports).
@@ -133,6 +136,7 @@ pub(crate) fn read_keyset_page_bounded(
         // The source's own lossless token (Mongo BSON `_id`) when it reported
         // one, else the column-extracted string (every SQL engine).
         next_cursor: sink.effective_cursor(),
+        first_cursor: sink.first_cursor_value.clone(),
         column_checksums: std::mem::take(&mut sink.column_checksums),
         checksum_key_column,
     }))
@@ -468,6 +472,7 @@ fn run_keyset_parallel(
     // is skipped), which is acceptable — parallel keyset is a full snapshot, not an
     // incremental anchor, so its cursor range is descriptive, not a resume floor.
     let range_max: Mutex<Vec<Option<String>>> = Mutex::new(vec![None; total_ranges]);
+    let range_first: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
     let errors: Mutex<Vec<String>> = Mutex::new(Vec::new());
 
     std::thread::scope(|scope| {
@@ -475,6 +480,7 @@ fn run_keyset_parallel(
             let dest = std::sync::Arc::clone(&dest);
             let (plan_r, key_plan_r, ext_r, tag_r, key_r) =
                 (plan, &key_plan, &ext, run_tag.as_str(), key.as_str());
+            let rfirst_r = &range_first;
             let (rows_r, parts_r, checks_r, fp_r, rmax_r, errs_r) = (
                 &rows,
                 &parts_mx,
@@ -552,6 +558,11 @@ fn run_keyset_parallel(
                             rows: p.rows,
                             bytes: p.bytes as i64,
                         });
+                    }
+                    if ridx == 0 && rfirst_r.lock().unwrap().is_none() {
+                        // Range 0 is the LOWEST range: its first key is the
+                        // run's observed floor (#151).
+                        *rfirst_r.lock().unwrap() = page.first_cursor.clone();
                     }
                     local_parts.extend(page.parts);
                     local_checks.push((page.column_checksums, page.checksum_key_column));
@@ -693,7 +704,9 @@ fn run_keyset_parallel(
     }
     // cursor_high = the highest populated range's max (forensics v18); see range_max.
     summary.cursor_high = highest_range_max(range_max.into_inner().unwrap());
-    summary.cursor_low = None; // a fresh parallel run seeks from the floor of each range
+    // #151: the observed floor = range 0's first key (the lowest range);
+    // the incremental block below overwrites this with the anchor floor.
+    summary.cursor_low = range_first.into_inner().unwrap();
 
     // Resume completeness: reconstruct the parts of the ranges that completed in a
     // PRIOR (crashed) run — they were not re-run, so they are absent from
@@ -938,6 +951,13 @@ pub(crate) fn run_keyset(
             summary.cursor_high = last.clone();
             break;
         };
+
+        // #151: the run's observed FLOOR — first page's first key. With
+        // cursor_min+max in the metrics, key density is derivable from the
+        // state DB alone (the keyset-vs-range input, no source round-trip).
+        if summary.cursor_low.is_none() {
+            summary.cursor_low = page.first_cursor.clone();
+        }
 
         // ADR-0012 M3: capture the dest schema fingerprint from the first
         // non-empty page; idempotent run-wide.

--- a/src/pipeline/sink/cursor.rs
+++ b/src/pipeline/sink/cursor.rs
@@ -29,6 +29,25 @@ pub(crate) fn extract_last_cursor_value(
     cursor_column: &str,
     schema: &SchemaRef,
 ) -> Option<String> {
+    extract_cursor_value_at(batch, cursor_column, schema, true)
+}
+
+/// First NON-NULL cursor value of the batch — the run's observed floor (#151:
+/// with min+max recorded, key density is derivable from the state DB alone).
+pub(crate) fn extract_first_cursor_value(
+    batch: &RecordBatch,
+    cursor_column: &str,
+    schema: &SchemaRef,
+) -> Option<String> {
+    extract_cursor_value_at(batch, cursor_column, schema, false)
+}
+
+fn extract_cursor_value_at(
+    batch: &RecordBatch,
+    cursor_column: &str,
+    schema: &SchemaRef,
+    from_end: bool,
+) -> Option<String> {
     let col_idx = schema.index_of(cursor_column).ok()?;
     let array = batch.column(col_idx);
 
@@ -48,7 +67,11 @@ pub(crate) fn extract_last_cursor_value(
     //
     // An all-NULL batch still yields None, which the caller must treat as "this
     // batch says nothing" and NOT as "reset the mark" — see `ExportSink::on_batch`.
-    let last_row = (0..batch.num_rows()).rev().find(|&i| !array.is_null(i))?;
+    let last_row = if from_end {
+        (0..batch.num_rows()).rev().find(|&i| !array.is_null(i))?
+    } else {
+        (0..batch.num_rows()).find(|&i| !array.is_null(i))?
+    };
 
     match array.data_type() {
         DataType::Int16 => Some(

--- a/src/pipeline/sink/mod.rs
+++ b/src/pipeline/sink/mod.rs
@@ -6,7 +6,7 @@
 
 mod cursor;
 mod pipelined;
-pub(crate) use cursor::extract_last_cursor_value;
+pub(crate) use cursor::{extract_first_cursor_value, extract_last_cursor_value};
 pub(crate) use pipelined::PipelinedSink;
 
 use std::io::BufWriter;
@@ -49,6 +49,9 @@ pub(crate) struct ExportSink {
     pub(in crate::pipeline) cursor_column: Option<String>,
     /// Last extracted cursor value — set by `on_batch`, consumed by `run_single_export`.
     pub(in crate::pipeline) last_cursor_value: Option<String>,
+    /// First observed cursor value of the RUN (first non-null of the first
+    /// batch carrying one) — the floor for cursor_min metrics (#151).
+    pub(in crate::pipeline) first_cursor_value: Option<String>,
     /// A lossless keyset token the SOURCE reported via `set_source_cursor`
     /// (MongoDB's BSON `_id`), overriding the type-ambiguous string extracted
     /// from the output column. `effective_cursor()` prefers it. `None` for SQL.
@@ -144,6 +147,7 @@ impl ExportSink {
             part_rows: 0,
             cursor_column: plan.strategy.cursor_extract_column().map(str::to_string),
             last_cursor_value: None,
+            first_cursor_value: None,
             source_cursor: None,
             schema: None,
             dest_schema: None,
@@ -746,6 +750,9 @@ impl BatchSink for ExportSink {
             // unconditional assignment let it overwrite the good mark
             // accumulated from every prior batch with None, after which nothing
             // was recorded and nothing committed.
+            if self.first_cursor_value.is_none() {
+                self.first_cursor_value = extract_first_cursor_value(batch, col, schema);
+            }
             if let Some(v) = extract_last_cursor_value(batch, col, schema) {
                 self.last_cursor_value = Some(v);
             }

--- a/src/pipeline/sink/tests.rs
+++ b/src/pipeline/sink/tests.rs
@@ -387,6 +387,7 @@ fn minimal_sink() -> ExportSink {
         part_rows: 0,
         cursor_column: None,
         last_cursor_value: None,
+        first_cursor_value: None,
         source_cursor: None,
         schema: None,
         dest_schema: None,

--- a/tests/live/live_keyset_metrics.rs
+++ b/tests/live/live_keyset_metrics.rs
@@ -1,0 +1,56 @@
+//! #151: keyset runs must record the same metric FIELDS chunked runs do —
+//! `parallel`, `cursor_min`/`cursor_max`, and the v23 `bytes_read` — asserted
+//! ON the run's own metrics row (never re-derived in the test). The field DB
+//! had `parallel` NULL on every keyset run (4 worker ranges demonstrably ran)
+//! and cursor bounds NULL on 0 of 51: the runner-bypass class, in metrics.
+
+use crate::common::*;
+
+#[test]
+#[ignore = "live: requires docker compose up -d postgres"]
+fn keyset_run_records_parallel_cursor_bounds_and_bytes_read() {
+    require_alive(LiveService::Postgres);
+    let table = unique_name("km_pg");
+    let mut c = pg_connect();
+    c.batch_execute(&format!(
+        "DROP TABLE IF EXISTS {table};
+         CREATE TABLE {table} (id BIGINT PRIMARY KEY, payload INT NOT NULL);
+         INSERT INTO {table} SELECT g, g FROM generate_series(1, 2000) g;"
+    ))
+    .unwrap();
+    let rig = Rig::pg_batch(&format!("public.{table}"))
+        .mode("chunked")
+        .export_line("chunk_by_key: id")
+        .export_line("parallel: 2")
+        .export_line("chunk_size: 400");
+    rig.run_ok();
+
+    // THE metrics row — the artifact the product wrote, not a re-derivation.
+    let db = rig.config_path().parent().unwrap().join(".rivet_state.db");
+    let conn = rusqlite::Connection::open(&db).unwrap();
+    let (parallel, cur_min, cur_max, bytes_read): (
+        Option<i64>,
+        Option<String>,
+        Option<String>,
+        Option<i64>,
+    ) = conn
+        .query_row(
+            "SELECT parallel, cursor_min, cursor_max, bytes_read FROM export_metrics \
+             WHERE status='success' ORDER BY id DESC LIMIT 1",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+        )
+        .unwrap();
+    assert_eq!(parallel, Some(2), "#151-1: keyset must record its fan-out");
+    assert_eq!(
+        cur_min.as_deref(),
+        Some("1"),
+        "#151-2: the observed floor (density derivable from the DB alone)"
+    );
+    assert_eq!(cur_max.as_deref(), Some("2000"), "#151-2: the high-water");
+    assert!(
+        bytes_read.unwrap_or(0) > 0,
+        "#151-3: the read leg's cost must be recorded"
+    );
+    let _ = c.execute(&format!("DROP TABLE IF EXISTS {table}"), &[]);
+}

--- a/tests/live_suite.rs
+++ b/tests/live_suite.rs
@@ -111,6 +111,8 @@ mod live_init;
 mod live_init_extended;
 #[path = "live/live_keyset.rs"]
 mod live_keyset;
+#[path = "live/live_keyset_metrics.rs"]
+mod live_keyset_metrics;
 #[path = "live/live_keyset_parallel.rs"]
 mod live_keyset_parallel;
 #[path = "live/live_metrics_persist.rs"]


### PR DESCRIPTION
Closes #151. Keyset arm in build_metric_row (parallel/chunk_size); first-cursor tracking in the sink (shared picker body) -> KeysetPage -> seq first page / parallel range-0 floor; bytes_read already landed as v23. Live proof green on the run's own metrics row: parallel=2, cursor_min=1, cursor_max=2000, bytes_read>0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)