### PR TITLE
fix(preflight): #202 overlay recomputes warnings + MSSQL/Mongo max-connections parity

### DIFF
--- a/src/plan/explain.rs
+++ b/src/plan/explain.rs
@@ -315,6 +315,9 @@ mod tests {
             recommended_parallel: (1, "small dataset"),
             warnings: vec![],
             suggestion: None,
+            chunk_min: None,
+            chunk_max: None,
+            db_max_connections: None,
         }
     }
 

--- a/src/preflight/analysis.rs
+++ b/src/preflight/analysis.rs
@@ -189,6 +189,19 @@ pub(crate) fn overlay_measured_rows(
         if diag.suggestion.is_some() {
             diag.suggestion = build_suggestion(&diag.verdict, est, diag.uses_index, export);
         }
+        // #202: the warnings are row-estimate-scaled too (parallel-memory-risk,
+        // sparse-range, oversized-chunk) — re-run collect_warnings from the
+        // MEASURED figure so they don't keep quoting the catalog while the
+        // verdict/row line is measured. Inputs the diagnostic carries for exactly
+        // this recompute.
+        diag.warnings = collect_warnings(
+            export,
+            est,
+            diag.avg_row_bytes,
+            diag.chunk_min.as_deref(),
+            diag.chunk_max.as_deref(),
+            diag.db_max_connections,
+        );
     }
 }
 
@@ -955,6 +968,9 @@ mod tests {
             recommended_profile: "balanced",
             recommended_parallel: (1, "test"),
             suggestion: None,
+            chunk_min: None,
+            chunk_max: None,
+            db_max_connections: None,
         };
         let export = cfg("table: t\nmode: chunked\nchunk_column: id\nchunk_size: 100000\n");
         // Seed a profile as if computed from the CATALOG (small) estimate.
@@ -974,6 +990,57 @@ mod tests {
                 .starts_with("measured "),
             "the report must SAY it stands on the measurement: {:?}",
             diag.row_source
+        );
+    }
+
+    /// #202 (roast 2026-08-10): the overlay recomputes verdict/profile but left
+    /// diag.warnings on the CATALOG estimate — so a measured figure that crosses
+    /// a warning threshold (parallel-memory-risk at >5M rows) never surfaced. The
+    /// warnings must be re-run from the measured figure. RED against not
+    /// recomputing warnings.
+    #[test]
+    fn overlay_recomputes_row_scaled_warnings_from_the_measure() {
+        let state = crate::state::StateStore::open_in_memory().unwrap();
+        state
+            .record_metric_full(&crate::state::MetricRow {
+                export_name: "big_chunked".into(),
+                run_id: "r1".into(),
+                total_rows: 10_000_000, // > 5M → parallel-memory-risk fires
+                status: "success".into(),
+                ..Default::default()
+            })
+            .unwrap();
+        let export =
+            cfg("table: t\nmode: chunked\nchunk_column: id\nchunk_size: 100000\nparallel: 4\n");
+        let mut diag = super::super::ExportDiagnostic {
+            export_name: "big_chunked".into(),
+            strategy: "chunked(id, size=100000)".into(),
+            mode: "chunked (column: id, size: 100000)".into(),
+            cursor_column: None,
+            row_estimate: Some(1000), // catalog: small → no memory-risk warning
+            row_source: None,
+            avg_row_bytes: None,
+            cursor_min: None,
+            cursor_max: None,
+            scan_type: None,
+            uses_index: true,
+            verdict: super::super::HealthVerdict::Efficient,
+            warnings: Vec::new(), // as collect_warnings(1000, parallel=4) produced
+            recommended_profile: "fast",
+            recommended_parallel: (4, "test"),
+            suggestion: None,
+            chunk_min: None,
+            chunk_max: None,
+            db_max_connections: None,
+        };
+        overlay_measured_rows(&mut diag, &export, &state);
+        assert_eq!(diag.row_estimate, Some(10_000_000));
+        assert!(
+            diag.warnings
+                .iter()
+                .any(|w| w.message.contains("Parallel=4")),
+            "the parallel-memory-risk warning must be recomputed from the measured 10M rows: {:?}",
+            diag.warnings.iter().map(|w| &w.message).collect::<Vec<_>>()
         );
     }
 
@@ -1009,6 +1076,9 @@ mod tests {
             recommended_profile: "safe",
             recommended_parallel: (1, "test"),
             suggestion: None,
+            chunk_min: None,
+            chunk_max: None,
+            db_max_connections: None,
         };
         let export = cfg("table: coll\nmode: full\n");
         overlay_measured_rows(&mut diag, &export, &state);
