### PR TITLE
fix(ci): green the live + preflight tiers broken by merging without CI

### DIFF
--- a/tests/live/audit_preflight_table.rs
+++ b/tests/live/audit_preflight_table.rs
@@ -68,7 +68,12 @@ fn parse_row_estimate(stdout: &str) -> i64 {
         .split('~')
         .nth(1)
         .unwrap_or_else(|| panic!("malformed Row estimate line: {line:?}"))
-        .trim();
+        // #149 appends a source label — `~5M  (catalog estimate)` /
+        // `(measured YYYY-MM-DD)`; take only the leading count token
+        // (split_whitespace also trims leading space).
+        .split_whitespace()
+        .next()
+        .unwrap_or("");
     if let Some(k) = raw.strip_suffix('K') {
         k.trim().parse::<i64>().expect("K-suffixed number") * 1_000
     } else if let Some(m) = raw.strip_suffix('M') {

--- a/tests/live/live_density_probe.rs
+++ b/tests/live/live_density_probe.rs
@@ -12,6 +12,7 @@ use crate::common::*;
 use mysql::prelude::Queryable;
 
 #[test]
+#[ignore = "live: requires docker compose up -d mysql"]
 fn init_probe_overrules_a_stale_table_rows_on_a_versioned_table() {
     let mut c = mysql_connect();
     c.query_drop("SET SESSION cte_max_recursion_depth = 60000")

--- a/tests/live/live_pool_toxiproxy.rs
+++ b/tests/live/live_pool_toxiproxy.rs
@@ -26,6 +26,7 @@ const HEAVY_ROWS: i64 = 120_000;
 const SMALL_ROWS: i64 = 15_000;
 
 #[test]
+#[ignore = "live: requires docker compose up -d postgres toxiproxy"]
 fn pool_apply_through_a_bandwidth_capped_link_is_exact_and_grades_itself() {
     let _lock = toxiproxy_guard();
     ensure_toxi_proxy("postgres", 15432, "postgres:5432");
@@ -104,6 +105,7 @@ fn pool_apply_through_a_bandwidth_capped_link_is_exact_and_grades_itself() {
 /// re-exporting — the wave path's resume contract, preserved verbatim by the
 /// pool. The union stays exact (no clobber, no double rows).
 #[test]
+#[ignore = "live: requires docker compose up -d postgres toxiproxy"]
 fn pool_apply_resume_skips_complete_exports_and_loses_nothing() {
     let _lock = toxiproxy_guard();
     ensure_toxi_proxy("postgres", 15432, "postgres:5432");


### PR DESCRIPTION
Two CI-only breakages (offline stayed green — the gap the no-merge-without-CI rule guards): (1) new live tests lacked #[ignore] so the non-live all-targets job ran them and panicked on the absent stand; (2) #149's Row-estimate source label broke audit's parse_row_estimate. Both fixed, verified green on the stand + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)