### PR TITLE
fix: the four pre-existing bugs from the 2026-08-09 bughunt (#200)

### DIFF
--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -238,11 +238,15 @@ fn dispatch_cdc(a: CdcArgs) -> Result<()> {
             },
             CdcEngine::Postgres => CdcEngineOpts::Postgres { slot: a.slot },
             CdcEngine::Mssql => CdcEngineOpts::Mssql {
-                // The `rivet cdc` CLI names no tables — it captures whatever the
-                // capture instance emits — so there is nothing to cross-check
-                // against and the guard stays off. Config mode (`mode: cdc`)
-                // supplies them.
-                configured_tables: Vec::new(),
+                // `--table` IS the routing filter on this path too (the NDJSON leg
+                // passes it to `run(...)`, the `--output` leg requires exactly
+                // one), so it is exactly the set the catalog-identity guard must
+                // cross-check against — a capture instance whose NAME splits to a
+                // different `schema.table` than the catalog spells would otherwise
+                // route/drop every event silently. Empty (`rivet cdc` with no
+                // `--table`) keeps the guard off: nothing named ⇒ nothing to
+                // cross-check, capture whatever the instance emits.
+                configured_tables: a.table.clone(),
                 capture_instance: a.capture_instance,
             },
             CdcEngine::Mongo => CdcEngineOpts::Mongo { canonical: false },

--- a/src/pipeline/chunked/mod.rs
+++ b/src/pipeline/chunked/mod.rs
@@ -311,6 +311,20 @@ pub(super) fn ensure_chunk_checkpoint_plan(
                         n
                     );
                 }
+                // Un-pin chunks a prior run gave up on (retryable budget
+                // exhausted OR permanent `retryable=false`): `--resume` is the
+                // operator's deliberate retry after fixing the cause, so the
+                // permanently-failed pin — which `claim_next_chunk_task` would
+                // otherwise skip forever — must be lifted here or the run's own
+                // "fix and --resume" remediation is a false promise (#200-4).
+                let f = state.reset_failed_chunk_tasks_for_resume(&rid)?;
+                if f > 0 {
+                    log::warn!(
+                        "export '{}': re-queued {} failed chunk task(s) for retry after resume",
+                        plan.export_name,
+                        f
+                    );
+                }
                 return Ok(rid);
             }
             None => {

--- a/src/pipeline/keyset.rs
+++ b/src/pipeline/keyset.rs
@@ -597,7 +597,6 @@ fn run_keyset_parallel(
                 // Parts this range committed — recorded to file_log atomically with
                 // its `done` flip at completion (checkpoint only).
                 let mut range_parts: Vec<crate::state::KeysetRangePart> = Vec::new();
-                let mut local_parts: Vec<super::commit::PartRecord> = Vec::new();
                 let mut local_checks: Vec<(
                     std::collections::BTreeMap<String, u64>,
                     Option<String>,
@@ -621,6 +620,22 @@ fn run_keyset_parallel(
                         "keyset_parallel_worker",
                         ridx as i64,
                     ) {
+                        errs_r.lock().unwrap().push(format!("range {ridx}: {e}"));
+                        return;
+                    }
+                    // Test-only: a MID-RANGE error — fires only once this range has
+                    // ALREADY made page(s) durable (`pages > 0`), unlike the hook
+                    // above which fires at the range's first page (range writes
+                    // nothing). This is the fixture #200-1 needs: pre-failure pages
+                    // are on disk but the range never commits, so they must still
+                    // reach `files_committed` (published per-page below), not be
+                    // dropped with the uncommitted range.
+                    if pages > 0
+                        && let Err(e) = crate::test_hook::maybe_error_at_index(
+                            "keyset_parallel_worker_midrange",
+                            ridx as i64,
+                        )
+                    {
                         errs_r.lock().unwrap().push(format!("range {ridx}: {e}"));
                         return;
                     }
@@ -665,7 +680,19 @@ fn run_keyset_parallel(
                         // run's observed floor (#151).
                         *rfirst_r.lock().unwrap() = page.first_cursor.clone();
                     }
-                    local_parts.extend(page.parts);
+                    // Publish the parts THIS page just wrote to the destination to
+                    // the shared count IMMEDIATELY — the parquet is durable the
+                    // moment `read_keyset_page_bounded` returns, before the range's
+                    // checkpoint commit below. Deferring this to range-completion
+                    // (the old `local_parts` at line 741) dropped every page a
+                    // FAILED range had already made durable from `files_committed`,
+                    // handing `decide_export_retry` a short count — the same
+                    // durable-parts blind spot as the worker-level bail, one level
+                    // deeper (page granularity within a range, #200-1). Cursor
+                    // (`rmax`) and checksums stay commit-gated below — those feed
+                    // the SUMMARY and must reflect only committed data — but the
+                    // durability count must reflect what is physically on disk.
+                    parts_r.lock().unwrap().extend(page.parts);
                     local_checks.push((page.column_checksums, page.checksum_key_column));
                     let last_page = page.rows < page_size;
                     if !last_page {
@@ -738,7 +765,11 @@ fn run_keyset_parallel(
                 // Publish to the shared merge state ONLY after the checkpoint commits,
                 // so a failed commit does not leave half-merged summary state.
                 rmax_r.lock().unwrap()[ridx] = rmax;
-                parts_r.lock().unwrap().extend(local_parts);
+                // Parts were published per-page above (they are durable pre-commit);
+                // only the cursor and checksums — SUMMARY state — publish here, gated
+                // on the checkpoint commit so a failed commit leaves no half-merged
+                // summary (the parts count is intentionally NOT gated: it must show
+                // on-disk debris even for a range that failed to commit).
                 checks_r.lock().unwrap().extend(local_checks);
             });
         }

--- a/src/source/mysql/cdc.rs
+++ b/src/source/mysql/cdc.rs
@@ -380,10 +380,42 @@ impl MysqlChangeStream {
                     self.pending.push_back(ev);
                 }
             }
+            // #200-2: a compressed transaction. `binlog_transaction_compression`
+            // can be turned on AFTER this run opened (the open-time
+            // `refuse_compressed_binlog` guard saw it OFF and passed), or a
+            // compressed span can already sit in the binlog before the checkpoint
+            // (written while it was ON, then turned OFF). Either way a
+            // `Transaction_payload_event` reaches here, and this reader cannot
+            // expand it. The `_ => {}` arm below would SILENTLY skip it —
+            // capturing NOTHING for that transaction while the checkpoint advances
+            // past it (an at-least-once break, and the open-time refusal's
+            // remediation replays over the already-skipped span). Refuse loudly
+            // instead; the un-acked span is re-read from the checkpoint once
+            // compression is off.
+            Some(EventData::TransactionPayloadEvent(_)) => {
+                return Err(compressed_payload_refusal());
+            }
             _ => {}
         }
         Ok(true)
     }
