### PR TITLE
fix(split): merge-back consumers over a --split prefix — validate/load/keyset_incremental (3 HIGH)

### DIFF
--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -1150,7 +1150,7 @@ fn prepare_load(
         Some(s) => s.loaded_source_run_ids(target_fqtn).unwrap_or_default(),
         None => std::collections::HashSet::new(),
     };
-    let new = load::reconcile::select_runs(keyed, &loaded, plan.mode);
+    let new = load::reconcile::select_runs(keyed, &loaded, plan.mode)?;
     if new.is_empty() {
         return Ok(None);
     }

--- a/src/load/reconcile.rs
+++ b/src/load/reconcile.rs
@@ -371,6 +371,53 @@ fn finished_after(a: &str, b: &str) -> bool {
     }
 }
 
+/// A Full selection must be ONE coherent split generation (or a single plain snapshot). A
+/// `--pool --split` prefix accumulates a manifest copy per unit per run (different run_ids →
+/// different part names → nothing overwrites), and there is no generation id, so if a later run
+/// split into a DIFFERENT unit count — or the export toggled unsplit↔split — [`latest_full`]'s
+/// group-by-unit selection would mix TWO generations: their windows overlap and a Full (replace)
+/// load would DUPLICATE rows (the count gate can't catch it — `expected_rows` inflates with the
+/// parts). Every coherent split generation has EXACTLY one bottom unit (`lo == None`) and one
+/// top (`hi == None`) and no plain/split mix; violate that and we cannot tell which parts form
+/// the current snapshot, so REFUSE loudly rather than silently duplicate. (Proper fix: stamp a
+/// split-generation id on the units — tracked follow-up.)
+fn ensure_single_split_generation(selected: &[(String, RunManifest)]) -> Result<()> {
+    let split: Vec<&RunManifest> = selected
+        .iter()
+        .map(|(_, m)| m)
+        .filter(|m| m.split_window.is_some())
+        .collect();
+    if split.is_empty() {
+        return Ok(()); // a plain single-snapshot selection is always coherent
+    }
+    let plain = selected.len() - split.len();
+    let bottoms = split
+        .iter()
+        .filter(|m| m.split_window.as_ref().unwrap().lo.is_none())
+        .count();
+    let tops = split
+        .iter()
+        .filter(|m| m.split_window.as_ref().unwrap().hi.is_none())
+        .count();
+    if plain > 0 || bottoms > 1 || tops > 1 {
+        anyhow::bail!(
+            "Full load over a --pool --split prefix selected parts from MORE THAN ONE split \
+             generation ({} split units incl. {bottoms} bottom + {tops} top window(s){}); \
+             loading their union would DUPLICATE rows. The prefix holds a prior split run's \
+             leftover parts (a later run split into a different unit count, or the export \
+             toggled split↔unsplit). Load into a FRESH destination prefix (or clear the stale \
+             generation) and re-run.",
+            split.len(),
+            if plain > 0 {
+                format!(", plus {plain} non-split snapshot(s)")
+            } else {
+                String::new()
+            }
+        );
+    }
+    Ok(())
+}
+
 /// Which run manifests to load for `mode`, given the ledger's already-`loaded`
 /// run_ids. The single mode→selection decision, pure and testable so the load's
 /// central invariant isn't buried in dispatch I/O:
@@ -384,7 +431,7 @@ pub fn select_runs(
     keyed: Vec<(String, RunManifest)>,
     loaded: &std::collections::HashSet<String>,
     mode: crate::load::plan::LoadMode,
-) -> Vec<(String, RunManifest)> {
+) -> Result<Vec<(String, RunManifest)>> {
     // Only a `Success` run is loadable, so drop every other status BEFORE
     // selection. `Running` is a live run's in-flight marker (no committed
     // parts); `Failed`/`Interrupted` is an ABORTED run whose parts are partial —
@@ -409,11 +456,15 @@ pub fn select_runs(
         .filter(|(_, m)| m.status == ManifestStatus::Success)
         .collect();
     match mode {
-        crate::load::plan::LoadMode::Full => latest_full(keyed),
-        _ => keyed
+        crate::load::plan::LoadMode::Full => {
+            let sel = latest_full(keyed);
+            ensure_single_split_generation(&sel)?;
+            Ok(sel)
+        }
+        _ => Ok(keyed
             .into_iter()
             .filter(|(_, m)| !loaded.contains(&m.run_id))
-            .collect(),
+            .collect()),
     }
 }
 
@@ -1105,7 +1156,8 @@ mod tests {
             vec![keyed(failed), keyed(ok8), keyed(ok9)],
             &std::collections::HashSet::new(),
             crate::load::plan::LoadMode::Cdc,
-        );
+        )
+        .unwrap();
         let ids: Vec<&str> = sel.iter().map(|(_, m)| m.run_id.as_str()).collect();
         assert_eq!(
             ids,
@@ -1467,7 +1519,8 @@ mod tests {
             vec![run_marker, ok],
             &std::collections::HashSet::new(),
             crate::load::plan::LoadMode::Incremental,
-        );
+        )
+        .unwrap();
         assert_eq!(sel.len(), 1, "only the Success run is selected");
         assert_eq!(sel[0].1.run_id, "r_ok");
         assert!(sel.iter().all(|(_, m)| m.status != ManifestStatus::Running));
