### PR TITLE
Gate speedup + harness bughunt hardening + split/pool fixes (#167 GA)

### DIFF
--- a/dev/release_oracle/__main__.py
+++ b/dev/release_oracle/__main__.py
@@ -136,6 +136,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     ap.add_argument("--no-cloud", action="store_true", help="local stage only (skip BigQuery)")
     ap.add_argument("--keep", action="store_true", help="leave engine containers up (debug)")
+    ap.add_argument(
+        "--engine-parallel", type=int, default=3,
+        help="how many engines to run CONCURRENTLY in the engine loop (default 3). Each engine "
+             "owns its own containers/ports, and the scenarios race on the SHARED state backend "
+             "— which doubles as a real concurrent-writer test. The dominant serial cost is CDC "
+             "capture-job waits (sleep-for-the-agent), which overlap under parallelism, so the "
+             "engine-loop wall drops from sum(engines) toward max(engine). Set 1 for the old "
+             "serial behaviour, or lower if Docker memory is tight (MSSQL is the ~1.6 GiB hog).")
     ap.add_argument("--no-clean", action="store_true",
                     help="skip the clean rebuild (iteration only — a release must be gated on a "
                          "tree built from nothing)")
@@ -389,53 +397,82 @@ def seed_engine(engine: str, tag: str, url: str) -> str:
     return "; ".join(hits) or f"exit {p.returncode}"
 
 
+def _run_one_engine(led: Ledger, ns: argparse.Namespace, engine: str) -> None:
+    """One engine's whole leg: every gridded version brought up, seeded, and run
+    through the scenarios, then torn down. Takes `led` so a parallel caller can
+    hand it a BUFFERED sub-ledger (its output is flushed as one block afterwards)."""
+    version_lines = [
+        l for l in matrix_cfg("versions", engine).splitlines() if len(l.split()) >= 3
+    ]
+    # --latest-only: keep just the last version of the family (the newest,
+    # matrix.yaml lists them ascending). Cuts the dev-loop wall roughly in
+    # proportion to the version count (postgres 4→1, mongo 5→1) while every
+    # scenario × store × state cell still runs once.
+    if ns.latest_only and version_lines:
+        skipped = len(version_lines) - 1
+        version_lines = version_lines[-1:]
+        if skipped:
+            led.add(engine, "-", "older-versions", "-", Status.SKIP,
+                    f"--latest-only: {skipped} older {engine} version(s) not run")
+    for line in version_lines:
+        parts = line.split()
+        tag, image, port = parts[0], parts[1], int(parts[2])
+        led.phase(f"{engine} {tag} ({image})")
+        url = bring_up(led, engine, tag, image, port)
+        if not url:
+            led.add(engine, tag, "all", "-", Status.SKIP, "bring-up failed")
+            continue
+        # The seed is idempotent (DROP TABLE IF EXISTS …), so a transient
+        # failure is retried: a fresh container under load can drop the seed
+        # connection mid-stream, and crying wolf on that is worse than a retry.
+        err = ""
+        for attempt in range(3):
+            err = seed_engine(engine, tag, url)
+            if not err:
+                break
+            # Back off between attempts. Without this the three retries fire
+            # back-to-back and all land inside the SAME startup window, so a
+            # race the retry exists to absorb is retried three times in the
+            # few hundred ms during which it cannot possibly succeed — which
+            # is how a transient became a FAIL.
+            time.sleep(2.0 * (attempt + 1))
+        if err:
+            led.failed(engine, tag, "seed", "-", f"{engine}:{tag} seed had errors", err)
+            continue
+        led.ok("seeded")
+        scenarios.run_scenarios(led, engine, tag, url)
+        if not ns.keep:
+            docker("rm", "-fv", engine_container(engine, tag))
+
+
 def engine_loop(led: Ledger, ns: argparse.Namespace) -> None:
     wanted = [e for e in ns.engines.split(",") if e] if ns.engines else None
-    for engine in matrix_cfg("engines").split():
-        if wanted and engine not in wanted:
-            continue
-        version_lines = [
-            l for l in matrix_cfg("versions", engine).splitlines() if len(l.split()) >= 3
-        ]
-        # --latest-only: keep just the last version of the family (the newest,
-        # matrix.yaml lists them ascending). Cuts the dev-loop wall roughly in
-        # proportion to the version count (postgres 4→1, mongo 5→1) while every
-        # scenario × store × state cell still runs once.
-        if ns.latest_only and version_lines:
-            skipped = len(version_lines) - 1
-            version_lines = version_lines[-1:]
-            if skipped:
-                led.add(engine, "-", "older-versions", "-", Status.SKIP,
-                        f"--latest-only: {skipped} older {engine} version(s) not run")
-        for line in version_lines:
-            parts = line.split()
-            tag, image, port = parts[0], parts[1], int(parts[2])
-            led.phase(f"{engine} {tag} ({image})")
-            url = bring_up(led, engine, tag, image, port)
-            if not url:
-                led.add(engine, tag, "all", "-", Status.SKIP, "bring-up failed")
-                continue
-            # The seed is idempotent (DROP TABLE IF EXISTS …), so a transient
-            # failure is retried: a fresh container under load can drop the seed
-            # connection mid-stream, and crying wolf on that is worse than a retry.
-            err = ""
-            for attempt in range(3):
-                err = seed_engine(engine, tag, url)
-                if not err:
-                    break
-                # Back off between attempts. Without this the three retries fire
-                # back-to-back and all land inside the SAME startup window, so a
-                # race the retry exists to absorb is retried three times in the
-                # few hundred ms during which it cannot possibly succeed — which
-                # is how a transient became a FAIL.
-                time.sleep(2.0 * (attempt + 1))
-            if err:
-                led.failed(engine, tag, "seed", "-", f"{engine}:{tag} seed had errors", err)
-                continue
-            led.ok("seeded")
-            scenarios.run_scenarios(led, engine, tag, url)
-            if not ns.keep:
-                docker("rm", "-fv", engine_container(engine, tag))
+    engines = [e for e in matrix_cfg("engines").split() if not wanted or e in wanted]
+    cap = max(1, ns.engine_parallel)
+
+    # Serial (unchanged behaviour) when asked or with nothing to overlap.
+    if cap == 1 or len(engines) <= 1:
+        for engine in engines:
+            _run_one_engine(led, ns, engine)
+        return
+
+    # Parallel: each engine owns its own containers/ports; the scenarios race on
+    # the shared state backend (a real concurrent-writer test). The big serial
+    # cost — CDC capture-job waits — overlaps, so the wall drops toward the
+    # slowest single engine. Output would interleave, so each engine runs into a
+    # BUFFERED sub-ledger and its block is flushed IN ENGINE ORDER after the join.
+    workers = min(cap, len(engines))
+    led.phase(
+        f"Engine matrix — {len(engines)} engines, up to {workers} concurrent "
+        f"(wall ≈ slowest engine; scenarios race on the shared state backend)"
+    )
+    subs = {e: led.buffered_child() for e in engines}
+    from concurrent.futures import ThreadPoolExecutor
+
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        list(ex.map(lambda e: _run_one_engine(subs[e], ns, e), engines))
+    for engine in engines:  # deterministic order, not completion order
+        subs[engine].flush_into(led)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/dev/release_oracle/__main__.py
+++ b/dev/release_oracle/__main__.py
@@ -137,6 +137,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     ap.add_argument("--no-cloud", action="store_true", help="local stage only (skip BigQuery)")
     ap.add_argument("--keep", action="store_true", help="leave engine containers up (debug)")
     ap.add_argument(
+        "--cell-parallel", type=int, default=8,
+        help="global cap on concurrent MATRIX CELLS (blessed_flow/blessed_path) across "
+             "ALL engines. The matrix is I/O-bound (~62%% CPU idle at 4-way), so running "
+             "its independent cells concurrently fills the idle cores; this bounds the "
+             "total so the shared state DB / source containers are not stampeded.")
+    ap.add_argument(
         "--engine-parallel", type=int, default=3,
         help="how many engines to run CONCURRENTLY in the engine loop (default 3). Each engine "
              "owns its own containers/ports, and the scenarios race on the SHARED state backend "
@@ -507,6 +513,8 @@ def engine_loop(led: Ledger, ns: argparse.Namespace) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     ns = parse_args(argv)
+    from .core import set_cell_parallel
+    set_cell_parallel(ns.cell_parallel)
 
     if not rivet_bin().is_file() or not os.access(rivet_bin(), os.X_OK):
         print(f"rivet binary not found at {rivet_bin()} (build --release or set RIVET_BIN)", file=sys.stderr)

--- a/dev/release_oracle/__main__.py
+++ b/dev/release_oracle/__main__.py
@@ -147,6 +147,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     ap.add_argument("--no-clean", action="store_true",
                     help="skip the clean rebuild (iteration only — a release must be gated on a "
                          "tree built from nothing)")
+    ap.add_argument("--fast-clean", action="store_true",
+                    help="rebuild removing ONLY target/package (the documented `cargo package` "
+                         "fingerprint poison), not the whole target/ — keeps the binary=HEAD "
+                         "guarantee via cargo's own honest fingerprints while skipping the full "
+                         "dependency recompile. NOT a cache: no external keying heuristic can "
+                         "return a stale artifact. The tag verdict should still use the full "
+                         "clean (default); this is for fast pre-tag hunt passes.")
     ap.add_argument("--state-url", default="",
                     help="state backend for EVERY cell (default: SQLite beside each config). "
                          "A gate pass grades ONE backend; run it twice to grade both.")
@@ -161,7 +168,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return ns
 
 
-def clean_tree_and_build(led: Ledger) -> bool:
+def clean_tree_and_build(led: Ledger, *, fast: bool = False) -> bool:
     """Step ZERO: gate a binary built from nothing.
 
     A release must be graded on a tree with no history in it. `cargo package`
@@ -176,13 +183,26 @@ def clean_tree_and_build(led: Ledger) -> bool:
     So the gate starts by deleting the target directory and its own scratch, then
     builds `--release` itself. It costs one full compile; it buys the guarantee
     that the binary every cell below exercises is the code in the tree.
+
+    `fast=True` removes ONLY `target/package` — the exact directory the poison
+    lives in — instead of the whole `target/`. Cargo's own fingerprints are honest
+    once that snapshot is gone (every freshness-lie this repo has hit was
+    package-related), so the binary=HEAD guarantee holds while the dependency
+    recompile is skipped. This is NOT a compilation cache: there is no external
+    hash-keying heuristic (sccache's build-script / env / include! edge cases) that
+    can hand back a stale object — it is cargo's normal, sound incremental build
+    with the one known liar deleted. The full clean stays the default for the tag
+    verdict; `fast` is for the fast pre-tag hunt passes.
     """
     led.phase("Clean tree — the gate builds the binary it grades")
     for stale in ("/tmp/rivet_conc", "/tmp/rivet_iso", "/tmp/rivet_sweep", "/tmp/rivet_cdc_sweep"):
         shutil.rmtree(stale, ignore_errors=True)
     for lock in Path("/tmp").glob(".rivet_cdc_sweep*.lock"):
         lock.unlink(missing_ok=True)
-    if not run(["cargo", "clean"], cwd=ROOT, timeout=600).ok:
+    if fast:
+        # Delete ONLY the poison directory; cargo's honest fingerprints do the rest.
+        shutil.rmtree(ROOT / "target" / "package", ignore_errors=True)
+    elif not run(["cargo", "clean"], cwd=ROOT, timeout=600).ok:
         led.failed("-", "-", "clean_tree", "-",
                    "clean tree: `cargo clean` failed — the gate cannot vouch for the binary it "
                    "is about to grade")
@@ -195,9 +215,11 @@ def clean_tree_and_build(led: Ledger) -> bool:
             f"anything: {(build.err or build.out)[-300:]}",
         )
         return False
+    how = ("target/package removed (fast: cargo fingerprints trusted, binary=HEAD)"
+           if fast else "target/ removed and the release binary rebuilt from nothing")
     led.passed(
         "-", "-", "clean_tree", "-",
-        f"clean tree: target/ removed and the release binary rebuilt from nothing ({rivet_bin()})",
+        f"clean tree: {how} ({rivet_bin()})",
     )
     return True
 
@@ -418,7 +440,8 @@ def _run_one_engine(led: Ledger, ns: argparse.Namespace, engine: str) -> None:
         parts = line.split()
         tag, image, port = parts[0], parts[1], int(parts[2])
         led.phase(f"{engine} {tag} ({image})")
-        url = bring_up(led, engine, tag, image, port)
+        with led.span(f"{engine}: bring-up"):
+            url = bring_up(led, engine, tag, image, port)
         if not url:
             led.add(engine, tag, "all", "-", Status.SKIP, "bring-up failed")
             continue
@@ -426,7 +449,8 @@ def _run_one_engine(led: Ledger, ns: argparse.Namespace, engine: str) -> None:
         # failure is retried: a fresh container under load can drop the seed
         # connection mid-stream, and crying wolf on that is worse than a retry.
         err = ""
-        for attempt in range(3):
+        with led.span(f"{engine}: seed"):
+          for attempt in range(3):
             err = seed_engine(engine, tag, url)
             if not err:
                 break
@@ -469,8 +493,14 @@ def engine_loop(led: Ledger, ns: argparse.Namespace) -> None:
     subs = {e: led.buffered_child() for e in engines}
     from concurrent.futures import ThreadPoolExecutor
 
+    def _run(e: str) -> None:
+        # The per-engine total wall-clock — the "which engine is the long pole"
+        # number the opaque matrix phase can't give under parallelism.
+        with subs[e].span(f"{e}: engine-total"):
+            _run_one_engine(subs[e], ns, e)
+
     with ThreadPoolExecutor(max_workers=workers) as ex:
-        list(ex.map(lambda e: _run_one_engine(subs[e], ns, e), engines))
+        list(ex.map(_run, engines))
     for engine in engines:  # deterministic order, not completion order
         subs[engine].flush_into(led)
 
@@ -528,7 +558,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"  state backend under test: {backend}")
         print("  a pass grades ONE backend; --state-url runs the same cells against the other")
 
-        if not ns.no_clean and not clean_tree_and_build(led):
+        if not ns.no_clean and not clean_tree_and_build(led, fast=ns.fast_clean):
             return 1
         start_stores(led)
         preflight(led, bless_gifs=ns.bless_gifs)

--- a/dev/release_oracle/__main__.py
+++ b/dev/release_oracle/__main__.py
@@ -212,6 +212,7 @@ def preflight(led: Ledger, *, bless_gifs: bool = False) -> None:
     gifs.verify_gif_currency(led, bless=bless_gifs)
     scenarios.verify_replica_read(led)
     scenarios.verify_pool_e2e(led)
+    scenarios.verify_pool_split(led)
     cdc.verify_cdc_e2e(led)
     regression.verify_release_regression(led)
     regression.verify_scale_memory(led)

--- a/dev/release_oracle/__main__.py
+++ b/dev/release_oracle/__main__.py
@@ -572,7 +572,7 @@ def main(argv: list[str] | None = None) -> int:
             # BQ stage's mysql leg still hit the initdb race and recorded
             # `SKIP seed` where the previous run had a PASS. One definition now.
             bigquery.run_bigquery_golden(led, bless=ns.bless_bigquery_golden,
-                                         keep=ns.keep,
+                                         keep=ns.keep, parallel=ns.engine_parallel,
                                          bring_up=bring_up, seed_engine=seed_engine)
         return led.report()
     finally:

--- a/dev/release_oracle/bigquery.py
+++ b/dev/release_oracle/bigquery.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+import time
 from pathlib import Path
 from typing import Callable
 
