### PR TITLE
fix(init): #148 density-probe robustness — 4 confirmed bugs

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -37,6 +37,16 @@ exclude_re = [
     # RED-proven); the dispatch itself is live-guarded (query_scalar feeds
     # min/max bounds exercised by the live planner suites).
     "replace scalar_to_string -> Option<String>",
+    # density_probe (init/mysql.rs, init/postgres.rs) takes a live DB connection
+    # (mysql::PooledConn / postgres::Client) to run MIN/MAX + the windowed COUNTs
+    # — unkillable OFFLINE (the --in-diff gate has no DB). Its DECISION logic is
+    # extracted into pure, unit-tested helpers (stratified_offsets,
+    # estimate_from_windows, probe_trustworthy — all RED-proven), and the glue is
+    # live-guarded: init_probe_overrules_a_stale_table_rows_on_a_versioned_table
+    # (MySQL) + pg_density_probe_corrects_a_never_analyzed_table (PostgreSQL) fail
+    # against a stubbed probe or an inverted trustworthy guard on the real stand.
+    "replace density_probe with",
+    "delete ! in density_probe",
     # refuse_compressed_binlog takes a live `mysql::Conn` to read
     # @@global.binlog_transaction_compression — there is no offline caller, so a
     # body stub is unkillable HERE by construction. The DECISION it makes was

--- a/src/init/density.rs
+++ b/src/init/density.rs
@@ -110,6 +110,17 @@ pub(crate) fn stratified_offsets(min: i64, max: i64, k: usize, w: i64) -> Vec<i6
         .collect()
 }
 
+/// #148 sparse-key guard (roast 2026-08-09): the stratified grid can only
+/// estimate a key it actually SAMPLES. On a sparse/ID-encoded key (a Snowflake
+/// bigint whose span is ~4e17 over 10M rows), all K windows land in near-empty
+/// gaps, so `Σcount ≈ 0` and the extrapolation returns ~0 — replacing a sane
+/// catalog with garbage. Trust the probe only when the windows saw a floor of
+/// real rows (≥ K, i.e. ≥1 row/window on average); below that the key is too
+/// sparse for a windowed sample and the catalog stands, flagged `unverified`.
+pub(crate) fn probe_trustworthy(sampled_rows: i64, k: usize) -> bool {
+    k > 0 && sampled_rows >= k as i64
+}
+
 /// `rows ≈ span × Σcount/(sampled key-units)`; density = mean rows per
 /// key-unit. `counts[i]` is `COUNT(*) WHERE k BETWEEN off[i] AND off[i]+w-1`.
 /// Empty windows are DATA (a gappy key), not absence — they stay in the mean.
@@ -201,6 +212,19 @@ mod tests {
             "the 1 000 floor for tiny tables"
         );
         assert!(!span_agrees_with_claim(100, 1_500));
+    }
+
+    /// #148: a sparse key whose windows mostly miss must NOT replace the catalog.
+    #[test]
+    fn probe_trustworthy_rejects_a_sparse_sample() {
+        assert!(probe_trustworthy(500, 50), "dense: ~10 rows/window");
+        assert!(probe_trustworthy(50, 50), "exactly the floor (1/window)");
+        assert!(
+            !probe_trustworthy(3, 50),
+            "sparse: 3 rows across 50 windows"
+        );
+        assert!(!probe_trustworthy(0, 50), "all windows missed");
+        assert!(!probe_trustworthy(100, 0), "no windows");
     }
 
     #[test]

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -1135,6 +1135,62 @@ mod tests {
         }
     }
 
