### PR TITLE
refactor(cdc): TxnFramer — committed-boundary close as one pure contract (#158)

### DIFF
--- a/src/source/cdc/mod.rs
+++ b/src/source/cdc/mod.rs
@@ -173,6 +173,40 @@ impl TxnSeq {
     }
 }
 
+/// Closes a buffered source transaction (#158): the at-least-once contract's
+/// load-bearing rule, previously four inline copies inside live-server `fill`
+/// loops (mysql/pg/mssql), each re-deriving the same loss argument in prose —
+/// the exact shape that shipped the PG/MSSQL `committed:true`-on-every-event
+/// bugs (see CLAUDE.md's committed-flag section).
+///
+/// The rule: stamp the group's commit `position` on EVERY event, and mark ONLY
+/// its LAST event `committed`. The sink rolls (flush → checkpoint → ack) on a
+/// `committed` event, so marking every event committed would roll + checkpoint
+/// MID-transaction and a crash before the tail's flush would advance the resume
+/// position past the commit — resume reads strictly after it and skips the tail
+/// (an at-least-once break). Each engine's group DETECTION stays engine-side
+/// (XID / BEGIN…COMMIT / __$start_lsn run); only the CLOSE is shared here.
+pub(crate) struct TxnFramer;
+
+impl TxnFramer {
+    /// Frame one committed source transaction: `position = commit` on all,
+    /// `committed = true` on the last event only. Empty group is a no-op.
+    pub(crate) fn close_group(events: &mut [ChangeEvent], commit: &Position) {
+        let n = events.len();
+        for (i, ev) in events.iter_mut().enumerate() {
+            ev.position = commit.clone();
+            ev.committed = i + 1 == n;
+        }
+    }
+
+    /// Mongo's model: each change-stream event IS its own commit, so every
+    /// event is a boundary. A NAMED decision, not a divergence (#158). `position`
+    /// is already per-event here, so this only sets the flag.
+    pub(crate) fn single_event_commit(event: &mut ChangeEvent) {
+        event.committed = true;
+    }
+}
+
 impl ChangeEvent {
     /// Rough in-memory footprint of this buffered change — drives the sink's
     /// memory-budget rollover (`rollover_memory_mb`). The before/after value
@@ -1221,6 +1255,71 @@ mod tests {
                 "{bad:?} → {err}"
             );
         }
+    }
+
+    fn framer_ev(id: i64) -> super::ChangeEvent {
+        super::ChangeEvent {
+            op: super::ChangeOp::Insert,
+            schema: "public".into(),
+            table: "orders".into(),
+            before: None,
+            after: Some(vec![RivetValue::Int(id)]),
+            position: Position(serde_json::json!({ "lsn": "stale" })),
+            committed: false,
+            image_names: None,
+            seq: 0,
+            poison: None,
+        }
+    }
+
+    /// #158: the shared transaction close — commit position on ALL, committed on
+    /// the LAST only. RED against a `committed:true`-on-every-event mutant (the
+    /// exact shape that shipped the PG/MSSQL bugs).
+    #[test]
+    fn txn_framer_close_group_marks_only_the_last_committed() {
+        let commit = Position(serde_json::json!({ "lsn": "COMMIT" }));
+
+        // N-event group: every event gets the commit position; only the last
+        // is committed.
+        let mut g: Vec<super::ChangeEvent> = (0..4).map(framer_ev).collect();
+        super::TxnFramer::close_group(&mut g, &commit);
+        assert!(g.iter().all(|e| e.position == commit), "commit on all");
+        assert_eq!(
+            g.iter().map(|e| e.committed).collect::<Vec<_>>(),
+            vec![false, false, false, true],
+            "only the last event of a transaction is committed"
+        );
+
+        // 1-event group: that single event IS the boundary.
+        let mut one = vec![framer_ev(9)];
+        super::TxnFramer::close_group(&mut one, &commit);
+        assert!(one[0].committed && one[0].position == commit);
+
+        // Two groups back-to-back: each ends with exactly one committed.
+        let c1 = Position(serde_json::json!({ "lsn": "C1" }));
+        let c2 = Position(serde_json::json!({ "lsn": "C2" }));
+        let mut a: Vec<super::ChangeEvent> = (0..2).map(framer_ev).collect();
+        let mut b: Vec<super::ChangeEvent> = (0..3).map(framer_ev).collect();
+        super::TxnFramer::close_group(&mut a, &c1);
+        super::TxnFramer::close_group(&mut b, &c2);
+        assert_eq!(a.iter().filter(|e| e.committed).count(), 1);
+        assert_eq!(b.iter().filter(|e| e.committed).count(), 1);
+        assert!(a.iter().all(|e| e.position == c1));
+        assert!(b.iter().all(|e| e.position == c2));
+
+        // Empty group: no-op, no panic.
+        let mut empty: Vec<super::ChangeEvent> = Vec::new();
+        super::TxnFramer::close_group(&mut empty, &commit);
+        assert!(empty.is_empty());
+    }
+
+    /// Mongo's named single-event-commit model.
+    #[test]
+    fn txn_framer_single_event_commit_marks_the_event() {
+        let mut e = framer_ev(1);
+        assert!(!e.committed);
+        super::TxnFramer::single_event_commit(&mut e);
+        assert!(e.committed);
     }
 
     #[test]

--- a/src/source/mongo/cdc.rs
+++ b/src/source/mongo/cdc.rs
@@ -424,7 +424,7 @@ fn to_change_event(
         _ => (None, Some(image)),
     };
 