@@ -253,9 +254,22 @@ def verify_gc_survival(led: Ledger, *, bucket: str, pfx: str, cfg_text: str,
 
     fails: list[str] = []
 
+    def _gc_load_ok(tries: int = 3) -> bool:
+        # `rivet load` here hits REAL BigQuery/GCS, so a transient Google-side hiccup
+        # is an infra blip, not a gc-logic failure — retry like seed_engine/doctor
+        # (measured: one mssql arm-2 load flaked once and cleared on the very next run).
+        # A real gc failure fails every attempt.
+        p = rivet("load", "-c", str(gc_cfg), env=child, timeout=None)
+        for _ in range(tries - 1):
+            if p.ok:
+                break
+            time.sleep(2.0)
+            p = rivet("load", "-c", str(gc_cfg), env=child, timeout=None)
+        return p.ok
+
     # ── arm 1: no live run → the unmanifested part is debris → collected ──
     dead = plant_orphan("orphan-crash-debris.parquet")
-    if not rivet("load", "-c", str(gc_cfg), env=child, timeout=None).ok:
+    if not _gc_load_ok():
         led.failed(engine, "-", "gc_survival", "-",
                    f"gc_survival[{engine}]: the gc load itself failed", "load")
         return
@@ -278,7 +292,7 @@ def verify_gc_survival(led: Ledger, *, bucket: str, pfx: str, cfg_text: str,
     mk_remote = f"{base}/manifest-gc-survival-probe.json"
     run(["gcloud", "storage", "cp", str(mk_local), mk_remote], timeout=300)
 
-    if not rivet("load", "-c", str(gc_cfg), env=child, timeout=None).ok:
+    if not _gc_load_ok():
         fails.append("gc-load-failed-with-a-running-marker ")
     elif not exists(live):
         fails.append("inflight-part-DELETED(a live run's unmanifested part was collected) ")

--- a/dev/release_oracle/bigquery.py
+++ b/dev/release_oracle/bigquery.py
@@ -401,8 +401,15 @@ def _bq_one_engine(
     if not keep:
         docker("rm", "-fv", engine_container(engine, _TAG))
     if not got:
-        # Either the run/load leg already recorded its FAIL, or the read-back itself
-        # produced nothing (KNOWN GAP from the bash: that case records no row).
+        # A read-back that returns NOTHING after a SUCCESSFUL run+load is a failure of
+        # the INDEPENDENT oracle (Google's parquet reader via bq query), not a no-op —
+        # it used to record no row at all, so absence read as green. The run/load-failed
+        # path already recorded its FAIL above; only this (rp.ok and lp.ok) path did not.
+        if rp.ok and lp is not None and lp.ok:
+            led.failed("bigquery", engine, "golden", "-",
+                       f"BigQuery[{engine}]: run+load OK but the bq read-back returned nothing "
+                       f"({eng_dset}.{exp} empty) — the independent oracle saw zero rows",
+                       "empty-readback")
         return None
 
     if bless:

--- a/dev/release_oracle/bigquery.py
+++ b/dev/release_oracle/bigquery.py
@@ -294,11 +294,139 @@ def verify_gc_survival(led: Ledger, *, bucket: str, pfx: str, cfg_text: str,
                    "spared, manifested parts untouched", "3 arms")
 
 
+def _bq_one_engine(
+    led: Ledger,
+    engine: str,
+    *,
+    proj: str,
+    dset: str,
+    bucket: str,
+    matrix: str,
+    work: Path,
+    bless: bool,
+    keep: bool,
+    up: Callable[..., str | None],
+    seed: Callable[..., str],
+) -> dict | None:
+    """One engine's whole BQ leg: export → load → read back → compare → clean up.
+
+    Fully self-contained PER ENGINE — its own dataset (`{dset}_{engine}`), GCS prefix
+    (`bq/{engine}`), config, and container — which is exactly why the outer loop can
+    run these concurrently (the per-dataset fix below removed the shared-table hazard
+    the old sequential-only comment warned about). Records its rows/spans into `led`
+    (a buffered child under parallelism) and returns the blessed rows (bless mode) or
+    None. The `bq {engine}: run/load/readback` spans answer whether the load and the
+    read-back SELECT actually speed up under parallelism or are BQ-rate-limited."""
+    versions = _matrix_cfg("versions", engine).splitlines()
+    fields = versions[0].split() if versions else []
+    image = fields[1] if len(fields) > 1 else ""
+    port = _PORTS[engine]
+
+    url = up(led, engine, _TAG, image, port)
+    if not url:
+        led.skipped("bigquery", engine, "golden", "-",
+                    f"BigQuery[{engine}]: bring-up failed", "bring-up")
+        return None
+    if seed(engine, _TAG, url):
+        led.skipped("bigquery", engine, "golden", "-",
+                    f"BigQuery[{engine}]: seed errors", "seed")
+        if not keep:
+            docker("rm", "-fv", engine_container(engine, _TAG))
+        return None
+
+    tlsblk = "\n  tls: {accept_invalid_certs: true}" if engine == "mssql" else ""
+    exp = matrix
+    # ONE DATASET PER SOURCE. Every engine exports a table called `rivet_type_matrix`
+    # and `rivet load` derives the warehouse table from that name, so a shared dataset
+    # would mean three databases writing one table last-write-wins — which `rivet load`
+    # refuses, and rightly (2026-08-03: postgres owned it, mysql/mssql failed). Three
+    # configs → three DESTINATIONS (own dataset + own GCS prefix), so the legs are
+    # independent and the ownership guard stays ARMED. This independence is what makes
+    # the outer loop safe to parallelise.
+    eng_dset = f"{dset}_{engine}"
+    run(["bq", f"--project_id={proj}", "mk", "-f", "--dataset", f"{proj}:{eng_dset}"])
+    pfx = f"release-oracle/bq/{engine}"
+    cfgf = work / f"bqload_{engine}.yaml"
+    cfgf.write_text(
+        "source:\n"
+        f"  type: {engine}\n"
+        f"  url_env: ORACLE_URL{tlsblk}\n"
+        "exports:\n"
+        f"  - name: {exp}\n"
+        f"    table: {matrix}\n"
+        "    mode: full\n"
+        "    format: parquet\n"
+        f"    destination: {{type: gcs, bucket: {bucket}, prefix: {pfx}/}}\n"
+        "load:\n"
+        "  target: bigquery\n"
+        f"  project: {proj}\n"
+        f"  dataset: {eng_dset}\n"
+    )
+
+    # Clear the prefix first: a leftover part from an earlier run would be loaded
+    # alongside this one's and the read-back would compare a union.
+    run(["gcloud", "storage", "rm", "-r", f"gs://{bucket}/{pfx}"])
+
+    got = ""
+    child = {"ORACLE_URL": url}
+    with led.span(f"bq {engine}: run"):
+        rp = rivet("run", "-c", str(cfgf), env=child, timeout=None)
+    lp = None
+    if rp.ok:
+        with led.span(f"bq {engine}: load"):
+            lp = rivet("load", "-c", str(cfgf), env=child, timeout=None)
+    if rp.ok and lp is not None and lp.ok:
+        with led.span(f"bq {engine}: readback"):
+            q = run(["bq", f"--project_id={proj}", "query", "--nouse_legacy_sql",
+                     "--format=prettyjson",
+                     f"SELECT * FROM `{proj}.{eng_dset}.{exp}` ORDER BY id"], timeout=None)
+            got = run(["python3", str(_LIB / "normalize_bq.py")], stdin=q.stdout).stdout.strip()
+    else:
+        failed_proc = rp if not rp.ok else lp
+        leg = "run" if not rp.ok else "load"
+        why = ((failed_proc.stderr or failed_proc.stdout or "").strip()
+               if failed_proc is not None else "")
+        tail = " / ".join(why.splitlines()[-3:]) if why else "no output captured"
+        led.failed("bigquery", engine, "golden", "-",
+                   f"BigQuery[{engine}]: rivet {leg} failed — {tail}", "load")
+
+    # gc_survival needs the prefix AS LOADED (a success manifest + real parts), so it
+    # runs here — after the read-back, before the wipe.
+    if got:
+        verify_gc_survival(led, bucket=bucket, pfx=pfx, cfg_text=cfgf.read_text(),
+                           work=work, child=child, engine=engine)
+
+    run(["gcloud", "storage", "rm", "-r", f"gs://{bucket}/{pfx}"])
+    run(["bq", f"--project_id={proj}", "rm", "-f", "-t", f"{eng_dset}.{exp}"])
+    if not keep:
+        docker("rm", "-fv", engine_container(engine, _TAG))
+    if not got:
+        # Either the run/load leg already recorded its FAIL, or the read-back itself
+        # produced nothing (KNOWN GAP from the bash: that case records no row).
+        return None
+
+    if bless:
+        rows = json.loads(got)
+        led.passed("bigquery", engine, "golden", "-",
+                   f"BigQuery[{engine}] blessed ({len(rows)} rows)", "blessed")
+        return rows
+    want = _load_golden().get(engine, {}).get(matrix)
+    if want is not None and _canon(json.loads(got)) == _canon(want):
+        led.ok(f"BigQuery[{engine}] matches golden")
+        led.add("bigquery", engine, "golden", "-", Status.PASS)
+    else:
+        led.failed("bigquery", engine, "golden", "-",
+                   f"BigQuery[{engine}] DIVERGED from golden — "
+                   "rivet type export or BQ mapping changed", "diverged")
+    return None
+
+
 def run_bigquery_golden(
     led: Ledger,
     *,
     bless: bool = False,
     keep: bool = False,
+    parallel: int = 1,
     bring_up: Callable[..., str | None] | None = None,
     seed_engine: Callable[..., str] | None = None,
 ) -> None:
@@ -327,141 +455,41 @@ def run_bigquery_golden(
     work = _work_dir()
     blessed: dict[str, dict[str, object]] = {}
 
-    for engine in _matrix_cfg("engines").split():
-        if engine == "mongo":
-            continue  # no type matrix (full-scan only)
-        port = _PORTS.get(engine)
-        if port is None:
-            continue
+    engines = [e for e in _matrix_cfg("engines").split()
+               if e != "mongo" and _PORTS.get(e) is not None]  # mongo: no type matrix
 
-        versions = _matrix_cfg("versions", engine).splitlines()
-        fields = versions[0].split() if versions else []
-        image = fields[1] if len(fields) > 1 else ""
-
-        url = _up(led, engine, _TAG, image, port)
-        if not url:
-            led.skipped("bigquery", engine, "golden", "-",
-                        f"BigQuery[{engine}]: bring-up failed", "bring-up")
-            continue
-        if _seed(engine, _TAG, url):
-            led.skipped("bigquery", engine, "golden", "-",
-                        f"BigQuery[{engine}]: seed errors", "seed")
-            if not keep:
-                docker("rm", "-fv", engine_container(engine, _TAG))
-            continue
-
-        tlsblk = "\n  tls: {accept_invalid_certs: true}" if engine == "mssql" else ""
-        # `rivet load` names the BigQuery table after the `table:` field, so every
-        # engine lands in the SAME `rivet_type_matrix` table. That is fine ONLY
-        # because engines run SEQUENTIALLY here — load → read back → drop, before
-        # the next engine starts. Parallelising this loop would silently have the
-        # engines overwrite each other's read-back.
-        exp = matrix
-        # ONE DATASET PER SOURCE. Every engine exports a table called
-        # `rivet_type_matrix`, and `rivet load` derives the warehouse table from
-        # that name — so a single shared dataset means three DIFFERENT databases
-        # writing one warehouse table, which `rivet load` refuses, and rightly:
-        # a dataset must not take a same-named table from another database
-        # last-write-wins. The first load lands, the next one FAILS and says so.
-        #
-        # Measured 2026-08-03 on the Postgres pass: postgres PASS, mysql and mssql
-        # "rivet run/load failed", with one ledger row naming postgres the owner
-        # of `rivet_type_matrix`. The SQLite pass passed only because its state
-        # was not shared, so the ledger had no memory across engines — the gate
-        # was expressing the forbidden pattern either way.
-        #
-        # The fix is where it belongs: these are already three separate configs,
-        # so they get three separate DESTINATIONS. Nothing is renamed, and the
-        # guard stays ARMED — if two sources ever do land in one dataset here,
-        # the gate goes red, which is the point.
-        eng_dset = f"{dset}_{engine}"
-        run(["bq", f"--project_id={proj}", "mk", "-f", "--dataset", f"{proj}:{eng_dset}"])
-        pfx = f"release-oracle/bq/{engine}"
-        cfgf = work / f"bqload_{engine}.yaml"
-        cfgf.write_text(
-            "source:\n"
-            f"  type: {engine}\n"
-            f"  url_env: ORACLE_URL{tlsblk}\n"
-            "exports:\n"
-            f"  - name: {exp}\n"
-            f"    table: {matrix}\n"
-            "    mode: full\n"
-            "    format: parquet\n"
-            f"    destination: {{type: gcs, bucket: {bucket}, prefix: {pfx}/}}\n"
-            "load:\n"
-            "  target: bigquery\n"
-            f"  project: {proj}\n"
-            f"  dataset: {eng_dset}\n"
-        )
-
-        # Clear the prefix first: a leftover part from an earlier run would be
-        # loaded alongside this one's and the read-back would compare a union.
-        run(["gcloud", "storage", "rm", "-r", f"gs://{bucket}/{pfx}"])
-
-        got = ""
-        # ORACLE_URL is scoped to the child rather than exported process-wide, so
-        # it cannot leak into a later stage that resolves `url_env`.
-        child = {"ORACLE_URL": url}
-        # Keep the Procs: `rivet load` refuses for REASONS an operator must read
-        # — most sharply "target table X was last loaded from <other source>",
-        # which is rivet telling you a dataset must not take a same-named table
-        # from another database. Reporting a bare "run/load failed" throws that
-        # sentence away and sends the reader digging through a 400-line log for
-        # something the cell already knew. (2026-08-03: it cost exactly that.)
-        rp = rivet("run", "-c", str(cfgf), env=child, timeout=None)
-        lp = rivet("load", "-c", str(cfgf), env=child, timeout=None) if rp.ok else None
-        if rp.ok and lp is not None and lp.ok:
-            q = run(["bq", f"--project_id={proj}", "query", "--nouse_legacy_sql",
-                     "--format=prettyjson",
-                     f"SELECT * FROM `{proj}.{eng_dset}.{exp}` ORDER BY id"], timeout=None)
-            # `normalize_bq.py` sorts rows by id and re-serializes with sorted
-            # keys, so a golden diff is a real change rather than row-order or
-            # key-order noise. Reused, not re-implemented.
-            got = run(["python3", str(_LIB / "normalize_bq.py")], stdin=q.stdout).stdout.strip()
-        else:
-            failed_proc = rp if not rp.ok else lp
-            leg = "run" if not rp.ok else "load"
-            why = ((failed_proc.stderr or failed_proc.stdout or "").strip()
-                   if failed_proc is not None else "")
-            # The LAST lines: anyhow prints the context chain last, so the tail
-            # carries the actual refusal rather than the setup noise above it.
-            tail = " / ".join(why.splitlines()[-3:]) if why else "no output captured"
-            led.failed("bigquery", engine, "golden", "-",
-                       f"BigQuery[{engine}]: rivet {leg} failed — {tail}", "load")
-
-        # gc_survival needs the prefix AS LOADED (a success manifest + real
-        # parts), so it runs here — after the read-back, before the wipe.
-        if got:
-            verify_gc_survival(led, bucket=bucket, pfx=pfx, cfg_text=cfgf.read_text(),
-                               work=work, child=child, engine=engine)
-
-        run(["gcloud", "storage", "rm", "-r", f"gs://{bucket}/{pfx}"])
-        run(["bq", f"--project_id={proj}", "rm", "-f", "-t", f"{eng_dset}.{exp}"])
-        if not keep:
-            docker("rm", "-fv", engine_container(engine, _TAG))
-        if not got:
-            # Either the run/load leg already recorded its FAIL, or the read-back
-            # itself produced nothing. KNOWN GAP, carried over from the bash: the
-            # second case records NO row at all, so an engine whose `bq query`
-            # failed simply vanishes from the report — and absence reads as green.
-            continue
-
-        if bless:
-            rows = json.loads(got)
+    def collect(engine: str, rows: dict | None) -> None:
+        if rows is not None:
             blessed.setdefault(engine, {})[matrix] = rows
-            led.passed("bigquery", engine, "golden", "-",
-                       f"BigQuery[{engine}] blessed ({len(rows)} rows)", "blessed")
-        else:
-            want = _load_golden().get(engine, {}).get(matrix)
-            if want is not None and _canon(json.loads(got)) == _canon(want):
-                # Split rather than `led.passed`, because the bash row carried no
-                # detail and this table is compared transcript-to-transcript.
-                led.ok(f"BigQuery[{engine}] matches golden")
-                led.add("bigquery", engine, "golden", "-", Status.PASS)
-            else:
-                led.failed("bigquery", engine, "golden", "-",
-                           f"BigQuery[{engine}] DIVERGED from golden — "
-                           "rivet type export or BQ mapping changed", "diverged")
+
+    kw = dict(proj=proj, dset=dset, bucket=bucket, matrix=matrix, work=work,
+              bless=bless, keep=keep, up=_up, seed=_seed)
+    cap = max(1, parallel)
+    if cap == 1 or len(engines) <= 1:
+        for engine in engines:
+            with led.span(f"bq {engine}: engine-total"):
+                collect(engine, _bq_one_engine(led, engine, **kw))
+    else:
+        # Each engine's leg is independent (own dataset/prefix/config/container), so
+        # race them — same buffered-child pattern as the engine matrix, so an engine's
+        # output stays contiguous. BQ load jobs are async per-table and queries are
+        # slot-scheduled, so concurrency is COST-neutral (identical bytes) and only
+        # compresses wall-clock; the `bq {engine}: load/readback` spans measure how
+        # much the load and the read-back SELECT actually parallelise vs BQ throttling.
+        from concurrent.futures import ThreadPoolExecutor
+        subs = {e: led.buffered_child() for e in engines}
+
+        def run_one(engine: str) -> tuple[str, dict | None]:
+            with subs[engine].span(f"bq {engine}: engine-total"):
+                return engine, _bq_one_engine(subs[engine], engine, **kw)
+
+        workers = min(cap, len(engines))
+        with ThreadPoolExecutor(max_workers=workers) as ex:
+            results = list(ex.map(run_one, engines))
+        for engine in engines:  # deterministic order, not completion order
+            subs[engine].flush_into(led)
+        for engine, rows in results:
+            collect(engine, rows)
 
     if bless:
         # The opt-in write, and the only one. NOTE (bash behaviour, kept): this

--- a/dev/release_oracle/blessed_flow.py
+++ b/dev/release_oracle/blessed_flow.py
@@ -987,8 +987,17 @@ def _run_chain(led: Ledger, cell: Cell, url: str, state_url: str, work: Path,
             # (the old `duck > 0` passed with 4 of 5 lost). >= tolerates an
             # at-least-once duplicate; < is a real loss.
             want = cdc.CDC_EXPECT_EVENTS
-            _stage(led, cell, tag, "oracle", duck >= want,
-                   f"duckdb={duck} >= {want} deterministic changes (at-least-once floor)")
+            # Per-column null profile too (mirrors the batch branch + cdc.py): a decode
+            # regression can null a WHOLE captured typed column (amount/meta) while the
+            # change COUNT holds — and local/gcs CDC cells were guarded NOWHERE (cdc.py
+            # only null-profiles s3). Local reads on-disk; cloud reads the copy _readback
+            # already pulled to work/pull_<store>.
+            prof = dest_dir if cell.store == "local" else (work / f"pull_{cell.store}")
+            nn, _nc = scenarios.duckdb_allnull_columns(f"{prof}/**/*.parquet")
+            n_null = max(0, nn)
+            _stage(led, cell, tag, "oracle", duck >= want and n_null == 0,
+                   f"duckdb={duck} >= {want} deterministic changes (at-least-once floor)"
+                   + (f" · ALLNULL {n_null} cols" if n_null else ""))
 
     # ── validate ─────────────────────────────────────────────────────────────
     p = rivet("validate", "-c", str(cfg), *cell.flags.get("validate", []),

--- a/dev/release_oracle/blessed_flow.py
+++ b/dev/release_oracle/blessed_flow.py
@@ -59,6 +59,10 @@ import json
 import os
 import re
 import shutil
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import nullcontext
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -66,6 +70,8 @@ from . import blessed_path, cdc, scenarios
 from .core import (
     run,
     Ledger,
+    cell_gate,
+    cell_parallel,
     container_for_port,
     docker_exec,
     have,
@@ -479,6 +485,13 @@ def _meta_rows(cell: Cell, work: Path, state_url: str, mark: int,
     evidence about this one.
     """
     ids = ", ".join(f"'{r}'" for r in run_ids) if run_ids else "''"
+    # export_metrics has no run_id, so it is scoped by a watermark (id > mark). Under
+    # CONCURRENT cells this can also count a sibling's row, so its ≥1 check is
+    # best-effort: it can only ever produce a false PASS (never a false fail — the
+    # count only inflates), and that is masked by the cell-scoped, sibling-proof
+    # checks below (artifacts/oracle read THIS cell's own work-dir/prefix; file_log
+    # and run_status are scoped by THIS cell's run_ids). The authoritative per-cell
+    # signals are those; export_metrics ≥1 is corroboration.
     got = {
         "export_metrics": _state_sql(cell, work, state_url,
                                      f"SELECT count(*) FROM export_metrics "
@@ -803,6 +816,14 @@ def _run_chain(led: Ledger, cell: Cell, url: str, state_url: str, work: Path,
     for st in ("doctor", "check"):
         args = [st, "-c", str(cfg), *cell.flags.get(st, [])]
         p = rivet(*args, env=env, timeout=scenarios.NO_TIMEOUT)
+        # Read-only source probes; a transient connection blip under the parallel
+        # matrix is a false alarm — retry like seed_engine (a real failure fails
+        # every attempt; _why below still surfaces an exhausted one).
+        for _ in range(2):
+            if p.ok:
+                break
+            time.sleep(1.5)
+            p = rivet(*args, env=env, timeout=scenarios.NO_TIMEOUT)
         if not _stage(led, cell, tag, st, p.ok, f"exit={p.returncode} " + (p.out.strip().splitlines()[-1][:120] if p.ok and p.out.strip() else _why(p))):
             _unreached(led, cell, tag, st)
             return
@@ -1013,7 +1034,15 @@ def _load_leg(led: Ledger, cell: Cell, tag: str, work: Path, env: dict, url: str
     # — so all four engines' `users` land on ONE table. rivet caught this itself
     # and refused ("last loaded from `postgres:users`"), which is the guard doing
     # its job; nine cells failed on a collision the matrix created.
-    dset = os.environ.get("BQ_ORACLE_DATASET", "rivet_blessed") + "_" + cell.engine
+    # PER CELL, not just per engine. rivet load derives the warehouse table from
+    # `table:`, so every cell's `users` lands on ONE table; under the PARALLEL matrix
+    # concurrent cells then drop the table each other is querying (RED-proven: "Not
+    # found: rivet_blessed_mssql.users"). A per-cell dataset gives each its own
+    # `{dset}.users`. Only ~6 slugs × N engines distinct names, reused every run (bq
+    # mk -f is idempotent), so this does not accumulate datasets.
+    _cell_slug = f"{cell.lifecycle}_{cell.store}_{cell.state}"
+    dset = (os.environ.get("BQ_ORACLE_DATASET", "rivet_blessed")
+            + f"_{cell.engine}_{_cell_slug}")
     if cell.store != "gcs" or cell.pipeline != "batch":
         led.skipped(cell.engine, tag, "flow:load", cell.store,
                     f"{cell.engine} {cell.label} · load — the warehouse leg runs on the "
@@ -1030,7 +1059,7 @@ def _load_leg(led: Ledger, cell: Cell, tag: str, work: Path, env: dict, url: str
     tbl = cell.table.split(".")[-1]
     # Version-scoped for the same reason the readback prefix is: the gate runs
     # this once per gridded version and `cell.engine` does not distinguish them.
-    pfx = f"flow/{cell.engine}{tag}/{cell.pipeline}/{tbl}"
+    pfx = f"flow/{cell.engine}{tag}/{cell.pipeline}/{_cell_slug}/{tbl}"
     lcfg = work / "load.yaml"
     tls = "\n  tls: {accept_invalid_certs: true}" if cell.engine == "mssql" else ""
     lcfg.write_text(
@@ -1171,6 +1200,10 @@ def sc_blessed_flow(led: Ledger, engine: str, tag: str, url: str,
         verdicts = {}
 
     cdc_url = cdc_url or os.environ.get(f"RIVET_CDC_{engine.upper()}_URL", "")
+    # Skips are decided SEQUENTIALLY (no rivet, just a ledger row, kept in
+    # declaration order); only the cells that actually run a chain go through the
+    # pool, so no-op work never occupies a slot.
+    tasks: list[tuple[Cell, str, str]] = []
     for cell in cells:
         key = f"{engine}/{cell.pipeline}/{cell.lifecycle}/{cell.store}/{cell.state}"
         why = cell.na_reason()
@@ -1196,18 +1229,55 @@ def sc_blessed_flow(led: Ledger, engine: str, tag: str, url: str,
             led.skipped(cell.engine, tag, "flow:chain", cell.store,
                         f"{cell.engine} {cell.label} — {cell.store} store not up")
             continue
-        before = sum(1 for c in led.cells if c.status.value == "FAIL")
-        with led.span(f"cell {engine} flow {cell.pipeline}/{cell.lifecycle}/{cell.store}/{cell.state}"):
-            run_cell(led, cell, u, state_url, tag)
-        after = sum(1 for c in led.cells if c.status.value == "FAIL")
-        verdicts[key] = "fail" if after > before else "pass"
-        # Written after EVERY cell, not at the end: a matrix killed at minute ten
-        # would otherwise leave nothing to resume from, which is the same defect
-        # the CDC checkpoint exists to prevent one layer down.
+        tasks.append((cell, key, u))
+
+    if not tasks:
+        return
+
+    # Cells are independent (own work-dir + own destination prefix), so run them
+    # concurrently. Each records into its OWN buffered child, so (a) its rows/spans
+    # stay contiguous instead of interleaving with a sibling's, and (b) its pass/fail
+    # is that child's alone — thread-safe, unlike counting FAILs on the shared ledger.
+    # cell_gate() caps concurrency ACROSS engines (which also run in parallel). Flush +
+    # verdict write happen under a lock as each cell completes, so a matrix killed
+    # mid-run still leaves a resumable verdicts file — the property the per-cell write
+    # has always guarded, preserved under parallelism.
+    lock = threading.Lock()
+    # cdc cells DESTRUCTIVELY set up the ONE shared source probe per engine
+    # (drop/create/enable orc_cdc_probe), so they cannot run concurrently WITH EACH
+    # OTHER on this engine — RED-proven: 12 "orc_cdc_probe does not exist" collisions.
+    # Each engine has its own lock (sc_blessed_flow is per-engine), so cdc still
+    # overlaps ACROSS the 4 engines; batch cells never take it.
+    cdc_lock = threading.Lock()
+
+    def run_one(task: tuple[Cell, str, str]) -> None:
+        cell, key, u = task
+        child = led.buffered_child()
+        # Take the per-engine cdc lock BEFORE the global slot, so a queued cdc cell
+        # does not hold a cell_gate() permit while it waits (that would starve batch
+        # cells). Non-cdc cells use a no-op context and never serialise.
+        serialize = cdc_lock if cell.pipeline == "cdc" else nullcontext()
         try:
-            vp.write_text(json.dumps(verdicts, indent=1, sort_keys=True))
-        except OSError:
-            pass
+            with serialize, cell_gate():
+                with child.span(
+                    f"cell {engine} flow {cell.pipeline}/{cell.lifecycle}/{cell.store}/{cell.state}"
+                ):
+                    run_cell(child, cell, u, state_url, tag)
+        except Exception as e:  # a raising cell must not abort the whole matrix
+            child.failed(cell.engine, tag, f"flow:{cell.pipeline}/{cell.lifecycle}",
+                         cell.store, f"{cell.engine} {cell.label} — cell raised: {e}", "raised")
+        failed = any(c.status.value == "FAIL" for c in child.cells)
+        with lock:
+            child.flush_into(led)
+            verdicts[key] = "fail" if failed else "pass"
+            try:
+                vp.write_text(json.dumps(verdicts, indent=1, sort_keys=True))
+            except OSError:
+                pass
+
+    workers = min(len(tasks), cell_parallel())
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        list(ex.map(run_one, tasks))
 
 
 def flag_coverage(cells: list[Cell]) -> dict[str, set[str]]:

--- a/dev/release_oracle/blessed_flow.py
+++ b/dev/release_oracle/blessed_flow.py
@@ -1197,7 +1197,8 @@ def sc_blessed_flow(led: Ledger, engine: str, tag: str, url: str,
                         f"{cell.engine} {cell.label} — {cell.store} store not up")
             continue
         before = sum(1 for c in led.cells if c.status.value == "FAIL")
-        run_cell(led, cell, u, state_url, tag)
+        with led.span(f"cell {engine} flow {cell.pipeline}/{cell.lifecycle}/{cell.store}/{cell.state}"):
+            run_cell(led, cell, u, state_url, tag)
         after = sum(1 for c in led.cells if c.status.value == "FAIL")
         verdicts[key] = "fail" if after > before else "pass"
         # Written after EVERY cell, not at the end: a matrix killed at minute ten

--- a/dev/release_oracle/blessed_flow.py
+++ b/dev/release_oracle/blessed_flow.py
@@ -970,15 +970,27 @@ def _run_chain(led: Ledger, cell: Cell, url: str, state_url: str, work: Path,
                 # readable dataset is the UNION: 2x. That is the assertion — a
                 # clobbered second run reads back 1x and looks like a clean run.
                 mult = 2 if cell.lifecycle == "repeat" else 1
-                _stage(led, cell, tag, "oracle", duck == want * mult,
-                       f"duckdb={duck} source={want}x{mult}")
+                # Per-column null profile (local only — parts are on disk): a decode
+                # regression can null a WHOLE column while the row count matches (the
+                # documented uuid→FixedSizeBinary silent loss). Count-parity alone is
+                # blind to it.
+                n_null = 0
+                if cell.store == "local":
+                    nn, _nc = scenarios.duckdb_allnull_columns(f"{dest_dir}/**/*.parquet")
+                    n_null = max(0, nn)
+                _stage(led, cell, tag, "oracle", duck == want * mult and n_null == 0,
+                       f"duckdb={duck} source={want}x{mult}"
+                       + (f" · ALLNULL {n_null} cols" if n_null else ""))
         else:
-            # A change stream is not the table: the count is of CHANGES, which
-            # only the source's own write history predicts. What DuckDB can say
-            # independently is that the parts decode and are non-empty — a
-            # capture that wrote unreadable or zero rows fails here.
-            _stage(led, cell, tag, "oracle", duck > 0,
-                   f"duckdb={duck} changes decoded by an independent reader")
+            # A change stream is not the table: the count is of CHANGES. But the
+            # change set here is the SHARED, DETERMINISTIC cdc.changes() — cdc.py's
+            # e2e proves it is exactly CDC_EXPECT_EVENTS across every engine. So the
+            # floor is at-least-once: fewer than that means capture DROPPED a change
+            # (the old `duck > 0` passed with 4 of 5 lost). >= tolerates an
+            # at-least-once duplicate; < is a real loss.
+            want = cdc.CDC_EXPECT_EVENTS
+            _stage(led, cell, tag, "oracle", duck >= want,
+                   f"duckdb={duck} >= {want} deterministic changes (at-least-once floor)")
 
     # ── validate ─────────────────────────────────────────────────────────────
     p = rivet("validate", "-c", str(cfg), *cell.flags.get("validate", []),

--- a/dev/release_oracle/blessed_flow.py
+++ b/dev/release_oracle/blessed_flow.py
@@ -59,7 +59,6 @@ import json
 import os
 import re
 import shutil
-import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -670,13 +669,11 @@ def run_cell(led: Ledger, cell: Cell, url: str, state_url: str, tag: str = "live
         # Retried: SQL Server's fixture disables and re-enables CDC on the table,
         # and `sp_cdc_enable_table` can fail while the previous capture job is
         # still shutting down. Six of eight mssql cells failed that way — a race
-        # in the fixture, reported as a source failure.
-        blk = spec.setup(url, work)
-        for _ in range(2):
-            if blk is not None:
-                break
-            time.sleep(3.0)
-            blk = spec.setup(url, work)
+        # in the fixture, reported as a source failure. The retry lives in
+        # `cdc.setup_with_retry` — ONE definition, shared with verify_cdc_e2e, so
+        # the preflight and engine-matrix setup paths cannot drift (they did:
+        # verify_cdc_e2e retried nothing and went RED on this very race).
+        blk = cdc.setup_with_retry(spec, url, work)
         if blk is None:
             _stage(led, cell, tag, "init", False, "cdc fixture setup failed on the source")
             _unreached(led, cell, tag, "init")

--- a/dev/release_oracle/blessed_flow.py
+++ b/dev/release_oracle/blessed_flow.py
@@ -1102,8 +1102,12 @@ def _load_leg(led: Ledger, cell: Cell, tag: str, work: Path, env: dict, url: str
         return
     # Unique per cell: the id is what the ledger check scopes on, and a shared
     # one would let one cell's rows satisfy another's assertion.
+    # + PID: work_dir().name is STABLE across gate invocations when RIVET_ORACLE_WORK is
+    # set, so without a per-invocation token the load_id repeats and _load_rows' `LIKE
+    # load_id%` count on the shared, never-reset Postgres ledger passes on a PRIOR run's
+    # rows. rivet records THIS load under this id (--run-id), so the scoping isolates it.
     load_id = (
-        f"flow-{cell.engine}-{cell.lifecycle}-{cell.state}-{scenarios.work_dir().name}"
+        f"flow-{cell.engine}-{cell.lifecycle}-{cell.state}-{scenarios.work_dir().name}-{os.getpid()}"
     )
     p = rivet("load", "-c", str(lcfg), "--rivet-bin", str(rivet_bin()),
               "--run-id", load_id, env=env, timeout=scenarios.NO_TIMEOUT)

--- a/dev/release_oracle/blessed_flow.py
+++ b/dev/release_oracle/blessed_flow.py
@@ -479,23 +479,20 @@ def _meta_rows(cell: Cell, work: Path, state_url: str, mark: int,
                run_ids: list[str]) -> tuple[bool, str]:
     """Did THIS run record itself, on whichever backend this cell uses?
 
-    Scoped three ways, one per table's own key: `export_metrics` by the
-    watermark (it has no run_id), `file_log` and `run_status` by the run ids the
-    manifests actually name. A count that a previous cell could satisfy is not
+    Scoped by run_id — ALL THREE tables. `export_metrics` DOES have a run_id column
+    (src/state/metrics.rs), so the old `id > mark` watermark (a workaround for a
+    limitation that never existed) is dropped: under the parallel gate a concurrent
+    sibling 'flow' cell inserts id>mark rows on the shared Postgres ledger, so the
+    watermark counted a sibling's row and an export_metrics-specific writer regression
+    passed GREEN. run_id scoping isolates THIS run regardless of concurrent writers, so
+    the check actually bites. (`mark` is now vestigial — kept only to avoid churning the
+    caller's _state_watermark this pass.) A count a previous cell could satisfy is not
     evidence about this one.
     """
     ids = ", ".join(f"'{r}'" for r in run_ids) if run_ids else "''"
-    # export_metrics has no run_id, so it is scoped by a watermark (id > mark). Under
-    # CONCURRENT cells this can also count a sibling's row, so its ≥1 check is
-    # best-effort: it can only ever produce a false PASS (never a false fail — the
-    # count only inflates), and that is masked by the cell-scoped, sibling-proof
-    # checks below (artifacts/oracle read THIS cell's own work-dir/prefix; file_log
-    # and run_status are scoped by THIS cell's run_ids). The authoritative per-cell
-    # signals are those; export_metrics ≥1 is corroboration.
     got = {
         "export_metrics": _state_sql(cell, work, state_url,
-                                     f"SELECT count(*) FROM export_metrics "
-                                     f"WHERE id > {mark} AND export_name = 'flow'"),
+                                     f"SELECT count(*) FROM export_metrics WHERE run_id IN ({ids})"),
         "file_log": _state_sql(cell, work, state_url,
                                f"SELECT count(*) FROM file_log WHERE run_id IN ({ids})"),
         "run_status": _state_sql(cell, work, state_url,

--- a/dev/release_oracle/blessed_flow.py
+++ b/dev/release_oracle/blessed_flow.py
@@ -970,14 +970,15 @@ def _run_chain(led: Ledger, cell: Cell, url: str, state_url: str, work: Path,
                 # readable dataset is the UNION: 2x. That is the assertion — a
                 # clobbered second run reads back 1x and looks like a clean run.
                 mult = 2 if cell.lifecycle == "repeat" else 1
-                # Per-column null profile (local only — parts are on disk): a decode
-                # regression can null a WHOLE column while the row count matches (the
-                # documented uuid→FixedSizeBinary silent loss). Count-parity alone is
-                # blind to it.
-                n_null = 0
-                if cell.store == "local":
-                    nn, _nc = scenarios.duckdb_allnull_columns(f"{dest_dir}/**/*.parquet")
-                    n_null = max(0, nn)
+                # Per-column null profile: a decode/write regression can null a WHOLE
+                # column while the row count matches (the documented uuid→FixedSizeBinary
+                # silent loss — which happened on a CLOUD run). Count-parity is blind to
+                # it. Local reads the parts on disk; cloud reads the copy _readback ALREADY
+                # pulled to work/pull_<store> — so every store gets the same oracle, not
+                # just local (the GCS store is exactly where the real incident occurred).
+                prof = dest_dir if cell.store == "local" else (work / f"pull_{cell.store}")
+                nn, _nc = scenarios.duckdb_allnull_columns(f"{prof}/**/*.parquet")
+                n_null = max(0, nn)
                 _stage(led, cell, tag, "oracle", duck == want * mult and n_null == 0,
                        f"duckdb={duck} source={want}x{mult}"
                        + (f" · ALLNULL {n_null} cols" if n_null else ""))

--- a/dev/release_oracle/blessed_flow.py
+++ b/dev/release_oracle/blessed_flow.py
@@ -1163,21 +1163,37 @@ def _load_rows(cell: Cell, work: Path, state_url: str, load_id: str,
 VERDICTS = "blessed-flow-verdicts.json"
 
 
-def _verdict_path() -> Path:
-    return Path(os.environ.get("RIVET_FLOW_VERDICTS", scenarios.work_dir() / VERDICTS))
+def _verdict_path(engine: str | None = None) -> Path:
+    base = Path(os.environ.get("RIVET_FLOW_VERDICTS", scenarios.work_dir() / VERDICTS))
+    # PER ENGINE. engine_loop runs the four engines' sc_blessed_flow concurrently, and
+    # each read-modify-overwrites this file under its OWN per-engine lock — so a shared
+    # path means the last engine to write CLOBBERS the others' resume anchors (a crashed
+    # matrix could then re-run only one engine's cells). A file per engine keeps each
+    # engine's incremental verdicts independent; failed_cells() unions them back.
+    if engine:
+        return base.with_name(f"{base.stem}.{engine}{base.suffix}")
+    return base
 
 
 def failed_cells(path: Path | None = None) -> set[str]:
     """The cell keys a previous run failed, for `only=`.
 
     The matrix is ~15 minutes; re-running all 76 cells to re-check four is how a
-    feedback loop gets long enough that people stop closing it.
+    feedback loop gets long enough that people stop closing it. Unions the per-engine
+    verdict files (see _verdict_path) plus any legacy shared file.
     """
-    p = path or _verdict_path()
-    try:
-        return {k for k, v in json.loads(p.read_text()).items() if v == "fail"}
-    except (OSError, json.JSONDecodeError):
-        return set()
+    if path is not None:
+        paths = [path]
+    else:
+        base = _verdict_path()
+        paths = [base, *sorted(base.parent.glob(f"{base.stem}.*{base.suffix}"))]
+    out: set[str] = set()
+    for p in paths:
+        try:
+            out |= {k for k, v in json.loads(p.read_text()).items() if v == "fail"}
+        except (OSError, json.JSONDecodeError):
+            continue
+    return out
 
 
 def sc_blessed_flow(led: Ledger, engine: str, tag: str, url: str,
@@ -1205,7 +1221,7 @@ def sc_blessed_flow(led: Ledger, engine: str, tag: str, url: str,
            f"{len(cells) - len(runnable)} na")
 
     verdicts: dict[str, str] = {}
-    vp = _verdict_path()
+    vp = _verdict_path(engine)  # per-engine: concurrent engines must not clobber
     try:
         verdicts = json.loads(vp.read_text())
     except (OSError, json.JSONDecodeError):

--- a/dev/release_oracle/blessed_path.py
+++ b/dev/release_oracle/blessed_path.py
@@ -303,6 +303,32 @@ def _downstream_unreached(led: Ledger, engine: str, tag: str, store: str, after:
         )
 
 
+def _pg_query(state_url: str, sql: str) -> str | None:
+    """One scalar query against the Postgres state DB behind state_url. None if the
+    backing container cannot be resolved (caller turns that into a FAIL, not a pass)."""
+    port = port_of(state_url)
+    c = container_for_port(port) if port else None
+    if not c:
+        return None
+    db = state_url.rsplit("/", 1)[-1]
+    return docker_exec(c, "psql", "-U", "rivet", "-d", db, "-tA", "-c", sql).stdout.strip()
+
+
+def _run_ids(work: Path) -> list[str]:
+    """This cell's run ids, from `.rivet/runs/*/summary.json` (rivet writes it beside
+    the CONFIG for every run, cloud or local — no destination-manifest asymmetry).
+    Used to scope the shared Postgres ledger to THIS run, mirroring blessed_flow."""
+    out: list[str] = []
+    for f in sorted((work / ".rivet" / "runs").glob("*/summary.json")):
+        try:
+            rid = json.loads(f.read_text()).get("run_id")
+        except (OSError, json.JSONDecodeError):
+            continue
+        if rid:
+            out.append(rid)
+    return out
+
+
 def sc_blessed_path(
     led: Ledger,
     engine: str,
@@ -452,6 +478,14 @@ def sc_blessed_path(
     # a shape assertion is what stayed green for two months while apply
     # rejected every plan.json on disk (the `verify` field became required and
     # the fixture test never deserialized with the real type).
+    # Watermark BEFORE apply: export_metrics has no run_id, and every cell names its
+    # export 'blessed' on a shared long-lived Postgres ledger, so `id > pg_mark` is the
+    # only way to isolate THIS run's row (a constant-name count passes on history — the
+    # very defect this cell's docstring warns about; mirrors blessed_flow._state_watermark).
+    pg_mark = 0
+    if state_url:
+        w = _pg_query(state_url, "SELECT coalesce(max(id),0) FROM export_metrics")
+        pg_mark = int(w) if w and w.lstrip("-").isdigit() else 0
     r = rivet("apply", str(plan_path), env=env, timeout=scenarios.NO_TIMEOUT)
     if not _stage(led, engine, tag, store, "apply", r.ok, f"exit={r.returncode} {r.stderr[-200:]}"):
         _downstream_unreached(led, engine, tag, store, "apply")
@@ -488,27 +522,30 @@ def sc_blessed_path(
         # written against, and I wrote one. The backend is a separate SQL
         # implementation of the same contract; "the other pass covers it" is the
         # assumption, not the evidence.
-        port = port_of(state_url)
-        c = container_for_port(port) if port else None
-        if not c:
-            ok, detail = False, f"state backend container not resolvable from {state_url}"
+        # Scoped to THIS RUN, not just this export name. An unscoped count on the
+        # shared, long-lived Postgres ledger passes on history — the cell stayed green
+        # even if apply recorded NOTHING for this run (the exact defect the docstring
+        # above claims to prevent, caught by the harness bughunt). export_metrics has
+        # no run_id → the pre-apply watermark (id > pg_mark) isolates it; file_log and
+        # run_status ARE run-scoped → the exact rows this run wrote. Mirrors blessed_flow.
+        ids = _run_ids(work)
+        idlist = ", ".join(f"'{r}'" for r in ids) if ids else "''"
+        scoped = {
+            "export_metrics": f"SELECT count(*) FROM export_metrics WHERE id > {pg_mark} AND export_name='blessed'",
+            "file_log":       f"SELECT count(*) FROM file_log WHERE run_id IN ({idlist})",
+            "run_status":     f"SELECT count(*) FROM run_status WHERE run_id IN ({idlist})",
+        }
+        got = {}
+        for t, q in scoped.items():
+            out = _pg_query(state_url, q)
+            got[t] = int(out) if out and out.lstrip("-").isdigit() else -1
+        if got.get("export_metrics", -1) < 0:
+            ok, detail = False, f"state backend not queryable from {state_url}"
         else:
-            db = state_url.rsplit("/", 1)[-1]
-            # Scoped to THIS export. An unscoped count on a shared, long-lived
-            # state DB passes on history — the cell would stay green if apply
-            # recorded nothing at all today.
-            scoped = {
-                "export_metrics": "SELECT count(*) FROM export_metrics WHERE export_name='blessed'",
-                "file_log":       "SELECT count(*) FROM file_log WHERE export_name='blessed'",
-                "run_status":     "SELECT count(*) FROM run_status WHERE export_name='blessed'",
-            }
-            got = {}
-            for t, q in scoped.items():
-                out = docker_exec(c, "psql", "-U", "rivet", "-d", db, "-tA", "-c", q).stdout.strip()
-                got[t] = int(out) if out.lstrip("-").isdigit() else -1
             missing = [t for t, n in got.items() if n < 1]
             ok = not missing
-            detail = f"{db}@{c} (export=blessed): " + ", ".join(f"{t}={n}" for t, n in got.items())
+            detail = (f"(export=blessed, id>{pg_mark}, {len(ids)} run id(s)): "
+                      + ", ".join(f"{t}={n}" for t, n in got.items()))
     else:
         db = cfg.parent / ".rivet_state.db"
         counts = _state_counts(db)

--- a/dev/release_oracle/blessed_path.py
+++ b/dev/release_oracle/blessed_path.py
@@ -546,13 +546,17 @@ def sc_blessed_path(
         man_rows = int(man.get("row_count", -1)) if man else -1
         man_files = int(man.get("part_count", -1)) if man else -1
 
-        if want < 0 or duck_rows < 0:
+        if want < 0:
+            # Source truth unreachable → cannot compare, legitimately SKIP.
             led.skipped(
                 engine, tag, "blessed:oracle", store,
-                f"{engine} {tag} {store} · oracle — unreadable "
-                f"(source={want} duckdb={duck_rows})",
+                f"{engine} {tag} {store} · oracle — source unreachable (source={want})",
             )
         else:
+            # want>=0 and duckdb works (checked above): a duck_rows<0 here is an
+            # EMPTY/undelivered destination, NOT "unreadable" — it must FAIL, not SKIP
+            # (a run that reports success but delivered zero parts to the bucket used to
+            # read as release-ready). The compare below does exactly that: -1 != want.
             agree = duck_rows == want and (man_rows < 0 or man_rows == want)
             files_agree = duck_files < 0 or man_files < 0 or duck_files == man_files
             # Per-column null profile, independent of rivet: a decode regression can

--- a/dev/release_oracle/blessed_path.py
+++ b/dev/release_oracle/blessed_path.py
@@ -666,13 +666,15 @@ def verify_blessed_path(
                 led.skipped(engine, tag, f"blessed:{name}", "local",
                             f"{engine} {tag} {t} · {name} — not applicable to this table/engine")
                 continue
-            sc_blessed_path(led, engine, tag, url, t, store="local", scenario=name)
+            with led.span(f"cell {engine} path {name}/local/sq"):
+                sc_blessed_path(led, engine, tag, url, t, store="local", scenario=name)
     if state_url:
         for t in tables:
             for name, sc in SCENARIOS.items():
                 if sc["applies"](t, engine):
-                    sc_blessed_path(led, engine, tag, url, t, store="local",
-                                    state_url=state_url, scenario=name)
+                    with led.span(f"cell {engine} path {name}/local/pg"):
+                        sc_blessed_path(led, engine, tag, url, t, store="local",
+                                        state_url=state_url, scenario=name)
     else:
         led.skipped(
             engine, tag, "blessed:backend", "postgres",
@@ -687,6 +689,7 @@ def verify_blessed_path(
         for t in tables:
             for name, sc in SCENARIOS.items():
                 if sc["applies"](t, engine):
-                    sc_blessed_path(led, engine, tag, url, t, store="gcs", scenario=name)
+                    with led.span(f"cell {engine} path {name}/gcs/sq"):
+                        sc_blessed_path(led, engine, tag, url, t, store="gcs", scenario=name)
     else:
         led.skipped(engine, tag, "blessed:store", "gcs", f"{engine} {tag} · gcs — store not up")

--- a/dev/release_oracle/blessed_path.py
+++ b/dev/release_oracle/blessed_path.py
@@ -77,9 +77,13 @@ import json
 import os
 import shutil
 import sqlite3
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-from .core import Ledger, container_for_port, docker_exec, have, port_of, run, rivet
+from .core import (Ledger, cell_gate, cell_parallel, container_for_port, docker_exec,
+                   have, port_of, run, rivet)
 from . import scenarios
 
 BUCKET = "rivet-blessed"
@@ -405,7 +409,19 @@ def sc_blessed_path(
     # ── doctor / check ────────────────────────────────────────────────────────
     for stage in ("doctor", "check"):
         r = rivet(stage, "-c", str(cfg), env=env, timeout=scenarios.NO_TIMEOUT)
-        if not _stage(led, engine, tag, store, stage, r.ok, f"exit={r.returncode}"):
+        # doctor/check are READ-ONLY source probes. Under the parallel matrix a
+        # transient connection blip (many cells hitting one source at once) is a
+        # false alarm, not a config error — retry like seed_engine does ("a source
+        # under load can drop the connection; crying wolf is worse than a retry"). A
+        # real failure fails every attempt. Capture the last error line so an
+        # exhausted retry is diagnosable (it was `exit=1` and nothing else before).
+        for _ in range(2):
+            if r.ok:
+                break
+            time.sleep(1.5)
+            r = rivet(stage, "-c", str(cfg), env=env, timeout=scenarios.NO_TIMEOUT)
+        why = "" if r.ok else " " + ((r.stderr or r.stdout or "").strip().splitlines() or [""])[-1][:160]
+        if not _stage(led, engine, tag, store, stage, r.ok, f"exit={r.returncode}{why}"):
             _downstream_unreached(led, engine, tag, store, stage)
             return
 
@@ -660,36 +676,59 @@ def verify_blessed_path(
     """
     led.phase(f"blessed path · {engine} {tag}")
     tables = (table,) if table else GOLDEN_TABLES
+    # Collect the runnable cells across the three store×backend planes; skips are
+    # recorded inline (no rivet), the chains run through the pool. Each cell has its
+    # own work-dir + cloud prefix, so they are independent.
+    tasks: list[tuple[str, str, str, str, str]] = []  # (table, scenario, store, state_url, slug)
     for t in tables:
         for name, sc in SCENARIOS.items():
             if not sc["applies"](t, engine):
                 led.skipped(engine, tag, f"blessed:{name}", "local",
                             f"{engine} {tag} {t} · {name} — not applicable to this table/engine")
                 continue
-            with led.span(f"cell {engine} path {name}/local/sq"):
-                sc_blessed_path(led, engine, tag, url, t, store="local", scenario=name)
+            tasks.append((t, name, "local", "", "local/sq"))
     if state_url:
         for t in tables:
             for name, sc in SCENARIOS.items():
                 if sc["applies"](t, engine):
-                    with led.span(f"cell {engine} path {name}/local/pg"):
-                        sc_blessed_path(led, engine, tag, url, t, store="local",
-                                        state_url=state_url, scenario=name)
+                    tasks.append((t, name, "local", state_url, "local/pg"))
     else:
         led.skipped(
             engine, tag, "blessed:backend", "postgres",
             f"{engine} {tag} · postgres state backend — no --state-url given",
         )
-    # The warehouse cycle runs on ONE table per engine, deliberately: it costs a
-    # real GCS round-trip and a BigQuery job, and what it proves — that a
-    # foreign reader can decode what rivet wrote — does not multiply with the
-    # row count. The strategy axis is where breadth belongs.
-    sc_bq_cycle(led, engine, tag, url, tables[0])
     if scenarios.store_up("gcs"):
         for t in tables:
             for name, sc in SCENARIOS.items():
                 if sc["applies"](t, engine):
-                    with led.span(f"cell {engine} path {name}/gcs/sq"):
-                        sc_blessed_path(led, engine, tag, url, t, store="gcs", scenario=name)
+                    tasks.append((t, name, "gcs", "", "gcs/sq"))
     else:
         led.skipped(engine, tag, "blessed:store", "gcs", f"{engine} {tag} · gcs — store not up")
+
+    # The warehouse cycle runs on ONE table per engine, deliberately: it costs a
+    # real GCS round-trip and a BigQuery job, and what it proves — that a foreign
+    # reader can decode what rivet wrote — does not multiply with the row count. Kept
+    # sequential (one real BQ job; the BQ golden stage already parallelises engines).
+    sc_bq_cycle(led, engine, tag, url, tables[0])
+
+    if not tasks:
+        return
+    lock = threading.Lock()
+
+    def run_one(task: tuple[str, str, str, str, str]) -> None:
+        t, name, store, st, slug = task
+        child = led.buffered_child()
+        try:
+            with cell_gate():
+                with child.span(f"cell {engine} path {name}/{slug}"):
+                    sc_blessed_path(child, engine, tag, url, t, store=store,
+                                    state_url=st, scenario=name)
+        except Exception as e:  # a raising cell must not abort the matrix
+            child.failed(engine, tag, f"blessed:{name}", store,
+                         f"{engine} {tag} {t} · {name}/{slug} — cell raised: {e}", "raised")
+        with lock:
+            child.flush_into(led)
+
+    workers = min(len(tasks), cell_parallel())
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        list(ex.map(run_one, tasks))

--- a/dev/release_oracle/blessed_path.py
+++ b/dev/release_oracle/blessed_path.py
@@ -555,10 +555,21 @@ def sc_blessed_path(
         else:
             agree = duck_rows == want and (man_rows < 0 or man_rows == want)
             files_agree = duck_files < 0 or man_files < 0 or duck_files == man_files
+            # Per-column null profile, independent of rivet: a decode regression can
+            # null a WHOLE column while the row count stays correct (the documented
+            # uuid→FixedSizeBinary GCS incident). Local store only for now — the parts
+            # are on disk; the cloud path reads rows via store_readback, not a pulled
+            # dir. -1 means unreadable (the count oracle already SKIPs that).
+            n_null, n_cols = (-1, -1)
+            if store == "local":
+                n_null, n_cols = scenarios.duckdb_allnull_columns(f"{dest_dir}/**/*.parquet")
+            cols_ok = n_null <= 0
             _stage(
-                led, engine, tag, store, "oracle", agree and files_agree,
+                led, engine, tag, store, "oracle", agree and files_agree and cols_ok,
                 f"source={want} duckdb={duck_rows} manifest={man_rows} · "
-                f"files duckdb={duck_files} manifest={man_files}",
+                f"files duckdb={duck_files} manifest={man_files}"
+                + (f" · ALLNULL {n_null}/{n_cols} cols" if n_null > 0 else
+                   (f" · cols ok {n_cols}" if n_cols > 0 else "")),
             )
 
     # ── validate ──────────────────────────────────────────────────────────────

--- a/dev/release_oracle/blessed_path.py
+++ b/dev/release_oracle/blessed_path.py
@@ -531,7 +531,12 @@ def sc_blessed_path(
         ids = _run_ids(work)
         idlist = ", ".join(f"'{r}'" for r in ids) if ids else "''"
         scoped = {
-            "export_metrics": f"SELECT count(*) FROM export_metrics WHERE id > {pg_mark} AND export_name='blessed'",
+            # export_metrics DOES have a run_id (src/state/metrics.rs) — scope all three
+            # by run_id, not a watermark: under the parallel gate a concurrent sibling
+            # 'blessed' cell inserts id>mark rows on the shared ledger, so the watermark
+            # counted a sibling and an export_metrics-specific regression passed. run_id
+            # isolates THIS run regardless of concurrency. (pg_mark now vestigial.)
+            "export_metrics": f"SELECT count(*) FROM export_metrics WHERE run_id IN ({idlist})",
             "file_log":       f"SELECT count(*) FROM file_log WHERE run_id IN ({idlist})",
             "run_status":     f"SELECT count(*) FROM run_status WHERE run_id IN ({idlist})",
         }
@@ -544,7 +549,7 @@ def sc_blessed_path(
         else:
             missing = [t for t, n in got.items() if n < 1]
             ok = not missing
-            detail = (f"(export=blessed, id>{pg_mark}, {len(ids)} run id(s)): "
+            detail = (f"(export=blessed, {len(ids)} run id(s)): "
                       + ", ".join(f"{t}={n}" for t, n in got.items()))
     else:
         db = cfg.parent / ".rivet_state.db"

--- a/dev/release_oracle/blessed_path.py
+++ b/dev/release_oracle/blessed_path.py
@@ -598,12 +598,17 @@ def sc_blessed_path(
             files_agree = duck_files < 0 or man_files < 0 or duck_files == man_files
             # Per-column null profile, independent of rivet: a decode regression can
             # null a WHOLE column while the row count stays correct (the documented
-            # uuid→FixedSizeBinary GCS incident). Local store only for now — the parts
-            # are on disk; the cloud path reads rows via store_readback, not a pulled
-            # dir. -1 means unreadable (the count oracle already SKIPs that).
-            n_null, n_cols = (-1, -1)
+            # uuid→FixedSizeBinary GCS incident — a CLOUD run). Local reads parts on
+            # disk; cloud reads them store-native via duckdb_allnull_cloud (the same
+            # read path as store_readback). -1 means unreadable (count oracle SKIPs that).
             if store == "local":
                 n_null, n_cols = scenarios.duckdb_allnull_columns(f"{dest_dir}/**/*.parquet")
+            else:
+                # Cloud (gcs here): read the parts store-native (same path as
+                # store_readback) — the GCS store is exactly where the documented
+                # uuid→null incident happened, so the profile must run here too.
+                pfx = cloud_prefix(engine, tag, table, scenario)
+                n_null, n_cols = scenarios.duckdb_allnull_cloud(store, BUCKET, pfx, work)
             cols_ok = n_null <= 0
             _stage(
                 led, engine, tag, store, "oracle", agree and files_agree and cols_ok,

--- a/dev/release_oracle/cdc.py
+++ b/dev/release_oracle/cdc.py
@@ -698,7 +698,7 @@ def verify_cdc_e2e(led: Ledger) -> None:
         # 2. crash-recovery: an extra row (id=4) + crash at cdc_after_flush_before_ack →
         #    anchor held → recovery re-reads it (at-least-once, no loss).
         spec.crash_delta(url)
-        rivet("run", "-c", str(cap.yaml), env={"RIVET_TEST_PANIC_AT": CDC_HOOK_FLUSH})  # crash
+        crashp = rivet("run", "-c", str(cap.yaml), env={"RIVET_TEST_PANIC_AT": CDC_HOOK_FLUSH})  # crash
         rivet("run", "-c", str(cap.yaml))  # recover
         ids = _cdc_store_ids("s3", cap.bucket, cap.prefix, idc, work)
         # An id-SET membership test. The bash `grep -q 4` was a substring match —
@@ -713,6 +713,12 @@ def verify_cdc_e2e(led: Ledger) -> None:
             reasons.append("validate-not-PASSED")
         if not spop:
             reasons.append("state-not-populated")
+        if crashp.ok:
+            # The panic run MUST have crashed (non-zero exit). If it exited 0 the fault
+            # hook never fired — id=4 was acked normally, nothing was left un-acked, and
+            # the lost-tail invariant was never exercised: crashok would be green on a
+            # non-crash. (mirrors blessed_flow.py's `if c.ok: FAIL` for the batch path.)
+            reasons.append("crash-hook-inert[panic run exited 0 — cdc_after_flush_before_ack did not fire]")
         if not crashok:
             reasons.append(f"crash-lost-the-delta[ids={ids}]")
         if cdc_null > 0:
@@ -790,7 +796,7 @@ def _cdc_large_tx_atomic(led: Ledger) -> None:
     rivet("run", "-c", str(yaml))  # anchor
     # ONE transaction of 12 rows — larger than rollover 5. Must NOT split.
     _psql(url, sql="BEGIN;\nINSERT INTO orc_ltx SELECT g FROM generate_series(1,12) g;\nCOMMIT;\n")
-    rivet("run", "-c", str(yaml), env={"RIVET_TEST_PANIC_AT": CDC_HOOK_ACK})  # crash mid-flush
+    crashp = rivet("run", "-c", str(yaml), env={"RIVET_TEST_PANIC_AT": CDC_HOOK_ACK})  # crash mid-flush
     rivet("run", "-c", str(yaml))  # recover
     ids = _cdc_store_ids("s3", bkt, pfx, "id", work)
     cnt = sum(1 for t in ids.split(",") if re.fullmatch(r"[0-9]+", t.strip()))
@@ -800,7 +806,9 @@ def _cdc_large_tx_atomic(led: Ledger) -> None:
         f"SELECT pg_drop_replication_slot('{slot}') FROM pg_replication_slots WHERE slot_name='{slot}'; "
         "DROP TABLE IF EXISTS orc_ltx;",
     )
-    if cnt == 12:
+    # The crash MUST have fired: if the panic run exited 0 the hook never ran, no tail was
+    # left mid-flush, and 12/12 proves nothing about atomicity across a crash.
+    if cnt == 12 and not crashp.ok:
         led.passed(
             "postgres",
             "cdc",
@@ -808,6 +816,12 @@ def _cdc_large_tx_atomic(led: Ledger) -> None:
             "s3",
             "cdc large-tx-atomic: all 12 rows of the >rollover transaction survived the mid-flush crash",
             "12/12",
+        )
+    elif crashp.ok:
+        led.failed(
+            "postgres", "cdc", "large-tx-atomic", "s3",
+            "cdc large-tx-atomic: crash-hook INERT — the panic run exited 0, so no mid-flush "
+            f"crash was exercised (cnt={cnt}/12 proves nothing)", "crash-inert",
         )
     else:
         led.failed(

--- a/dev/release_oracle/cdc.py
+++ b/dev/release_oracle/cdc.py
@@ -687,6 +687,12 @@ def verify_cdc_e2e(led: Ledger) -> None:
         before = _runs_seen()  # the key set this cell will subtract, see _state_populated
         rivet("run", "-c", str(cap.yaml))
         n = _store_readback("s3", cap.bucket, cap.prefix, work)  # INDEPENDENT (DuckDB)
+        # Per-column null profile, independent of rivet: the change set writes typed
+        # columns (amount numeric, meta jsonb), and a decode regression can null a WHOLE
+        # captured column while n stays 5 and validate re-reads its own null parts green —
+        # the exact uuid→FixedSizeBinary silent-loss class, on the CDC pipeline it
+        # occurred on. The batch legs guard this; CDC did not. Same helper.
+        cdc_null, _cdc_cols = scenarios.duckdb_allnull_cloud("s3", cap.bucket, cap.prefix, work)
         vout = rivet("validate", "-c", str(cap.yaml)).out
         vp = "passed" in vout.lower()
         spop = _state_populated(work / ".rivet_state.db", before=before)
@@ -711,6 +717,8 @@ def verify_cdc_e2e(led: Ledger) -> None:
             reasons.append("state-not-populated")
         if not crashok:
             reasons.append(f"crash-lost-the-delta[ids={ids}]")
+        if cdc_null > 0:
+            reasons.append(f"cdc-allnull-column[{cdc_null} col(s) 100% NULL]")
         if not reasons:
             led.passed(
                 eng,

--- a/dev/release_oracle/cdc.py
+++ b/dev/release_oracle/cdc.py
@@ -634,6 +634,27 @@ def _state_populated(
 
 
 # ── the CDC end-to-end preflight (once, env-driven, SKIP-if-absent) ──────────
+def setup_with_retry(spec, url: str, work: Path, *, tries: int = 3, delay: float = 3.0):
+    """Run a CDC fixture's `setup`, retrying a transient failure.
+
+    SQL Server's `sp_cdc_enable_table` can fail while the PREVIOUS capture job is
+    still shutting down — six of eight mssql cells once failed exactly this way,
+    and it read as a source failure when it is a fixture race. `blessed_flow` had
+    absorbed it with an inline retry loop for MONTHS while `verify_cdc_e2e` called
+    `setup` ONCE — so the preflight CDC[mssql] cell went RED on the same race the
+    engine-matrix cell shrugged off (measured: min_lsn populated in ~5s, so the
+    None came from `not p.ok` on the enable, not the readiness poll). This is the
+    ONE definition both paths now share, so they cannot drift again. The other
+    engines succeed on the first try, so the retry is a no-op for them."""
+    blk = spec.setup(url, work)
+    for _ in range(max(0, tries - 1)):
+        if blk is not None:
+            return blk
+        time.sleep(delay)
+        blk = spec.setup(url, work)
+    return blk
+
+
 def verify_cdc_e2e(led: Ledger) -> None:
     any_engine = False
     _export_store_creds()
@@ -651,7 +672,7 @@ def verify_cdc_e2e(led: Ledger) -> None:
         )
         work = _workdir()
         idc = spec.id_col
-        cdc_block = spec.setup(url, work)
+        cdc_block = setup_with_retry(spec, url, work)
         if cdc_block is None:
             led.failed(eng, "cdc", "e2e", "-", f"cdc[{eng}]: source setup failed", "setup")
             continue

--- a/dev/release_oracle/cdc.py
+++ b/dev/release_oracle/cdc.py
@@ -504,17 +504,15 @@ def _store_readback(store: str, bkt: str, pfx: str, work: Path) -> str:
     return scenarios.store_readback(store, bkt, pfx, work)
 
 
-def _cdc_store_ids(store: str, bkt: str, pfx: str, idc: str) -> str:
-    """The INDEPENDENT distinct id-set the store holds (never rivet) — the
-    completeness oracle, as a bare comma-joined string so it can be quoted
-    verbatim into a failure reason."""
-    if store != "s3":
-        return ""
-    return _duckdb(
-        _S3_PREAMBLE
-        + f"SELECT string_agg(DISTINCT CAST({idc} AS VARCHAR),',') "
-        f"FROM read_parquet('s3://{bkt}/{pfx}/**/*.parquet')"
-    )
+def _cdc_store_ids(store: str, bkt: str, pfx: str, idc: str, work) -> str:
+    """The INDEPENDENT distinct id-set the store DELIVERS per its MANIFESTS (never rivet,
+    never RAW parquet) — the crash-recovery completeness oracle. Raw `**/*.parquet` would
+    count the crashed run's flushed-but-UNMANIFESTED orphan (the cdc_after_flush_before_ack
+    hook fires BEFORE write_manifest), so it could not tell a real re-read on recovery from
+    an orphan a consumer (rivet load) never sees — a recovery that re-anchored PAST the
+    un-acked change would still read as green. manifest_scoped_ids reads only what a consumer
+    consumes, so the orphan is invisible and the lost re-read goes RED."""
+    return scenarios.manifest_scoped_ids(store, bkt, pfx, work, idc)
 
 
 @dataclass(frozen=True)
@@ -702,7 +700,7 @@ def verify_cdc_e2e(led: Ledger) -> None:
         spec.crash_delta(url)
         rivet("run", "-c", str(cap.yaml), env={"RIVET_TEST_PANIC_AT": CDC_HOOK_FLUSH})  # crash
         rivet("run", "-c", str(cap.yaml))  # recover
-        ids = _cdc_store_ids("s3", cap.bucket, cap.prefix, idc)
+        ids = _cdc_store_ids("s3", cap.bucket, cap.prefix, idc, work)
         # An id-SET membership test. The bash `grep -q 4` was a substring match —
         # equivalent on this probe's {1,2,3,4}, a false pass on any wider set.
         crashok = "4" in [t.strip() for t in ids.split(",")]
@@ -794,7 +792,7 @@ def _cdc_large_tx_atomic(led: Ledger) -> None:
     _psql(url, sql="BEGIN;\nINSERT INTO orc_ltx SELECT g FROM generate_series(1,12) g;\nCOMMIT;\n")
     rivet("run", "-c", str(yaml), env={"RIVET_TEST_PANIC_AT": CDC_HOOK_ACK})  # crash mid-flush
     rivet("run", "-c", str(yaml))  # recover
-    ids = _cdc_store_ids("s3", bkt, pfx, "id")
+    ids = _cdc_store_ids("s3", bkt, pfx, "id", work)
     cnt = sum(1 for t in ids.split(",") if re.fullmatch(r"[0-9]+", t.strip()))
     _psql(
         url,

--- a/dev/release_oracle/cdc.py
+++ b/dev/release_oracle/cdc.py
@@ -358,7 +358,33 @@ def _cdc_mssql(url: str, work: Path) -> str | None:
     )
 
 
+def _mssql_max_lsn(url: str) -> str:
+    """The highest LSN the CDC capture job has PROCESSED, or 'NULL' if none yet.
+    Database-wide (`sys.fn_cdc_get_max_lsn`), so once the job ingests our
+    just-committed transaction it strictly advances past the value read before the
+    write — the precise "the capture job has caught up to my changes" signal that
+    a fixed `time.sleep` only guessed at."""
+    return _sqlcmd(
+        url,
+        q="SELECT ISNULL(CONVERT(varchar(64), sys.fn_cdc_get_max_lsn(), 1), 'NULL')",
+    ).stdout.strip()
+
+
+def _wait_mssql_captured(url: str, before: str) -> None:
+    """Poll until the capture job advances past `before` (the max-LSN read BEFORE
+    the write). Replaces a blind `time.sleep(8)`: it returns the instant the job
+    has captured our changes (often ~1-3s) and only waits out the full budget when
+    the Agent is genuinely slow — the same readiness-poll the fixture SETUP already
+    uses (`fn_cdc_get_min_lsn`), applied to the CHANGES too."""
+    wait_until(
+        lambda: _mssql_max_lsn(url) not in ("NULL", before),
+        tries=30,
+        delay=1.0,
+    )
+
+
 def _cdc_mssql_changes(url: str) -> None:
+    before = _mssql_max_lsn(url)
     _sqlcmd(
         url,
         sql=(
@@ -367,12 +393,13 @@ def _cdc_mssql_changes(url: str) -> None:
             "DELETE FROM dbo.orc_cdc_probe WHERE id=3;\n"
         ),
     )
-    time.sleep(8)  # let the CDC capture job populate the change table
+    _wait_mssql_captured(url, before)
 
 
 def _cdc_mssql_crashdelta(url: str) -> None:
+    before = _mssql_max_lsn(url)
     _sqlcmd(url, q='INSERT INTO dbo.orc_cdc_probe VALUES (4,4.4400,\'{"k":4}\');')
-    time.sleep(8)
+    _wait_mssql_captured(url, before)
 
 
 def _cdc_mssql_cleanup(url: str, work: Path) -> None:

--- a/dev/release_oracle/concurrency.py
+++ b/dev/release_oracle/concurrency.py
@@ -310,7 +310,12 @@ def verify_concurrent_writers_share_a_prefix(
                  "concurrent-writers: could not seed the probe table", "no seed")
         return
 
-    stamp = time.strftime("%H%M%S")
+    # Date + PID, not a bare %H%M%S: the export_prefix scopes the aggregates on the
+    # SHARED, never-reset Postgres ledger (WHERE export_name LIKE '<prefix>%'), so a
+    # date-less stamp lets a prior gate run at the same hh:mm:ss satisfy this run's
+    # counts. The PID makes it unique per gate invocation; the date removes the
+    # once-a-day collision.
+    stamp = time.strftime("%Y%m%d_%H%M%S") + f"_{os.getpid()}"
     work = work_dir() / f"conc_{stamp}"
     work.mkdir(parents=True, exist_ok=True)
 

--- a/dev/release_oracle/concurrency.py
+++ b/dev/release_oracle/concurrency.py
@@ -44,6 +44,7 @@ import shutil
 import subprocess
 import sys
 import time
+from typing import Callable
 from pathlib import Path
 
 try:
@@ -87,6 +88,18 @@ def _psql_state(container: str, sql: str) -> str | None:
     return p.stdout.strip() if p.ok else None
 
 
+def _sqlite_state(db: Path, sql: str) -> str | None:
+    """The scalar from a SQLite state file, or None when the query DID NOT RUN
+    (same "unreadable != clean" discipline as `_psql_state`). Used by the
+    shared-SQLite concurrent-writers leg: all writers open ONE `.rivet_state.db`,
+    so its rows are the SQLite backend's answer to the same three questions the
+    Postgres leg asks. The queries are ANSI SQL — identical on both backends."""
+    if not db.is_file():
+        return None
+    p = run(["sqlite3", str(db), sql])
+    return p.stdout.strip() if p.ok else None
+
+
 def _seed(src_container: str) -> bool:
     return run(
         [
@@ -114,13 +127,27 @@ def _config(path: Path, name: str, dest_block: str, src_url: str) -> None:
     )
 
 
-def _run_writers(cfgs: list[Path], state_url: str) -> tuple[list[int], str]:
+def _run_writers(cfgs: list[Path], state_url: str | None) -> tuple[list[int], str]:
     """Start every writer, THEN wait. Sequential `run()` calls would make this a
     consecutive-runs test wearing a concurrent name.
+
+    `state_url` selects the shared state backend every writer contends on:
+      * a Postgres URL → all writers set RIVET_STATE_URL to it (one Postgres DB);
+      * `None` → RIVET_STATE_URL is UNSET, so each writer falls back to the
+        beside-config `.rivet_state.db`. When the configs share a directory
+        (the shared-SQLite leg), that is ONE SQLite file every writer opens at
+        once — the SQLite concurrent-writer contract (lock/BUSY/WAL), untested
+        until now. Must remove the var, not just skip setting it: the gate exports
+        RIVET_GATE_STATE_URL → RIVET_STATE_URL into os.environ.
 
     Output is KEPT, not discarded: "writer exit codes [1,1,1,1]" with nothing to
     read is a cell that can only tell you it is unhappy.
     """
+    env = {**os.environ}
+    if state_url:
+        env["RIVET_STATE_URL"] = state_url
+    else:
+        env.pop("RIVET_STATE_URL", None)
     procs = [
         (
             c,
@@ -129,7 +156,7 @@ def _run_writers(cfgs: list[Path], state_url: str) -> tuple[list[int], str]:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,
-                env={**os.environ, "RIVET_STATE_URL": state_url},
+                env=env,
             ),
         )
         for c in cfgs
@@ -162,7 +189,7 @@ def _judge(
     files: int,
     copies: list[dict],
     rows_read: int | None,
-    state_container: str,
+    state_query: Callable[[str], str | None],
     export_prefix: str,
 ) -> bool:
     """The five assertions, each named so a red cell says which one broke."""
@@ -195,8 +222,7 @@ def _judge(
             f"{WRITERS * ROWS}"
         )
 
-    dupes = _psql_state(
-        state_container,
+    dupes = state_query(
         f"SELECT count(*) FROM (SELECT run_id FROM export_metrics WHERE export_name LIKE "
         f"'{export_prefix}%' AND run_id IS NOT NULL GROUP BY run_id HAVING count(*) > 1) d",
     )
@@ -208,14 +234,13 @@ def _judge(
         problems.append(
             "the duplicate-export_metrics check DID NOT RUN — the state DB was "
             "unreadable, which is not the same as clean"
-        )
+    )
     elif dupes != "0":
         problems.append(
             f"{dupes} run(s) left MORE THAN ONE export_metrics row — under concurrency an "
             f"UPDATE-or-INSERT becomes two INSERTs, and every sum then double-counts"
         )
-    stuck = _psql_state(
-        state_container,
+    stuck = state_query(
         f"SELECT count(*) FROM run_status a WHERE a.export_name LIKE '{export_prefix}%' "
         f"AND a.status='running' AND NOT EXISTS (SELECT 1 FROM run_status b "
         f"WHERE b.export_name=a.export_name AND b.started_at > a.started_at)",
@@ -223,21 +248,20 @@ def _judge(
     if stuck is None:
         problems.append(
             "the stuck-active check DID NOT RUN — the state DB was unreadable"
-        )
+    )
     elif stuck != "0":
         problems.append(
             f"{stuck} run(s) still read as ACTIVE with nothing superseding them — gc_orphans "
             f"would defer on that prefix forever"
         )
-    meta_rows = _psql_state(
-        state_container,
+    meta_rows = state_query(
         f"SELECT coalesce(sum(total_rows),0) FROM export_metrics WHERE export_name LIKE "
         f"'{export_prefix}%' AND status='success'",
     )
     if meta_rows is None:
         problems.append(
             "the meta-row/manifest agreement check DID NOT RUN — the state DB was unreadable"
-        )
+    )
     elif meta_rows != str(claimed_rows):
         problems.append(
             f"the state DB records {meta_rows} rows for these runs, the manifests claim "
@@ -269,15 +293,8 @@ def verify_concurrent_writers_share_a_prefix(
     src_url: str,
     bucket: str | None = None,
 ) -> None:
-    """LOCAL leg, then the CLOUD leg when a bucket is given."""
-    if not state_url:
-        _skipped(
-            led, "-", "-", "concurrent_writers_share_a_prefix", "-",
-            "concurrent-writers: no shared state URL — the whole point is ONE backend for every "
-            "writer, and a per-writer SQLite file would prove the opposite of what is asked",
-            "no state url",
-        )
-        return
+    """SQLite-shared leg (always), then the Postgres LOCAL + CLOUD legs when a
+    state_url is given — the concurrent-writer contract on BOTH backends."""
     if not _rivet_bin().exists():
         _skipped(led, "-", "-", "concurrent_writers_share_a_prefix", "-",
                  "concurrent-writers: no rivet binary", "no binary")
@@ -291,7 +308,47 @@ def verify_concurrent_writers_share_a_prefix(
     work = work_dir() / f"conc_{stamp}"
     work.mkdir(parents=True, exist_ok=True)
 
-    # ── LOCAL ────────────────────────────────────────────────────────────────
+    # ── SQLITE (one shared file) ───────────────────────────────────────────────
+    # N writers, ONE directory → ONE beside-config `.rivet_state.db` they all open
+    # at once. This is the SQLite backend's concurrent-writer contract — file
+    # lock / SQLITE_BUSY / WAL — which the Postgres-only leg below never touched:
+    # the prior code SKIPPED without a Postgres URL, so SQLite under concurrency
+    # was unverified. A writer that dies on a BUSY it does not retry fails here.
+    if have("sqlite3"):
+        sq = work / "sqlite"
+        sq_dest = sq / "shared"
+        sq_dest.mkdir(parents=True, exist_ok=True)
+        sq_cfgs = []
+        for i in range(WRITERS):
+            c = sq / f"sqlite_{i}.yaml"  # same dir ⇒ shared sq/.rivet_state.db
+            _config(c, f"conc_{stamp}_s{i}", f"{{ type: local, path: {sq_dest} }}", src_url)
+            sq_cfgs.append(c)
+        exits, chatter = _run_writers(sq_cfgs, None)  # None ⇒ beside-config SQLite
+        sq_db = sq / ".rivet_state.db"
+        _judge(
+            led, "sqlite-shared",
+            exits=exits,
+            chatter=chatter,
+            files=len(list(sq_dest.rglob("*.parquet"))),
+            copies=[json.loads(p.read_text()) for p in sorted(sq_dest.rglob("manifest-*.json"))],
+            rows_read=_duckdb_count(f"{sq_dest}/*.parquet"),
+            state_query=lambda s: _sqlite_state(sq_db, s),
+            export_prefix=f"conc_{stamp}_s",
+        )
+    else:
+        _skipped(led, "-", "-", "concurrent_writers_share_a_prefix", "sqlite-shared",
+                 "concurrent-writers[sqlite-shared]: sqlite3 CLI absent", "no sqlite3")
+
+    if not state_url:
+        _skipped(
+            led, "-", "-", "concurrent_writers_share_a_prefix", "postgres",
+            "concurrent-writers[postgres]: no shared Postgres state URL — the SQLite-shared leg "
+            "ran; pass --state-url to also race the writers on one Postgres backend",
+            "no state url",
+        )
+        return
+
+    # ── LOCAL (Postgres state) ─────────────────────────────────────────────────
     dest = work / "shared"
     shutil.rmtree(dest, ignore_errors=True)
     dest.mkdir(parents=True, exist_ok=True)
@@ -313,7 +370,7 @@ def verify_concurrent_writers_share_a_prefix(
         files=files,
         copies=copies,
         rows_read=_duckdb_count(f"{dest}/*.parquet"),
-        state_container=state_container,
+        state_query=lambda s: _psql_state(state_container, s),
         export_prefix=f"conc_{stamp}_w",
     )
 
@@ -377,7 +434,7 @@ def verify_concurrent_writers_share_a_prefix(
         files=files,
         copies=copies,
         rows_read=rows_read,
-        state_container=state_container,
+        state_query=lambda s: _psql_state(state_container, s),
         export_prefix=f"conc_{stamp}_g",
     )
     run(["gsutil", "-m", "rm", "-r", f"gs://{bucket}/{pfx}"], timeout=600)

--- a/dev/release_oracle/concurrency.py
+++ b/dev/release_oracle/concurrency.py
@@ -212,7 +212,13 @@ def _judge(
             f"{files} data file(s) on the prefix but the manifests claim {claimed_parts} parts — "
             f"a shortfall is one writer's part written at another's path"
         )
-    if rows_read is not None and rows_read != claimed_rows:
+    if rows_read is None:
+        problems.append(
+            "the DuckDB physical readback DID NOT RUN (no duckdb) — the only foreign-reader "
+            "oracle is absent, which is NOT the same as agreement; the manifest self-report "
+            "cannot vouch for itself"
+        )
+    elif rows_read != claimed_rows:
         problems.append(
             f"DuckDB reads {rows_read} rows from the prefix, the manifests claim {claimed_rows}"
         )

--- a/dev/release_oracle/core.py
+++ b/dev/release_oracle/core.py
@@ -34,6 +34,7 @@ import shutil
 import subprocess
 import sys
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -91,6 +92,15 @@ class Ledger:
         # do not interleave into an unreadable stream. The parent `flush_into`s
         # each engine's block in engine order after the join. `None` = print live.
         self._buf: list[str] | None = None
+        # Named sub-spans INSIDE a phase — the granularity `phase()` cannot give
+        # under the PARALLEL engine matrix, where every engine collapses into one
+        # wrapping phase and the buffered children's `_phase_times` are dropped at
+        # merge (summing overlapping child phases would overcount). A `span` is a
+        # single wall-clock ("mssql: blessed_flow", "postgres: seed"); `flush_into`
+        # folds a child's spans into the parent, and `report()` prints them as a
+        # SEPARATE breakdown that is honest about the overlap — spans in different
+        # engines run concurrently, so they are ranked, never summed into a total.
+        self._spans: list[tuple[str, float]] = []
 
     # ── printing ──
     def _c(self, code: str, text: str) -> str:
@@ -120,6 +130,19 @@ class Ledger:
     def skip(self, msg: str) -> None:
         self._emit(self._c("1;33", f"  ⊘ {msg}"))
 
+    @contextmanager
+    def span(self, name: str):
+        """Time a named step inside a phase (e.g. one scenario of one engine).
+        Records a single wall-clock into `_spans`; survives the buffered-child
+        merge that drops `_phase_times`, so the parallel engine matrix's internals
+        are visible in the final timing breakdown. Nesting is fine — a span and a
+        sub-span it contains are ranked independently, not netted."""
+        t0 = time.perf_counter()
+        try:
+            yield
+        finally:
+            self._spans.append((name, time.perf_counter() - t0))
+
     def buffered_child(self) -> "Ledger":
         """A sub-ledger that BUFFERS output (for one parallel engine). Its cells +
         buffered lines are folded back with `flush_into` after the engine finishes."""
@@ -136,6 +159,10 @@ class Ledger:
         for line in self._buf or []:
             parent._emit(line)
         parent.cells.extend(self.cells)
+        # Spans DO travel (unlike _phase_times): each is a per-engine wall-clock
+        # the parent reports ranked, not summed, so overlap across engines is not
+        # double-counted. This is the only window into the parallel matrix.
+        parent._spans.extend(self._spans)
 
     # ── recording ──
     def add(
@@ -188,6 +215,15 @@ class Ledger:
                 pct = (dur / total * 100.0) if total > 0 else 0.0
                 print(f"  {dur / 60.0:6.1f} min  {pct:4.0f}%  {name}")
             print(f"  {total / 60.0:6.1f} min  total (sum of phases)")
+            print()
+        # Inside-the-phase breakdown — the per-engine / per-scenario spans that the
+        # opaque "Engine matrix" phase hides. Ranked slowest-first; NOT summed,
+        # because spans in different engines overlap under `--engine-parallel`. This
+        # is the "where does the time go INSIDE the calls" view.
+        if self._spans:
+            self.phase("Timing — inside the engine matrix (per span; concurrent, so ranked not summed)")
+            for name, dur in sorted(self._spans, key=lambda p: p[1], reverse=True)[:25]:
+                print(f"  {dur / 60.0:6.1f} min  {name}")
             print()
         if self.red:
             print(self._c("1;31", "  NOT RELEASABLE — one or more cells failed (see ✗ above)."))

--- a/dev/release_oracle/core.py
+++ b/dev/release_oracle/core.py
@@ -80,12 +80,24 @@ class Ledger:
         if colour is None:
             colour = sys.stdout.isatty() or os.environ.get("FORCE_COLOR") == "1"
         self._colour = colour
+        # Per-phase wall-clock, so the gate self-reports WHERE the 30–60 min goes
+        # (each `phase()` closes the previous one; `report()` prints the breakdown
+        # sorted slowest-first). Answers "what takes so long" every run, cheaply.
+        self._phase_times: list[tuple[str, float]] = []
+        self._cur_phase: str | None = None
+        self._phase_start: float = time.perf_counter()
 
     # ── printing ──
     def _c(self, code: str, text: str) -> str:
         return f"\033[{code}m{text}\033[0m" if self._colour else text
 
     def phase(self, msg: str) -> None:
+        # Close the previous phase's wall-clock before opening this one.
+        now = time.perf_counter()
+        if self._cur_phase is not None:
+            self._phase_times.append((self._cur_phase, now - self._phase_start))
+        self._cur_phase = msg
+        self._phase_start = now
         print(self._c("1;34", f"▸ {msg}"), flush=True)
 
     def ok(self, msg: str) -> None:
@@ -137,6 +149,18 @@ class Ledger:
                 f"{c.status.value} {c.detail}"
             )
         print()
+        # Wall-clock breakdown — the phases that actually cost the 30–60 min,
+        # slowest first. `phase("Release Oracle result")` above closed the last
+        # real phase, so `_phase_times` now holds every phase but this report line.
+        timed = [t for t in self._phase_times if not t[0].startswith("Release Oracle result")]
+        if timed:
+            total = sum(d for _, d in timed)
+            self.phase("Timing (wall-clock, slowest first)")
+            for name, dur in sorted(timed, key=lambda p: p[1], reverse=True)[:15]:
+                pct = (dur / total * 100.0) if total > 0 else 0.0
+                print(f"  {dur / 60.0:6.1f} min  {pct:4.0f}%  {name}")
+            print(f"  {total / 60.0:6.1f} min  total (sum of phases)")
+            print()
         if self.red:
             print(self._c("1;31", "  NOT RELEASABLE — one or more cells failed (see ✗ above)."))
             return 1

--- a/dev/release_oracle/core.py
+++ b/dev/release_oracle/core.py
@@ -221,8 +221,8 @@ class Ledger:
         # because spans in different engines overlap under `--engine-parallel`. This
         # is the "where does the time go INSIDE the calls" view.
         if self._spans:
-            self.phase("Timing — inside the engine matrix (per span; concurrent, so ranked not summed)")
-            for name, dur in sorted(self._spans, key=lambda p: p[1], reverse=True)[:25]:
+            self.phase("Timing — inside the parallel stages (per span; concurrent, so ranked not summed)")
+            for name, dur in sorted(self._spans, key=lambda p: p[1], reverse=True)[:40]:
                 print(f"  {dur / 60.0:6.1f} min  {name}")
             print()
         if self.red:

--- a/dev/release_oracle/core.py
+++ b/dev/release_oracle/core.py
@@ -33,6 +33,7 @@ import os
 import shutil
 import subprocess
 import sys
+import threading
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -318,6 +319,36 @@ def docker_exec(container: str, *args: str, stdin: str | None = None, **kw) -> P
 
 def have(tool: str) -> bool:
     return shutil.which(tool) is not None
+
+
+# ── matrix cell concurrency ──────────────────────────────────────────────────────
+# The engine matrix is I/O-wait-bound (measured: ~62% CPU idle on 12 cores while
+# 4 engines run), so its many small, INDEPENDENT cells (own work-dir/prefix each)
+# can run concurrently to fill the idle cores. Engines ALSO run in parallel, so a
+# per-engine cell pool alone would oversubscribe (engines × pool); this ONE global
+# semaphore, shared by every engine's cell pool, caps TOTAL in-flight cells so the
+# shared state DB and source containers are not stampeded. Tune with --cell-parallel.
+_cell_parallel_n = 8
+_cell_gate = threading.BoundedSemaphore(_cell_parallel_n)
+
+
+def set_cell_parallel(n: int) -> None:
+    """Resize the global cell-concurrency cap (called once from main after arg parse)."""
+    global _cell_gate, _cell_parallel_n
+    _cell_parallel_n = max(1, n)
+    _cell_gate = threading.BoundedSemaphore(_cell_parallel_n)
+
+
+def cell_parallel() -> int:
+    """The configured cap value — for sizing a per-engine pool (the semaphore is the
+    real global limiter; this just avoids spawning far more threads than can ever run)."""
+    return _cell_parallel_n
+
+
+def cell_gate() -> threading.BoundedSemaphore:
+    """The shared limiter. Use as `with cell_gate(): run_cell(...)`. Read via a
+    function, not a captured value, so `set_cell_parallel` is honoured after import."""
+    return _cell_gate
 
 
 def wait_until(check, *, tries: int = 45, delay: float = 2.0) -> bool:

--- a/dev/release_oracle/core.py
+++ b/dev/release_oracle/core.py
@@ -86,10 +86,21 @@ class Ledger:
         self._phase_times: list[tuple[str, float]] = []
         self._cur_phase: str | None = None
         self._phase_start: float = time.perf_counter()
+        # Buffered mode: a per-ENGINE sub-ledger under parallel `engine_loop`
+        # collects its lines here instead of printing them, so concurrent engines
+        # do not interleave into an unreadable stream. The parent `flush_into`s
+        # each engine's block in engine order after the join. `None` = print live.
+        self._buf: list[str] | None = None
 
     # ── printing ──
     def _c(self, code: str, text: str) -> str:
         return f"\033[{code}m{text}\033[0m" if self._colour else text
+
+    def _emit(self, line: str) -> None:
+        if self._buf is None:
+            print(line, flush=True)
+        else:
+            self._buf.append(line)
 
     def phase(self, msg: str) -> None:
         # Close the previous phase's wall-clock before opening this one.
@@ -98,16 +109,33 @@ class Ledger:
             self._phase_times.append((self._cur_phase, now - self._phase_start))
         self._cur_phase = msg
         self._phase_start = now
-        print(self._c("1;34", f"▸ {msg}"), flush=True)
+        self._emit(self._c("1;34", f"▸ {msg}"))
 
     def ok(self, msg: str) -> None:
-        print(self._c("1;32", f"  ✓ {msg}"), flush=True)
+        self._emit(self._c("1;32", f"  ✓ {msg}"))
 
     def bad(self, msg: str) -> None:
-        print(self._c("1;31", f"  ✗ {msg}"), flush=True)
+        self._emit(self._c("1;31", f"  ✗ {msg}"))
 
     def skip(self, msg: str) -> None:
-        print(self._c("1;33", f"  ⊘ {msg}"), flush=True)
+        self._emit(self._c("1;33", f"  ⊘ {msg}"))
+
+    def buffered_child(self) -> "Ledger":
+        """A sub-ledger that BUFFERS output (for one parallel engine). Its cells +
+        buffered lines are folded back with `flush_into` after the engine finishes."""
+        child = Ledger(colour=self._colour)
+        child._buf = []
+        return child
+
+    def flush_into(self, parent: "Ledger") -> None:
+        """Fold this buffered child into `parent`: print its collected block (in one
+        contiguous run, so an engine's output is not interleaved with a sibling's)
+        and merge its cells. Per-phase timings are NOT merged — the parent's
+        wrapping phase already holds the parallel wall-clock; summing overlapping
+        child phases would overcount."""
+        for line in self._buf or []:
+            parent._emit(line)
+        parent.cells.extend(self.cells)
 
     # ── recording ──
     def add(

--- a/dev/release_oracle/core.py
+++ b/dev/release_oracle/core.py
@@ -225,6 +225,27 @@ class Ledger:
             for name, dur in sorted(self._spans, key=lambda p: p[1], reverse=True)[:40]:
                 print(f"  {dur / 60.0:6.1f} min  {name}")
             print()
+            # Per-CELL rollup: a matrix cell span is named "cell <engine> <kind> …".
+            # There are too many to list flat, and the distribution — not any one
+            # cell — is what decides whether cell-level parallelism would pay. Bucket
+            # by "<engine> <kind>" and show count / sum / mean / max / slowest. Sums
+            # are within ONE engine's SEQUENTIAL cell loop, so they ARE additive; the
+            # gap between a group's SUM and its MAX is exactly the wall-clock a
+            # parallel cell loop could reclaim.
+            cells = [(n, d) for n, d in self._spans if n.startswith("cell ")]
+            if cells:
+                groups: dict[str, list[tuple[str, float]]] = {}
+                for n, d in cells:
+                    key = " ".join(n.split()[1:3])  # "<engine> <kind>"
+                    groups.setdefault(key, []).append((n, d))
+                self.phase("Timing — matrix cells per engine×kind (SUM is sequential; SUM−MAX = parallelisable slack)")
+                for key in sorted(groups, key=lambda k: sum(d for _, d in groups[k]), reverse=True):
+                    members = groups[key]
+                    tot = sum(d for _, d in members)
+                    mx_name, mx = max(members, key=lambda p: p[1])
+                    print(f"  {tot / 60.0:6.1f} min  {key:22} n={len(members):<3} "
+                          f"mean={tot / len(members):4.1f}s  max={mx:4.1f}s ({mx_name.split(maxsplit=3)[-1]})")
+                print()
         if self.red:
             print(self._c("1;31", "  NOT RELEASABLE — one or more cells failed (see ✗ above)."))
             return 1

--- a/dev/release_oracle/scenarios.py
+++ b/dev/release_oracle/scenarios.py
@@ -222,6 +222,33 @@ def _duckdb_list(sql: str) -> str:
     return run(["duckdb", "-noheader", "-list", "-c", sql]).stdout.strip()
 
 
+def duckdb_allnull_columns(path_glob: str) -> tuple[int, int]:
+    """Independent per-column null profile via DuckDB (never rivet's own summary).
+
+    Returns (n_all_null, n_cols): how many columns are 100% NULL while rows > 0, and
+    the total column count. That is the documented silent-loss class — a decode
+    regression (e.g. the FixedSizeBinary uuid path) nulling a WHOLE column while the
+    row count stays green and every count/sum check passes. `count(COLUMNS(*))` yields
+    one non-null count per column generically, so this needs no per-engine schema
+    knowledge and no column names. (-1, -1) = unreadable/empty (the row-count oracle
+    already SKIPs those); a genuinely present all-null column returns n_all_null > 0.
+    """
+    out = _duckdb_list(
+        f"SELECT count(*), count(COLUMNS(*)) FROM read_parquet('{path_glob}')"
+    )
+    if not out:
+        return (-1, -1)
+    vals = out.splitlines()[0].split("|")
+    try:
+        nums = [int(v) for v in vals]
+    except ValueError:
+        return (-1, -1)
+    rows, cols = nums[0], nums[1:]
+    if rows <= 0 or not cols:
+        return (-1, -1)
+    return (sum(1 for c in cols if c == 0), len(cols))
+
+
 def _duckdb_json_normalized(sql: str) -> str:
     """`duckdb -json -c SQL | lib/normalize_bq.py` — the canonical golden form.
 

--- a/dev/release_oracle/scenarios.py
+++ b/dev/release_oracle/scenarios.py
@@ -233,9 +233,13 @@ def duckdb_allnull_columns(path_glob: str) -> tuple[int, int]:
     knowledge and no column names. (-1, -1) = unreadable/empty (the row-count oracle
     already SKIPs those); a genuinely present all-null column returns n_all_null > 0.
     """
-    out = _duckdb_list(
-        f"SELECT count(*), count(COLUMNS(*)) FROM read_parquet('{path_glob}')"
+    return _allnull_parse(
+        _duckdb_list(f"SELECT count(*), count(COLUMNS(*)) FROM read_parquet('{path_glob}')")
     )
+
+
+def _allnull_parse(out: str) -> tuple[int, int]:
+    """Parse `count(*), count(COLUMNS(*))` (one `|`-joined row) into (n_all_null, n_cols)."""
     if not out:
         return (-1, -1)
     vals = out.splitlines()[0].split("|")
@@ -247,6 +251,34 @@ def duckdb_allnull_columns(path_glob: str) -> tuple[int, int]:
     if rows <= 0 or not cols:
         return (-1, -1)
     return (sum(1 for c in cols if c == 0), len(cols))
+
+
+def duckdb_allnull_cloud(store: str, bucket: str, prefix: str, work: Path) -> tuple[int, int]:
+    """Per-column null profile of a CLOUD prefix, read the SAME store-native way as
+    `store_readback` (s3 over httpfs, gcs via the JSON-API pull) — an INDEPENDENT DuckDB
+    oracle for the object-store path, where the documented uuid→FixedSizeBinary silent
+    loss actually happened. Returns (n_all_null, n_cols); (-1,-1) if unreadable/empty or
+    a store not profiled here (azure). Mirrors store_readback so the two agree on reads."""
+    cols = "count(*), count(COLUMNS(*))"
+    if store == "s3":
+        return _allnull_parse(_duckdb_list(
+            "INSTALL httpfs; LOAD httpfs; SET s3_endpoint='127.0.0.1:9000'; "
+            "SET s3_use_ssl=false; SET s3_url_style='path'; "
+            "SET s3_access_key_id='minioadmin'; SET s3_secret_access_key='minioadmin'; "
+            f"SELECT {cols} FROM read_parquet('s3://{bucket}/{prefix}/**/*.parquet')"
+        ))
+    if store == "gcs":
+        dl = work / f"nullprof_gcs_{random.randint(0, 32767)}"
+        dl.mkdir(parents=True, exist_ok=True)
+        got = run([PY, str(_asset("lib/gcs_pull.py")),
+                   "http://127.0.0.1:4443", bucket, prefix, str(dl)]).stdout.strip()
+        try:
+            if int(got) <= 0:
+                return (-1, -1)
+        except ValueError:
+            return (-1, -1)
+        return _allnull_parse(_duckdb_list(f"SELECT {cols} FROM read_parquet('{dl}/**/*.parquet')"))
+    return (-1, -1)
 
 
 def _duckdb_json_normalized(sql: str) -> str:

--- a/dev/release_oracle/scenarios.py
+++ b/dev/release_oracle/scenarios.py
@@ -70,6 +70,7 @@ __all__ = [
     "store_up",
     "verify_coverage_matrices",
     "verify_pool_e2e",
+    "verify_pool_split",
     "verify_replica_read",
     "verify_state_migrations",
 ]
@@ -1153,32 +1154,76 @@ def verify_pool_e2e(led: Ledger) -> None:
             "no toxiproxy",
         )
         return
-    led.phase(
-        "Pool scheduler e2e (apply --pool through a bandwidth-capped link — "
-        "exact rows + the predicted-vs-actual makespan contract)"
+    _run_pool_module(
+        led,
+        test_filter="live_pool_toxiproxy::pool_apply",
+        scenario="e2e",
+        phase="Pool scheduler e2e (apply --pool through a bandwidth-capped link — "
+        "exact rows + the predicted-vs-actual makespan contract)",
+        ok_detail="pool e2e: bandwidth-capped --pool run exact + self-grading; resume defers, drops nothing",
     )
-    log_path = work_dir() / "pool_e2e.log"
+
+
+def verify_pool_split(led: Ledger) -> None:
+    """The `--pool --split` scenarios AS THEIR OWN GATE CELLS (#167): a dominating
+    export is broken into N range sub-exports over its key span. Three scenarios,
+    each an independent live oracle in tests/live/live_pool_toxiproxy.rs
+    (`pool_split_*`):
+
+      * realize — the split fires, the units share one prefix + fold to one
+        family, and the DuckDB union reads back every row once (no seam gap/dup);
+      * manifest coherence — validate does not flag a sibling unit's parts as
+        untracked, yet a true foreign orphan still is;
+      * per-unit resume — a crashed split re-runs ONLY the incomplete units on
+        `--resume` (skip complete, resume crashed), no gap/no dup.
+
+    Separate from `verify_pool_e2e` so the split coverage is a NAMED matrix cell,
+    not bundled invisibly into the pool cell. Needs toxiproxy (:8474) + postgres
+    (:5432); SKIP when down.
+    """
+    _run_pool_module(
+        led,
+        test_filter="live_pool_toxiproxy::pool_split",
+        scenario="split",
+        phase="Pool --split range sub-exports (#167): realize + manifest coherence "
+        "+ per-unit crash resume, each an independent DuckDB oracle",
+        ok_detail="pool split: units share one prefix/family (union exact), validate "
+        "coherent, per-unit resume recovers a crash with no gap/dup",
+    )
+
+
+def _run_pool_module(
+    led: Ledger, *, test_filter: str, scenario: str, phase: str, ok_detail: str
+) -> None:
+    """Run one `live_pool_toxiproxy` filter as a gate cell + emit a per-TEST ledger
+    row for each `pool_*` case the filter matched, so every scenario is visible in
+    the report (not just an aggregate pass/fail)."""
+    led.phase(phase)
+    log_path = work_dir() / f"pool_{scenario}.log"
     p = run(
         # `--ignored` is REQUIRED: the pool e2e tests carry #[ignore] (they need
-        # the live stand), added in the CI-tier split. Without it they are SKIPPED
-        # and the gate read "0 passed" as a FAIL (roast 2026-08-10). The pass check
-        # below is count-agnostic (0 failed AND at least one passed) so adding a
-        # pool test never silently breaks the gate the way pinning "2 passed" did.
+        # the live stand). The pass check is count-agnostic (0 failed AND at least
+        # one passed) so adding a pool test never silently breaks the gate the way
+        # pinning "N passed" did (roast 2026-08-10).
         ["cargo", "test", "--manifest-path", str(ROOT / "Cargo.toml"), "--test", "live_suite",
-         "--", "--ignored", "--test-threads=1", "live_pool_toxiproxy"],
+         "--", "--ignored", "--test-threads=1", test_filter],
         env={"RIVET_BIN": str(rivet_bin())},
         timeout=NO_TIMEOUT,
     )
     log_path.write_text(p.out)
+    # Per-test visibility: one ledger row per matched case (`test <mod>::<name> ... ok`).
+    for m in re.finditer(r"test live_pool_toxiproxy::(\w+) \.\.\. (ok|FAILED)", p.out):
+        name, res = m.group(1), m.group(2)
+        if res == "ok":
+            led.add("pool", scenario, name[:16], "-", Status.PASS, name)
+        else:
+            led.failed("pool", scenario, name[:16], "-", f"pool {scenario}: {name} FAILED")
     if p.ok and "0 failed" in p.out and "0 passed" not in p.out:
-        _passed(
-            led, "pool", "e2e", "-", "-",
-            "pool e2e: bandwidth-capped --pool run exact + self-grading; resume defers, drops nothing",
-        )
+        _passed(led, "pool", scenario, "-", "-", ok_detail)
     else:
         _failed(
-            led, "pool", "e2e", "-", "-",
-            f"pool e2e FAILED (see {log_path})",
+            led, "pool", scenario, "-", "-",
+            f"pool {scenario} FAILED (see {log_path})",
             _first_match(p.out, r"FAILED|panic|assert|error"),
         )
 

--- a/dev/release_oracle/scenarios.py
+++ b/dev/release_oracle/scenarios.py
@@ -48,12 +48,13 @@ from pathlib import Path
 from tempfile import mkdtemp
 
 try:  # importable both as a package module and as a plain sibling file
-    from .core import HERE, ROOT, Ledger, Status, docker, docker_exec, have, rivet, rivet_bin, run
+    from .core import HERE, ROOT, Ledger, Proc, Status, docker, docker_exec, have, rivet, rivet_bin, run
 except ImportError:  # pragma: no cover - depends on how the driver is invoked
     from core import (  # type: ignore
         HERE,
         ROOT,
         Ledger,
+        Proc,
         Status,
         docker,
         docker_exec,
@@ -617,8 +618,13 @@ def _export_local(
     mode: str,
     fmt: str = "parquet",
     parallel: int | None = None,
-) -> bool:
-    """Export one table to a LOCAL dir. mode: chunked|full, fmt: parquet|csv."""
+) -> Proc:
+    """Export one table to a LOCAL dir. mode: chunked|full, fmt: parquet|csv.
+
+    Returns the Proc (not a bool) so a caller can tell an intended REFUSAL (rivet exits
+    non-zero with a specific message, e.g. CSV cannot serialize an array column) from a
+    real export FAILURE — conflating the two let a broken CSV export read as the golden
+    refusal. Callers that only need success use `.ok`."""
     yaml_path = work_dir() / f"ex_{os.getpid()}_{table.replace('.', '_')}_{fmt}.yaml"
     shutil.rmtree(dest_dir, ignore_errors=True)
     if engine == "mongo":
@@ -641,7 +647,7 @@ def _export_local(
         f"    format: {fmt}\n"
         f"    destination: {{type: local, path: {dest_dir}/}}\n"
     )
-    return rivet("run", "-c", str(yaml_path), env={"ORACLE_URL": url}, timeout=NO_TIMEOUT).ok
+    return rivet("run", "-c", str(yaml_path), env={"ORACLE_URL": url}, timeout=NO_TIMEOUT)
 
 
 # ── verdicts: init+check → {table: {strategy, verdict}} == GOLDEN ────────────
@@ -742,7 +748,7 @@ def sc_integrity_types(led: Ledger, engine: str, tag: str, url: str) -> None:
     out.mkdir(parents=True, exist_ok=True)
 
     # (1) users loss/dup — all engines.
-    if _export_local(engine, url, "users", out / "users", "chunked"):
+    if _export_local(engine, url, "users", out / "users", "chunked").ok:
         scnt = _source_count_distinct(engine, url, "users", "id")
         id_col = "_id" if engine == "mongo" else "id"
         dcnt = _duckdb_list(
@@ -760,7 +766,7 @@ def sc_integrity_types(led: Ledger, engine: str, tag: str, url: str) -> None:
     #     tests/type_roundtrip/fixtures/<eng>_schema.sql.
     if engine != "mongo":
         for tmt in ("rivet_type_matrix",):
-            if _export_local(engine, url, tmt, out / tmt, "full"):
+            if _export_local(engine, url, tmt, out / tmt, "full").ok:
                 got = _duckdb_json_normalized(
                     f"SELECT * FROM read_parquet('{out}/{tmt}/**/*.parquet') ORDER BY id"
                 )
@@ -778,11 +784,17 @@ def sc_integrity_types(led: Ledger, engine: str, tag: str, url: str) -> None:
             # way a fixed truth the compare asserts, and a regression that starts
             # emitting a corrupted array flips it.
             csv_dir = out / f"{tmt}_csv"
-            exported = _export_local(engine, url, tmt, csv_dir, "full", "csv")
+            pc = _export_local(engine, url, tmt, csv_dir, "full", "csv")
             # bash 3.2 has no globstar, so its `**/*.csv` was really one level
             # deep — mirrored here rather than an unbounded rglob.
             has_csv = bool(list(csv_dir.glob("*/*.csv")) or list(csv_dir.glob("*.csv")))
-            if exported and has_csv:
+            # rivet's INTENDED refusal exits non-zero with a specific message
+            # (src/format/csv.rs: "CSV cannot serialize column ..."). Only THAT is the
+            # golden refusal; any other non-zero exit is a real export FAILURE and must
+            # not read as the refusal sentinel (the old elif conflated the two, so a
+            # broken csv export on postgres — whose golden IS the refusal — passed green).
+            refused = (not pc.ok) and re.search(r"cannot serialize|unrepresentable", pc.out, re.IGNORECASE)
+            if pc.ok and has_csv:
                 gotc = _duckdb_json_normalized(
                     f"SELECT * FROM read_csv('{csv_dir}/**/*.csv', all_varchar=true, header=true) "
                     f"ORDER BY id"
@@ -791,10 +803,15 @@ def sc_integrity_types(led: Ledger, engine: str, tag: str, url: str) -> None:
                     fails += f"{tmt}-csv-readback "
                 elif not _fidelity_check(engine, f"{tmt}__csv", gotc):
                     fails += f"{tmt}-CSV-DIVERGED "
-            elif not _fidelity_check(
-                engine, f"{tmt}__csv", '{"csv_writer":"refused-unrepresentable-column"}'
-            ):
-                fails += f"{tmt}-CSV-REFUSAL-CHANGED "
+            elif refused:
+                if not _fidelity_check(
+                    engine, f"{tmt}__csv", '{"csv_writer":"refused-unrepresentable-column"}'
+                ):
+                    fails += f"{tmt}-CSV-REFUSAL-CHANGED "
+            else:
+                # not the intended refusal, yet no readable csv: a real export failure
+                # (or an empty write) — a bug, not the golden refusal.
+                fails += f"{tmt}-CSV-EXPORT-FAILED[exit={pc.returncode}] "
 
     if _bless("BLESS_DUCKDB"):
         _passed(led, engine, tag, "integrity_types", "-", f"blessed duckdb-types[{engine}]", "blessed")
@@ -829,7 +846,7 @@ def sc_keyset_parallel(led: Ledger, engine: str, tag: str, url: str) -> None:
         return
     out = work_dir() / f"kp_{engine}_{_tag(tag)}"
     out.mkdir(parents=True, exist_ok=True)
-    if not _export_local(engine, url, "users", out / "users", "chunked", "parquet", 4):
+    if not _export_local(engine, url, "users", out / "users", "chunked", "parquet", 4).ok:
         _failed(led, engine, tag, "keyset_parallel", "-", f"keyset_parallel[{engine}]: export failed", "export")
         return
 

--- a/dev/release_oracle/scenarios.py
+++ b/dev/release_oracle/scenarios.py
@@ -907,7 +907,17 @@ def sc_load(led: Ledger, engine: str, tag: str, url: str, store: str) -> None:
     if n and n == scnt:
         _passed(led, engine, tag, "load", store, f"load→{store} gcloud-verified {n} rows", n)
     elif not n:
-        _skipped(led, engine, tag, "load", store, f"{store} readback tool unavailable", "no readback tool")
+        # An EMPTY readback is a delivery failure, not an absent tool, on the stores that
+        # need no extra CLI: s3 (DuckDB httpfs) and gcs (the JSON-API pull) are always
+        # available, so "" there means the destination holds ZERO parts after a run that
+        # exited 0 — the exact "success but delivered nothing → release-ready" shape
+        # blessed_path already FAILs. Only azure (needs `az`) keeps the SKIP.
+        if store in ("s3", "gcs"):
+            _failed(led, engine, tag, "load", store,
+                    f"load→{store} delivered 0 rows (source {scnt}) — empty destination after a "
+                    f"0-exit run", "empty-destination")
+        else:
+            _skipped(led, engine, tag, "load", store, f"{store} readback tool unavailable", "no readback tool")
     else:
         _failed(
             led, engine, tag, "load", store,

--- a/dev/release_oracle/scenarios.py
+++ b/dev/release_oracle/scenarios.py
@@ -826,7 +826,8 @@ def run_scenarios(led: Ledger, engine: str, tag: str, url: str) -> None:
     # nothing — skip them.
     if _bless("BLESS_VERDICTS") or _bless("BLESS_DUCKDB"):
         return
-    sc_keyset_parallel(led, engine, tag, url)
+    with led.span(f"{engine}: keyset_parallel"):
+        sc_keyset_parallel(led, engine, tag, url)
     # The one integrity column a reader is asked to trust, checked by something
     # that is not rivet — see rowhash.py for why the in-tree auditor cannot.
     from . import corruption, rowhash
@@ -843,10 +844,12 @@ def run_scenarios(led: Ledger, engine: str, tag: str, url: str) -> None:
     from . import schema_drift
 
     schema_drift.verify_schema_fingerprint_moves_with_the_schema(led, engine, tag, url)
-    for store in cfg("stores").split():
-        sc_load(led, engine, tag, url, store)
+    with led.span(f"{engine}: load (all stores)"):
+        for store in cfg("stores").split():
+            sc_load(led, engine, tag, url, store)
     if engine == "postgres":
-        sc_gc_survival(led, engine, tag, url)
+        with led.span(f"{engine}: gc_survival"):
+            sc_gc_survival(led, engine, tag, url)
     # The COMMAND CHAIN, end to end. Both of these were registered in
     # docs/release-gate-matrix.yaml as `test` while `verify_blessed_path` had no
     # caller anywhere in the tree — the matrix guard checks that a gate function
@@ -857,8 +860,10 @@ def run_scenarios(led: Ledger, engine: str, tag: str, url: str) -> None:
     state_url = os.environ.get("RIVET_GATE_STATE_URL", "") or os.environ.get(
         "RIVET_CDC_STATE_URL", ""
     )
-    blessed_path.verify_blessed_path(led, engine, tag, url, state_url=state_url)
-    blessed_flow.sc_blessed_flow(led, engine, tag, url, state_url=state_url)
+    with led.span(f"{engine}: blessed_path"):
+        blessed_path.verify_blessed_path(led, engine, tag, url, state_url=state_url)
+    with led.span(f"{engine}: blessed_flow"):
+        blessed_flow.sc_blessed_flow(led, engine, tag, url, state_url=state_url)
     # Does the chain above have working oracles at all? Breaks each artifact
     # class and requires the matching stage to go RED — a green stage that was
     # never red is unverified, and this module's own first draft had one.

--- a/dev/release_oracle/scenarios.py
+++ b/dev/release_oracle/scenarios.py
@@ -281,6 +281,60 @@ def duckdb_allnull_cloud(store: str, bucket: str, prefix: str, work: Path) -> tu
     return (-1, -1)
 
 
+def _manifest_declared_parts(root: Path) -> list[str]:
+    """Absolute paths of the parts the manifest(s) under `root` DECLARE as committed — the
+    union across immutable manifest-*.json copies (plus the canonical manifest.json), i.e.
+    exactly what a consumer (`rivet load`) reads. Mirrors blessed_flow._manifest_files;
+    lives here so cdc.py can share it without a circular import."""
+    copies = sorted(root.rglob("manifest-*.json"))
+    docs = copies or ([root / "manifest.json"] if (root / "manifest.json").is_file() else [])
+    out: list[str] = []
+    for d in docs:
+        try:
+            art = json.loads(d.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        for f in art.get("parts", []) or []:
+            if isinstance(f, dict) and f.get("status") not in (None, "committed"):
+                continue
+            name = (f.get("path") or f.get("name")) if isinstance(f, dict) else f
+            if not name:
+                continue
+            cand = Path(name)
+            if not cand.is_absolute():
+                cand = d.parent / cand
+            if cand.is_file():
+                out.append(str(cand))
+    return sorted(set(out))
+
+
+def manifest_scoped_ids(store: str, bucket: str, prefix: str, work: Path, idc: str) -> str:
+    """Distinct id-set the store DELIVERS per its MANIFESTS (not raw parquet), comma-joined.
+
+    For the CDC crash oracle: at cdc_after_flush_before_ack the crashed run's part is durable
+    but UNMANIFESTED (the hook fires BEFORE write_manifest), so a raw `**/*.parquet` id-set is
+    fooled by that orphan — it cannot tell 'recovery re-read id=4' from 'id=4 left as an orphan
+    that rivet load never sees'. Reading only manifest-declared committed parts (what a consumer
+    reads) makes the orphan invisible, so a recovery that re-anchored PAST the un-acked change
+    reads back WITHOUT it. s3 only (the CDC store); '' if mc or a manifest is absent."""
+    if store != "s3" or not have("mc"):
+        return ""
+    dl = work / f"cdcmanifest_{random.randint(0, 32767)}"
+    shutil.rmtree(dl, ignore_errors=True)
+    dl.mkdir(parents=True, exist_ok=True)
+    alias = "rivetcdcmani"
+    run(["mc", "alias", "set", alias, "http://127.0.0.1:9000", MINIO_ACCESS_KEY, MINIO_SECRET_KEY])
+    if not run(["mc", "cp", "--recursive", f"{alias}/{bucket}/{prefix}/", str(dl)]).ok:
+        return ""
+    parts = _manifest_declared_parts(dl)
+    if not parts:
+        return ""
+    lst = ", ".join(f"'{f}'" for f in parts)
+    return _duckdb_list(
+        f"SELECT string_agg(DISTINCT CAST({idc} AS VARCHAR), ',') FROM read_parquet([{lst}])"
+    )
+
+
 def _duckdb_json_normalized(sql: str) -> str:
     """`duckdb -json -c SQL | lib/normalize_bq.py` — the canonical golden form.
 

--- a/docs/release-gate-matrix.yaml
+++ b/docs/release-gate-matrix.yaml
@@ -141,9 +141,13 @@ preflights:
     infra: [mysql-replica]
     status: test        # verify_replica_read — drives cdc_reads_changes_from_a_replica
   - id: pool_e2e
-    what: "the pool scheduler's e2e flow (#166): `apply --pool 2` on a multi-export config (one heavy + three parallel_safe) through a toxiproxy BANDWIDTH-CAPPED source — the shared-tunnel field pathology. Oracles: exact per-export rows (independent DuckDB readback), the predicted-vs-actual makespan contract on stdout (the model grades itself), and --resume defer-not-drop. Drives tests/live/live_pool_toxiproxy.rs; SKIP when toxiproxy :8474 is down."
+    what: "the pool scheduler's e2e flow (#166): `apply --pool 2` on a multi-export config (one heavy + three parallel_safe) through a toxiproxy BANDWIDTH-CAPPED source — the shared-tunnel field pathology. Oracles: exact per-export rows (independent DuckDB readback), the predicted-vs-actual makespan contract on stdout (the model grades itself), and --resume defer-not-drop. Drives the `pool_apply_*` cases in tests/live/live_pool_toxiproxy.rs; SKIP when toxiproxy :8474 is down."
     backends: [postgres]
-    status: test        # verify_pool_e2e — drives live_pool_toxiproxy (both tests)
+    status: test        # verify_pool_e2e — drives live_pool_toxiproxy::pool_apply_* (bandwidth / resume / two-heavy)
+  - id: pool_split
+    what: "the `--pool --split` range sub-export flow (#167): a dominating export is broken into N range sub-exports over its key span — separate scheduler units sharing ONE prefix + folding to ONE family. THREE independent DuckDB oracles (`pool_split_*` in tests/live/live_pool_toxiproxy.rs), each a NAMED gate cell: (1) realize — the split fires and the union reads back every row once, no seam gap/dup; (2) manifest coherence — validate does not flag a sibling unit's parts as untracked yet a true orphan still is; (3) per-unit crash resume — `--resume` re-runs ONLY the incomplete units (skip complete, resume crashed), no gap/no dup. SKIP when toxiproxy :8474 is down."
+    backends: [postgres]
+    status: test        # verify_pool_split — drives live_pool_toxiproxy::pool_split_* (realize / coherence / resume)
   - id: release_regression
     what: "regression vs the PREVIOUS RELEASE (not a golden, not the gate itself). B-format: the new binary must READ what the prev release WROTE — prev exports a 100K keyset+zstd fixture, cur `validate` re-reads its manifest+parts (PASSED) + DuckDB row-count == source (a format bump that can't read old artifacts silently breaks every existing user on upgrade). B-perf: cur wall <= the DOWNLOADED prev-release binary's wall × tol (default 1.5×; a 3× slowdown / RSS blow-up ships green through every correctness check), benchmarked against the artifact users actually run, never a rebuilt parent. Env: RIVET_PREV_RELEASE_BIN + RIVET_REGRESSION_SOURCE_URL; SKIP-if-absent."
     backends: [postgres]

--- a/src/pipeline/chunked/resume_m8.rs
+++ b/src/pipeline/chunked/resume_m8.rs
@@ -366,6 +366,15 @@ pub(crate) fn apply_m8_resume_decisions(
             run_id,
             plan.export_name
         );
+        // A --split unit's canonical manifest.json is last-writer-wins → usually a SIBLING
+        // unit's (foreign run_id), so this branch is the norm for split resume, not a rare
+        // restore/collision. We still must NOT reset chunk_tasks off a foreign manifest — but
+        // we MUST rehydrate THIS run's OWN committed parts from file_log (run_id-scoped, so
+        // the foreign manifest is irrelevant to it), exactly as the no-manifest branch does.
+        // Without this, a resuming unit's pre-crash completed-chunk parts sit on disk but are
+        // dropped from the finalize manifest — silent, manifest-authoritative row loss that
+        // `rivet load` inherits (RED-proven: 225000/300000 declared after a crash+resume).
+        rehydrate_manifest_parts_from_file_log(state, run_id, summary)?;
         return Ok(M8Stats::default());
     }
 

--- a/src/pipeline/split.rs
+++ b/src/pipeline/split.rs
@@ -22,7 +22,7 @@
 
 use std::path::Path;
 
-use crate::config::{Config, ExportConfig, ExportMode, SplitSynth};
+use crate::config::{Config, ExportConfig, ExportMode, SourceType, SplitSynth};
 use crate::error::Result;
 
 /// The N half-open key windows `(lo, hi]` that partition the whole key span,
@@ -56,6 +56,15 @@ fn windows(bounds: &[String]) -> Vec<(Option<String>, Option<String>)> {
 /// A plain `mode: full` export (chunk_column ignored) is NOT split — it has no
 /// per-unit checkpoint, so a crashed unit could not resume without duplicating.
 /// Returns the key column, or `None` (leave the export whole).
+/// Whether a source can be RANGE-SPLIT into `WHERE key > lo AND key <= hi` sub-exports.
+/// MongoDB cannot: it has no inline SQL range literal ([`crate::source::query::inline_literal`]
+/// is `unreachable!()` for it — a key window is expressed through the driver, not a textual
+/// predicate), so a split unit would PANIC at plan build. `--pool --split` therefore leaves a
+/// Mongo giant WHOLE (its own keyset/parallel path fans out differently) rather than crash.
+pub(crate) fn source_type_supports_split(st: SourceType) -> bool {
+    !matches!(st, SourceType::Mongo)
+}
+
 pub(crate) fn splittable_key(export: &ExportConfig) -> Option<String> {
     if export.mode == ExportMode::Cdc {
         return None; // a stream, not a range scan
@@ -137,6 +146,12 @@ pub(crate) fn probe_and_synthesize(
     config_dir: &Path,
     n: usize,
 ) -> Result<Option<Vec<ExportConfig>>> {
+    // MongoDB has no inline SQL range literal, so a range-split unit would panic at plan
+    // build (inline_literal is unreachable for Mongo). Leave a Mongo giant whole — fail
+    // fast BEFORE the boundary probe, never crash. Every SQL engine range-splits normally.
+    if !source_type_supports_split(config.source.source_type) {
+        return Ok(None);
+    }
     let Some(key) = splittable_key(giant) else {
         return Ok(None);
     };
@@ -290,5 +305,18 @@ mod tests {
         let mut nokey = sample_export("n");
         nokey.mode = ExportMode::Chunked;
         assert!(splittable_key(&nokey).is_none());
+    }
+
+    #[test]
+    fn mongo_source_is_not_range_split_capable() {
+        // inline_literal is unreachable!() for Mongo, so a range split would PANIC at plan
+        // build — probe_and_synthesize must leave a Mongo giant whole. Every SQL engine splits.
+        assert!(
+            !source_type_supports_split(SourceType::Mongo),
+            "Mongo has no inline SQL range literal — range-splitting it would panic"
+        );
+        assert!(source_type_supports_split(SourceType::Postgres));
+        assert!(source_type_supports_split(SourceType::Mysql));
+        assert!(source_type_supports_split(SourceType::Mssql));
     }
 }

--- a/src/pipeline/split.rs
+++ b/src/pipeline/split.rs
@@ -163,6 +163,27 @@ pub(crate) fn probe_and_synthesize(
     // cover. `resume=false`: the probe is read-only.
     let plan = crate::plan::build_plan(config, giant, config_dir, false, false, false, None)?;
     let mut src = crate::source::create_source(&plan.source)?;
+    // NULL-keyed guard for a RANGE split (chunk_column). Each unit's window is
+    // `key > lo AND key <= hi`, which excludes NULL (SQL 3-valued logic), and the
+    // per-unit `bail_if_null_keyed` is BLIND on a split unit because it probes the
+    // already-windowed subquery — so NULL-keyed rows would be SILENTLY DROPPED while
+    // every unit reports success. The un-split chunked path bails loudly (and
+    // chunk_dense covers NULLs); the split cannot, so refuse it here against the WHOLE
+    // table's key domain, before any unit runs. Keyset (chunk_by_key) keys are
+    // planner-enforced NOT NULL — exempt; only chunk_column/dense range keys can be null.
+    if giant.chunk_by_key.is_none() && giant.chunk_column.is_some() {
+        let probe = crate::sql::null_key_probe_sql(config.source.source_type, &key, &plan.base_query);
+        if src.as_mut().query_scalar(&probe)?.is_some() {
+            anyhow::bail!(
+                "export '{}': `--pool --split` over chunk_column '{}' would SILENTLY DROP \
+                 NULL-keyed rows — each range sub-export's window excludes NULL, and unlike the \
+                 un-split path (which bails or, with chunk_dense, covers them) the split has no \
+                 way to carry them. Fix one of: use a NOT NULL column; add `WHERE {} IS NOT NULL` \
+                 to drop them explicitly; or run this export with `mode: full` (unsplit).",
+                giant.name, key, key
+            );
+        }
+    }
     let bounds = super::keyset::sample_key_boundaries(src.as_mut(), &plan, &key, n, None, None)?;
     if bounds.is_empty() {
         // Too few distinct keys to partition (a tiny or single-valued key) —

--- a/src/pipeline/split.rs
+++ b/src/pipeline/split.rs
@@ -172,7 +172,8 @@ pub(crate) fn probe_and_synthesize(
     // table's key domain, before any unit runs. Keyset (chunk_by_key) keys are
     // planner-enforced NOT NULL — exempt; only chunk_column/dense range keys can be null.
     if giant.chunk_by_key.is_none() && giant.chunk_column.is_some() {
-        let probe = crate::sql::null_key_probe_sql(config.source.source_type, &key, &plan.base_query);
+        let probe =
+            crate::sql::null_key_probe_sql(config.source.source_type, &key, &plan.base_query);
         if src.as_mut().query_scalar(&probe)?.is_some() {
             anyhow::bail!(
                 "export '{}': `--pool --split` over chunk_column '{}' would SILENTLY DROP \
@@ -180,7 +181,9 @@ pub(crate) fn probe_and_synthesize(
                  un-split path (which bails or, with chunk_dense, covers them) the split has no \
                  way to carry them. Fix one of: use a NOT NULL column; add `WHERE {} IS NOT NULL` \
                  to drop them explicitly; or run this export with `mode: full` (unsplit).",
-                giant.name, key, key
+                giant.name,
+                key,
+                key
             );
         }
     }

--- a/tests/live/live_pool_toxiproxy.rs
+++ b/tests/live/live_pool_toxiproxy.rs
@@ -539,5 +539,20 @@ fn pool_split_resume_recovers_a_crashed_partial_with_no_gap_or_dup() {
          parts, or re-ran with a fresh run_id beside the survivors, fails here"
     );
 
+    // MANIFEST-authoritative oracle (the raw parquet count above is blind to it): the
+    // resuming unit's pre-crash COMPLETED-chunk parts must be DECLARED by the manifest,
+    // not merely present on disk. On resume the unit's M8 preamble reads the SHARED
+    // canonical manifest.json (last-writer-wins → a completed SIBLING's run_id), takes the
+    // foreign-manifest branch, and must still rehydrate ITS OWN committed parts from
+    // file_log — else they sit on disk unmanifested and `rivet load` (manifest-authoritative)
+    // silently misses them. Sum of the run-unique manifest copies must equal the whole table.
+    assert_eq!(
+        dir_manifest_copy_total_rows(&rig.out_dir()),
+        N,
+        "the manifest copies must DECLARE every row after resume — a resuming split unit \
+         whose canonical manifest is a sibling's (foreign run_id) must rehydrate its own \
+         pre-crash committed parts, else they are on disk but unmanifested (silent load loss)"
+    );
+
     let _ = c.batch_execute(&format!("DROP TABLE IF EXISTS {table};"));
 }


### PR DESCRIPTION
Three themes on one branch (21 commits). Every commit was green through the local pre-release
gate (`RIVET_ORACLE_LATEST_ONLY=1 make release-oracle-full`, --engine-parallel 4 --cell-parallel 8);
product fixes were RED→GREEN proven with independent DuckDB oracles.

## 1. Release-gate speedup (~45 → ~16 min full-clean / ~9 min --no-clean)
- Engine matrix parallelised by engine AND by cell (global BoundedSemaphore, `--cell-parallel`);
  matrix wall 26 → 5.4 min. Coverage proven IDENTICAL by a 2300-row ledger diff (sequential vs parallel).
- BigQuery golden stage parallelised by dataset (4.1 → 1.5 min).
- MSSQL CDC fixture waits replaced by `fn_cdc_get_max_lsn` polling; shared cdc setup-retry.
- `--fast-clean` (remove only `target/package`, not all of `target/`): 0.6s vs 6m42s on an unchanged tree.
- Per-engine/per-cell timing spans so the gate self-reports where the wall goes.

## 2. Harness bughunt — 25 findings fixed (dev/release_oracle + tests/offline)
Four multi-agent hunt rounds, adversarially verified. The through-line: **every data/coverage
assertion now has an INDEPENDENT DuckDB oracle**, never rivet's own summary. Highlights:
- Per-column null profile (`count(COLUMNS(*))`) on EVERY store (local/s3/gcs) and EVERY pipeline
  (batch + CDC) — the documented uuid→FixedSizeBinary silent-loss class.
- Shared-Postgres-ledger checks scoped by run_id (export_metrics HAS a run_id; the watermark was a
  workaround for a non-existent limitation).
- absence-reads-as-green closed (empty cloud/bq/load readback → FAIL, not SKIP).
- CDC crash oracle reads MANIFEST-declared parts (not raw parquet, which counted the crash orphan)
  AND asserts the fault hook actually fired.

## 3. split+pool (#167) product hardening — 4 real data-loss/crash bugs
Found by a multi-agent product hunt, each RED-proven:
- `--pool --split` on a **MongoDB** source PANICKED at plan build (`inline_literal` unreachable) → gated off.
- **NULL-keyed chunk_column split silently dropped NULL rows** → refused (the window excludes NULL and
  the per-unit guard was blind to the already-windowed subquery).
- **Split resume dropped its own pre-crash parts** on a foreign (sibling) manifest → now rehydrates
  from file_log. RED→GREEN: manifest-declared 225000/300000 → 300000, via a new manifest-authoritative
  oracle (the resume test's old raw-parquet oracle was blind).

## Known-remaining (documented, NOT in this PR — need careful work)
- **finding 2 (HIGH):** `--pool --split --resume` re-samples key windows (offset/percentile-based, so
  unstable under inserts) and skips completed units by ordinal name — a source that grows between crash
  and resume shifts boundaries → silent gap. Fix = persist windows in the manifest + reconstruct the
  exact partition on resume (no safe shortcut). Being done on a follow-up branch.
- mysql/mssql `pool_split` live coverage (implemented, tested only on postgres).
- 2 redaction self-oracle tests (`tests/offline/redaction_invariant.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168uwctCn3W1rP4Kt4kZXvE