+}
+
+/// The stream-time sibling of [`compression_refusal`]: a `Transaction_payload_event`
+/// reached the reader even though the OPEN-time check passed. Pure so both the
+/// message and the fact that it IS an error are testable offline — deleting the
+/// match arm that calls it (falling through to `_ => {}`) is exactly the silent-skip
+/// bug, which only a live compressed server would otherwise flip.
+fn compressed_payload_refusal() -> anyhow::Error {
+    anyhow::anyhow!(
+        "mysql cdc: encountered a Transaction_payload_event in the binlog — the source has \
+         binlog_transaction_compression enabled (turned on after this run opened, or a compressed \
+         span already in the binlog written while it was on), and this reader cannot expand it. \
+         Skipping it would capture NOTHING for that transaction while the checkpoint advanced past \
+         it — a silent data loss. Turn compression off for the replica rivet reads \
+         (SET GLOBAL binlog_transaction_compression = OFF; and remove it from my.cnf), then \
+         re-run: the un-acked span is re-read from the checkpoint."
+    )
 }
 
 /// Refuse to stream when the source packs transactions into
@@ -629,6 +661,24 @@ mod tests {
                 "{ok:?} is not a compressed binlog — the run must proceed"
             );
         }
+    }
+
+    /// #200-2: the open-time guard is not the whole story — compression turned on
+    /// AFTER open (or a compressed span already in the binlog) reaches `fill()` as
+    /// a `Transaction_payload_event`, which the reader cannot expand. Its arm must
+    /// REFUSE (naming the setting + the harm), never fall through to `_ => {}` and
+    /// silently skip the transaction while the checkpoint advances past it. Pure
+    /// message check here; the routing (arm calls this, not `_ => {}`) is proven
+    /// live by `mysql_cdc_compressed_payload_in_stream_refuses_not_skips`.
+    #[test]
+    fn compressed_payload_refusal_names_the_setting_and_the_harm() {
+        let msg = compressed_payload_refusal().to_string();
+        assert!(
+            msg.contains("Transaction_payload_event")
+                && msg.contains("binlog_transaction_compression")
+                && msg.contains("capture NOTHING"),
+            "the stream-time refusal must name the event, the setting, and the harm: {msg}"
+        );
     }
 
     // The `mysql-cdc` instance (cdc profile, :3307) — binlog + a REPLICATION grant.