-    Ok(ChangeEvent {
+    let mut ev = ChangeEvent {
         op,
         schema: db_name.to_string(),
         table,
@@ -432,12 +432,16 @@ fn to_change_event(
         after,
         // The per-event resume token is the exact re-open position.
         position: encode_resume_token(&cse.id)?,
-        // Every change-stream event is already committed (post-commit oplog).
-        committed: true,
+        committed: false,
         image_names: Some(std::sync::Arc::clone(&IMAGE_NAMES)),
         seq: 0, // stamped by TxnSeq as the stream is consumed
         poison: None,
-    })
+    };
+    // #158: Mongo's model — each change-stream event IS its own commit (post-
+    // commit oplog), so every event is a boundary. A NAMED decision via the
+    // shared framer, not an inline `committed: true` that reads as a divergence.
+    crate::source::cdc::TxnFramer::single_event_commit(&mut ev);
+    Ok(ev)
 }
 
 impl ChangeStream for MongoChangeStream {

--- a/src/source/mssql/cdc.rs
+++ b/src/source/mssql/cdc.rs
@@ -681,14 +681,25 @@ impl MssqlChangeStream {
                 );
             }
         }
-        // Mark the commit boundary: a row is the last of its transaction when it
-        // is the final row of the batch OR the next row has a different start LSN.
-        let n = batch.len();
-        for i in 0..n {
-            let is_boundary = i + 1 == n || batch[i].0 != batch[i + 1].0;
-            batch[i].1.committed = is_boundary;
+        // #158: a batch holds one or more transactions, each a run of rows
+        // sharing `__$start_lsn`. Close EACH run through the shared framer —
+        // committed on the run's last row only (position is already the run's
+        // lsn, so close_group's position stamp is a no-op confirming it). The
+        // per-run split is MSSQL's engine-specific group detection; the CLOSE
+        // is shared. Marking every row committed would roll mid-transaction.
+        let lsns: Vec<String> = batch.iter().map(|(l, _)| l.clone()).collect();
+        let mut evs: Vec<ChangeEvent> = batch.into_iter().map(|(_, e)| e).collect();
+        let mut start = 0;
+        while start < evs.len() {
+            let mut end = start + 1;
+            while end < evs.len() && lsns[end] == lsns[start] {
+                end += 1;
+            }
+            let commit = Position(json!({ "lsn": lsns[start] }));
+            crate::source::cdc::TxnFramer::close_group(&mut evs[start..end], &commit);
+            start = end;
         }
-        for (_, ev) in batch {
+        for ev in evs {
             self.pending.push_back(ev);
         }
         match max_lsn {

--- a/src/source/mysql/cdc.rs
+++ b/src/source/mysql/cdc.rs
@@ -371,12 +371,12 @@ impl MysqlChangeStream {
                     return Ok(false);
                 }
                 let commit = Position(json!({ "file": self.file, "pos": log_pos }));
-                let tx: Vec<ChangeEvent> = self.tx.drain(..).collect();
+                let mut tx: Vec<ChangeEvent> = self.tx.drain(..).collect();
                 self.tx_bytes = 0;
-                let n = tx.len();
-                for (i, mut ev) in tx.into_iter().enumerate() {
-                    ev.position = commit.clone();
-                    ev.committed = i + 1 == n;
+                // #158: the shared close — commit position on all, committed on
+                // the last only (the XID marks the whole transaction's boundary).
+                crate::source::cdc::TxnFramer::close_group(&mut tx, &commit);
+                for ev in tx {
                     self.pending.push_back(ev);
                 }
             }

--- a/src/source/postgres/cdc.rs
+++ b/src/source/postgres/cdc.rs
@@ -358,21 +358,15 @@ impl PgChangeStream {
                             self.yielded_data = true;
                         }
                         let commit = Position(json!({ "lsn": lsn }));
-                        // `committed` marks the COMMIT BOUNDARY, and the sink
-                        // only rolls (flush → checkpoint → ack) on a committed
-                        // event — "never split a transaction across parts". Every
-                        // event `parse_test_decoding` builds carries
-                        // `committed: true`, but they all belong to ONE source
-                        // transaction here, so mark ONLY THE LAST one committed
-                        // (mirroring MySQL's XID model). Otherwise a transaction
-                        // larger than `rollover` rolls + acks MID-transaction,
-                        // and a crash between that ack and the tail's flush loses
-                        // the un-flushed tail (the slot advanced past the commit,
-                        // so resume never re-reads it — an at-least-once break).
-                        let n = tx.len();
-                        for (i, mut ev) in tx.drain(..).enumerate() {
-                            ev.position = commit.clone();
-                            ev.committed = i + 1 == n;
+                        // #158: the shared close — commit LSN on all, committed on
+                        // the last only (BEGIN…COMMIT frames one transaction here).
+                        // Otherwise a transaction larger than `rollover` rolls +
+                        // acks MID-transaction and a crash before the tail's flush
+                        // loses it (the slot advanced past the commit — resume
+                        // never re-reads it, an at-least-once break).
+                        let mut group: Vec<ChangeEvent> = std::mem::take(&mut tx);
+                        crate::source::cdc::TxnFramer::close_group(&mut group, &commit);
+                        for ev in group {
                             self.pending.push_back(ev);
                         }
                         self.frontier = commit_lsn;


### PR DESCRIPTION
Closes #158. Four inline copies of the at-least-once close (commit position on the group, committed on last only) unified into TxnFramer::close_group beside TxnSeq; Mongo gets the named single_event_commit. All four adapters routed (group detection stays engine-side). Unit matrix RED-proven vs a committed-on-every mutant; the three live large-tx-atomicity roast tests stay green on the stand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)