### PR TITLE
fix(init): density probe only samples an INDEXED key (#199)

### DIFF
--- a/src/init/candidates.rs
+++ b/src/init/candidates.rs
@@ -118,6 +118,7 @@ mod tests {
             is_nullable: nullable,
             numeric_precision: None,
             numeric_scale: None,
+            is_indexed: false,
         }
     }
 

--- a/src/init/catalog_replay.rs
+++ b/src/init/catalog_replay.rs
@@ -148,8 +148,10 @@ mod tests {
             is_nullable: false,
             numeric_precision: None,
             numeric_scale: None,
+            is_indexed: false,
         }
     }
+
     fn tbl(rows: i64, bytes: i64, cols: Vec<ColumnInfo>) -> TableInfo {
         TableInfo {
             density: None,

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -33,6 +33,13 @@ pub(crate) struct ColumnInfo {
     /// `None` when not applicable or when precision is unbounded.
     pub numeric_precision: Option<u32>,
     pub numeric_scale: Option<u32>,
+    /// `true` when the column is backed by an index (PK, unique, or secondary).
+    /// The density probe (#148/#199) only samples an INDEXED key — MIN/MAX + K
+    /// windowed COUNTs on an UNINDEXED fallback column is up to 51 sequential
+    /// scans of a large table inside `rivet init`. `#[serde(default)]` (false)
+    /// so pre-existing catalog-replay fixtures still parse.
+    #[serde(default)]
+    pub is_indexed: bool,
 }
 
 /// Table metadata used to generate the config scaffold and discovery artifact.
@@ -69,6 +76,24 @@ impl TableInfo {
             .or_else(|| {
                 // Fall back to first integer column
                 self.columns.iter().find(|c| is_integer_type(&c.data_type))
+            })
+            .map(|c| c.name.as_str())
+    }
+
+    /// Like [`best_chunk_column`](Self::best_chunk_column) but the fallback
+    /// integer column must be INDEXED (#199). The density probe runs MIN/MAX + K
+    /// windowed COUNTs on this key — on an UNINDEXED column that is up to 51
+    /// SEQUENTIAL SCANS of a large table inside `rivet init`. An integer PK is
+    /// always indexed; a non-PK integer key is used only when an index backs it,
+    /// else `None` (the probe then skips → catalog kept, unverified).
+    pub(crate) fn best_indexed_chunk_column(&self) -> Option<&str> {
+        self.columns
+            .iter()
+            .find(|c| c.is_primary_key && is_integer_type(&c.data_type))
+            .or_else(|| {
+                self.columns
+                    .iter()
+                    .find(|c| c.is_indexed && is_integer_type(&c.data_type))
             })
             .map(|c| c.name.as_str())
     }
@@ -1132,7 +1157,52 @@ mod tests {
             is_nullable: false,
             numeric_precision: None,
             numeric_scale: None,
+            is_indexed: false,
         }
+    }
+
+    /// #199: the density probe's key must be INDEXED. PK (always indexed) →
+    /// returned; an unindexed integer fallback → None (probe skips, no 51-scan);
+    /// an indexed non-PK integer → returned (the versioned KEY(ref_id) case #148
+    /// targets). RED against best_chunk_column (which returns the unindexed one).
+    #[test]
+    fn best_indexed_chunk_column_requires_an_index() {
+        let c = |n: &str, ty: &str, pk: bool, idx: bool| ColumnInfo {
+            name: n.into(),
+            data_type: ty.into(),
+            is_primary_key: pk,
+            is_nullable: false,
+            numeric_precision: None,
+            numeric_scale: None,
+            is_indexed: idx,
+        };
+        // integer PK → indexed → returned.
+        let t = make_table(1, vec![c("id", "bigint", true, true)]);
+        assert_eq!(t.best_indexed_chunk_column(), Some("id"));
+        // uuid PK + UNINDEXED integer fallback → None (no scan).
+        let t = make_table(
+            1,
+            vec![c("uid", "uuid", true, true), c("qty", "int", false, false)],
+        );
+        assert_eq!(
+            t.best_indexed_chunk_column(),
+            None,
+            "unindexed fallback must not be probed"
+        );
+        assert_eq!(
+            t.best_chunk_column(),
+            Some("qty"),
+            "but best_chunk_column still picks it"
+        );
+        // indexed non-PK integer → returned (versioned KEY(ref_id)).
+        let t = make_table(
+            1,
+            vec![
+                c("uid", "uuid", true, true),
+                c("ref_id", "bigint", false, true),
+            ],
+        );
+        assert_eq!(t.best_indexed_chunk_column(), Some("ref_id"));
     }
 
     fn make_table(rows: i64, cols: Vec<ColumnInfo>) -> TableInfo {
@@ -1217,6 +1287,7 @@ mod tests {
             is_nullable: true,
             numeric_precision: None,
             numeric_scale: None,
+            is_indexed: false,
         };
         let info = make_table(
             500_000,
@@ -1383,6 +1454,7 @@ mod tests {
                     is_nullable: false,
                     numeric_precision: Some(20),
                     numeric_scale: Some(0),
+                    is_indexed: false,
                 },
                 col("name", "text", false),
             ],
@@ -2138,6 +2210,7 @@ mod tests {
                     is_nullable: true,
                     numeric_precision: None,
                     numeric_scale: None,
+                    is_indexed: false,
                 },
             ],
         );