--- a/src/state/checkpoint.rs
+++ b/src/state/checkpoint.rs
@@ -180,6 +180,39 @@ impl StateStore {
         }
     }
 
+    /// Un-pin chunks a prior run gave up on so an explicit `--resume` retries them.
+    ///
+    /// `fail_chunk_task(retryable=false)` pins `attempts = max_chunk_attempts` to
+    /// stop the SAME run burning the whole timeout budget on a deterministic
+    /// failure (the 300-minutes-for-nothing case its doc names). But that pin also
+    /// makes `claim_next_chunk_task` — whose predicate is `attempts <
+    /// max_chunk_attempts` — skip the chunk FOREVER, so the run's own remediation
+    /// ("fix the errors, then `rivet run --resume`") could not actually re-run it:
+    /// resume rescued only `running` (crash) tasks, never `failed` ones, and the
+    /// operator's fix was silently never retried.
+    ///
+    /// `--resume` is a DELIBERATE operator action after fixing the cause, so it is
+    /// exactly the moment to give every failed chunk (pinned-permanent OR
+    /// budget-exhausted) a fresh attempt budget. Reset only `failed` tasks —
+    /// `completed` and `pending` are untouched, so it never re-does finished work.
+    /// Returns the number of chunks un-pinned.
+    pub fn reset_failed_chunk_tasks_for_resume(&self, run_id: &str) -> Result<usize> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let sql = "UPDATE chunk_task SET status = 'pending', attempts = 0, updated_at = ?1
+             WHERE run_id = ?2 AND status = 'failed'";
+        match &self.conn {
+            StateConn::Sqlite(c) => {
+                let n = c.execute(sql, rusqlite::params![now, run_id])?;
+                Ok(n)
+            }
+            StateConn::Postgres(client) => {
+                let mut c = client.borrow_mut();
+                let n = c.execute(&pg_sql(sql), &[&now, &run_id])?;
+                Ok(n as usize)
+            }
+        }
+    }
+
     /// Atomically claim the next pending or retryable failed chunk.
     pub fn claim_next_chunk_task(&self, run_id: &str) -> Result<Option<(i64, String, String)>> {
         Self::claim_next_chunk_task_at_ref(&self.state_ref, run_id)
@@ -599,6 +632,69 @@ mod tests {
             "a chunk that failed on a deterministic error was re-claimed; the next attempt runs \
              the identical query against the identical data and cannot succeed. Retrying it to \
              the attempt cap spends the source's time budget N times over."
+        );
+    }
+
+    /// #200-4: an explicit `--resume` must un-pin a permanently-failed chunk so
+    /// the operator's fix is actually retried. Without
+    /// `reset_failed_chunk_tasks_for_resume` the pin (`attempts =
+    /// max_chunk_attempts`) survives resume and `claim_next_chunk_task` skips the
+    /// chunk forever — the run's own "fix errors and --resume" hint is a lie.
+    /// RED: drop the reset call and the second claim stays `None`.
+    #[test]
+    fn resume_un_pins_a_permanently_failed_chunk() {
+        let (_dir, s) = store_on_disk();
+        s.create_chunk_run("run_r", "orders", "h", 4).unwrap();
+        s.insert_chunk_tasks("run_r", &[(1, 5)]).unwrap();
+        s.claim_next_chunk_task("run_r").unwrap().expect("claim");
+        s.fail_chunk_task("run_r", 0, "deterministic boom (ERROR 3024)", false)
+            .unwrap();
+        // Precondition: pinned, so a bare re-claim (what resume did before) skips it.
+        assert!(
+            s.claim_next_chunk_task("run_r").unwrap().is_none(),
+            "precondition: a permanently-failed chunk is not re-claimable while pinned"
+        );
+
+        // The resume un-pin the operator's `--resume` now performs.
+        let n = s.reset_failed_chunk_tasks_for_resume("run_r").unwrap();
+        assert_eq!(n, 1, "exactly the one failed chunk is re-queued");
+
+        // Now the operator's fix gets a real retry: the chunk is claimable again,
+        // and it is the SAME chunk (index 0, keyspace 1..5), attempts reset.
+        let claimed = s
+            .claim_next_chunk_task("run_r")
+            .unwrap()
+            .expect("the un-pinned chunk must be re-claimable after resume");
+        assert_eq!(claimed.0, 0, "the same chunk index");
+        assert_eq!((claimed.1.as_str(), claimed.2.as_str()), ("1", "5"));
+    }
+
+    /// The reset is surgical: a COMPLETED chunk is never re-queued (that would
+    /// re-do finished work), only `failed` ones are. RED against a `WHERE` that
+    /// forgets the `status = 'failed'` clause.
+    #[test]
+    fn resume_reset_leaves_completed_chunks_alone() {
+        let (_dir, s) = store_on_disk();
+        s.create_chunk_run("run_c", "orders", "h", 4).unwrap();
+        s.insert_chunk_tasks("run_c", &[(1, 5), (6, 10)]).unwrap();
+        // chunk 0 completes; chunk 1 fails permanently.
+        s.claim_next_chunk_task("run_c").unwrap().unwrap();
+        s.complete_chunk_task("run_c", 0, 3, Some("part0.csv"))
+            .unwrap();
+        s.claim_next_chunk_task("run_c").unwrap().unwrap();
+        s.fail_chunk_task("run_c", 1, "boom", false).unwrap();
+
+        let n = s.reset_failed_chunk_tasks_for_resume("run_c").unwrap();
+        assert_eq!(
+            n, 1,
+            "only the failed chunk is re-queued, not the completed one"
+        );
+        // The completed chunk stays completed: the only claimable task is chunk 1.
+        let claimed = s.claim_next_chunk_task("run_c").unwrap().expect("claim");
+        assert_eq!(claimed.0, 1, "the completed chunk 0 must not be re-queued");
+        assert!(
+            s.claim_next_chunk_task("run_c").unwrap().is_none(),
+            "chunk 0 stays completed — nothing else to claim"
         );
     }
 

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -4714,6 +4714,13 @@ fn roast_pg_cdc_destination_placeholders_resolve_like_the_batch_path() {
     );
 }
 
