### PR TITLE
feat(keyset): OPT-2 concurrency governor on the keyset runner (#152)

### DIFF
--- a/docs/runner-coverage-matrix.yaml
+++ b/docs/runner-coverage-matrix.yaml
@@ -79,6 +79,13 @@ scenarios:
     keyset:         { test: parallel_keyset_worker_error_still_counts_the_durable_parts_postgres }
     mongo_parallel: { na: "the drain does `let out = res?` — the FIRST worker error propagates immediately, so there is no keep-going path and therefore no end-of-run guard that can silently fail to fire. The residual risk is the opposite one (a later worker's parts unrecorded because the bail preceded their drain), which is the durable-part-count scenario, not this one" }
 
+  - id: adaptive_concurrency_governor
+    what: "OPT-2 governor sheds parallel workers under source pressure (backs off to min_parallel, recovers as pressure eases). Runner-bypass class on the SAFETY knob: it was chunked-only, so a `parallel: N` keyset export on a straining replica adapted batches but never shed workers (#152). Now wired into keyset per-page (permit-per-page semaphore + the same Governor loop + min_parallel floor); the run journal records each ParallelismAdjusted."
+    single:         { na: "single has no worker fan-out to govern (parallel is a multi-part-runner concept)" }
+    chunked:        { test: governor_backs_off_under_concurrent_write_pressure }
+    keyset:         { test: keyset_governor_backs_off_under_concurrent_write_pressure }
+    mongo_parallel: { na: "mongo_parallel spawns one thread per _id range with NO shared permit ceiling — the governor's resize target does not exist there. The reader-level adaptive batch sizing (engine pressure counters) still applies; the concurrency governor is a permit-ceiling mechanism and mongo_parallel has no ceiling to shrink. A future ceiling would take a `test` cell here." }
+
   - id: schema_drift_gate
     what: "on_schema_drift enforcement — a drifted schema under `fail` aborts (exit 4). Each runner bypasses run_single_export, so each must re-apply the gate (check_from_sink_schema / check_from_type_mappings). Round-8: keyset + mongo_parallel had SILENTLY dropped it (exit 0 on drift)."
     single:         { test: schema_drift_removed_column_is_detected }

--- a/src/pipeline/keyset.rs
+++ b/src/pipeline/keyset.rs
@@ -475,7 +475,86 @@ fn run_keyset_parallel(
     let range_first: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
     let errors: Mutex<Vec<String>> = Mutex::new(Vec::new());
 
+    // #152: the OPT-2 concurrency governor, previously chunked-only. Each worker
+    // acquires a permit PER PAGE (the guard releases at each iteration's end, on
+    // every path), so shrinking the ceiling sheds workers at page granularity —
+    // the same shape the range-chunked runner uses at chunk granularity. `finished`
+    // counts workers that have exited (success OR error) so the governor's exit
+    // predicate can't be stranded by a failing worker.
+    let semaphore = crate::resource::Semaphore::new(parallel.max(1));
+    let finished = std::sync::atomic::AtomicUsize::new(0);
+    let governor_floor = plan
+        .tuning
+        .min_parallel
+        .unwrap_or(1)
+        .clamp(1, parallel.max(1));
+    let governor_on = plan.tuning.adaptive && parallel > 1;
+    let governor_monitor: Option<Box<dyn Source>> = if governor_on {
+        match source::create_source(&plan.source) {
+            Ok(s) => {
+                log::info!(
+                    "export '{}': adaptive concurrency governor active on keyset (parallel {}..{})",
+                    plan.export_name,
+                    governor_floor,
+                    parallel
+                );
+                Some(s)
+            }
+            Err(e) => {
+                log::warn!(
+                    "export '{}': keyset governor monitoring connection failed; parallelism stays static at {}: {:#}",
+                    plan.export_name,
+                    parallel,
+                    e
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+    let governor_log: Mutex<Vec<(usize, usize, String)>> = Mutex::new(Vec::new());
+
     std::thread::scope(|scope| {
+        // Governor thread — mirrors chunked/exec.rs: samples source pressure on
+        // its own monitoring connection and resizes the permit semaphore within
+        // [floor, parallel], self-terminating once every worker has finished.
+        if let Some(mut monitor) = governor_monitor {
+            let semaphore = &semaphore;
+            let finished = &finished;
+            let governor_log = &governor_log;
+            let total = pending.len();
+            let ceiling = parallel;
+            let floor = governor_floor;
+            let export_name = plan.export_name.as_str();
+            scope.spawn(move || {
+                let mut gov = crate::tuning::Governor::new(ceiling, floor, ceiling);
+                gov.run(
+                    &mut monitor,
+                    || finished.load(Ordering::Relaxed) >= total,
+                    |from, to| {
+                        semaphore.resize(to);
+                        let reason = if to < from {
+                            "source pressure rising: backed off"
+                        } else {
+                            "source pressure eased: recovered"
+                        };
+                        log::info!(
+                            "export '{}': keyset governor parallelism {} → {} ({})",
+                            export_name,
+                            from,
+                            to,
+                            reason
+                        );
+                        governor_log
+                            .lock()
+                            .unwrap()
+                            .push((from, to, reason.to_string()));
+                    },
+                );
+            });
+        }
+
         for (ridx, lo, hi) in pending.iter().cloned() {
             let dest = std::sync::Arc::clone(&dest);
             let (plan_r, key_plan_r, ext_r, tag_r, key_r) =
@@ -490,7 +569,18 @@ fn run_keyset_parallel(
                 &errors,
             );
             let (sref_r, rid_r, fmt_r, cmp_r) = (&state_ref, run_id.as_str(), fmt_label, cmp_label);
+            let sem_r = &semaphore;
+            let fin_r = &finished;
             scope.spawn(move || {
+                // Count this worker as finished on EVERY exit path (success or
+                // error) so the governor's exit predicate can't be stranded.
+                struct FinishGuard<'a>(&'a std::sync::atomic::AtomicUsize);
+                impl Drop for FinishGuard<'_> {
+                    fn drop(&mut self) {
+                        self.0.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+                let _finish = FinishGuard(fin_r);
                 let mut wsrc = match source::create_source(&plan_r.source) {
                     Ok(s) => s,
                     Err(e) => {
@@ -513,6 +603,17 @@ fn run_keyset_parallel(
                     Option<String>,
                 )> = Vec::new();
                 loop {
+                    // #152: one permit per page (guard releases at the end of
+                    // THIS iteration on every path), so the governor sheds
+                    // workers at page granularity when it shrinks the ceiling.
+                    struct PermitGuard<'a>(&'a crate::resource::Semaphore);
+                    impl Drop for PermitGuard<'_> {
+                        fn drop(&mut self) {
+                            self.0.release();
+                        }
+                    }
+                    sem_r.acquire();
+                    let _permit = PermitGuard(sem_r);
                     // Test-only: simulate a per-worker SQL error mid-range (Err path,
                     // not a crash). The worker records it + returns; the post-join check
                     // bails, so the run fails cleanly with no _SUCCESS / finalized manifest.
@@ -701,6 +802,13 @@ fn run_keyset_parallel(
     }
     if let Some(sc) = fingerprint.get() {
         manifest_writer::record_run_schema_fingerprint(summary, sc);
+    }
+    // #152: drain the governor's off-thread decisions into the run journal
+    // (same as chunked) so a keyset run records when it shed/recovered workers.
+    for (from, to, reason) in governor_log.into_inner().unwrap() {
+        summary
+            .journal
+            .record(crate::journal::RunEvent::ParallelismAdjusted { from, to, reason });
     }
     // cursor_high = the highest populated range's max (forensics v18); see range_max.
     summary.cursor_high = highest_range_max(range_max.into_inner().unwrap());

--- a/tests/live/live_governor.rs
+++ b/tests/live/live_governor.rs
@@ -346,3 +346,120 @@ exports:
         }
     }
 }
+
+/// #152: the SAME back-off, on the KEYSET runner. The governor was chunked-only;
+/// a `parallel: N` keyset export on a straining source adapted batches but never
+/// shed workers. Identical pressure workload, `chunk_by_key` instead of
+/// `chunk_column` — the run must arm the keyset governor and shed at least one
+/// worker under rising checkpoint pressure. RED against a build with the keyset
+/// governor wiring removed (batches still adapt, but no "backed off" line).
+#[test]
+#[ignore = "live: requires docker compose up -d postgres"]
+fn keyset_governor_backs_off_under_concurrent_write_pressure() {
+    require_alive(LiveService::Postgres);
+
+    const ROWS: i64 = 20_000;
+    let table = seed_pg_wide_table(ROWS, 1024);
+    let out_dir = tempfile::tempdir().unwrap();
+    let cfg_dir = tempfile::tempdir().unwrap();
+    let yaml = format!(
+        r#"
+source:
+  type: postgres
+  url: "{POSTGRES_URL}"
+  tuning:
+    adaptive: true
+    min_parallel: 2
+    batch_size: 250
+    throttle_ms: 100
+exports:
+  - name: {name}
+    table: {name}
+    mode: chunked
+    chunk_by_key: id
+    chunk_size: 1000
+    parallel: 8
+    format: parquet
+    destination:
+      type: local
+      path: {out}
+"#,
+        name = table.name(),
+        out = out_dir.path().display(),
+    );
+    let cfg = write_config(&cfg_dir, &yaml);
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let table_name = table.name().to_string();
+    let writer = {
+        let stop = Arc::clone(&stop);
+        std::thread::spawn(move || {
+            let mut c = pg_connect();
+            let mut k: i64 = 1;
+            while !stop.load(Ordering::Relaxed) {
+                let _ = c.batch_execute(&format!(
+                    "UPDATE {table_name} SET payload = repeat('z', 1024), updated_at = now() \
+                     WHERE id BETWEEN {k} AND {k} + 999; CHECKPOINT;"
+                ));
+                k += 1000;
+                if k > ROWS {
+                    k = 1;
+                }
+                std::thread::sleep(Duration::from_millis(70));
+            }
+        })
+    };
+    std::thread::sleep(Duration::from_millis(400));
+
+    let log_path = cfg_dir.path().join("rivet.stderr");
+    let log_file = std::fs::File::create(&log_path).unwrap();
+    let mut child = std::process::Command::new(RIVET_BIN)
+        .args([
+            "run",
+            "--config",
+            cfg.to_str().unwrap(),
+            "--export",
+            table.name(),
+        ])
+        .env("RUST_LOG", "info")
+        .env("RIVET_GOVERNOR_INTERVAL_MS", "200")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::from(log_file))
+        .spawn()
+        .expect("spawn rivet run");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(120);
+    let status = loop {
+        match child.try_wait().expect("try_wait") {
+            Some(s) => break s,
+            None if std::time::Instant::now() >= deadline => {
+                let _ = child.kill();
+                stop.store(true, Ordering::Relaxed);
+                let _ = writer.join();
+                panic!("governed keyset run under write pressure did not finish within 120s");
+            }
+            None => std::thread::sleep(Duration::from_millis(100)),
+        }
+    };
+    stop.store(true, Ordering::Relaxed);
+    writer.join().expect("writer thread");
+
+    let stderr = std::fs::read_to_string(&log_path).unwrap_or_default();
+    assert!(
+        status.success(),
+        "governed keyset run must complete; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("adaptive concurrency governor active on keyset"),
+        "the KEYSET governor must arm for adaptive + parallel>1; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("backed off"),
+        "#152: under rising pressure the keyset governor must shed at least one worker; stderr:\n{stderr}"
+    );
+    assert_eq!(
+        duckdb_total_parquet_rows(out_dir.path()),
+        ROWS as usize,
+        "every row must round-trip through the governed keyset run"
+    );
+}


### PR DESCRIPTION
Closes #152. The governor was chunked-only; keyset's N percentile-workers adapted batches but never shed under pressure — runner-bypass on the safety knob. Same Governor loop, permit-per-page semaphore, min_parallel floor, journal ParallelismAdjusted. runner-coverage-matrix row (chunked test / keyset test / mongo_parallel na-with-reason). Live proof green; RED-proven against governor_on=false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)