### PR TITLE
fix(pool): refuse --split --resume — a partial split cannot be resumed per-unit (#167 GA)

### DIFF
--- a/src/pipeline/apply_cmd.rs
+++ b/src/pipeline/apply_cmd.rs
@@ -432,6 +432,38 @@ mod tests {
         );
     }
 
+    /// #167 resume coherence: `apply --pool --split --resume` must be REFUSED,
+    /// not silently mis-handled. A partial split leaves the shared prefix's
+    /// `_SUCCESS` (from the first unit to finish) which the skip-completed filter
+    /// reads as "the whole giant is done" → a silent GAP; a fresh re-run instead
+    /// DUPs. Refusing converts both silent failures into a clear error. RED
+    /// against removing the bail (run_pool then proceeds to "nothing to run" and
+    /// returns Ok, so `unwrap_err` panics).
+    #[test]
+    fn pool_split_refuses_resume() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let cfg = dir.path().join("c.yaml");
+        std::fs::write(
+            &cfg,
+            "source: { type: postgres, url: \"postgresql://u:p@localhost/db\" }\nexports: []\n",
+        )
+        .unwrap();
+        let err = run_apply_command(
+            cfg.to_str().unwrap(),
+            false, // force
+            false, // parallel
+            true,  // resume
+            Some(2),
+            true, // split
+        )
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("does not support --resume") && msg.contains("--split"),
+            "expected a --split + --resume refusal, got: {msg}"
+        );
+    }
+
     // ── cursor drift ─────────────────────────────────────────────────────────
 
     #[test]

--- a/src/pipeline/run.rs
+++ b/src/pipeline/run.rs
@@ -767,6 +767,30 @@ pub(crate) fn run_pool(
     split: bool,
 ) -> Result<()> {
     let m = m.max(1);
+    // #167 resume coherence: `--split --resume` is refused, LOUDLY. A range-split
+    // export's N units share ONE destination prefix, so a partial run cannot be
+    // resumed per-unit yet — the single prefix-level `_SUCCESS` cannot say WHICH
+    // units finished. Measured both silent failure modes on a partial split:
+    //   * `--resume`      → the shared `_SUCCESS` (written by the FIRST unit to
+    //                       finish) makes the skip-completed filter treat the whole
+    //                       giant as done → the incomplete unit is never re-run →
+    //                       a silent GAP (150k of 300k rows).
+    //   * fresh (no resume) → a re-run re-splits and writes NEW run-id part names
+    //                       beside the survivors → silent DUP (450k of 300k).
+    // Refusing converts the silent loss/dup into a clear error the operator can act
+    // on. Recovery: clear the prefix and re-run fresh, or drop `--split` to resume
+    // the export whole. (Per-unit split resume is tracked as a follow-up on #167.)
+    if split && resume {
+        anyhow::bail!(
+            "apply --pool --split does not support --resume: a range-split export's N \
+             sub-units share one destination prefix, so a partial run cannot be resumed \
+             per-unit — the prefix's single _SUCCESS cannot say which units finished, and \
+             resuming would either skip the whole export (dropping the unfinished unit's \
+             rows) or re-run it (duplicating the finished units'). Recover by clearing the \
+             destination prefix and re-running WITHOUT --resume, or drop --split to resume \
+             the export as a single unit."
+        );
+    }
     let config = Config::load_with_params(config_path, None)?;
     let config_dir = Path::new(config_path)
         .parent()


### PR DESCRIPTION
Second GA-hardening item for #167 (opt-in `apply --pool --split`): resume coherence.

## What I measured (not theorized)
Reproduced a partial split — a giant split into N units sharing ONE prefix, unit #0 finished (wrote the shared `_SUCCESS`), unit #1 crashed — and tried both recovery paths:

| Recovery | Result |
|---|---|
| `--split --resume` | shared `_SUCCESS` → skip-filter treats the whole giant as done → **silent GAP, 150001/300000 rows** |
| fresh `--split` (no resume) | re-splits with new run-id part names beside the survivors → **silent DUP, 450001/300000** |

Both silently wrong. Per-unit resume across a shared prefix is a genuine architecture problem: the single prefix-level `_SUCCESS` cannot say *which* units finished, and a completed unit's chunk-checkpoint is finalized (not resumable).

## Fix
For this opt-in feature, the correct v1 is to **refuse the unsafe combination loudly** rather than ship a subtly-wrong resume. `run_pool` bails on `split && resume` with a clear message and the recovery (clear the prefix + re-run fresh, or drop `--split` to resume the export whole). This converts both silent failures into an actionable error.

## Verified
- **offline** `pool_split_refuses_resume` — `--split --resume` errors with the refusal; RED-proven (removing the bail lets `run_pool` reach "nothing to run" → Ok → the `unwrap_err` panics).
- **control**: `--pool --resume` without `--split` is unaffected (normal pool resume still skips complete exports).

Offline: 2523 passed, clippy clean.

Remaining #167 GA items: full per-unit split resume (the fuller version of this), `check`/`plan` awareness of split units, cold makespan measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