+/// Serialises the TWO :3306 binlog-compression tests. They both flip
+/// `SET GLOBAL binlog_transaction_compression` on the shared batch server, so
+/// running them in parallel races (one turns it OFF mid-way through the other's
+/// ON window). A dedicated lock for just these two is cheap — unlike serialising
+/// the 60 :3307 CDC call sites the isolation note below deliberately avoided.
+static COMPRESSION_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// The binlog-compression guard, live.
 ///
 /// `binlog_transaction_compression` (MySQL 8.0.20+) packs a transaction's
@@ -4757,6 +4764,7 @@ fn roast_pg_cdc_destination_placeholders_resolve_like_the_batch_path() {
 #[test]
 #[ignore = "live: requires docker compose up -d mysql (:3306, log_bin=ON)"]
 fn mysql_cdc_refuses_a_compressed_binlog_instead_of_capturing_nothing() {
+    let _serial = COMPRESSION_SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let root_url = MYSQL_URL.replace("rivet:rivet@", "root:rivet@");
     let mut admin = match mysql::Conn::new(mysql::Opts::from_url(&root_url).unwrap()) {
         Ok(c) => c,
@@ -4871,5 +4879,134 @@ fn mysql_cdc_refuses_a_compressed_binlog_instead_of_capturing_nothing() {
         manifest_rows(&out2),
         2,
         "with compression off the same table must capture both rows"
+    );
+}
+
+/// #200-2: the STREAM-time sibling of the open-time guard above. Compression can
+/// be turned on AFTER a run has opened (the open-time `refuse_compressed_binlog`
+/// saw it OFF and passed), leaving a `Transaction_payload_event` in the binlog
+/// AHEAD of the checkpoint. The reader cannot expand it, and before the fix the
+/// `_ => {}` arm in `fill()` SILENTLY skipped it — the resume captured NOTHING for
+/// that transaction while the checkpoint advanced past it, an at-least-once break
+/// that every count/manifest check would call success.
+///
+/// The sequence forces exactly that: anchor with compression OFF (open-time guard
+/// passes), write a compressed transaction, then RESUME with compression still
+/// OFF at open (guard passes again) so the compressed span reaches `fill()`. The
+/// resume must FAIL loudly, not report a clean zero-capture.
+#[test]
+#[ignore = "live: requires docker compose up -d mysql (:3306, log_bin=ON, 8.0.20+)"]
+fn mysql_cdc_compressed_payload_in_stream_refuses_not_skips() {
+    let _serial = COMPRESSION_SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    let root_url = MYSQL_URL.replace("rivet:rivet@", "root:rivet@");
+    let mut admin = match mysql::Conn::new(mysql::Opts::from_url(&root_url).unwrap()) {
+        Ok(c) => c,
+        Err(e) => panic!("cdc-profile MySQL admin connection: {e}"),
+    };
+    let supported: Option<String> = admin
+        .query_first("SELECT @@global.binlog_transaction_compression")
+        .ok()
+        .flatten();
+    if supported.is_none() {
+        eprintln!("skip: server has no binlog_transaction_compression (pre-8.0.20)");
+        return;
+    }
+
+    struct CompressionGuard(String);
+    impl Drop for CompressionGuard {
+        fn drop(&mut self) {
+            if let Ok(mut c) = mysql::Conn::new(mysql::Opts::from_url(&self.0).unwrap()) {
+                let _ = c.query_drop("SET GLOBAL binlog_transaction_compression = OFF");
+            }
+        }
+    }
+    let _restore = CompressionGuard(root_url.clone());
+    // Start from OFF so the anchor run's OPEN-time guard passes.
+    admin
+        .query_drop("SET GLOBAL binlog_transaction_compression = OFF")
+        .unwrap();
+
+    let tbl = unique_name("cdc_cmp_stream");
+    let mut c = mysql::Conn::new(mysql::Opts::from_url(MYSQL_URL).unwrap()).expect("batch mysql");
+    c.query_drop(format!("DROP TABLE IF EXISTS {tbl}")).unwrap();
+    c.query_drop(format!("CREATE TABLE {tbl} (id INT PRIMARY KEY, v TEXT)"))
+        .unwrap();
+    struct BatchTable(String);
+    impl Drop for BatchTable {
+        fn drop(&mut self) {
+            if let Ok(mut c) = mysql::Conn::new(mysql::Opts::from_url(MYSQL_URL).unwrap()) {
+                let _ = c.query_drop(format!("DROP TABLE IF EXISTS {}", self.0));
+            }
+        }
+    }
+    let _guard = BatchTable(tbl.clone());
+
+    let d = tempfile::tempdir().unwrap();
+    let ckpt = d.path().join("cdc.ckpt");
+    let cfg_into = |dest: &std::path::Path| {
+        write_config(
+            &d,
+            &Rig::mysql_cdc(&tbl)
+                .source_url(&root_url)
+                .checkpoint_path(ckpt.clone())
+                .dest_path(dest.to_path_buf())
+                .yaml(),
+        )
+    };
+
+    // 1) Anchor with compression OFF — pins the checkpoint at the current coords,
+    //    open-time guard passes cleanly.
+    let out1 = d.path().join("out1");
+    std::fs::create_dir_all(&out1).unwrap();
+    run_rivet_ok(&cfg_into(&out1));
+
+    // 2) Turn compression ON, then write a sizeable, highly-compressible
+    //    transaction from a FRESH session (the session captures the global at
+    //    connect) so MySQL packs it into a Transaction_payload_event in the binlog
+    //    AHEAD of the checkpoint.
+    admin
+        .query_drop("SET GLOBAL binlog_transaction_compression = ON")
+        .unwrap();
+    let mut writer = mysql::Conn::new(mysql::Opts::from_url(MYSQL_URL).unwrap()).expect("writer");
+    writer.query_drop("BEGIN").unwrap();
+    for i in 1..=50 {
+        writer
+            .query_drop(format!(
+                "INSERT INTO {tbl} VALUES ({i}, REPEAT('rivet-compressible-', 200))"
+            ))
+            .unwrap();
+    }
+    writer.query_drop("COMMIT").unwrap();
+
+    // 3) Turn compression OFF so the RESUME's open-time guard passes too — the
+    //    only thing that can catch the compressed span now is the stream-time arm.
+    admin
+        .query_drop("SET GLOBAL binlog_transaction_compression = OFF")
+        .unwrap();
+    let out2 = d.path().join("out2");
+    std::fs::create_dir_all(&out2).unwrap();
+    let o = run_rivet(&["run", "--config", cfg_into(&out2).to_str().unwrap()]);
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&o.stdout),
+        String::from_utf8_lossy(&o.stderr)
+    );
+    assert!(
+        !o.status.success(),
+        "a compressed transaction in the stream must FAIL the resume, not silently \
+         skip it and report success:\n{text}"
+    );
+    assert!(
+        text.contains("Transaction_payload_event")
+            && text.contains("binlog_transaction_compression"),
+        "the stream-time refusal must name the event + the setting so it is actionable:\n{text}"
+    );
+    // The compressed rows were NOT captured (correct — refused, not skipped): the
+    // checkpoint did not advance past them, so once compression is truly off they
+    // re-read. The point of #200-2 is that rivet said so loudly instead of
+    // shipping a _SUCCESS over a hole.
+    assert!(
+        !out2.join("_SUCCESS").exists(),
+        "a refused resume must not write _SUCCESS"
     );
 }