--- a/src/init/mssql.rs
+++ b/src/init/mssql.rs
@@ -146,6 +146,7 @@ fn parse_columns_agg(agg: &str) -> Vec<ColumnInfo> {
                 return None;
             }
             Some(ColumnInfo {
+                is_indexed: f[2] == "1",
                 name: f[0].to_string(),
                 data_type: f[1].to_string(),
                 is_primary_key: f[2] == "1",

--- a/src/init/mysql.rs
+++ b/src/init/mysql.rs
@@ -105,6 +105,7 @@ pub(super) fn introspect(conn: &mut mysql::PooledConn, table: &str) -> Result<Ta
         .map(
             |(name, data_type, column_key, nullable, numeric_precision, numeric_scale)| {
                 ColumnInfo {
+                    is_indexed: !column_key.is_empty(),
                     is_primary_key: column_key == "PRI",
                     is_nullable: nullable.eq_ignore_ascii_case("YES"),
                     name,
@@ -137,7 +138,7 @@ pub(super) fn density_probe(conn: &mut mysql::PooledConn, info: &mut super::Tabl
     use mysql::prelude::Queryable;
 
     let catalog = info.row_estimate;
-    let Some(key) = info.best_chunk_column().map(str::to_string) else {
+    let Some(key) = info.best_indexed_chunk_column().map(str::to_string) else {
         // No integer key to stratify on: small → honest COUNT(*); large → keep
         // the estimate but SAY so (never silently trust it).
         let method = if catalog < 1_000_000 {

--- a/src/init/postgres.rs
+++ b/src/init/postgres.rs
@@ -120,6 +120,21 @@ pub(super) fn introspect(client: &mut Client, schema: &str, table: &str) -> Resu
     let pk_cols: std::collections::HashSet<String> =
         pk_rows.iter().map(|r| r.get::<_, String>(0)).collect();
 
+    // Any indexed column (PK, unique, or secondary) — same shape as pk_rows
+    // minus `indisprimary`. Feeds ColumnInfo.is_indexed so the density probe
+    // (#199) samples only an indexed key, never an unindexed fallback.
+    let indexed_rows = client.query(
+        "SELECT a.attname
+         FROM pg_index i
+         JOIN pg_attribute a ON a.attrelid = i.indrelid
+             AND a.attnum = ANY(i.indkey)
+         WHERE i.indrelid = to_regclass($1 || '.' || $2)
+           AND i.indrelid IS NOT NULL",
+        &[&schema, &table],
+    )?;
+    let indexed_cols: std::collections::HashSet<String> =
+        indexed_rows.iter().map(|r| r.get::<_, String>(0)).collect();
+
     // Column metadata — including NULL-ability and numeric precision/scale for decimal columns.
     let col_rows = client.query(
         "SELECT column_name, data_type, is_nullable, numeric_precision, numeric_scale
@@ -145,7 +160,9 @@ pub(super) fn introspect(client: &mut Client, schema: &str, table: &str) -> Resu
             let numeric_precision: Option<i32> = row.get(3);
             let numeric_scale: Option<i32> = row.get(4);
             let is_primary_key = pk_cols.contains(&name);
+            let is_indexed = indexed_cols.contains(&name);
             ColumnInfo {
+                is_indexed,
                 name,
                 data_type,
                 is_primary_key,
@@ -186,7 +203,7 @@ pub(super) fn density_probe(client: &mut Client, info: &mut super::TableInfo) {
     if (1..PG_PROBE_LINE).contains(&catalog) {
         return;
     }
-    let Some(key) = info.best_chunk_column().map(str::to_string) else {
+    let Some(key) = info.best_indexed_chunk_column().map(str::to_string) else {
         info.density = Some(DensityProbe {
             rows: catalog,
             density: 0.0,

--- a/src/init/yaml_scaffold.rs
+++ b/src/init/yaml_scaffold.rs
@@ -1130,6 +1130,7 @@ mod tests {
             is_nullable: true,
             numeric_precision: None,
             numeric_scale: None,
+            is_indexed: false,
         }
     }
 
@@ -1148,6 +1149,7 @@ mod tests {
             is_nullable: false,
             numeric_precision: None,
             numeric_scale: None,
+            is_indexed: false,
         };
         let info = TableInfo {
             density: None,
@@ -1202,6 +1204,7 @@ mod tests {
             is_nullable: nullable,
             numeric_precision: None,
             numeric_scale: None,
+            is_indexed: false,
         };
         let info = TableInfo {
             density: None,
@@ -1353,6 +1356,7 @@ mod tests {
         ColumnInfo {
             numeric_precision: Some(p),
             numeric_scale: Some(s),
+            is_indexed: false,
             ..col(name, "numeric")
         }
     }


### PR DESCRIPTION
Closes #199 (B4). density_probe fell back to the first integer column, which may be UNINDEXED → up to 51 sequential scans inside rivet init. ColumnInfo gains is_indexed (MySQL free via COLUMN_KEY, PG via pg_index, MSSQL from PK); best_indexed_chunk_column requires an index (PK or indexed fallback), else the probe skips (unverified). A PK-only guard was rejected (skips the versioned KEY(ref_id) case). RED-proven; live density tests stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)