@@ -1062,6 +1132,9 @@ mod tests {
             recommended_profile: "balanced",
             recommended_parallel: (1, "test"),
             suggestion: None,
+            chunk_min: None,
+            chunk_max: None,
+            db_max_connections: None,
         };
         let export = cfg("table: t\nmode: incremental\ncursor_column: updated_at\n");
         overlay_measured_rows(&mut diag, &export, &state);

--- a/src/preflight/mod.rs
+++ b/src/preflight/mod.rs
@@ -90,6 +90,14 @@ pub(crate) struct ExportDiagnostic {
     pub recommended_parallel: (u32, &'static str),
     pub warnings: Vec<analysis::Warning>,
     pub suggestion: Option<String>,
+    /// The three `collect_warnings` inputs NOT otherwise on the diagnostic —
+    /// stored so the #149 overlay can RE-RUN the row-estimate-scaled warnings
+    /// after it moves `row_estimate` (else the warnings keep quoting the catalog
+    /// figure while the verdict/row line stands on the measure — #202). Not
+    /// serialized (internal recompute inputs, not part of the JSON surface).
+    pub chunk_min: Option<String>,
+    pub chunk_max: Option<String>,
+    pub db_max_connections: Option<u32>,
 }
 
 // Hand-rolled `Serialize` (rather than `#[derive]`) so the JSON shape stays
@@ -696,6 +704,9 @@ mod tests {
                 analysis::Warning::new(analysis::Severity::High, "memory risk".to_string()),
             ],
             suggestion: Some("create an index".to_string()),
+            chunk_min: None,
+            chunk_max: None,
+            db_max_connections: None,
         }
     }
 

--- a/src/preflight/mongo.rs
+++ b/src/preflight/mongo.rs
@@ -51,7 +51,10 @@ fn diagnose_mongo(
     let verdict = compute_verdict(row_estimate, uses_index, false, None, export.parallel);
     let recommended_profile = recommend_profile(row_estimate, uses_index, export);
     let recommended_parallel = recommend_parallelism(export, row_estimate, uses_index);
-    let warnings = collect_warnings(export, row_estimate, None, None, None, None);
+    // Mongo's connection headroom (serverStatus().connections.available) — the
+    // analogue of PG/MySQL max_connections for the mongo_parallel worker count.
+    let db_max_connections = crate::source::mongo::max_connections(url, tls);
+    let warnings = collect_warnings(export, row_estimate, None, None, None, db_max_connections);
 
     Ok(ExportDiagnostic {
         row_source: None,
@@ -74,5 +77,8 @@ fn diagnose_mongo(
         // document source cannot do. Profile/parallel advice still rides the
         // fields above.
         suggestion: None,
+        chunk_min: None,
+        chunk_max: None,
+        db_max_connections: None,
     })
 }

--- a/src/preflight/mssql.rs
+++ b/src/preflight/mssql.rs
@@ -57,6 +57,18 @@ pub(super) fn diagnose_export_mssql(
     diagnose_mssql(&mut conn, export)
 }
 
+/// `@@MAX_CONNECTIONS` — SQL Server's configured `user connections` cap and the
+/// portable analogue of PG `max_connections` / MySQL `@@max_connections`. Read
+/// over the scalar seam; `None` when the probe fails (fail-soft, like the other
+/// engines) — the connection-limit check then only emits its skipped-note.
+fn fetch_max_connections_mssql(conn: &mut MssqlSource) -> Option<u32> {
+    conn.query_scalar("SELECT @@MAX_CONNECTIONS")
+        .ok()
+        .flatten()
+        .and_then(|s| s.trim().parse::<u32>().ok())
+        .filter(|&n| n > 0)
+}
+
 fn diagnose_mssql(conn: &mut MssqlSource, export: &ExportConfig) -> Result<ExportDiagnostic> {
     let mode_str = diagnose_mode_str(export);
 
@@ -141,18 +153,20 @@ fn diagnose_mssql(conn: &mut MssqlSource, export: &ExportConfig) -> Result<Expor
     );
     let recommended_profile = recommend_profile(row_estimate, uses_index, export);
     let recommended_parallel = recommend_parallelism(export, row_estimate, uses_index);
-    // SQL Server has no portable per-user `max_connections` server variable
-    // readable over this seam (the cap is per-edition / Resource Governor), so
-    // the connection-limit warning is skipped — `None` makes `collect_warnings`
-    // emit the "check skipped" note only when parallel > 1, exactly like the
-    // PG/MySQL path when that probe fails.
+    // SQL Server's `@@MAX_CONNECTIONS` IS the portable analogue of PG
+    // max_connections / MySQL @@max_connections (the configured `user
+    // connections` cap; default 32767 ≈ unlimited, so the warning is inert on a
+    // default install and fires only when an admin lowers it). Read it over the
+    // same query_scalar seam so the connection-limit check has parity with the
+    // other engines.
+    let db_max_connections = fetch_max_connections_mssql(conn);
     let warnings = collect_warnings(
         export,
         row_estimate,
         avg_row_bytes,
         range_min.as_deref(),
         range_max.as_deref(),
-        None,
+        db_max_connections,
     );
     let suggestion = build_suggestion(&verdict, row_estimate, uses_index, export);
 
@@ -164,8 +178,8 @@ fn diagnose_mssql(conn: &mut MssqlSource, export: &ExportConfig) -> Result<Expor
         cursor_column: export.cursor_column.clone(),
         row_estimate,
         avg_row_bytes,
-        cursor_min: range_min,
-        cursor_max: range_max,
+        cursor_min: range_min.clone(),
+        cursor_max: range_max.clone(),
         scan_type,
         uses_index,
         verdict,
@@ -173,6 +187,9 @@ fn diagnose_mssql(conn: &mut MssqlSource, export: &ExportConfig) -> Result<Expor
         recommended_parallel,
         warnings,
         suggestion,
+        chunk_min: range_min.clone(),
+        chunk_max: range_max.clone(),
+        db_max_connections,
     })
 }
 