+    /// #148 (roast 2026-08-09): avg_row_bytes must return None once the density
+    /// probe CORRECTED row_estimate — total_bytes is still frozen, so the ratio
+    /// would mix a corrected numerator with a stale denominator. Kills the
+    /// mod.rs:278 guard mutants (guard->true, &&->||, >->>=).
+    #[test]
+    fn avg_row_bytes_none_when_a_probe_corrected_the_rows() {
+        use crate::init::density::{DensityProbe, EstimateMethod};
+        // Frozen catalog 1000, probe corrected to 148_000; bytes still frozen.
+        let mut t = make_table(148_000, vec![]);
+        t.total_bytes = Some(4_000_000);
+        t.density = Some(DensityProbe {
+            rows: 148_000,
+            density: 3.0,
+            method: EstimateMethod::Probed,
+            catalog_rows: 1000,
+            k: 50,
+            w: 10_000,
+        });
+        assert_eq!(
+            t.avg_row_bytes(),
+            None,
+            "corrected rows + frozen bytes = unknown per-row"
+        );
+
+        // No probe correction (catalog trusted): the ratio is honest.
+        let mut t2 = make_table(1000, vec![]);
+        t2.total_bytes = Some(4_000_000);
+        assert_eq!(t2.avg_row_bytes(), Some(4000));
+        // Zero rows: None (no division).
+        let mut t3 = make_table(0, vec![]);
+        t3.total_bytes = Some(4_000_000);
+        assert_eq!(t3.avg_row_bytes(), None);
+    }
+
+    /// #148 (roast 2026-08-09): mark_mssql_catalog_exact must NOT stamp
+    /// catalog-exact on a 0 (a VIEW or stats-unavailable table yields 0 — a
+    /// documented UNKNOWN). Kills the mod.rs:822 mutants (stub, >->==, >-><, >->>=).
+    #[test]
+    fn mssql_catalog_exact_only_for_a_positive_count() {
+        use crate::init::density::EstimateMethod;
+        let mut base = make_table(500_000, vec![]);
+        mark_mssql_catalog_exact(&mut base);
+        assert_eq!(
+            base.density.as_ref().unwrap().method,
+            EstimateMethod::CatalogExact,
+            "a positive dm_db_partition_stats count IS catalog-exact"
+        );
+        let mut view = make_table(0, vec![]);
+        mark_mssql_catalog_exact(&mut view);
+        assert_eq!(
+            view.density.as_ref().unwrap().method,
+            EstimateMethod::Unverified,
+            "0 from a view / no-stats is UNKNOWN, not an audited exact 0"
+        );
+    }
+
     /// A3/A2 (roast 2026-08-09): where best_cursor_column (name-preference) and
     /// chosen_cursor_column (scored) DIVERGE, every user-facing surface that
     /// names the cursor must name the CHOSEN one — the column actually written as

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -265,8 +265,17 @@ impl TableInfo {
     /// a fast engine's sequential scan. `None` when the size is unknown —
     /// callers then fall back to a row-count-only heuristic.
     pub(crate) fn avg_row_bytes(&self) -> Option<i64> {
+        // #148 (roast 2026-08-09): when the density probe CORRECTED row_estimate
+        // (frozen stats), total_bytes is still the FROZEN figure — the ratio
+        // mixes a corrected numerator with a stale denominator and defeats the
+        // wide-row parallelism guard. A probe re-samples rows, not bytes, so the
+        // per-row size is unknown after a correction; report None.
+        let probe_corrected = matches!(
+            &self.density,
+            Some(p) if p.method == crate::init::density::EstimateMethod::Probed
+        );
         match self.total_bytes {
-            Some(b) if self.row_estimate > 0 => Some(b / self.row_estimate),
+            Some(b) if self.row_estimate > 0 && !probe_corrected => Some(b / self.row_estimate),
             _ => None,
         }
     }
@@ -806,10 +815,19 @@ fn init_yaml(
 /// MSSQL's `dm_db_partition_stats` row counts are near-exact by construction —
 /// no probe needed; the snapshot still SAYS where the number came from (#148).
 fn mark_mssql_catalog_exact(info: &mut TableInfo) {
+    // #148 (roast 2026-08-09): dm_db_partition_stats yields 0 for a VIEW or when
+    // stats are unavailable — a documented UNKNOWN, not an exact count. Stamping
+    // `catalog-exact` on a 0 turns "unknown" into an audited "exactly 0 rows".
+    // Only a positive figure is genuinely catalog-exact; 0 is unverified.
+    let method = if info.row_estimate > 0 {
+        crate::init::density::EstimateMethod::CatalogExact
+    } else {
+        crate::init::density::EstimateMethod::Unverified
+    };
     info.density = Some(crate::init::density::DensityProbe {
         rows: info.row_estimate,
         density: 0.0,
-        method: crate::init::density::EstimateMethod::CatalogExact,
+        method,
         catalog_rows: info.row_estimate,
         k: 0,
         w: 0,

--- a/src/init/mysql.rs
+++ b/src/init/mysql.rs
@@ -223,6 +223,21 @@ pub(super) fn density_probe(conn: &mut mysql::PooledConn, info: &mut super::Tabl
             }
         }
     }
+    // #148 sparse-key guard: if the windows barely sampled any rows the key is
+    // too sparse for a windowed estimate — keep the catalog, flag unverified,
+    // rather than replace a sane figure with ~0 garbage.
+    let sampled: i64 = counts.iter().sum();
+    if !super::density::probe_trustworthy(sampled, offsets.len()) {
+        info.density = Some(DensityProbe {
+            rows: catalog,
+            density: 0.0,
+            method: EstimateMethod::Unverified,
+            catalog_rows: catalog,
+            k: offsets.len(),
+            w: PROBE_W,
+        });
+        return;
+    }
     let (rows, density) = estimate_from_windows(min, max, &counts, PROBE_W);
     info.row_estimate = rows;
     info.density = Some(DensityProbe {

--- a/src/init/postgres.rs
+++ b/src/init/postgres.rs
@@ -178,8 +178,13 @@ pub(super) fn density_probe(client: &mut Client, info: &mut super::TableInfo) {
 
     const PG_PROBE_LINE: i64 = 5_000_000;
     let catalog = info.row_estimate;
-    if catalog < PG_PROBE_LINE {
-        return; // policy: reltuples trusted below the line (density stays None)
+    // #148 (roast 2026-08-09): a never-analyzed table has reltuples -1, clamped
+    // to 0 at introspect — `0 < 5M` would skip the probe and trust 0 on a table
+    // that may hold 100M rows (the just-restored/just-migrated moment users run
+    // init). Probe when the figure is 0/unknown OR large; trust only a REAL
+    // small figure (1..5M) where reltuples is a fresh ANALYZE.
+    if (1..PG_PROBE_LINE).contains(&catalog) {
+        return;
     }
     let Some(key) = info.best_chunk_column().map(str::to_string) else {
         info.density = Some(DensityProbe {
@@ -218,6 +223,19 @@ pub(super) fn density_probe(client: &mut Client, info: &mut super::TableInfo) {
             Ok(r) => counts.push(r.get::<_, i64>(0)),
             Err(_) => return,
         }
+    }
+    let sampled: i64 = counts.iter().sum();
+    if !super::density::probe_trustworthy(sampled, offsets.len()) {
+        // #148 sparse-key guard: too few sampled rows to trust the extrapolation.
+        info.density = Some(DensityProbe {
+            rows: catalog,
+            density: 0.0,
+            method: EstimateMethod::Unverified,
+            catalog_rows: catalog,
+            k: offsets.len(),
+            w: PROBE_W,
+        });
+        return;
     }
     let (rows, density) = estimate_from_windows(min, max, &counts, PROBE_W);
     info.row_estimate = rows;

--- a/tests/live/live_density_probe.rs
+++ b/tests/live/live_density_probe.rs
@@ -91,3 +91,60 @@ fn init_probe_overrules_a_stale_table_rows_on_a_versioned_table() {
         "probe must overrule the stale catalog (catalog={catalog}, true={true_rows}):\n{yaml}"
     );
 }
+
+/// #148 PG leg: a NEVER-ANALYZED table has reltuples -1 (clamped 0) — the gate
+/// now probes it (a 0/unknown catalog on a table that may hold real rows is
+/// exactly when the probe is needed). Fresh table, no ANALYZE, 60_000 rows:
+/// `init` must probe and scaffold `mode: chunked`, not trust the 0 into `full`.
+/// Live-covers the postgres.rs density_probe mutants the offline gate can't.
+#[test]
+#[ignore = "live: requires docker compose up -d postgres"]
+fn pg_density_probe_corrects_a_never_analyzed_table() {
+    require_alive(LiveService::Postgres);
+    let table = unique_name("pg_probe_fresh");
+    let mut c = pg_connect();
+    // Create + bulk-load but DELIBERATELY never ANALYZE → reltuples stays -1.
+    c.batch_execute(&format!(
+        "DROP TABLE IF EXISTS {table};
+         CREATE TABLE {table} (id BIGINT PRIMARY KEY, payload INT NOT NULL);
+         INSERT INTO {table} SELECT g, g FROM generate_series(1, 150000) g;"
+    ))
+    .unwrap();
+    let reltuples: f32 = c
+        .query_one(
+            "SELECT reltuples FROM pg_class WHERE relname = $1",
+            &[&table],
+        )
+        .unwrap()
+        .get(0);
+    assert!(
+        reltuples <= 0.0,
+        "fixture must be un-analyzed (reltuples {reltuples} should be -1/0)"
+    );
+
+    let dir = tempfile::tempdir().unwrap();
+    let out_yaml = dir.path().join("probe.yaml");
+    let out = run_rivet_env(
+        &[
+            "init",
+            "--source",
+            POSTGRES_URL,
+            "--table",
+            &format!("public.{table}"),
+            "-o",
+            out_yaml.to_str().unwrap(),
+        ],
+        &[],
+    );
+    assert!(
+        out.status.success(),
+        "init: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let yaml = std::fs::read_to_string(&out_yaml).unwrap();
+    assert!(
+        yaml.contains("mode: chunked"),
+        "probe must overrule reltuples=-1 on a never-analyzed 150k table:\n{yaml}"
+    );
+    let _ = c.execute(&format!("DROP TABLE IF EXISTS {table}"), &[]);
+}


### PR DESCRIPTION
From the session bughunt (all verified): (1) HIGH sparse-key garbage — a windowed grid over a Snowflake-style key replaced a sane catalog with ~0; new probe_trustworthy guard, RED-proven, wired into MySQL+PG; (2) PG never-analyzed (reltuples -1→0) bypassed the probe and trusted 0; (3) MSSQL stamped catalog-exact on a view/no-stats 0; (4) avg_row_bytes mixed corrected rows with frozen bytes. Deferred (needs index introspection): the probe can still scan an unindexed fallback column — a PK-only guard was wrong for indexed non-PK keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)