### PR TITLE
fix(pool): #166/#167 robustness — panic-hang guard + advisory floor-gate

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -73,5 +73,19 @@ exclude_re = [
     # matters against a real TLS handshake — there is no offline caller, so the
     # `guard -> true`/`-> false` mutant is unkillable HERE by construction. It is
     # live-guarded by the blessed-path `init --tls` + MSSQL connect scenarios.
+    # run_pool (pipeline/run.rs) is the bounded work-stealing pool executor — it
+    # needs a live source, real exports, and spawned worker threads; there is no
+    # offline caller, so a body stub / operator-inversion is unkillable HERE by
+    # construction (the same live-only class as density_probe). Its DECISIONS are
+    # pure and unit-tested + RED-proven: next_eligible (heavy-serialization) and
+    # advise_split (floor+shape gate). The executor glue — the HeavyGuard reset,
+    # the giant-lookup for the advisory log line — is live-guarded by
+    # live_pool_toxiproxy (exact rows + the makespan contract) and
+    # pool_apply_two_heavy_exports_both_complete (the HeavyGuard reset between two
+    # heavies; a stubbed drop / deleted `!` deadlocks the second heavy).
+    "replace run_pool -> Result",
+    "replace == with != in run_pool",
+    "impl Drop for HeavyGuard",
+    "delete ! in run_pool",
     "replace match guard mssql_trusts_cert_without_verify\\(cfg\\) with (true|false) in MssqlSource::connect_with_tls",
 ]

--- a/src/pipeline/pool.rs
+++ b/src/pipeline/pool.rs
@@ -139,6 +139,34 @@ pub(crate) fn split_dominating(items: &[PoolItem], r: f64, max_split: usize) -> 
     out
 }
 
+/// Should `apply --pool` advise splitting a dominating export, and if so into
+/// how many + to what wall? Returns `(name, n, broken_makespan_secs)`.
+///
+/// TWO gates, both required (roast 2026-08-09 caught a shape-only check that
+/// phantom-fired when the giant was NOT the floor):
+/// 1. the export must ACTUALLY be the floor — `longest > total/m` (else total/m
+///    is already the wall and a split buys nothing);
+/// 2. it must dominate by SHAPE — [`split_factor`] (> R× the next-longest).
+pub(crate) fn advise_split(
+    items: &[PoolItem],
+    m: usize,
+    r: f64,
+    max_split: usize,
+) -> Option<(String, usize, f64)> {
+    let mut by: Vec<&PoolItem> = items.iter().collect();
+    by.sort_by(|a, b| b.predicted_secs.total_cmp(&a.predicted_secs));
+    let [longest, second, ..] = by.as_slice() else {
+        return None;
+    };
+    let total: f64 = items.iter().map(|i| i.predicted_secs).sum();
+    if longest.predicted_secs <= total / m.max(1) as f64 {
+        return None; // total/m is the wall, not the giant — no split needed
+    }
+    let n = split_factor(longest.predicted_secs, second.predicted_secs, r, max_split)?;
+    let broken = predicted_makespan_secs(&split_dominating(items, r, max_split), m);
+    Some((longest.name.clone(), n, broken))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -201,6 +229,33 @@ mod tests {
             "the split MUST break the floor: {split_wall} < {unsplit_wall}"
         );
         assert_eq!(split_wall, 810.0, "reaches total/6 = 4860/6");
+    }
+
+    /// #167 advisory floor-gate (roast 2026-08-09): advise a split ONLY when the
+    /// giant is actually the floor. A 200s "giant" with 20×60s (total 1400, m=2 →
+    /// floor 700) must NOT advise — total/m is the wall, splitting buys nothing.
+    #[test]
+    fn advise_split_needs_the_giant_to_be_the_floor() {
+        // Giant IS the floor: 3060s + 30×60s, m=6 → floor 3060.
+        let mut dominating = vec![it("giant", 3060.0)];
+        for n in 0..30 {
+            dominating.push(it(&format!("s{n:02}"), 60.0));
+        }
+        let advice = advise_split(&dominating, 6, 3.0, 6);
+        assert!(advice.is_some(), "a real giant must be advised");
+        let (name, n, broken) = advice.unwrap();
+        assert_eq!(name, "giant");
+        assert!(n >= 2 && broken < 3060.0, "the split must drop the wall");
+
+        // Giant is NOT the floor: 200s + 20×60s, m=2 → floor max(200,700)=700.
+        let mut balanced = vec![it("tall", 200.0)];
+        for n in 0..20 {
+            balanced.push(it(&format!("s{n:02}"), 60.0));
+        }
+        assert!(
+            advise_split(&balanced, 2, 3.0, 2).is_none(),
+            "no advice when total/m is the wall — a split would be a false alarm"
+        );
     }
 
     #[test]

--- a/src/pipeline/run.rs
+++ b/src/pipeline/run.rs
@@ -834,30 +834,22 @@ pub(crate) fn run_pool(config_path: &str, force: bool, resume: bool, m: usize) -
     // (separate scheduler units with separate write legs), and the wall it would
     // reach. Shape-driven (M-free) via the pure planner; a warn, not info, so it
     // is visible at the default level exactly where a 51-min giant pins a refresh.