@@ -1578,6 +1631,75 @@ mod tests {
     }
 
     #[test]
+    fn select_runs_full_refuses_a_mixed_generation_split_prefix() {
+        // Two split generations accumulated under one prefix: gen A split into 3
+        // (orders#0..#2), a later clean run gen B into 2 (orders#0..#1). Nothing deletes gen
+        // A's copies, so latest_full's group-by-name picks B#0, B#1, and STALE A#2 — TWO top
+        // (hi=None) units → overlapping coverage → a Full (replace) load would DUPLICATE the
+        // (700, ∞) rows. select_runs must REFUSE, not silently duplicate.
+        let unit = |name: &str, run: &str, lo: Option<&str>, hi: Option<&str>, at: &str| {
+            let mut m = manifest(run, 100, None);
+            m.export_name = name.into();
+            m.export_family = "orders".into();
+            m.finished_at = at.into();
+            m.split_window = Some(crate::manifest::SplitWindow {
+                key_column: "id".into(),
+                lo: lo.map(String::from),
+                hi: hi.map(String::from),
+            });
+            (format!("orders/manifest-{run}.json"), m)
+        };
+        let keyed = vec![
+            unit("orders#0", "b0", None, Some("500"), "2026-01-02T00:00:00Z"),
+            unit("orders#1", "b1", Some("500"), None, "2026-01-02T00:00:01Z"),
+            unit("orders#2", "a2", Some("700"), None, "2026-01-01T00:00:00Z"), // stale gen A top
+        ];
+        let err = select_runs(
+            keyed,
+            &std::collections::HashSet::new(),
+            crate::load::plan::LoadMode::Full,
+        )
+        .expect_err("a mixed-generation split prefix must be refused, not silently loaded");
+        assert!(
+            err.to_string().contains("more than one split generation")
+                || err.to_string().contains("DUPLICATE"),
+            "error must name the multi-generation duplication hazard: {err}"
+        );
+    }
+
+    #[test]
+    fn select_runs_full_accepts_one_coherent_split_generation() {
+        // A single clean split generation (one bottom lo=None, one top hi=None) loads all its
+        // units — the headline fix — without tripping the guard.
+        let unit = |name: &str, run: &str, lo: Option<&str>, hi: Option<&str>| {
+            let mut m = manifest(run, 100, None);
+            m.export_name = name.into();
+            m.export_family = "orders".into();
+            m.split_window = Some(crate::manifest::SplitWindow {
+                key_column: "id".into(),
+                lo: lo.map(String::from),
+                hi: hi.map(String::from),
+            });
+            (format!("orders/manifest-{run}.json"), m)
+        };
+        let keyed = vec![
+            unit("orders#0", "r0", None, Some("500")),
+            unit("orders#1", "r1", Some("500"), None),
+        ];
+        let sel = select_runs(
+            keyed,
+            &std::collections::HashSet::new(),
+            crate::load::plan::LoadMode::Full,
+        )
+        .unwrap();
+        assert_eq!(
+            sel.len(),
+            2,
+            "both units of one coherent generation must load"
+        );
+    }
+
+    #[test]
     fn latest_full_re_materializes_even_when_the_latest_is_already_loaded() {
         // Full is NOT ledger-skipped: a re-load re-OVERWRITEs from the latest
         // snapshot, self-healing a drifted target and staying resilient to hidden
@@ -1626,12 +1748,12 @@ mod tests {
         ];
         // Stateful, r2 already loaded → still selects r2 (re-materialize/self-heal).
         let loaded = HashSet::from(["r2".to_string()]);
-        let sel = select_runs(keyed.clone(), &loaded, LoadMode::Full);
+        let sel = select_runs(keyed.clone(), &loaded, LoadMode::Full).unwrap();
         assert_eq!(sel.len(), 1);
         assert_eq!(sel[0].1.run_id, "r2", "Full picks latest, loaded or not");
         // STATELESS (empty loaded) → the latest, NEVER a blanket load of both
         // snapshots (the duplicate-rows bug this fix closes).
-        let sel = select_runs(keyed, &HashSet::new(), LoadMode::Full);
+        let sel = select_runs(keyed, &HashSet::new(), LoadMode::Full).unwrap();
         assert_eq!(sel.len(), 1, "stateless Full is not a blanket load");
         assert_eq!(sel[0].1.run_id, "r2");
     }
