### PR TITLE
fix(validate): manifest coherence under a --pool --split shared prefix (#167 GA)

### DIFF
--- a/src/pipeline/validate_manifest.rs
+++ b/src/pipeline/validate_manifest.rs
@@ -33,11 +33,11 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::destination::Destination;
+use crate::destination::{Destination, ObjectMeta};
 use crate::error::Result;
 use crate::manifest::{
-    MANIFEST_FILENAME, RunManifest, SUCCESS_FILENAME, join_key, parse_success_marker,
-    success_marker_body,
+    MANIFEST_FILENAME, PartStatus, RunManifest, SUCCESS_FILENAME, is_run_unique_manifest_name,
+    join_key, parse_success_marker, success_marker_body,
 };
 use crate::pipeline::manifest_reconcile::{PartPresence, reconcile_manifest_against_listing};
 
@@ -569,6 +569,58 @@ impl ManifestVerification {
 ///
 /// Regardless of depth, `depth_level` on the returned verdict records the
 /// level this pass ran at.
+/// Read every run-unique manifest COPY (`manifest-<run_id>.json`) named in the
+/// prefix listing. Best-effort: a copy that fails to read or parse is skipped —
+/// the untracked scan it feeds is advisory, so a bad sibling copy must never turn
+/// validate into an error (worst case a part it would have claimed stays flagged,
+/// the pre-#167 behaviour). The canonical `manifest.json` is not a copy and is
+/// excluded (it is already the primary manifest).
+fn read_sibling_manifests(dest: &dyn Destination, listing: &[ObjectMeta]) -> Vec<RunManifest> {
+    let mut out = Vec::new();
+    for meta in listing {
+        let base = meta.key.rsplit('/').next().unwrap_or("");
+        if !is_run_unique_manifest_name(base) {
+            continue;
+        }
+        if let Ok(bytes) = read_capped(dest, &meta.key, MANIFEST_MAX_BYTES)
+            && let Ok(m) = serde_json::from_slice::<RunManifest>(&bytes)
+        {
+            out.push(m);
+        }
+    }
+    out
+}
+
+/// The set of destination keys claimed by a SAME-FAMILY sibling run-unique
+/// manifest copy (#167 merge-back). A part is claimed only when a sibling of the
+/// SAME `export_family` declared it `Committed`, so a foreign export's parts under
+/// a mistakenly-shared prefix are still surfaced as untracked. Pure — the I/O
+/// (reading the copies) is [`read_sibling_manifests`]'s job.
+fn sibling_claimed_part_keys(
+    siblings: &[RunManifest],
+    canonical_family: &str,
+    manifest_dir: &str,
+) -> std::collections::BTreeSet<String> {
+    let mut out = std::collections::BTreeSet::new();
+    if canonical_family.is_empty() {
+        // A legacy manifest with no family: never claim across copies — keep the
+        // pre-#167 behaviour (a legacy prefix is single-run, so there is nothing
+        // to claim, and folding by empty family could hide cross-contamination).
+        return out;
+    }
+    for m in siblings {
+        if m.export_family != canonical_family {
+            continue;
+        }
+        for p in &m.parts {
+            if p.status == PartStatus::Committed {
+                out.insert(join_key(manifest_dir, &p.path));
+            }
+        }
+    }
+    out
+}
+
 pub fn verify_at_destination(
     dest: &dyn Destination,
     manifest_dir: &str,
@@ -687,11 +739,27 @@ pub fn verify_at_destination(
     // the parts are physically present.
     let reconciliation = if depth.runs_part_reconcile() {
         match dest.list_prefix(manifest_dir) {
-            Ok(listing) => Some(reconcile_manifest_against_listing(
-                &manifest,
-                &listing,
-                manifest_dir,
-            )),
+            Ok(listing) => {
+                let mut rec = reconcile_manifest_against_listing(&manifest, &listing, manifest_dir);
+                // #167: a `--pool --split` prefix holds N run-unique manifest
+                // copies of ONE family, each declaring a DISJOINT set of parts.
+                // The canonical `manifest.json` lists only the LAST writer's
+                // parts, so every sibling unit's parts would read as untracked
+                // surplus — noise that also MASKS a genuine orphan. Claim any
+                // listed part a SAME-FAMILY sibling copy declared committed, so
+                // only truly foreign objects stay untracked. (Also cleans up the
+                // repeated-run / CDC-soak case, where the historical runs' parts
+                // are likewise declared by their own copies.) Safe by
+                // construction: this only NARROWS untracked — it can never add a
+                // failure — and a foreign family's parts are never claimed.
+                if !rec.untracked.is_empty() && !manifest.export_family.is_empty() {
+                    let siblings = read_sibling_manifests(dest, &listing);
+                    let claimed =
+                        sibling_claimed_part_keys(&siblings, &manifest.export_family, manifest_dir);
+                    rec.untracked.retain(|o| !claimed.contains(&o.key));
+                }
+                Some(rec)
+            }
             Err(e) => {
                 out.failures.push(Failure::ListPrefixError {
                     detail: format!("{e:#}"),
@@ -934,6 +1002,63 @@ mod tests {
         if matches!(m.status, ManifestStatus::Success) {
             std::fs::write(dir.join(SUCCESS_FILENAME), success_marker_body(&body)).unwrap();
         }
+    }
+
+    // ── #167 sibling-copy claim (manifest coherence under a shared prefix) ──
+
+    /// A same-family sibling copy's committed parts are claimed; a FOREIGN
+    /// family's are not. RED against claiming across families (which would hide a
+    /// cross-contamination the shared-prefix guard exists to surface).
+    #[test]
+    fn sibling_claimed_part_keys_claims_same_family_only() {
+        let unit = |name: &str, path: &str, fam: &str| {
+            let mut m = build_manifest(vec![part(0, 10, 100, "fp")], ManifestStatus::Success);
+            m.export_family = fam.into();
+            m.export_name = name.into();
+            m.parts[0].path = path.into();
+            m
+        };
+        let siblings = vec![
+            unit("daily#0", "daily#0_p.parquet", "daily"),
+            unit("daily#1", "daily#1_p.parquet", "daily"),
+            unit("other", "other_p.parquet", "other"),
+        ];
+        let claimed = sibling_claimed_part_keys(&siblings, "daily", "");
+        assert!(
+            claimed.contains("daily#0_p.parquet") && claimed.contains("daily#1_p.parquet"),
+            "same-family split units' parts must be claimed: {claimed:?}"
+        );
+        assert!(
+            !claimed.contains("other_p.parquet"),
+            "a FOREIGN family's part must NOT be claimed — cross-contamination must still surface"
+        );
+    }
+
+    /// A legacy canonical (empty family) claims nothing — pre-#167 behaviour, so
+    /// the widening never applies where a family cannot disambiguate.
+    #[test]
+    fn sibling_claimed_part_keys_empty_family_claims_nothing() {
+        let mut m = build_manifest(vec![part(0, 10, 100, "fp")], ManifestStatus::Success);
+        m.export_family = "daily".into();
+        m.parts[0].path = "p.parquet".into();
+        assert!(
+            sibling_claimed_part_keys(&[m], "", "").is_empty(),
+            "an empty canonical family must claim nothing"
+        );
+    }
+
+    /// A non-committed (quarantined) sibling part is NOT claimed — only durable
+    /// committed parts belong to the dataset.
+    #[test]
+    fn sibling_claimed_part_keys_skips_non_committed() {
+        let mut m = build_manifest(vec![part(0, 10, 100, "fp")], ManifestStatus::Success);
+        m.export_family = "daily".into();
+        m.parts[0].path = "q.parquet".into();
+        m.parts[0].status = PartStatus::Quarantined;
+        assert!(
+            sibling_claimed_part_keys(&[m], "daily", "").is_empty(),
+            "a quarantined part must not be claimed as a tracked dataset part"
+        );
     }
 
     // ── happy path ───────────────────────────────────────────────────────

--- a/tests/live/live_pool_toxiproxy.rs
+++ b/tests/live/live_pool_toxiproxy.rs
@@ -314,3 +314,127 @@ fn pool_split_realizes_the_range_split_and_the_union_is_exact() {
         "the small export must still be exact"
     );
 }
+
+/// #167 GA-hardening: manifest coherence under the shared prefix.
+///
+/// A `--split` prefix holds N concurrent run-unique manifest copies of ONE
+/// family, each declaring a DISJOINT part set. Three coherence properties, each
+/// measured on the real prefix the split writes (not theorized):
+///
+/// 1. LOAD view (authoritative): the copies all fold to the parent family and
+///    their row_counts sum to the whole (`dir_manifest_copy_total_rows`) — so
+///    `rivet load`'s cross-run reconcile reads one table with the full count, not
+///    N families or one unit's rows. This is the silent-under-count guard.
+/// 2. VALIDATE view: `rivet validate` does NOT flag a sibling unit's parts as
+///    untracked — before the fix the canonical manifest (last writer) listed one
+///    unit and every other unit's parts read as untracked surplus.
+/// 3. SAFETY: a genuinely foreign object IS still flagged — the fix only claims
+///    SAME-FAMILY siblings, so a real orphan is not masked by the noise removal.
+#[test]
+#[ignore = "live: requires docker compose up -d postgres"]
+fn pool_split_prefix_is_manifest_coherent() {
+    const HEAVY: i64 = 200_000;
+    const SMALL: i64 = 1_000;
+
+    let rig = Rig::pg_batch("mcoh_giant")
+        .query(&format!(
+            "SELECT g AS id, md5(g::text) AS a, md5((g*3)::text) AS b \
+             FROM generate_series(1, {HEAVY}) g"
+        ))
+        .mode("chunked")
+        .export_line("chunk_column: id")
+        .export_line("chunk_size: 50000")
+        .export_line("parallel_safe: true")
+        .also_export(
+            "mcoh_small",
+            &format!("SELECT g AS id, md5(g::text) AS payload FROM generate_series(1, {SMALL}) g"),
+        )
+        .also_export_line("parallel_safe: true");
+    let cfg = rig.config_path();
+
+    // Prime durations, clear, then split (advise_split keys off recorded duration).
+    let prime = run_rivet_env(&["apply", cfg.to_str().unwrap(), "--pool", "2"], &[]);
+    assert!(
+        prime.status.success(),
+        "prime: {}",
+        String::from_utf8_lossy(&prime.stderr)
+    );
+    for d in [rig.out_dir(), rig.out_dir_for("mcoh_small")] {
+        let _ = std::fs::remove_dir_all(&d);
+        std::fs::create_dir_all(&d).unwrap();
+    }
+    let split = run_rivet_env(
+        &["apply", cfg.to_str().unwrap(), "--pool", "2", "--split"],
+        &[],
+    );
+    let slog = format!(
+        "{}{}",
+        String::from_utf8_lossy(&split.stdout),
+        String::from_utf8_lossy(&split.stderr)
+    );
+    assert!(split.status.success(), "split run must succeed:\n{slog}");
+    assert!(
+        slog.contains("split 'mcoh_giant' into"),
+        "the split must have fired (else this test is vacuous):\n{slog}"
+    );
+
+    let giant = rig.out_dir();
+
+    // (1) LOAD coherence: >=2 unit copies, all folding to family "mcoh_giant",
+    //     summing to the whole. RED if a unit recorded its own name as the family
+    //     (the load would then see N families and REFUSE) or if a unit's rows
+    //     were dropped from the sum.
+    assert!(
+        dir_manifest_copy_count(&giant) >= 2,
+        "the split must write >=2 run-unique unit manifests, got {}",
+        dir_manifest_copy_count(&giant)
+    );
+    assert_eq!(
+        dir_manifest_copy_total_rows(&giant),
+        HEAVY,
+        "the run-unique manifest copies must sum to the whole table — the cross-run \
+         reconcile the loader runs"
+    );
+    for entry in std::fs::read_dir(&giant).unwrap() {
+        let p = entry.unwrap().path();
+        let name = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        if name.starts_with("manifest-") && name.ends_with(".json") {
+            let m: serde_json::Value = serde_json::from_slice(&std::fs::read(&p).unwrap()).unwrap();
+            assert_eq!(
+                m["export_family"].as_str(),
+                Some("mcoh_giant"),
+                "every split unit copy must fold to the parent family (load sees one table): {name}"
+            );
+        }
+    }
+
+    // (2) VALIDATE coherence: no sibling unit's parts flagged as untracked.
+    let v = run_rivet_env(&["validate", "--config", cfg.to_str().unwrap()], &[]);
+    let vlog = format!(
+        "{}{}",
+        String::from_utf8_lossy(&v.stdout),
+        String::from_utf8_lossy(&v.stderr)
+    );
+    assert!(
+        !vlog.contains("untracked object: mcoh_giant#"),
+        "a split unit's own parts must not be flagged untracked (the merge-back \
+         claims same-family siblings):\n{vlog}"
+    );
+
+    // (3) SAFETY: a genuinely foreign object under the prefix IS still flagged —
+    //     the fix narrows untracked to non-sibling objects, it does not blind it.
+    let orphan = giant.join("mcoh_foreign_orphan.parquet");
+    std::fs::write(&orphan, b"not a real rivet part").unwrap();
+    let v2 = run_rivet_env(&["validate", "--config", cfg.to_str().unwrap()], &[]);
+    let vlog2 = format!(
+        "{}{}",
+        String::from_utf8_lossy(&v2.stdout),
+        String::from_utf8_lossy(&v2.stderr)
+    );
+    assert!(
+        vlog2.contains("mcoh_foreign_orphan.parquet"),
+        "a true foreign orphan must STILL be flagged untracked — the fix must not \
+         mask a real orphan behind the sibling-claim:\n{vlog2}"
+    );
+    let _ = std::fs::remove_file(&orphan);
+}


### PR DESCRIPTION
First GA-hardening item for #167 (opt-in `apply --pool --split`): manifest coherence under the shared prefix.

## What I measured (not theorized)
Reproduced a real `--pool --split` prefix and inspected the manifests:

| View | Result |
|---|---|
| Run-unique copies | `giant#0` fam=**giant** 150001 · `giant#1` fam=**giant** 149999 |
| **Summed copies** (`dir_manifest_copy_total_rows`) | **300000 ✓** |
| **Families** | **{giant} → ONE ✓** (`load`'s `ensure_single_export` permits) |
| Canonical `manifest.json` | 150001 — **one unit** (last-writer-wins) |

So the **LOAD path is already coherent** — `run_export_job` records `export.family()`, which folds the `#i` suffix, so the copies fold to one family and sum to the whole. The gap was **`rivet validate`**: it reads only the canonical manifest (one unit), so every *other* split unit's parts read as untracked surplus — noise that under-reports **and masks a genuine orphan**.

## Fix
`verify_at_destination`: a listed part claimed by a **same-family** sibling run-unique copy is not flagged untracked. Safe by construction — only NARROWS untracked (never adds a failure), never claims a **foreign** family's parts (cross-contamination still surfaces), and a copy that fails to read is skipped (pre-fix behaviour). Pure `sibling_claimed_part_keys` + best-effort `read_sibling_manifests`.

Also cleans up the repeated-run / CDC-soak case (historical runs' parts are likewise declared by their own copies).

## Verified
- **unit**: `sibling_claimed_part_keys` claims same-family only / empty-family claims nothing / skips non-committed — RED-proven against dropping the family guard.
- **live** `pool_split_prefix_is_manifest_coherent`: copies fold to one family + sum to the whole (load coherence) → validate flags no sibling part (**RED-proven** against neutering the claim) → a planted foreign orphan **is still flagged** (safety).

Offline: 2522 passed, clippy clean.

Remaining #167 GA items (separate PRs): resume coherence across N units, `check`/`plan` awareness of split units, cold makespan measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
