### PR TITLE
fix(init): MySQL density probe panicked on BIGINT UNSIGNED key (init exit 101)

### DIFF
--- a/src/init/mysql.rs
+++ b/src/init/mysql.rs
@@ -172,9 +172,21 @@ pub(super) fn density_probe(conn: &mut mysql::PooledConn, info: &mut super::Tabl
     };
     let tbl = info.table.replace('`', "``");
     let k_q = key.replace('`', "``");
-    let Ok(Some((Some(min), Some(max)))) = conn.query_first::<(Option<i64>, Option<i64>), _>(
-        format!("SELECT MIN(`{k_q}`), MAX(`{k_q}`) FROM `{tbl}`"),
-    ) else {
+    // Read MIN/MAX as TEXT and parse — never as (Option<i64>, Option<i64>): a
+    // BIGINT UNSIGNED key past i64::MAX (18446744073709551615) makes the mysql
+    // crate's FromRow PANIC on the i64 conversion (not a catchable Err), crashing
+    // `rivet init` (roast 2026-08-10, gate exit 101). Text always converts; a
+    // value that does not fit i64 (unsigned overflow), a non-integer key, or NULL
+    // (empty table) → skip the probe, keep the catalog, mark unverified — the
+    // stratified offsets are i64 arithmetic and cannot span such a key anyway.
+    let min_max = conn
+        .query_first::<(Option<String>, Option<String>), _>(format!(
+            "SELECT MIN(`{k_q}`), MAX(`{k_q}`) FROM `{tbl}`"
+        ))
+        .ok()
+        .flatten()
+        .and_then(|(lo, hi)| Some((lo?.parse::<i64>().ok()?, hi?.parse::<i64>().ok()?)));
+    let Some((min, max)) = min_max else {
         info.density = Some(DensityProbe {
             rows: catalog,
             density: 0.0,

--- a/tests/live/live_density_probe.rs
+++ b/tests/live/live_density_probe.rs
@@ -148,3 +148,47 @@ fn pg_density_probe_corrects_a_never_analyzed_table() {
     );
     let _ = c.execute(&format!("DROP TABLE IF EXISTS {table}"), &[]);
 }
+
+/// #148 (roast 2026-08-10, gate exit 101): the MySQL density probe read
+/// MIN/MAX as (Option<i64>, Option<i64>); a BIGINT UNSIGNED key past i64::MAX
+/// made the mysql crate's FromRow PANIC (not a catchable Err), crashing
+/// `rivet init`. A table whose id reaches u64::MAX must init CLEANLY (the probe
+/// skips it as unverified — i64 offsets cannot span it). RED against the i64 read.
+#[test]
+#[ignore = "live: requires docker compose up -d mysql"]
+fn init_does_not_panic_on_a_bigint_unsigned_key_past_i64() {
+    let mut c = mysql_connect();
+    let name = unique_name("ubig_key");
+    c.query_drop(format!(
+        "CREATE TABLE {name} (id BIGINT UNSIGNED PRIMARY KEY, v INT NOT NULL)"
+    ))
+    .unwrap();
+    let _guard = MysqlTable::adopt(name.clone());
+    // Rows straddling i64::MAX so MIN fits i64 but MAX (u64::MAX) does not.
+    c.query_drop(format!(
+        "INSERT INTO {name} (id, v) VALUES (1, 1), (18446744073709551615, 2)"
+    ))
+    .unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let out_yaml = dir.path().join("u.yaml");
+    let out = run_rivet_env(
+        &[
+            "init",
+            "--source",
+            MYSQL_URL,
+            "--table",
+            &name,
+            "-o",
+            out_yaml.to_str().unwrap(),
+        ],
+        &[],
+    );
+    assert!(
+        out.status.success(),
+        "init must NOT panic on a BIGINT UNSIGNED key past i64 (exit {:?}):\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(out_yaml.exists(), "init must still scaffold a config");
+}


### PR DESCRIPTION
The final night gate hit exit 101 on every MySQL init cell: #148's density probe read MIN/MAX as (Option<i64>,Option<i64>), and a BIGINT UNSIGNED key past i64::MAX makes the mysql crate FromRow PANIC (uncatchable) → rivet init crashes. Now reads as TEXT + parses; overflow/non-int/NULL → skip probe (unverified). Live-proven (ids {1, u64::MAX} init clean, was exit 101).

🤖 Generated with [Claude Code](https://claude.com/claude-code)