--- a/tests/live/live_cdc_mssql.rs
+++ b/tests/live/live_cdc_mssql.rs
@@ -1575,3 +1575,123 @@ fn mssql_cdc_case_only_table_mismatch_must_not_silently_drop_events() {
          collation is case-insensitive, so every other layer accepted the name."
     );
 }
+
+/// #200-3: the catalog-identity guard must also fire on the `rivet cdc` CLI path,
+/// not only in `mode: cdc` config mode. `dispatch.rs` hard-coded
+/// `configured_tables = Vec::new()` for the CLI, and `mssql/cdc.rs` disables the
+/// cross-check when that set is empty — so `rivet cdc --capture-instance X
+/// --table Y` opened WITHOUT the guard the config path has, and a `--table`
+/// spelled in a case the catalog does not use routes ZERO events while the
+/// checkpoint advances past them (the same silent drop the config-mode test above
+/// guards, on the sibling entry point).
+///
+/// The fix passes `--table` — which the CLI ALREADY routes/filters by — as
+/// `configured_tables`, so the guard has the same subject it does in config mode.
+/// The `--output` leg is used (durable sink + checkpoint), because the drop is
+/// only dangerous once a checkpoint can advance.
+// AUDIT-RED cdc-cli-identity: a case-only --table mismatch on the CLI path routes ZERO events while the checkpoint advances — expected to FAIL until the CLI passes --table as configured_tables.
+#[test]
+#[ignore = "live: requires docker compose mssql with SQL Server Agent + CDC"]
+fn mssql_cdc_cli_path_case_only_table_mismatch_must_not_silently_drop_events() {
+    let _serial = CDC_SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+
+    let table = format!("CliIdent{}", std::process::id() % 100_000);
+    let table = table.as_str();
+    let ci = &format!("dbo_{table}");
+    mssql_cdc_drop_table(&format!("dbo.{table}"));
+    mssql_cdc_exec(&format!(
+        "CREATE TABLE dbo.{table} (id int PRIMARY KEY, v nvarchar(50))"
+    ));
+    enable_cdc(table, ci);
+    let _guard = MssqlCdcTable {
+        table: table.to_string(),
+        ci: ci.clone(),
+    };
+
+    let d = tempfile::tempdir().unwrap();
+    let out = tempfile::tempdir().unwrap();
+    let ckpt = d.path().join("cli.ckpt");
+
+    // The CLI invocation, mirroring config mode's mismatch: --table in a case the
+    // catalog does not use. The anchor is allowed to REFUSE (the guard firing at
+    // open is exactly the fix) — refusing before any checkpoint advances is the
+    // outcome this test wants.
+    let cli = |dir: &std::path::Path, tbl: &str| {
+        run_rivet_env(
+            &[
+                "cdc",
+                "--source",
+                MSSQL_CDC_URL,
+                "--capture-instance",
+                ci,
+                "--table",
+                tbl,
+                "--checkpoint",
+                ckpt.to_str().unwrap(),
+                "--output",
+                dir.to_str().unwrap(),
+            ],
+            &[],
+        )
+    };
+
+    let anchor = cli(out.path(), &table.to_lowercase());
+    if !anchor.status.success() {
+        let why = String::from_utf8_lossy(&anchor.stderr);
+        assert!(
+            why.contains("no configured table matches"),
+            "the CLI anchor run failed for an unrelated reason:\n{why}"
+        );
+        return; // refused at open, before any checkpoint could advance — correct
+    }
+
+    mssql_cdc_exec(&format!(
+        "INSERT INTO dbo.{table} VALUES (1,'a'),(2,'b'),(3,'c');"
+    ));
+    wait_for_capture(ci, 3);
+
+    let o = cli(out.path(), &table.to_lowercase());
+    if !o.status.success() {
+        return; // refused — the guard the fix adds; correct
+    }
+
+    // A 0-capture CDC run writes NO parquet parts (the sink rolls only on a
+    // committed event), so part presence is the robust "did it capture" signal —
+    // avoiding a cell-type parse of the CLI --output shape.
+    let captured = files_with_extension(out.path(), "parquet").len();
+    if captured > 0 {
+        return; // routed correctly; nothing to guard
+    }
+
+    // Captured nothing AND exited 0 — the pre-fix silent drop. Prove the changes
+    // were there all along: a correctly-cased CLI run against a FRESH checkpoint
+    // recovers them (parts appear on disk).
+    let still_in_ct = mssql_cdc_query_i64(&format!("SELECT COUNT(*) FROM cdc.{ci}_CT"));
+    let out_fixed = tempfile::tempdir().unwrap();
+    let fixed_ckpt = d.path().join("cli_fixed.ckpt");
+    let _ = run_rivet_env(
+        &[
+            "cdc",
+            "--source",
+            MSSQL_CDC_URL,
+            "--capture-instance",
+            ci,
+            "--table",
+            &format!("dbo.{table}"),
+            "--checkpoint",
+            fixed_ckpt.to_str().unwrap(),
+            "--output",
+            out_fixed.path().to_str().unwrap(),
+        ],
+        &[],
+    );
+    let after_fix = files_with_extension(out_fixed.path(), "parquet").len();
+
+    panic!(
+        "the `rivet cdc` CLI path captured 0 of the {still_in_ct} change row(s) on a case-only \
+         --table mismatch and exited 0; a correctly-cased run wrote {after_fix} part(s). The CLI \
+         passed configured_tables = Vec::new() (dispatch.rs), which disables the catalog-identity \
+         cross-check (mssql/cdc.rs), so the guard the config path has never fired here — every \
+         event was dropped while the checkpoint advanced past it."
+    );
+}

