### PR TITLE
fix: 5 confirmed findings from the fix-PR bughunt (roast 2026-08-10)

### DIFF
--- a/dev/release_oracle/blessed_flow.py
+++ b/dev/release_oracle/blessed_flow.py
@@ -361,6 +361,16 @@ def _verify_surface(led: Ledger, cell: Cell, tag: str, stage: str, p) -> None:
     pipes = _SURFACE_PIPELINES.get(stage)
     if pipes is not None and cell.pipeline not in pipes:
         return
+    # The `check` cell rotates `--json` on some cells (see _flags_for), which
+    # SUPPRESSES the entire human verdict block (preflight/mod.rs gates it behind
+    # `if !json_output`) and emits lowercase JSON keys instead. The human-surface
+    # substrings (Strategy:/Row estimate:/Verdict:) legitimately do not appear
+    # there, so this contract only applies to the HUMAN rendering — skip it when
+    # the stage ran under --json (roast 2026-08-10: the contract failed every
+    # --json check cell, an own-goal in #195). The JSON surface has its own
+    # golden shape and is not what this operator-readability check is about.
+    if "--json" in cell.flags.get(stage, []):
+        return
     missing = [
         f"{stream}:{sub!r}"
         for stream, sub in reqs

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -270,9 +270,20 @@ impl TableInfo {
         // mixes a corrected numerator with a stale denominator and defeats the
         // wide-row parallelism guard. A probe re-samples rows, not bytes, so the
         // per-row size is unknown after a correction; report None.
+        // Any method that REPLACED row_estimate from a live re-count (Probed or
+        // Counted) leaves total_bytes on the FROZEN catalog figure — the ratio
+        // mixes a corrected numerator with a stale denominator either way (roast
+        // 2026-08-10: the Probed-only guard left the keyless Counted path exposed,
+        // and frozen TABLE_ROWS/DATA_LENGTH freeze together, the guard's own
+        // premise). CatalogTriaged/CatalogExact/Unverified keep row_estimate, so
+        // the ratio is honest there.
         let probe_corrected = matches!(
             &self.density,
-            Some(p) if p.method == crate::init::density::EstimateMethod::Probed
+            Some(p) if matches!(
+                p.method,
+                crate::init::density::EstimateMethod::Probed
+                    | crate::init::density::EstimateMethod::Counted
+            )
         );
         match self.total_bytes {
             Some(b) if self.row_estimate > 0 && !probe_corrected => Some(b / self.row_estimate),

--- a/src/pipeline/keyset.rs
+++ b/src/pipeline/keyset.rs
@@ -786,6 +786,17 @@ fn run_keyset_parallel(
     }
     summary.total_rows += rows.into_inner();
 
+    // #152 (roast 2026-08-10): drain the governor's decisions into the journal
+    // BEFORE the error bail — the failure path is EXACTLY where the back-off
+    // forensics matter (was the source under pressure when it failed?). Draining
+    // after the bail lost every ParallelismAdjusted event on a failed run, unlike
+    // chunked/exec.rs which drains before its error check.
+    for (from, to, reason) in governor_log.into_inner().unwrap() {
+        summary
+            .journal
+            .record(crate::journal::RunEvent::ParallelismAdjusted { from, to, reason });
+    }
+
     if !errs.is_empty() {
         anyhow::bail!(
             "export '{}': parallel keyset failed on {} range(s): {}",
@@ -802,13 +813,6 @@ fn run_keyset_parallel(
     }
     if let Some(sc) = fingerprint.get() {
         manifest_writer::record_run_schema_fingerprint(summary, sc);
-    }
-    // #152: drain the governor's off-thread decisions into the run journal
-    // (same as chunked) so a keyset run records when it shed/recovered workers.
-    for (from, to, reason) in governor_log.into_inner().unwrap() {
-        summary
-            .journal
-            .record(crate::journal::RunEvent::ParallelismAdjusted { from, to, reason });
     }
     // cursor_high = the highest populated range's max (forensics v18); see range_max.
     summary.cursor_high = highest_range_max(range_max.into_inner().unwrap());

--- a/src/pipeline/pool.rs
+++ b/src/pipeline/pool.rs
@@ -188,8 +188,21 @@ pub(crate) fn advise_split(
     if longest.predicted_secs <= total / m.max(1) as f64 {
         return None; // total/m is the wall, not the giant — no split needed
     }
+    // The giant must be parallel_safe for a split to help: its range sub-exports
+    // inherit its heavy flag (split_dominating), so splitting a HEAVY giant just
+    // makes N heavy units that STILL serialize — the heavy-serialization floor
+    // (C3) is unchanged and the advice is a false promise (roast 2026-08-10: on
+    // the DEFAULT all-heavy config the advisory fired but the wall never moved).
+    if !longest.parallel_safe {
+        return None;
+    }
     let n = split_factor(longest.predicted_secs, second.predicted_secs, r, max_split)?;
     let broken = predicted_makespan_secs(&split_dominating(items, r, max_split), m);
+    // Only advise when the split ACTUALLY lowers the wall — never promise an
+    // improvement the model itself does not predict.
+    if broken >= predicted_makespan_secs(items, m) {
+        return None;
+    }
     Some((longest.name.clone(), n, broken))
 }
 
@@ -341,6 +354,19 @@ mod tests {
         assert!(
             advise_split(&balanced, 2, 3.0, 2).is_none(),
             "no advice when total/m is the wall — a split would be a false alarm"
+        );
+
+        // #4 (roast 2026-08-10): a HEAVY giant (the DEFAULT — parallel_safe unset)
+        // must NOT be advised: its range sub-exports inherit the heavy flag and
+        // STILL serialize (C3 floor unchanged), so the split promises a gain the
+        // model does not deliver. RED against advising a non-parallel_safe giant.
+        let mut all_heavy = vec![heavy("giant", 3060.0)];
+        for n in 0..30 {
+            all_heavy.push(heavy(&format!("s{n:02}"), 60.0));
+        }
+        assert!(
+            advise_split(&all_heavy, 6, 3.0, 6).is_none(),
+            "a heavy giant's split does not lower the wall (heavies serialize) — no advice"
         );
     }
 

--- a/src/preflight/analysis.rs
+++ b/src/preflight/analysis.rs
@@ -180,7 +180,15 @@ pub(crate) fn overlay_measured_rows(
         );
         diag.recommended_profile = recommend_profile(est, diag.uses_index, export);
         diag.recommended_parallel = recommend_parallelism(export, est, diag.uses_index);
-        diag.suggestion = build_suggestion(&diag.verdict, est, diag.uses_index, export);
+        // Only recompute the suggestion for engines that HAD one. diagnose_mongo
+        // deliberately emits `suggestion: None` (Mongo is full-only — the
+        // cursor/incremental advice build_suggestion produces is for a mode it
+        // cannot do), and it is the sole engine that never calls build_suggestion.
+        // Recomputing unconditionally re-introduced that SQL-only advice for Mongo
+        // (roast 2026-08-10). Keep None as None.
+        if diag.suggestion.is_some() {
+            diag.suggestion = build_suggestion(&diag.verdict, est, diag.uses_index, export);
+        }
     }
 }
 
@@ -966,6 +974,52 @@ mod tests {
                 .starts_with("measured "),
             "the report must SAY it stands on the measurement: {:?}",
             diag.row_source
+        );
+    }
+
+    /// #1 (roast 2026-08-10): Mongo emits suggestion: None (full-only — the
+    /// cursor/incremental advice does not apply). The overlay recompute must NOT
+    /// re-introduce it. RED against the unconditional build_suggestion recompute.
+    #[test]
+    fn overlay_keeps_a_none_suggestion_none_for_mongo() {
+        let state = crate::state::StateStore::open_in_memory().unwrap();
+        state
+            .record_metric_full(&crate::state::MetricRow {
+                export_name: "mongo_coll".into(),
+                run_id: "r1".into(),
+                total_rows: 12_000_000,
+                status: "success".into(),
+                ..Default::default()
+            })
+            .unwrap();
+        let mut diag = super::super::ExportDiagnostic {
+            export_name: "mongo_coll".into(),
+            strategy: "full".into(),
+            mode: "full".into(),
+            cursor_column: None,
+            row_estimate: Some(5_000_000),
+            row_source: None,
+            avg_row_bytes: None,
+            cursor_min: None,
+            cursor_max: None,
+            scan_type: None,
+            uses_index: false,
+            verdict: super::super::HealthVerdict::Degraded,
+            warnings: Vec::new(),
+            recommended_profile: "safe",
+            recommended_parallel: (1, "test"),
+            suggestion: None,
+        };
+        let export = cfg("table: coll\nmode: full\n");
+        overlay_measured_rows(&mut diag, &export, &state);
+        assert_eq!(
+            diag.row_estimate,
+            Some(12_000_000),
+            "measured overlay applied"
+        );
+        assert_eq!(
+            diag.suggestion, None,
+            "a None suggestion (Mongo) must stay None through the recompute"
         );
     }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -610,25 +610,25 @@ const PG_MIGRATIONS: &[(i64, &str)] = &[
     // Additive + nullable; BOOLEAN for the bool flags, BIGINT for counts.
     (
         9,
-        "ALTER TABLE export_metrics ADD COLUMN files_committed BIGINT;
-        ALTER TABLE export_metrics ADD COLUMN reconciled BOOLEAN;
-        ALTER TABLE export_metrics ADD COLUMN source_count BIGINT;
-        ALTER TABLE export_metrics ADD COLUMN quality_passed BOOLEAN;
-        ALTER TABLE export_metrics ADD COLUMN pg_temp_bytes_delta BIGINT;
-        ALTER TABLE export_metrics ADD COLUMN batch_size BIGINT;
-        ALTER TABLE export_metrics ADD COLUMN batch_size_memory_mb BIGINT;
-        ALTER TABLE export_metrics ADD COLUMN skip_reason TEXT;
-        ALTER TABLE export_metrics ADD COLUMN schema_fingerprint TEXT;
-        ALTER TABLE export_metrics ADD COLUMN chunk_size BIGINT;
-        ALTER TABLE export_metrics ADD COLUMN parallel BIGINT;
-        ALTER TABLE export_metrics ADD COLUMN source_type TEXT;
-        ALTER TABLE export_metrics ADD COLUMN destination_type TEXT;
-        ALTER TABLE export_metrics ADD COLUMN rivet_version TEXT;",
+        "ALTER TABLE export_metrics ADD COLUMN IF NOT EXISTS files_committed BIGINT;
+        ALTER TABLE export_metrics ADD COLUMN IF NOT EXISTS reconciled BOOLEAN;
+        ALTER TABLE export_metrics ADD COLUMN IF NOT EXISTS source_count BIGINT;
+        ALTER TABLE export_metrics ADD COLUMN IF NOT EXISTS quality_passed BOOLEAN;
+        ALTER TABLE export_metrics ADD COLUMN IF NOT EXISTS pg_temp_bytes_delta BIGINT;
+        ALTER TABLE export_metrics ADD COLUMN IF NOT EXISTS batch_size BIGINT;
+        ALTER TABLE export_metrics ADD COLUMN IF NOT EXISTS batch_size_memory_mb BIGINT;
+        ALTER TABLE export_metrics ADD COLUMN IF NOT EXISTS skip_reason TEXT;
+        ALTER TABLE export_metrics ADD COLUMN IF NOT EXISTS schema_fingerprint TEXT;
+        ALTER TABLE export_metrics ADD COLUMN IF NOT EXISTS chunk_size BIGINT;
+        ALTER TABLE export_metrics ADD COLUMN IF NOT EXISTS parallel BIGINT;
+        ALTER TABLE export_metrics ADD COLUMN IF NOT EXISTS source_type TEXT;
+        ALTER TABLE export_metrics ADD COLUMN IF NOT EXISTS destination_type TEXT;
+        ALTER TABLE export_metrics ADD COLUMN IF NOT EXISTS rivet_version TEXT;",
     ),
     // v10: longest single-chunk wall time (ms). See the SQLite array.
     (
         10,
-        "ALTER TABLE export_metrics ADD COLUMN longest_chunk_ms BIGINT;",
+        "ALTER TABLE export_metrics ADD COLUMN IF NOT EXISTS longest_chunk_ms BIGINT;",
     ),
     // v11: per-run source-harm deltas (see the SQLite array for rationale).
     (
@@ -644,7 +644,10 @@ const PG_MIGRATIONS: &[(i64, &str)] = &[
         CREATE INDEX IF NOT EXISTS idx_export_harm_run ON export_harm(run_id);",
     ),
     // v12: chunking diagnostics (see the SQLite array for rationale).
-    (12, "ALTER TABLE export_metrics ADD COLUMN chunk_key TEXT;"),
+    (
+        12,
+        "ALTER TABLE export_metrics ADD COLUMN IF NOT EXISTS chunk_key TEXT;",
+    ),
     // v13: load ledger (see the SQLite array for rationale). rows_loaded is BIGINT.
     (
         13,
@@ -711,7 +714,7 @@ const PG_MIGRATIONS: &[(i64, &str)] = &[
     // rehydrate every committed page from file_log; cleared when the run finalizes.
     (
         16,
-        "ALTER TABLE export_state ADD COLUMN resume_run_id TEXT;",
+        "ALTER TABLE export_state ADD COLUMN IF NOT EXISTS resume_run_id TEXT;",
     ),
     // v17: central run-status ledger. The AUTHORITATIVE record of each export
     // run's lifecycle — `running` at start, terminal at finalize. The bucket
@@ -736,12 +739,12 @@ const PG_MIGRATIONS: &[(i64, &str)] = &[
     // holds the same JSON/scalar payloads.
     (
         18,
-        "ALTER TABLE export_metrics ADD COLUMN error_class TEXT;
-         ALTER TABLE export_metrics ADD COLUMN cursor_min TEXT;
-         ALTER TABLE export_metrics ADD COLUMN cursor_max TEXT;
-         ALTER TABLE export_metrics ADD COLUMN key_descriptor_json TEXT;
-         ALTER TABLE export_metrics ADD COLUMN offending_value TEXT;
-         ALTER TABLE export_metrics ADD COLUMN server_context_json TEXT;",
+        "ALTER TABLE export_metrics ADD COLUMN IF NOT EXISTS error_class TEXT;
+         ALTER TABLE export_metrics ADD COLUMN IF NOT EXISTS cursor_min TEXT;
+         ALTER TABLE export_metrics ADD COLUMN IF NOT EXISTS cursor_max TEXT;
+         ALTER TABLE export_metrics ADD COLUMN IF NOT EXISTS key_descriptor_json TEXT;
+         ALTER TABLE export_metrics ADD COLUMN IF NOT EXISTS offending_value TEXT;
+         ALTER TABLE export_metrics ADD COLUMN IF NOT EXISTS server_context_json TEXT;",
     ),
     // v19: parallel-keyset crash-recovery ranges (see the SQLite v19 comment).
     // range_index/done are BIGINT (not the SQLite INTEGER): the state layer binds
@@ -815,15 +818,21 @@ const PG_MIGRATIONS: &[(i64, &str)] = &[
     ),
     (
         23,
-        "ALTER TABLE export_metrics ADD COLUMN bytes_read BIGINT;",
+        "ALTER TABLE export_metrics ADD COLUMN IF NOT EXISTS bytes_read BIGINT;",
     ),
     (
         24,
-        "ALTER TABLE strategy_snapshot ADD COLUMN catalog_rows BIGINT;
-        ALTER TABLE strategy_snapshot ADD COLUMN density DOUBLE PRECISION;
-        ALTER TABLE strategy_snapshot ADD COLUMN estimate_method TEXT;
-        ALTER TABLE strategy_snapshot ADD COLUMN probe_k BIGINT;
-        ALTER TABLE strategy_snapshot ADD COLUMN probe_w BIGINT;",
+        // IDEMPOTENT (ADD COLUMN IF NOT EXISTS): the gate's shared rivet_state
+        // reached a columns-present / version-23 state (a stale golden-state
+        // snapshot carried the v24 columns while its version row lagged), and a
+        // plain ADD COLUMN then failed \"column already exists\", breaking EVERY
+        // PG-state cell (concurrent-writers, keyset, parity, pool e2e) — roast
+        // 2026-08-10. PG supports IF NOT EXISTS; a migration must be re-runnable.
+        "ALTER TABLE strategy_snapshot ADD COLUMN IF NOT EXISTS catalog_rows BIGINT;
+        ALTER TABLE strategy_snapshot ADD COLUMN IF NOT EXISTS density DOUBLE PRECISION;
+        ALTER TABLE strategy_snapshot ADD COLUMN IF NOT EXISTS estimate_method TEXT;
+        ALTER TABLE strategy_snapshot ADD COLUMN IF NOT EXISTS probe_k BIGINT;
+        ALTER TABLE strategy_snapshot ADD COLUMN IF NOT EXISTS probe_w BIGINT;",
     ),
 ];
 
@@ -999,6 +1008,10 @@ fn migrate_locked(conn: &Connection) -> Result<()> {
                 "run_id TEXT",
             ];
             for col_def in &metrics_cols {
+                // SQLite has NO `ADD COLUMN IF NOT EXISTS` (unlike PostgreSQL) —
+                // idempotency here is the `let _ =` swallow of the duplicate-column
+                // error. Do NOT add IF NOT EXISTS: SQLite rejects the syntax and
+                // the whole legacy upgrade fails (roast 2026-08-10).
                 let sql = format!("ALTER TABLE export_metrics ADD COLUMN {}", col_def);
                 let _ = conn.execute(&sql, []);
             }
@@ -1486,6 +1499,32 @@ mod tests {
                     pg_tables,
                     "migration v{v}: SQLite and Postgres define different tables"
                 );
+            }
+        }
+    }
+
+    /// Every PG `ALTER TABLE … ADD COLUMN` must be IDEMPOTENT (`IF NOT EXISTS`).
+    /// A migration must be re-runnable: the gate's shared rivet_state reached a
+    /// columns-present / version-behind state (a stale golden-state snapshot) and
+    /// a plain ADD COLUMN then failed "column already exists", breaking EVERY
+    /// PG-state cell (roast 2026-08-10, v24). PostgreSQL supports IF NOT EXISTS;
+    /// this guards the whole class going forward. (SQLite ADD COLUMN has no
+    /// IF NOT EXISTS and is per-file fresh, so this applies to PG only.)
+    #[test]
+    fn every_pg_add_column_is_idempotent() {
+        for &(v, sql) in PG_MIGRATIONS {
+            for line in sql.lines() {
+                let l = line.trim();
+                if l.starts_with("//") || l.starts_with("--") {
+                    continue; // a comment, not a statement
+                }
+                if l.contains("ADD COLUMN") {
+                    assert!(
+                        l.contains("ADD COLUMN IF NOT EXISTS"),
+                        "PG migration v{v} has a non-idempotent ADD COLUMN — must be \
+                         `ADD COLUMN IF NOT EXISTS` so the migration is re-runnable: {l}"
+                    );
+                }
             }
         }
     }

--- a/tests/live/live_parallel_ux.rs
+++ b/tests/live/live_parallel_ux.rs
@@ -42,7 +42,13 @@ fn parallel_apply_common_mode_failure_shows_heartbeat_and_one_representative() {
         !result.status.success(),
         "a batch where every child fails must exit non-zero"
     );
-    // 1. heartbeat — silence is now idle-by-design, not unknown.
+    // 1. heartbeat PRESENCE — silence is now idle-by-design, not unknown.
+    //    NOTE (roast 2026-08-10): this pins the heartbeat is EMITTED, not the D1
+    //    TTY-ordering property (it corrupted the interactive card cursor). This
+    //    harness pipes stderr (non-TTY → the linear renderer, no cursor walk), so
+    //    it CANNOT reproduce the race. The ordering fix is correct-by-construction
+    //    (the eprintln is lexically before the UI-thread spawn); a PTY ordering
+    //    assertion is the proper guard and is deferred (needs a pty harness).
     assert!(
         stderr.contains("waiting for the first child event"),
         "#153-1: the parent must emit a spawn heartbeat:\n{stderr}"


### PR DESCRIPTION
The multiagent hunt over this session's OWN bugfixes found 7 confirmed; 5 fixed, 2 filed. #6 (HIGH) console-surface contract failed every --json check cell (own-goal in #195) — now skips human-surface under --json. #1 Mongo suggestion re-introduced by overlay recompute (now None stays None, RED). #3 avg_row_bytes now guards Counted too. #4 advise_split refuses a heavy giant / non-improving split (RED). #7 keyset governor journal drain moved before the error bail. #5 D1 test documented as presence-guard. Filed #202 (warnings consistency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)