### PR TITLE
fix(preflight): #149 A2 — recompute verdict/profile from measured estimate

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -97,5 +97,20 @@ exclude_re = [
     "replace == with != in run_pool",
     "impl Drop for HeavyGuard",
     "delete ! in run_pool",
+    # `check` (preflight/mod.rs) connects to the source and diagnoses every
+    # export — no offline caller, so its body stub / the `==` in the overlay
+    # export-match loop are unkillable HERE (live-only). It is live-guarded by
+    # audit_preflight_table + the check scenarios (cli/blessed-flow). The overlay
+    # DECISIONS are unit-tested in overlay_measured_rows.
+    "replace check -> Result<bool> with Ok",
+    "replace == with != in check",
+    # overlay_measured_rows: `est != before && est.is_some()` guards a RECOMPUTE
+    # that is IDEMPOTENT when the estimate is unchanged (recomputing verdict/
+    # profile from the same number yields the same values). `est` is None only
+    # when `before` is also None (choose_row_estimate returns the catalog when
+    # there is no measure), so `est != before && est.is_some()` never differs
+    # observably from the `||` form — the guard is a skip-redundant-work
+    # optimization, and the mutant is equivalent by construction.
+    "replace && with || in overlay_measured_rows",
     "replace match guard mssql_trusts_cert_without_verify\\(cfg\\) with (true|false) in MssqlSource::connect_with_tls",
 ]

--- a/src/pipeline/plan_cmd.rs
+++ b/src/pipeline/plan_cmd.rs
@@ -311,7 +311,7 @@ fn build_plan_artifact(
         Ok(mut diag) => {
             // #149: measured beats declared — same overlay `check` applies, so
             // the two surfaces quote the same figure with the same label.
-            crate::preflight::overlay_measured_rows(&mut diag, state);
+            crate::preflight::overlay_measured_rows(&mut diag, export, state);
             // The plan artifact's warnings stay flat strings (severity tags are a
             // `rivet check` surface); take each warning's message text.
             let mut warnings: Vec<String> =

--- a/src/preflight/analysis.rs
+++ b/src/preflight/analysis.rs
@@ -132,6 +132,7 @@ pub(crate) fn choose_row_estimate(
 /// cannot drift (#149). Best-effort: an unreadable store keeps the catalog.
 pub(crate) fn overlay_measured_rows(
     diag: &mut super::ExportDiagnostic,
+    export: &ExportConfig,
     state: &crate::state::StateStore,
 ) {
     // A measured `total_rows` is the TABLE SIZE only when the run read the whole
@@ -157,9 +158,30 @@ pub(crate) fn overlay_measured_rows(
                         .map(|t| (m.total_rows, t.with_timezone(&chrono::Utc)))
                 })
         });
+    let before = diag.row_estimate;
     let (est, label) = choose_row_estimate(diag.row_estimate, measured, chrono::Utc::now());
     diag.row_estimate = est;
     diag.row_source = Some(label);
+
+    // A2 (roast 2026-08-09): the engine diagnostics already computed verdict /
+    // profile / parallelism / suggestion from the CATALOG estimate, so before
+    // this the report printed a MEASURED number above decisions made for the
+    // catalog one (a 2.5× field lie ⇒ wrong profile/parallelism). When the
+    // overlay actually MOVED the estimate, recompute the row-estimate-scaled
+    // decisions from the truth. These depend only on fields the diagnostic
+    // already carries (uses_index, avg_row_bytes) + the export.
+    if est != before && est.is_some() {
+        diag.verdict = compute_verdict(
+            est,
+            diag.uses_index,
+            export.cursor_column.is_some(),
+            diag.avg_row_bytes,
+            export.parallel,
+        );
+        diag.recommended_profile = recommend_profile(est, diag.uses_index, export);
+        diag.recommended_parallel = recommend_parallelism(export, est, diag.uses_index);
+        diag.suggestion = build_suggestion(&diag.verdict, est, diag.uses_index, export);
+    }
 }
 
 /// Does this diagnostic's mode read the WHOLE table every run (so a measured
@@ -926,8 +948,17 @@ mod tests {
             recommended_parallel: (1, "test"),
             suggestion: None,
         };
-        overlay_measured_rows(&mut diag, &state);
+        let export = cfg("table: t\nmode: chunked\nchunk_column: id\nchunk_size: 100000\n");
+        // Seed a profile as if computed from the CATALOG (small) estimate.
+        diag.recommended_profile = "fast";
+        overlay_measured_rows(&mut diag, &export, &state);
         assert_eq!(diag.row_estimate, Some(835_700_000), "measured must win");
+        // A2: the profile must be RECOMPUTED from the measured 835M (a huge table
+        // is not "fast") — before the fix it kept the catalog-derived value.
+        assert_ne!(
+            diag.recommended_profile, "fast",
+            "verdict/profile must be recomputed from the measured estimate, not the catalog one"
+        );
         assert!(
             diag.row_source
                 .as_deref()
@@ -978,7 +1009,8 @@ mod tests {
             recommended_parallel: (1, "test"),
             suggestion: None,
         };
-        overlay_measured_rows(&mut diag, &state);
+        let export = cfg("table: t\nmode: incremental\ncursor_column: updated_at\n");
+        overlay_measured_rows(&mut diag, &export, &state);
         assert_eq!(
             diag.row_estimate,
             Some(300_000_000),

--- a/src/preflight/mod.rs
+++ b/src/preflight/mod.rs
@@ -321,7 +321,9 @@ pub fn check(
     let mut diagnostics = diagnostics;
     if let Ok(state) = crate::state::StateStore::open(config_path) {
         for d in &mut diagnostics {
-            analysis::overlay_measured_rows(d, &state);
+            if let Some(e) = exports.iter().find(|e| e.name == d.export_name) {
+                analysis::overlay_measured_rows(d, e, &state);
+            }
         }
     }
     if !json_output {


### PR DESCRIPTION
The overlay printed the measured number but verdict/profile/parallelism/suggestion still stood on the catalog figure (835M shown above decisions made for 332M). overlay_measured_rows now recomputes those four row-estimate-scaled decisions when the overlay moves the estimate. RED-proven (profile no longer catalog-derived 'fast' after an 835M overlay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)