### PR TITLE
fix(gate): verify_pool_e2e must pass --ignored (harness bug, gate's last ✗)

### DIFF
--- a/dev/release_oracle/scenarios.py
+++ b/dev/release_oracle/scenarios.py
@@ -1159,13 +1159,18 @@ def verify_pool_e2e(led: Ledger) -> None:
     )
     log_path = work_dir() / "pool_e2e.log"
     p = run(
+        # `--ignored` is REQUIRED: the pool e2e tests carry #[ignore] (they need
+        # the live stand), added in the CI-tier split. Without it they are SKIPPED
+        # and the gate read "0 passed" as a FAIL (roast 2026-08-10). The pass check
+        # below is count-agnostic (0 failed AND at least one passed) so adding a
+        # pool test never silently breaks the gate the way pinning "2 passed" did.
         ["cargo", "test", "--manifest-path", str(ROOT / "Cargo.toml"), "--test", "live_suite",
-         "--", "--test-threads=1", "live_pool_toxiproxy"],
+         "--", "--ignored", "--test-threads=1", "live_pool_toxiproxy"],
         env={"RIVET_BIN": str(rivet_bin())},
         timeout=NO_TIMEOUT,
     )
     log_path.write_text(p.out)
-    if p.ok and "test result: ok. 2 passed" in p.out:
+    if p.ok and "0 failed" in p.out and "0 passed" not in p.out:
         _passed(
             led, "pool", "e2e", "-", "-",
             "pool e2e: bandwidth-capped --pool run exact + self-grading; resume defers, drops nothing",


### PR DESCRIPTION
The final gate's last ✗ was pool e2e — a HARNESS bug: the pool e2e tests carry #[ignore] (CI-tier split), but verify_pool_e2e ran cargo test without --ignored → skipped → 'test result: ok. 0 passed' read as FAILED (mis-attributed to v24 earlier). Fix: --ignored + count-agnostic pass check ('0 failed' and not '0 passed'). 3 pool e2e tests pass on the stand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)