--- a/tests/live/live_keyset_parallel.rs
+++ b/tests/live/live_keyset_parallel.rs
@@ -68,6 +68,24 @@ fn id_set_and_fanout(dir: &std::path::Path) -> (usize, BTreeSet<i64>, usize) {
     (count, keys, workers.len())
 }
 
+/// Parquet parts per range worker, keyed `w{ridx}` (the `_pk_w{ridx}_{page}` token
+/// in every part name). Lets a test assert a SPECIFIC range left N durable pages —
+/// needed to prove a mid-range failure's pre-failure pages are on disk (#200-1).
+fn worker_part_counts(dir: &std::path::Path) -> std::collections::BTreeMap<String, usize> {
+    let mut out: std::collections::BTreeMap<String, usize> = std::collections::BTreeMap::new();
+    for p in files_with_extension(dir, "parquet") {
+        if let Some(ridx) = p
+            .file_name()
+            .and_then(|n| n.to_str())
+            .and_then(|n| n.split("_pk_w").nth(1))
+            .and_then(|s| s.split('_').next())
+        {
+            *out.entry(format!("w{ridx}")).or_default() += 1;
+        }
+    }
+    out
+}
+
 /// The shared scenario: run parallel keyset on an already-seeded `1..=n` integer
 /// key and assert (1) every row round-trips exactly once (structural parity across
 /// the N ranges) and (2) the run FANNED OUT to ≥2 workers (did not collapse).
