### PR TITLE
fix(apply): parallel-UX hardening — heartbeat-before-renderer + full alnum class mask (#153)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -112,5 +112,13 @@ exclude_re = [
     # observably from the `||` form — the guard is a skip-redundant-work
     # optimization, and the mutant is equivalent by construction.
     "replace && with || in overlay_measured_rows",
+    # run_exports_as_child_processes SPAWNS child `rivet run` processes and drives
+    # the IPC card UI — it has no offline caller, so a body stub is unkillable
+    # HERE by construction (the live-only class, cf. run_pool / density_probe). Its
+    # pure decision — the common-mode representative-error class key — is extracted
+    # into `representative_error` (unit-tested + RED-proven, incl. random-alnum
+    # collapse), and the heartbeat + card flow are live-guarded by
+    # live_parallel_ux (common-mode banner + heartbeat) and the parallel-cards GIF.
+    "replace run_exports_as_child_processes ->",
     "replace match guard mssql_trusts_cert_without_verify\\(cfg\\) with (true|false) in MssqlSource::connect_with_tls",
 ]

--- a/src/pipeline/parallel_children.rs
+++ b/src/pipeline/parallel_children.rs
@@ -79,6 +79,18 @@ pub(super) fn run_exports_as_child_processes(
 
     let (tx, rx) = mpsc::channel::<UiMessage>();
 
+    // #153 heartbeat: silence between spawn and the first child event is
+    // indistinguishable from a hang (the field: ~2.5 min blank terminal). Emit it
+    // BEFORE the UI thread starts drawing — a raw eprintln AFTER the renderer is
+    // live races its cursor and corrupts the card table in a TTY (roast
+    // 2026-08-09). Printed here, it scrolls above the cards the renderer then
+    // owns. Uses the intended count (exports.len()); per-child spawn failures
+    // surface as their own ✗ cards.
+    eprintln!(
+        "  … starting {} export process(es); waiting for the first child event",
+        exports.len()
+    );
+
     // `name_floor` (wave-wide max, from the caller) seeds the card table's name
     // column so it aligns from the first redraw and across batches.
     let n_cards = exports.len();
@@ -225,14 +237,6 @@ pub(super) fn run_exports_as_child_processes(
             }
         }
     }
-
-    // #153 heartbeat: silence between spawn and the first child event is
-    // indistinguishable from a hang (the field: ~2.5 min blank terminal). Emit
-    // an immediate parent-side line so silence reads as idle-by-design.
-    eprintln!(
-        "  … spawned {} export process(es); waiting for the first child event",
-        children.len()
-    );
 
     let mut failures = Vec::new();
     let mut wait_failures: HashMap<String, String> = HashMap::new();
@@ -381,19 +385,38 @@ pub(super) fn representative_error(
     }
     // Collapse each RUN of digits to one '#' (so host-1 and host-10 are one
     // class, not two) and normalize whitespace.