@@ -1646,12 +1768,14 @@ mod tests {
         ];
         let loaded = HashSet::from(["r1".to_string()]);
         for mode in [LoadMode::Incremental, LoadMode::Cdc] {
-            let sel = select_runs(keyed.clone(), &loaded, mode);
+            let sel = select_runs(keyed.clone(), &loaded, mode).unwrap();
             assert_eq!(sel.len(), 1, "{mode:?}: only the unloaded run");
             assert_eq!(sel[0].1.run_id, "r2");
             // Stateless → empty loaded → load all (at-least-once, dedup absorbs).
             assert_eq!(
-                select_runs(keyed.clone(), &HashSet::new(), mode).len(),
+                select_runs(keyed.clone(), &HashSet::new(), mode)
+                    .unwrap()
+                    .len(),
                 2,
                 "{mode:?}: stateless loads every run"
             );

--- a/src/load/reconcile.rs
+++ b/src/load/reconcile.rs
@@ -337,19 +337,38 @@ fn is_superseded(m: &RunManifest, keyed: &[(String, RunManifest)]) -> bool {
 /// on mixed RFC3339 precision (`…00.5Z` sorts before `…00Z`) — and falls back to
 /// lexical only if a timestamp fails to parse, so a malformed manifest can't panic.
 pub fn latest_full(keyed: Vec<(String, RunManifest)>) -> Vec<(String, RunManifest)> {
-    keyed
-        .into_iter()
-        .max_by(|a, b| {
-            match (
-                chrono::DateTime::parse_from_rfc3339(&a.1.finished_at).ok(),
-                chrono::DateTime::parse_from_rfc3339(&b.1.finished_at).ok(),
-            ) {
-                (Some(x), Some(y)) => x.cmp(&y),
-                _ => a.1.finished_at.cmp(&b.1.finished_at),
-            }
-        })
-        .into_iter()
-        .collect()
+    // Group by export_name, then take the LATEST manifest per group. A `--pool --split`
+    // snapshot is N units `{family}#0..#N-1`, each its OWN run_id/manifest that finishes at
+    // a slightly different instant; the old `max_by` over the WHOLE set picked exactly ONE
+    // manifest — silently dropping the other N-1 units on a Full (replace) load. Grouping by
+    // export_name loads each unit's latest run. A non-split full export keeps ONE export_name
+    // across repeated runs → a single group → the single latest snapshot, unchanged replace
+    // semantics. BTreeMap so the selection order is deterministic (by unit name).
+    let mut latest: std::collections::BTreeMap<String, (String, RunManifest)> =
+        std::collections::BTreeMap::new();
+    for (key, m) in keyed {
+        let newer = match latest.get(&m.export_name) {
+            None => true,
+            Some((_, prev)) => finished_after(&m.finished_at, &prev.finished_at),
+        };
+        if newer {
+            latest.insert(m.export_name.clone(), (key, m));
+        }
+    }
+    latest.into_values().collect()
+}
+
+/// True if `a`'s finished-at instant is strictly after `b`'s (RFC3339; falls back to a
+/// lexical compare only if either fails to parse — the same ordering `latest_full` used
+/// before it grouped by unit).
+fn finished_after(a: &str, b: &str) -> bool {
+    match (
+        chrono::DateTime::parse_from_rfc3339(a).ok(),
+        chrono::DateTime::parse_from_rfc3339(b).ok(),
+    ) {
+        (Some(x), Some(y)) => x > y,
+        _ => a > b,
+    }
 }
 
 /// Which run manifests to load for `mode`, given the ledger's already-`loaded`
@@ -1497,6 +1516,65 @@ mod tests {
         let sel = latest_full(keyed);
         assert_eq!(sel.len(), 1, "exactly one snapshot, never all");
         assert_eq!(sel[0].1.run_id, "r3", "the newest by finished_at");
+    }
+
+    #[test]
+    fn latest_full_over_a_split_family_selects_every_unit_not_just_the_last() {
+        // A `--pool --split` snapshot: 3 units {family}#0..#2, each its own run_id and a
+        // slightly different finished_at. Full load must select ALL THREE (the whole
+        // snapshot), not just whichever unit finished last — the old max_by-over-all
+        // dropped 2 of 3 units silently.
+        let unit = |name: &str, run: &str, at: &str| {
+            let mut m = manifest(run, 100, None);
+            m.export_name = name.into();
+            m.export_family = "orders".into();
+            m.finished_at = at.into();
+            (format!("orders/manifest-{run}.json"), m)
+        };
+        let keyed = vec![
+            unit("orders#0", "r0", "2026-01-01T00:00:01Z"),
+            unit("orders#1", "r1", "2026-01-01T00:00:02Z"),
+            unit("orders#2", "r2", "2026-01-01T00:00:03Z"),
+        ];
+        let mut sel = latest_full(keyed);
+        sel.sort_by(|a, b| a.1.export_name.cmp(&b.1.export_name));
+        let names: Vec<&str> = sel.iter().map(|(_, m)| m.export_name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["orders#0", "orders#1", "orders#2"],
+            "a Full load over a split prefix must select EVERY unit — one per {{family}}#i — \
+             not just the unit that finished last"
+        );
+    }
+
+    #[test]
+    fn latest_full_over_a_split_family_takes_the_newest_run_per_unit() {
+        // Repeated Full runs into a split prefix: each unit has TWO runs. Per unit, only
+        // the newest is selected (replace semantics), and all units are present.
+        let unit = |name: &str, run: &str, at: &str| {
+            let mut m = manifest(run, 100, None);
+            m.export_name = name.into();
+            m.export_family = "orders".into();
+            m.finished_at = at.into();
+            (format!("orders/manifest-{run}.json"), m)
+        };
+        let keyed = vec![
+            unit("orders#0", "r0a", "2026-01-01T00:00:00Z"),
+            unit("orders#0", "r0b", "2026-01-02T00:00:00Z"), // newer #0
+            unit("orders#1", "r1a", "2026-01-01T00:00:00Z"),
+            unit("orders#1", "r1b", "2026-01-02T00:00:00Z"), // newer #1
+        ];
+        let mut sel = latest_full(keyed);
+        sel.sort_by(|a, b| a.1.export_name.cmp(&b.1.export_name));
+        let picked: Vec<(&str, &str)> = sel
+            .iter()
+            .map(|(_, m)| (m.export_name.as_str(), m.run_id.as_str()))
+            .collect();
+        assert_eq!(
+            picked,
+            vec![("orders#0", "r0b"), ("orders#1", "r1b")],
+            "each unit contributes its NEWEST run; no unit is dropped and no stale run loaded"
+        );
     }
 
     #[test]

--- a/src/pipeline/split.rs
+++ b/src/pipeline/split.rs
@@ -281,6 +281,13 @@ pub(crate) fn reconstruct_units_from_prefix(
     family: &str,
     giant: &ExportConfig,
 ) -> Option<Vec<ExportConfig>> {
+    // A resume must not RESURRECT a split the fresh path would now refuse. `probe_and_synthesize`
+    // gates new splits through `splittable_key` (e.g. it refuses `keyset_incremental`), but
+    // reconstruct rebuilds from on-disk unit manifests and would bypass that gate — so a config
+    // that turned unsafe-to-split since the prior run (a flipped `keyset_incremental`, an added
+    // `cursor_column`) would resume its old split and silently drop/duplicate. Honour the same
+    // gate here: not splittable → leave the giant whole (probe agrees, so no split runs).
+    splittable_key(giant)?;
     let prefix = format!("{}#", giant.name); // this giant's unit names: "{giant}#<ordinal>"
     let mut key: Option<String> = None;
     // boundary position -> value. Position i is the boundary between unit#i and unit#(i+1),
@@ -568,6 +575,29 @@ mod tests {
                 (s.lo.clone(), s.hi.clone())
             })
             .collect()
+    }
+
+    #[test]
+    fn reconstruct_refuses_to_resurrect_a_now_unsplittable_export_on_resume() {
+        // A prior run split this export and left unit manifests; the config has since flipped
+        // `keyset_incremental: true` (append-only), which `splittable_key` now refuses. Resume
+        // must NOT rebuild the old split from the on-disk manifests (that would bypass the
+        // fresh-path guard and drop/duplicate) — reconstruct returns None, so the giant runs
+        // whole (probe_and_synthesize also returns None for it).
+        let dir = tempfile::tempdir().unwrap();
+        let mut giant = sample_export("daily");
+        giant.mode = ExportMode::Chunked;
+        giant.chunk_by_key = Some("id".into());
+        giant.destination.path = Some(dir.path().to_string_lossy().into_owned());
+        // On-disk split units from the prior (splittable) run.
+        write_unit_manifest(dir.path(), "daily#0", "r0", None, Some("500"));
+        write_unit_manifest(dir.path(), "daily#1", "r1", Some("500"), None);
+        // The config is now keyset_incremental → not splittable.
+        giant.keyset_incremental = true;
+        assert!(
+            reconstruct_units_from_prefix(&giant.destination, "daily", &giant).is_none(),
+            "a resume must not resurrect a split for a config that is no longer splittable"
+        );
     }
 
     #[test]

--- a/src/pipeline/split.rs
+++ b/src/pipeline/split.rs
@@ -72,8 +72,17 @@ pub(crate) fn splittable_key(export: &ExportConfig) -> Option<String> {
     if export.cursor_column.is_some() {
         return None; // incremental: a single per-export cursor, not per-range
     }
+    if export.keyset_incremental {
+        // Append-only incremental-by-key: on a clean re-run each unit would continue
+        // from ITS OWN window's high-water mark, but the partition is re-derived every
+        // run — so the per-unit water marks and the fresh windows disagree and rows are
+        // silently dropped/duplicated across runs. This is the "incremental split needs
+        // a per-range cursor" case scope v1 refuses; keep the export WHOLE (its own
+        // keyset_incremental high-water is correct only unsplit).
+        return None;
+    }
     if let Some(key) = &export.chunk_by_key {
-        return Some(key.clone()); // keyset — resumable in any mode
+        return Some(key.clone()); // keyset (non-incremental) — resumable in any mode
     }
     if export.mode == ExportMode::Chunked
         && let Some(col) = &export.chunk_column
@@ -438,6 +447,18 @@ mod tests {
         let mut nokey = sample_export("n");
         nokey.mode = ExportMode::Chunked;
         assert!(splittable_key(&nokey).is_none());
+
+        // append-only incremental-by-key (keyset_incremental) → NOT splittable: a split
+        // re-derives the partition every run, so per-unit high-water marks and fresh
+        // windows disagree and rows are silently dropped/duplicated across re-runs. Scope
+        // v1 refuses an incremental split; the unsplit keyset_incremental is correct.
+        let mut ks_incr = chunked.clone();
+        ks_incr.keyset_incremental = true;
+        assert!(
+            splittable_key(&ks_incr).is_none(),
+            "an append-only keyset_incremental export must not split — the per-unit \
+             high-water mark disagrees with a re-derived partition (silent drop/dup)"
+        );
     }
 
     // Build a minimal SUCCESS unit manifest carrying a split window, and write it as a

--- a/src/pipeline/validate_manifest.rs
+++ b/src/pipeline/validate_manifest.rs
@@ -591,11 +591,12 @@ fn read_sibling_manifests(dest: &dyn Destination, listing: &[ObjectMeta]) -> Vec
     out
 }
 
-/// The set of destination keys claimed by a SAME-FAMILY sibling run-unique
-/// manifest copy (#167 merge-back). A part is claimed only when a sibling of the
-/// SAME `export_family` declared it `Committed`, so a foreign export's parts under
-/// a mistakenly-shared prefix are still surfaced as untracked. Pure — the I/O
-/// (reading the copies) is [`read_sibling_manifests`]'s job.
+/// The set of destination keys claimed by a SAME-FAMILY sibling run-unique manifest copy
+/// (#167 merge-back). A part is claimed only when a sibling of the SAME `export_family`
+/// declared it `Committed`, so a foreign export's parts under a mistakenly-shared prefix are
+/// still surfaced as untracked. Covers BOTH split units AND a plain export's superseded
+/// historical / CDC-soak copies, so neither reads as surplus. Pure — the I/O (reading the
+/// copies) is [`read_sibling_manifests`]'s job.
 fn sibling_claimed_part_keys(
     siblings: &[RunManifest],
     canonical_family: &str,
@@ -603,9 +604,8 @@ fn sibling_claimed_part_keys(
 ) -> std::collections::BTreeSet<String> {
     let mut out = std::collections::BTreeSet::new();
     if canonical_family.is_empty() {
-        // A legacy manifest with no family: never claim across copies — keep the
-        // pre-#167 behaviour (a legacy prefix is single-run, so there is nothing
-        // to claim, and folding by empty family could hide cross-contamination).
+        // A legacy manifest with no family: never claim across copies (a legacy prefix is
+        // single-run, and folding by empty family could hide cross-contamination).
         return out;
     }
     for m in siblings {
@@ -619,6 +619,37 @@ fn sibling_claimed_part_keys(
         }
     }
     out
+}
+
+/// A working manifest whose `parts` are the UNION of `canonical`'s parts and every
+/// SAME-FAMILY **split-unit** sibling copy's `Committed` parts, deduped by declared path. The
+/// reconcile target for a `--pool --split` prefix: presence/size/md5 then cover EVERY unit,
+/// not just the last writer whose parts the canonical `manifest.json` happens to list.
+///
+/// A sibling is folded ONLY when it carries a `split_window` — the precise mark of a
+/// co-current split UNIT (finding 2). A plain export's family is its own name, so its
+/// HISTORICAL repeated-run copies share the family too, but they are SUPERSEDED snapshots
+/// (no `split_window`); folding them would presence-check a legitimately cleaned old part and
+/// false-fail. The canonical's own copy is among the siblings, so seeding `seen` with the
+/// canonical's parts keeps it from being added twice. Only `parts` differ from `canonical`.
+fn merge_split_unit_parts(canonical: &RunManifest, siblings: &[RunManifest]) -> RunManifest {
+    let mut merged = canonical.clone();
+    let mut seen: std::collections::BTreeSet<String> =
+        merged.parts.iter().map(|p| p.path.clone()).collect();
+    for m in siblings {
+        if m.export_family != canonical.export_family {
+            continue; // never fold a FOREIGN family's parts into the check
+        }
+        if m.split_window.is_none() {
+            continue; // only co-current SPLIT units — not superseded plain repeated-run copies
+        }
+        for p in &m.parts {
+            if p.status == PartStatus::Committed && seen.insert(p.path.clone()) {
+                merged.parts.push(p.clone());
+            }
+        }
+    }
+    merged
 }
 
 pub fn verify_at_destination(
@@ -740,20 +771,27 @@ pub fn verify_at_destination(
     let reconciliation = if depth.runs_part_reconcile() {
         match dest.list_prefix(manifest_dir) {
             Ok(listing) => {
-                let mut rec = reconcile_manifest_against_listing(&manifest, &listing, manifest_dir);
-                // #167: a `--pool --split` prefix holds N run-unique manifest
-                // copies of ONE family, each declaring a DISJOINT set of parts.
-                // The canonical `manifest.json` lists only the LAST writer's
-                // parts, so every sibling unit's parts would read as untracked
-                // surplus — noise that also MASKS a genuine orphan. Claim any
-                // listed part a SAME-FAMILY sibling copy declared committed, so
-                // only truly foreign objects stay untracked. (Also cleans up the
-                // repeated-run / CDC-soak case, where the historical runs' parts
-                // are likewise declared by their own copies.) Safe by
-                // construction: this only NARROWS untracked — it can never add a
-                // failure — and a foreign family's parts are never claimed.
+                // #167: a `--pool --split` prefix holds N run-unique manifest copies of ONE
+                // family, each declaring a DISJOINT set of parts. The canonical `manifest.json`
+                // lists only the LAST writer's parts, so reconciling the canonical alone
+                // presence/size/md5-checked ONLY the last unit — a missing/corrupt part of any
+                // OTHER split unit was invisible (no PartMissing: not in the canonical list; no
+                // UntrackedObject: not on disk), and the trust oracle silently PASSED an
+                // incomplete split (adjacent-bughunt finding, HIGH). Fold every SAME-FAMILY
+                // SPLIT-UNIT sibling's parts into the reconcile target so each unit is checked.
+                let siblings = if manifest.export_family.is_empty() {
+                    Vec::new()
+                } else {
+                    read_sibling_manifests(dest, &listing)
+                };
+                let target = merge_split_unit_parts(&manifest, &siblings);
+                let mut rec = reconcile_manifest_against_listing(&target, &listing, manifest_dir);
+                // Same-family sibling parts — the folded split units AND a plain export's
+                // SUPERSEDED historical / CDC-soak copies (no split_window, so NOT folded
+                // above) — are declared by their own copies elsewhere in the prefix, so they
+                // must not read as untracked surplus (noise that also MASKS a real orphan). A
+                // foreign family's parts are never claimed, so cross-contamination still shows.
                 if !rec.untracked.is_empty() && !manifest.export_family.is_empty() {
-                    let siblings = read_sibling_manifests(dest, &listing);
                     let claimed =
                         sibling_claimed_part_keys(&siblings, &manifest.export_family, manifest_dir);
                     rec.untracked.retain(|o| !claimed.contains(&o.key));
@@ -1005,11 +1043,94 @@ mod tests {
         }
     }
 
-    // ── #167 sibling-copy claim (manifest coherence under a shared prefix) ──
+    // ── #167 merge-back: reconcile the UNION of same-family split-unit parts ──
 
-    /// A same-family sibling copy's committed parts are claimed; a FOREIGN
-    /// family's are not. RED against claiming across families (which would hide a
-    /// cross-contamination the shared-prefix guard exists to surface).
+    fn split_win() -> crate::manifest::SplitWindow {
+        crate::manifest::SplitWindow {
+            key_column: "id".into(),
+            lo: None,
+            hi: Some("1000".into()),
+        }
+    }
+
+    /// merge_split_unit_parts folds every SAME-FAMILY SPLIT-UNIT sibling's committed parts
+    /// (those carrying a split_window) into the reconcile target, and EXCLUDES both a FOREIGN
+    /// family's parts and a SAME-FAMILY non-split (plain, superseded) copy's parts — so a
+    /// `--pool --split` snapshot is checked across ALL units without false-checking a plain
+    /// export's historical run or a foreign export sharing the prefix.
+    #[test]
+    fn merge_split_unit_parts_folds_split_siblings_only() {
+        let unit = |name: &str, path: &str, fam: &str, split: bool| {
+            let mut m = build_manifest(vec![part(0, 10, 100, "fp")], ManifestStatus::Success);
+            m.export_family = fam.into();
+            m.export_name = name.into();
+            m.parts[0].path = path.into();
+            m.split_window = if split { Some(split_win()) } else { None };
+            m
+        };
+        let canonical = unit("daily#3", "daily#3_p.parquet", "daily", true); // last split writer
+        let siblings = vec![
+            unit("daily#0", "daily#0_p.parquet", "daily", true),
+            unit("daily#1", "daily#1_p.parquet", "daily", true),
+            unit("daily#3", "daily#3_p.parquet", "daily", true), // canonical's OWN copy
+            unit("daily", "daily_old.parquet", "daily", false),  // SAME family, PLAIN (superseded)
+            unit("other#0", "other_p.parquet", "other", true),   // FOREIGN family
+        ];
+        let merged = merge_split_unit_parts(&canonical, &siblings);
+        let paths: std::collections::BTreeSet<&str> =
+            merged.parts.iter().map(|p| p.path.as_str()).collect();
+        assert_eq!(
+            paths,
+            [
+                "daily#0_p.parquet",
+                "daily#1_p.parquet",
+                "daily#3_p.parquet"
+            ]
+            .into_iter()
+            .collect(),
+            "fold same-family SPLIT units only — never a foreign family, never a same-family \
+             plain/superseded copy: {paths:?}"
+        );
+        assert_eq!(
+            merged
+                .parts
+                .iter()
+                .filter(|p| p.path == "daily#3_p.parquet")
+                .count(),
+            1,
+            "the canonical's own sibling copy must not double its part"
+        );
+    }
+
+    /// A non-committed (quarantined) split-unit sibling part is NOT merged — only durable
+    /// committed parts belong to the dataset the reconcile checks for presence.
+    #[test]
+    fn merge_split_unit_parts_skips_non_committed_siblings() {
+        let mut canonical = build_manifest(vec![part(0, 10, 100, "fp")], ManifestStatus::Success);
+        canonical.export_family = "daily".into();
+        canonical.export_name = "daily#0".into();
+        canonical.parts[0].path = "daily#0_p.parquet".into();
+        canonical.split_window = Some(split_win());
+
+        let mut sib = build_manifest(vec![part(0, 10, 100, "fp")], ManifestStatus::Success);
+        sib.export_family = "daily".into();
+        sib.export_name = "daily#1".into();
+        sib.parts[0].path = "daily#1_q.parquet".into();
+        sib.parts[0].status = PartStatus::Quarantined;
+        sib.split_window = Some(split_win());
+
+        let merged = merge_split_unit_parts(&canonical, &[sib]);
+        let paths: Vec<&str> = merged.parts.iter().map(|p| p.path.as_str()).collect();
+        assert_eq!(
+            paths,
+            vec!["daily#0_p.parquet"],
+            "a quarantined split-unit part must not be folded into the reconcile target"
+        );
+    }
+
+    /// sibling_claimed_part_keys claims a SAME-FAMILY sibling's committed parts (so a split
+    /// unit AND a plain export's superseded historical copy are both kept out of untracked),
+    /// but never a FOREIGN family's (cross-contamination must still surface as untracked).
     #[test]
     fn sibling_claimed_part_keys_claims_same_family_only() {
         let unit = |name: &str, path: &str, fam: &str| {
@@ -1021,22 +1142,22 @@ mod tests {
         };
         let siblings = vec![
             unit("daily#0", "daily#0_p.parquet", "daily"),
-            unit("daily#1", "daily#1_p.parquet", "daily"),
+            unit("daily", "daily_old.parquet", "daily"), // plain superseded copy, same family
             unit("other", "other_p.parquet", "other"),
         ];
         let claimed = sibling_claimed_part_keys(&siblings, "daily", "");
         assert!(
-            claimed.contains("daily#0_p.parquet") && claimed.contains("daily#1_p.parquet"),
-            "same-family split units' parts must be claimed: {claimed:?}"
+            claimed.contains("daily#0_p.parquet") && claimed.contains("daily_old.parquet"),
+            "same-family parts (split unit AND plain historical) must be claimed: {claimed:?}"
         );
         assert!(
             !claimed.contains("other_p.parquet"),
-            "a FOREIGN family's part must NOT be claimed — cross-contamination must still surface"
+            "a FOREIGN family's part must NOT be claimed — cross-contamination must surface"
         );
     }
 
-    /// A legacy canonical (empty family) claims nothing — pre-#167 behaviour, so
-    /// the widening never applies where a family cannot disambiguate.
+    /// A legacy canonical (empty family) claims nothing — the widening never applies where a
+    /// family cannot disambiguate.
     #[test]
     fn sibling_claimed_part_keys_empty_family_claims_nothing() {
         let mut m = build_manifest(vec![part(0, 10, 100, "fp")], ManifestStatus::Success);
@@ -1048,8 +1169,8 @@ mod tests {
         );
     }
 
-    /// A non-committed (quarantined) sibling part is NOT claimed — only durable
-    /// committed parts belong to the dataset.
+    /// A non-committed (quarantined) sibling part is NOT claimed — only durable committed
+    /// parts belong to the dataset.
     #[test]
     fn sibling_claimed_part_keys_skips_non_committed() {
         let mut m = build_manifest(vec![part(0, 10, 100, "fp")], ManifestStatus::Success);
@@ -1059,6 +1180,77 @@ mod tests {
         assert!(
             sibling_claimed_part_keys(&[m], "daily", "").is_empty(),
             "a quarantined part must not be claimed as a tracked dataset part"
+        );
+    }
+
+    /// End-to-end: a `--pool --split` prefix where a NON-last unit's part is missing must
+    /// FAIL validation. Before the merge-back fix, verify reconciled only the canonical
+    /// (last writer's) parts, so a lost part of any other unit was invisible — no PartMissing
+    /// (not in the canonical list) and no UntrackedObject (not on disk) — and the trust
+    /// oracle silently PASSED an incomplete split (adjacent-bughunt finding, HIGH).
+    #[test]
+    fn verify_over_a_split_prefix_catches_a_missing_non_last_unit_part() {
+        use crate::manifest::run_unique_manifest_name;
+        let dir = tempfile::tempdir().unwrap();
+
+        // Two split units of family "orders": #0 (run r0) and #1 (run r1 = LAST → canonical).
+        let mut u0 = build_manifest(
+            vec![part(0, 10, 4, "xxh3:0000000000000000")],
+            ManifestStatus::Success,
+        );
+        u0.export_family = "orders".into();
+        u0.export_name = "orders#0".into();
+        u0.run_id = "r0".into();
+        u0.parts[0].path = "orders#0-part.parquet".into();
+        u0.split_window = Some(crate::manifest::SplitWindow {
+            key_column: "id".into(),
+            lo: None,
+            hi: Some("1000".into()),
+        });
+
+        let mut u1 = build_manifest(
+            vec![part(1, 20, 5, "xxh3:1111111111111111")],
+            ManifestStatus::Success,
+        );
+        u1.export_family = "orders".into();
+        u1.export_name = "orders#1".into();
+        u1.run_id = "r1".into();
+        u1.parts[0].path = "orders#1-part.parquet".into();
+        u1.split_window = Some(crate::manifest::SplitWindow {
+            key_column: "id".into(),
+            lo: Some("1000".into()),
+            hi: None,
+        });
+
+        // Both units' run-unique copies on disk; canonical manifest.json = u1 (last writer).
+        std::fs::write(
+            dir.path().join(run_unique_manifest_name("r0")),
+            serde_json::to_vec(&u0).unwrap(),
+        )
+        .unwrap();
+        let u1_body = serde_json::to_vec(&u1).unwrap();
+        std::fs::write(dir.path().join(run_unique_manifest_name("r1")), &u1_body).unwrap();
+        std::fs::write(dir.path().join(MANIFEST_FILENAME), &u1_body).unwrap();
+        std::fs::write(
+            dir.path().join(SUCCESS_FILENAME),
+            success_marker_body(&u1_body),
+        )
+        .unwrap();
+        // u1's part present (5 bytes = its declared size); u0's part DELIBERATELY MISSING.
+        std::fs::write(dir.path().join("orders#1-part.parquet"), b"BBBBB").unwrap();
+
+        let dest = local_dest(dir.path());
+        let v = verify_at_destination(&dest, "", ValidateDepth::Full).unwrap();
+        assert!(
+            !v.passed,
+            "a missing part of a NON-last split unit must fail validation, not pass silently"
+        );
+        assert!(
+            v.failures
+                .iter()
+                .any(|f| matches!(f, Failure::PartMissing { .. })),
+            "expected a PartMissing for the dropped orders#0 part; got {:?}",
+            v.failures
         );
     }
 


### PR DESCRIPTION
## What

Multi-agent adjacent bughunt over the split+pool merge-back surfaces (the reconstruct/finding-2 path was already reviewed; this hunted validate, load, gc, scheduler, keyset). Three CONFIRMED HIGH silent-data bugs, each fixed + RED-proven.

### 1. `rivet validate` certified only the last unit (silent loss)
`verify_at_destination` reconciled only the canonical `manifest.json` (last-writer-wins → last unit's parts). A missing/corrupt part of any OTHER split unit was invisible (no PartMissing, no UntrackedObject) → the trust oracle passed an incomplete split, exit 0. **Fix:** reconcile against the union of the canonical + every same-family SPLIT-UNIT sibling (folded only when it carries a `split_window`, so a plain export's superseded historical copies are not false-checked). RED: `verify_over_a_split_prefix_catches_a_missing_non_last_unit_part`.

### 2. `rivet load` Full mode loaded only one unit (silent loss)
`latest_full` picked the single manifest with max `finished_at`; a split's N units have N run_ids → N-1 dropped on a Full (replace) load. **Fix:** group staged manifests by `export_name`, take the latest per group (non-split keeps one group → unchanged). RED: `latest_full_over_a_split_family_{selects_every_unit_not_just_the_last,takes_the_newest_run_per_unit}`.

### 3. `keyset_incremental` leaked into split units (silent drop/dup)
`splittable_key` guarded `cursor_column` but not `keyset_incremental` (append-only). A split re-derives the partition each run, so per-unit high-water marks and fresh windows disagree → rows dropped/duplicated across re-runs. **Fix:** one-line guard refusing to split a `keyset_incremental` export. RED: `incremental_and_cdc_exports_are_not_splittable`.

All fixes RED-proven (each test fails against the pre-fix code); lib + offline suites green; clippy clean. Committed through the pre-commit hook.

Remaining sub-gap noted in-commit (integrity, not loss): validate's value-checksum Form B still re-reads only the canonical manifest — a content-preserving corruption of a non-last unit's part is size/presence-checked but not Form-B-checked. Tracked for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)