@@ -790,6 +808,75 @@ fn parallel_keyset_worker_error_still_counts_the_durable_parts_postgres() {
         Some(on_disk as i64),
         "a failed parallel-keyset run must count the parts it left durable \
          ({on_disk} on disk) — the retry guard reads this and nothing else"
+    );
+
+    let mut c2 = pg_connect();
+    let _ = c2.batch_execute(&format!("DROP TABLE IF EXISTS {table};"));
+}
+
+/// #200-1: the SAME durable-parts blind spot, one level deeper — page granularity
+/// WITHIN a range. The worker-level template above fails a range at its FIRST page
+/// (`keyset_parallel_worker:2`), so the failing range writes nothing and every
+/// on-disk part belongs to a COMMITTED range — `files_committed == on_disk` holds
+/// even with the bug, because the bug only drops the parts of a range that both
+/// (a) wrote pages AND (b) never committed.
+///
+/// This fixture makes a range do exactly that: `keyset_parallel_worker_midrange:2`
+/// fires only after range 2 has already made page 0 durable, so range 2 leaves a
+/// parquet on disk yet never reaches its checkpoint commit. Pre-fix those parts
+/// lived in the worker's `local_parts`, published to the shared count ONLY at
+/// range completion — the mid-range `return` dropped them, so `files_committed`
+/// under-counted the debris the retry guard reads. RED before the per-page publish:
+/// `files_committed` = the committed ranges only, `on_disk` = those + range 2's
+/// page 0.
+///
+/// Needs ≥2 pages per range so page 0 lands before the mid-range fire: 4000 rows /
+/// `parallel: 4` = 1000-row ranges over `chunk_size: 500` = 2 pages each.
+#[test]
+#[ignore = "live: requires docker compose up -d postgres"]
+fn parallel_keyset_midrange_error_counts_pre_failure_page_parts_postgres() {
+    require_alive(LiveService::Postgres);
+    let table = unique_name("pk_midr");
+    let mut c = pg_connect();
+    c.batch_execute(&format!(
+        "DROP TABLE IF EXISTS {table};
+         CREATE TABLE {table} (id BIGINT PRIMARY KEY, payload INT NOT NULL);
+         INSERT INTO {table} SELECT g, g FROM generate_series(1, 4000) g;"
+    ))
+    .unwrap();
+    let rig = parallel_keyset(Rig::pg_batch(&format!("public.{table}")));
+    let out = rig.run_with_env("RIVET_TEST_ERROR_AT", "keyset_parallel_worker_midrange:2");
+    assert!(
+        !out.status.success(),
+        "a worker mid-range error must fail the run"
+    );
+
+    // The premise: range 2 wrote page 0 to disk BEFORE the mid-range failure, and
+    // the committed ranges wrote their pages too. If range 2 wrote nothing this
+    // test degenerates into the worker-level one and proves nothing new.
+    let per_worker = worker_part_counts(&rig.out_dir());
+    let on_disk: usize = per_worker.values().sum();
+    assert!(
+        per_worker.get("w2").copied().unwrap_or(0) >= 1,
+        "fixture is inert for #200-1: range 2 must leave ≥1 durable page BEFORE it \
+         fails mid-range, got per-worker parts {per_worker:?}"
+    );
+    assert!(
+        on_disk > per_worker.get("w2").copied().unwrap_or(0),
+        "fixture needs committed ranges too, got {per_worker:?}"
+    );
+
+    // The seam: files_committed must count EVERY durable part on disk, including
+    // range 2's pre-failure page — the retry guard reads this and nothing else.
+    // RED pre-fix: files_committed omitted range 2's uncommitted-but-durable page.
+    let db = StateDb::next_to_config(&rig.config_path());
+    let run_id = db.latest_run_id(rig.export_name());
+    let m = db.metrics_row(&run_id);
+    assert_eq!(
+        m.files_committed,
+        Some(on_disk as i64),
+        "a mid-range failure must count the pages the failing range already made \
+         durable ({on_disk} on disk, per-worker {per_worker:?})"
     );
 
     let mut c2 = pg_connect();


### PR DESCRIPTION
Closes #200 — the four bugs the adversarial verifier confirmed pre-existing (present at ff52f00, before this session's feature work). Each is a separate fix with a RED-proven live test.

## 1. keyset drops a failed range's already-durable page parts (`src/pipeline/keyset.rs`)
A parallel-keyset worker publishes its parts to the shared count (`parts_mx` → `files_committed`) only at range completion, after the checkpoint commit. Every mid-range error path returns before that, so pages a range had **already** written to the destination were dropped from `files_committed` — `decide_export_retry` then read a short count with parts on disk and decided "retry", producing a duplicate when a range's output shrank between attempts. Fix: publish each page's parts the moment they land (durable pre-commit); cursor/checksums stay commit-gated. Same durable-parts blind spot the worker-level bail already fixed, one level deeper (page granularity).
RED-proven: `parallel_keyset_midrange_error_counts_pre_failure_page_parts_postgres` — `Some(7)` vs `Some(8)` pre-fix.

## 2. MySQL binlog compression silently skipped in-stream (`src/source/mysql/cdc.rs`)
`refuse_compressed_binlog` checks `@@global.binlog_transaction_compression` at **open** only. Compression enabled after open — or a compressed span already ahead of the checkpoint — reaches `fill()` as a `Transaction_payload_event`, which the `_ => {}` catch-all silently skipped: captured nothing while the checkpoint advanced past it (an at-least-once break). Fix: an explicit arm bails loudly (`compressed_payload_refusal`, pure/offline-testable); the un-acked span re-reads once compression is off.
RED-proven: `mysql_cdc_compressed_payload_in_stream_refuses_not_skips`.

## 3. MSSQL catalog-identity guard bypassed on the `rivet cdc` CLI (`src/cli/dispatch.rs`)
The CLI hard-coded `configured_tables = Vec::new()`, which disables the catalog-identity cross-check (`mssql/cdc.rs`). So `rivet cdc --capture-instance X --table Y` opened without the guard config mode has, and a `--table` the catalog spells differently routed **zero** events while the checkpoint advanced past them. Fix: pass `--table` (already the CLI's routing filter) as `configured_tables`; empty still keeps the guard off.
RED-proven: `mssql_cdc_cli_path_case_only_table_mismatch_must_not_silently_drop_events` — captured 0 of 3 pre-fix.

## 4. permanently-failed chunk never un-pinned by `--resume` (`src/state/checkpoint.rs`)
`fail_chunk_task(retryable=false)` pins `attempts = max_chunk_attempts` (to stop one run burning its whole timeout budget on a deterministic failure), but that pin also made `claim_next_chunk_task` skip the chunk forever — the run's own "fix errors and `rivet run --resume`" remediation could never re-run it (resume rescued only `running` crash tasks). Fix: `--resume` now also re-queues every `failed` chunk (`reset_failed_chunk_tasks_for_resume`); surgical — completed/pending untouched.
RED-proven: `resume_un_pins_a_permanently_failed_chunk` + `resume_reset_leaves_completed_chunks_alone`.

Offline: 2511 passed, clippy clean. Every live test above run against the local stand (fixed = green, mutant = red).

🤖 Generated with [Claude Code](https://claude.com/claude-code)