+    // Mask the VARIABLE tokens so per-child ids collapse to one class. A pure
+    // digit run → `#` (host-1 / host-10 are one class); a run mixing letters AND
+    // digits → `#` whole (a hex id, uuid, or random staging suffix like
+    // `aB3xQ9k` — digit-masking alone left `aB#xQ#k`, still per-child distinct,
+    // so the common-mode banner never fired: roast 2026-08-09, the doc claimed
+    // "hex/paths blanked" but only digits were). A pure-letter run (a real word)
+    // is kept. Whitespace normalized.
     let class_of = |msg: &str| -> String {
-        let mut out = String::with_capacity(msg.len());
-        let mut prev_digit = false;
-        for c in msg.chars() {
-            if c.is_ascii_digit() {
-                if !prev_digit {
-                    out.push('#');
-                }
-                prev_digit = true;
+        let mask_token = |tok: &str| -> String {
+            let has_digit = tok.chars().any(|c| c.is_ascii_digit());
+            let has_alpha = tok.chars().any(|c| c.is_ascii_alphabetic());
+            if has_digit && (has_alpha || tok.chars().all(|c| c.is_ascii_digit())) {
+                "#".to_string()
             } else {
-                out.push(c);
-                prev_digit = false;
+                tok.to_string()
             }
+        };
+        let mut out = String::with_capacity(msg.len());
+        let mut run = String::new();
+        for c in msg.chars() {
+            if c.is_ascii_alphanumeric() {
+                run.push(c);
+            } else {
+                if !run.is_empty() {
+                    out.push_str(&mask_token(&run));
+                    run.clear();
+                }
+                out.push(c);
+            }
+        }
+        if !run.is_empty() {
+            out.push_str(&mask_token(&run));
         }
         out.split_whitespace().collect::<Vec<_>>().join(" ")
     };
@@ -788,6 +811,31 @@ mod representative_tests {
             representative_error(&many, true, 3).is_none(),
             "a batch with a success is not a common-mode failure"
         );
+    }
+
+    /// #153 D2 (roast 2026-08-09): a per-child RANDOM ALPHANUMERIC token (a
+    /// staging-dir suffix, a hex id) must not defeat the common-mode banner —
+    /// the class key must collapse mixed alnum runs whole, not just digit runs.
+    /// RED against the digit-only class_of (which left aB#xQ#k per-child distinct).
+    #[test]
+    fn representative_collapses_random_alphanumeric_suffixes() {
+        let failed: Vec<(String, String)> = (0..40)
+            .map(|i| {
+                // e.g. aB3xQ9k — LETTERS differ per child (not just digits), so
+                // digit-masking alone leaves distinct classes; only whole-run
+                // masking collapses them.
+                let a = (b'a' + (i % 20) as u8) as char;
+                let b = (b'A' + ((i * 3) % 20) as u8) as char;
+                let suffix = format!("{a}{i}x{b}{}k", i * 7 + 3);
+                (
+                    format!("child{i}"),
+                    format!("Error: could not create staging dir /tmp/rivet-stage-{suffix}: Permission denied (os error 13)"),
+                )
+            })
+            .collect();
+        let banner = representative_error(&failed, false, 3)
+            .expect("random suffixes must still collapse to ONE common-mode class");
+        assert!(banner.contains("40 children failed"), "{banner}");
     }
 
     #[test]

--- a/src/pipeline/parallel_children.rs
+++ b/src/pipeline/parallel_children.rs
@@ -375,6 +375,42 @@ pub(super) fn run_exports_as_child_processes(
 /// is not a common-mode failure). Class key = the message with digits/hex/paths
 /// blanked, so `token for host-1` and `token for host-2` collapse to one class.
 /// Returns `None` below the threshold or on a mixed/empty batch.
+/// The class KEY of one error message — variable tokens masked so per-child ids
+/// collapse to one common-mode class. A pure DIGIT run → `#` (host-1 / host-10
+/// are one class); a run mixing letters AND digits → `#` whole (a hex id, uuid,
+/// or random staging suffix like `aB3xQ9k` — digit-masking alone left `aB#xQ#k`,
+/// still per-child distinct, so the banner never fired: roast 2026-08-09). A
+/// pure-letter run (a real word) is KEPT. Whitespace normalized. Pure +
+/// directly unit-tested with exact expected strings.
+pub(super) fn error_class(msg: &str) -> String {
+    let mask_token = |tok: &str| -> String {
+        let has_digit = tok.chars().any(|c| c.is_ascii_digit());
+        let has_alpha = tok.chars().any(|c| c.is_ascii_alphabetic());
+        if has_digit && (has_alpha || tok.chars().all(|c| c.is_ascii_digit())) {
+            "#".to_string()
+        } else {
+            tok.to_string()
+        }
+    };
+    let mut out = String::with_capacity(msg.len());
+    let mut run = String::new();
+    for c in msg.chars() {
+        if c.is_ascii_alphanumeric() {
+            run.push(c);
+        } else {
+            if !run.is_empty() {
+                out.push_str(&mask_token(&run));
+                run.clear();
+            }
+            out.push(c);
+        }
+    }
+    if !run.is_empty() {
+        out.push_str(&mask_token(&run));
+    }
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
 pub(super) fn representative_error(
     failed: &[(String, String)],
     any_success: bool,
@@ -383,43 +419,6 @@ pub(super) fn representative_error(
     if any_success || failed.len() < threshold {
         return None;
     }
-    // Collapse each RUN of digits to one '#' (so host-1 and host-10 are one
-    // class, not two) and normalize whitespace.
-    // Mask the VARIABLE tokens so per-child ids collapse to one class. A pure
-    // digit run → `#` (host-1 / host-10 are one class); a run mixing letters AND
-    // digits → `#` whole (a hex id, uuid, or random staging suffix like
-    // `aB3xQ9k` — digit-masking alone left `aB#xQ#k`, still per-child distinct,
-    // so the common-mode banner never fired: roast 2026-08-09, the doc claimed
-    // "hex/paths blanked" but only digits were). A pure-letter run (a real word)
-    // is kept. Whitespace normalized.
-    let class_of = |msg: &str| -> String {
-        let mask_token = |tok: &str| -> String {
-            let has_digit = tok.chars().any(|c| c.is_ascii_digit());
-            let has_alpha = tok.chars().any(|c| c.is_ascii_alphabetic());
-            if has_digit && (has_alpha || tok.chars().all(|c| c.is_ascii_digit())) {
-                "#".to_string()
-            } else {
-                tok.to_string()
-            }
-        };
-        let mut out = String::with_capacity(msg.len());
-        let mut run = String::new();
-        for c in msg.chars() {
-            if c.is_ascii_alphanumeric() {
-                run.push(c);
-            } else {
-                if !run.is_empty() {
-                    out.push_str(&mask_token(&run));
-                    run.clear();
-                }
-                out.push(c);
-            }
-        }
-        if !run.is_empty() {
-            out.push_str(&mask_token(&run));
-        }
-        out.split_whitespace().collect::<Vec<_>>().join(" ")
-    };
     let mut counts: std::collections::HashMap<String, (usize, String)> =
         std::collections::HashMap::new();
     for (_, msg) in failed {
@@ -427,7 +426,7 @@ pub(super) fn representative_error(
         if m.is_empty() {
             continue;
         }
-        let e = counts.entry(class_of(m)).or_insert((0, m.to_string()));
+        let e = counts.entry(error_class(m)).or_insert((0, m.to_string()));
         e.0 += 1;
     }
     let (n, sample) = counts.into_values().max_by_key(|(n, _)| *n)?;
@@ -777,7 +776,33 @@ mod tests {
 
 #[cfg(test)]
 mod representative_tests {
-    use super::representative_error;
+    use super::{error_class, representative_error};
+
+    /// #197 (roast 2026-08-09): direct exact-string coverage of error_class, the
+    /// pure class-key masker. Each assertion pins a mutant the banner-level tests
+    /// couldn\'t (over-masking still collapses to one class): pure-letter words
+    /// KEPT (399 `&&`→`||` would mask them), the trailing run flushed (418
+    /// `delete !` would drop the last token), mid-token runs flushed at
+    /// separators (411 `delete !` would fuse tokens).
+    #[test]
+    fn error_class_masks_variable_tokens_exactly() {
+        // digit run → #; host-1 / host-10 are one class.
+        assert_eq!(error_class("token for host-42"), "token for host-#");
+        // mixed alnum (random suffix / hex) → whole run to #.
+        assert_eq!(
+            error_class("dir /tmp/rivet-stage-aB3xQ9k: denied"),
+            "dir /tmp/rivet-stage-#: denied"
+        );
+        // pure-letter words are KEPT (399 `&&`→`||` masks them → RED).
+        assert_eq!(error_class("plain words only"), "plain words only");
+        // trailing alnum run (no trailing separator) is flushed (418 `!` → RED,
+        // it would drop "here").
+        assert_eq!(error_class("ends here"), "ends here");
+        // mid runs flush at each separator (411 `!` → RED, it would fuse to "ab").
+        assert_eq!(error_class("a b"), "a b");
+        // whitespace normalized.
+        assert_eq!(error_class("two   spaces"), "two spaces");
+    }
 
     #[test]
     fn representative_collapses_a_common_mode_failure() {


### PR DESCRIPTION
Two confirmed bughunt findings: D1 heartbeat raced the TTY card-renderer (moved before the UI thread spawns); D2 class_of masked only digit runs so per-child random alphanumeric ids defeated the common-mode banner (now masks mixed alnum runs whole, RED-proven). Live parallel-ux + common-mode tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)