--- a/src/preflight/mysql.rs
+++ b/src/preflight/mysql.rs
@@ -224,8 +224,8 @@ fn diagnose_mysql(
         cursor_column: export.cursor_column.clone(),
         row_estimate,
         avg_row_bytes,
-        cursor_min: range_min,
-        cursor_max: range_max,
+        cursor_min: range_min.clone(),
+        cursor_max: range_max.clone(),
         scan_type,
         uses_index,
         verdict,
@@ -233,6 +233,9 @@ fn diagnose_mysql(
         recommended_parallel,
         warnings,
         suggestion,
+        chunk_min: range_min.clone(),
+        chunk_max: range_max.clone(),
+        db_max_connections,
     })
 }
 

--- a/src/preflight/postgres.rs
+++ b/src/preflight/postgres.rs
@@ -162,8 +162,8 @@ fn diagnose_pg(
         cursor_column: export.cursor_column.clone(),
         row_estimate,
         avg_row_bytes,
-        cursor_min: range_min,
-        cursor_max: range_max,
+        cursor_min: range_min.clone(),
+        cursor_max: range_max.clone(),
         scan_type,
         uses_index,
         verdict,
@@ -171,6 +171,9 @@ fn diagnose_pg(
         recommended_parallel,
         warnings,
         suggestion,
+        chunk_min: range_min.clone(),
+        chunk_max: range_max.clone(),
+        db_max_connections,
     })
 }
 

--- a/src/source/mongo/mod.rs
+++ b/src/source/mongo/mod.rs
@@ -891,6 +891,33 @@ pub(crate) fn sample_harm_counters(
 /// `estimatedDocumentCount` reads collection metadata, never scans the
 /// collection. `None` on any failure — the diagnostic then shows an unknown
 /// row count, exactly as MySQL does when its estimate is untrustworthy.
+/// The server's connection headroom for the preflight connection-limit check —
+/// `serverStatus().connections.available` (free slots), the Mongo analogue of PG
+/// `max_connections` / MySQL `@@max_connections`. Defaults high (the pool cap is
+/// usually 65536 / ulimit-derived), so the warning is inert unless the server is
+/// tightly capped and `parallel` (the mongo_parallel worker count) would exhaust
+/// it. `None` on any probe failure (fail-soft, like `estimated_count`).
+pub(crate) fn max_connections(url: &str, tls: Option<&TlsConfig>) -> Option<u32> {
+    let session = MongoSession::connect(url, tls).ok()?;
+    session.block_on(async {
+        let status = session
+            .client()
+            .database("admin")
+            .run_command(mongodb::bson::doc! { "serverStatus": 1 })
+            .await
+            .ok()?;
+        let conns = status.get_document("connections").ok()?;
+        // `available` is the free headroom; current + available ≈ the cap. The
+        // check compares `parallel` against what is actually usable now.
+        let avail = conns
+            .get_i32("available")
+            .ok()
+            .map(|v| v as i64)
+            .or_else(|| conns.get_i64("available").ok())?;
+        u32::try_from(avail).ok()
+    })
+}
+
 pub(crate) fn estimated_count(url: &str, tls: Option<&TlsConfig>, collection: &str) -> Option<i64> {
     let session = MongoSession::connect(url, tls).ok()?;
     session.block_on(async {


### PR DESCRIPTION
Closes #202. The overlay recomputed verdict/profile but left warnings on the catalog estimate (a measured >5M never surfaced the parallel-memory-risk warning). Now re-runs collect_warnings from the measured figure (diag carries chunk_min/chunk_max/db_max_connections). RED-proven. Also closed the connection-limit parity gap: MSSQL @@MAX_CONNECTIONS + Mongo serverStatus().connections.available (both fail-soft, default-high → inert unless the admin caps low) — all four engines now covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)