-    {
-        let mut by_secs: Vec<&super::pool::PoolItem> = items.iter().collect();
-        by_secs.sort_by(|a, b| b.predicted_secs.total_cmp(&a.predicted_secs));
-        if let [longest, second, ..] = by_secs.as_slice()
-            && let Some(n) = super::pool::split_factor(
-                longest.predicted_secs,
-                second.predicted_secs,
-                3.0,
-                m.max(2),
-            )
-        {
-            let split = super::pool::split_dominating(&items, 3.0, m.max(2));
-            let broken = super::pool::predicted_makespan_secs(&split, m);
-            log::warn!(
-                "apply --pool: export '{}' (~{:.1} min) dominates the pool floor — extra slots \
-                 cannot beat it. Split it into {} range sub-exports over its key (each a separate \
-                 scheduler unit with its own write leg) to drop the wall to ~{:.1} min. Give it a \
-                 `chunk_by_key:` and run each key range as its own export.",
-                longest.name,
-                longest.predicted_secs / 60.0,
-                n,
-                broken / 60.0,
-            );
-        }
+    if let Some((giant, n, broken)) = super::pool::advise_split(&items, m, 3.0, m.max(2)) {
+        let giant_secs = items
+            .iter()
+            .find(|i| i.name == giant)
+            .map(|i| i.predicted_secs)
+            .unwrap_or(0.0);
+        log::warn!(
+            "apply --pool: export '{}' (~{:.1} min) dominates the pool floor — extra slots cannot \
+             beat it. Split it into {} range sub-exports over its key (each a separate scheduler \
+             unit with its own write leg) to drop the wall to ~{:.1} min. Give it a `chunk_by_key:` \
+             and run each key range as its own export.",
+            giant,
+            giant_secs / 60.0,
+            n,
+            broken / 60.0,
+        );
     }
 
     let by_name: std::collections::HashMap<&str, &ExportConfig> =
@@ -919,6 +911,21 @@ pub(crate) fn run_pool(config_path: &str, force: bool, resume: bool, m: usize) -
                             }
                         }
                     };
+                    // Release the heavy slot on EVERY exit path — including a
+                    // PANIC inside run_export_job. Without the guard a panicking
+                    // heavy leaked heavy_running=true and every other worker
+                    // looped forever on next_eligible (only heavies left, one
+                    // "running") — the pool hung instead of failing (roast
+                    // 2026-08-09). The guard drops on normal end AND on unwind.
+                    struct HeavyGuard<'a>(&'a std::sync::atomic::AtomicBool, bool);
+                    impl Drop for HeavyGuard<'_> {
+                        fn drop(&mut self) {
+                            if self.1 {
+                                self.0.store(false, AtomicOrdering::SeqCst);
+                            }
+                        }
+                    }
+                    let _heavy = HeavyGuard(&heavy_running, !is_parallel_safe(export));
                     let pair = match StateStore::open(config_path) {
                         Ok(st) => job::run_export_job(
                             config_path,
@@ -938,9 +945,6 @@ pub(crate) fn run_pool(config_path: &str, force: bool, resume: bool, m: usize) -
                             (Err(err), summary)
                         }
                     };
-                    if !is_parallel_safe(export) {
-                        heavy_running.store(false, AtomicOrdering::SeqCst);
-                    }
                     collected.lock().unwrap().push(pair);
                 }
             });

--- a/tests/live/live_pool_toxiproxy.rs
+++ b/tests/live/live_pool_toxiproxy.rs
@@ -140,3 +140,45 @@ fn pool_apply_resume_skips_complete_exports_and_loses_nothing() {
         5000
     );
 }
+
+/// #166 HeavyGuard reset (roast 2026-08-09): two NON-parallel_safe (heavy)
+/// exports must BOTH complete through --pool 2 — the second can only be claimed
+/// after the first releases heavy_running. A stubbed HeavyGuard::drop or a
+/// deleted `!is_parallel_safe` never resets the flag, so the second heavy is
+/// never eligible and the run deadlocks (caught here by the union row count,
+/// under the test's own wall-clock; the pool has no internal timeout).
+#[test]
+#[ignore = "live: requires docker compose up -d postgres"]
+fn pool_apply_two_heavy_exports_both_complete() {
+    let _lock = toxiproxy_guard();
+    ensure_toxi_proxy("postgres", 15432, "postgres:5432");
+    toxi_reset_toxics("postgres");
+
+    // Two heavy exports (parallel_safe ABSENT → heavy): they must serialize with
+    // each other yet both finish. If HeavyGuard never resets, the 2nd starves.
+    let rig = Rig::pg_batch("pool_h1")
+        .source_url(POSTGRES_TOXI_URL)
+        .query("SELECT g AS id, md5(g::text) AS p FROM generate_series(1, 8000) g")
+        .also_export(
+            "pool_h2",
+            "SELECT g AS id, md5(g::text) AS p FROM generate_series(1, 6000) g",
+        );
+    let cfg = rig.config_path();
+    let out = run_rivet_env(&["apply", cfg.to_str().unwrap(), "--pool", "2"], &[]);
+    assert!(
+        out.status.success(),
+        "both heavy exports must complete (a leaked heavy_running deadlocks #2):\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        duckdb_total_parquet_rows(&rig.out_dir()) as i64,
+        8000,
+        "heavy #1"
+    );
+    assert_eq!(
+        duckdb_total_parquet_rows(&rig.out_dir_for("pool_h2")) as i64,
+        6000,
+        "heavy #2 must not starve behind the first"
+    );
+    toxi_reset_toxics("postgres");
+}


### PR DESCRIPTION
Two confirmed bugs: (1) a panic inside a heavy export leaked heavy_running=true and hung the pool forever — RAII HeavyGuard resets on unwind; (2) the #167 split advisory phantom-fired when the giant wasn't the floor — pool::advise_split now gates on both floor and shape, RED-proven. Deferred: makespan model is heavy-serialization-blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)