### PR TITLE
fix(init/pool): post-0.24.3 arch-MED — PG density COUNT-fallback + honest heavy-giant message

### DIFF
--- a/src/init/postgres.rs
+++ b/src/init/postgres.rs
@@ -203,19 +203,46 @@ pub(super) fn density_probe(client: &mut Client, info: &mut super::TableInfo) {
     if (1..PG_PROBE_LINE).contains(&catalog) {
         return;
     }
+    let q_ident = |s: &str| format!("\"{}\"", s.replace('"', "\"\""));
+    let rel = format!("{}.{}", q_ident(&info.schema), q_ident(&info.table));
     let Some(key) = info.best_indexed_chunk_column().map(str::to_string) else {
-        info.density = Some(DensityProbe {
-            rows: catalog,
-            density: 0.0,
-            method: EstimateMethod::Unverified,
-            catalog_rows: catalog,
-            k: 0,
-            w: 0,
+        // No integer-indexed chunk key to probe density with — a uuid/text PK is keysettable but
+        // not density-probeable here. If the catalog figure is the clamped/unknown 0 (the
+        // just-restored/just-migrated moment we probe FOR), trusting it scaffolds `mode: full` on
+        // a possibly-huge table. Match MySQL's leg: an honest COUNT(*) when the catalog is
+        // small/unknown (< 1M) — correct-but-slow beats fast-but-wrong; a genuinely large catalog
+        // (>= 5M, the only other way to reach here) is trusted as-is (no scan of a huge table).
+        let counted = (catalog < 1_000_000)
+            .then(|| {
+                client
+                    .query_one(&format!("SELECT COUNT(*)::bigint FROM {rel}"), &[])
+                    .ok()
+                    .and_then(|r| r.try_get::<_, i64>(0).ok())
+            })
+            .flatten();
+        info.density = Some(match counted {
+            Some(n) => {
+                info.row_estimate = n;
+                DensityProbe {
+                    rows: n,
+                    density: 0.0,
+                    method: EstimateMethod::Counted,
+                    catalog_rows: catalog,
+                    k: 0,
+                    w: 0,
+                }
+            }
+            None => DensityProbe {
+                rows: catalog,
+                density: 0.0,
+                method: EstimateMethod::Unverified,
+                catalog_rows: catalog,
+                k: 0,
+                w: 0,
+            },
         });
         return;
     };
-    let q_ident = |s: &str| format!("\"{}\"", s.replace('"', "\"\""));
-    let rel = format!("{}.{}", q_ident(&info.schema), q_ident(&info.table));
     let kq = q_ident(&key);
     let Ok(row) = client.query_one(
         &format!("SELECT MIN({kq})::bigint, MAX({kq})::bigint FROM {rel}"),

--- a/src/pipeline/run.rs
+++ b/src/pipeline/run.rs
@@ -895,9 +895,33 @@ pub(crate) fn run_pool(
                     ),
                 }
             }
-            None => log::info!(
-                "apply --pool --split: no export dominates the pool floor — nothing to split."
-            ),
+            None => {
+                // advise_split returns None for a heavy dominator too, not only a balanced set.
+                // The most actionable case is a giant that DOMINATES the floor but is HEAVY (not
+                // parallel_safe): its range sub-units inherit the heavy flag and still serialize
+                // under the C3 floor, so a split cannot lower the wall — the fix is to mark it
+                // parallel_safe (independent rows), not to add a chunk key. Say so at WARN
+                // (visible), instead of the misattributed "nothing dominates" at INFO. A
+                // genuinely balanced set stays informational.
+                let total: f64 = items.iter().map(|i| i.predicted_secs).sum();
+                match items
+                    .iter()
+                    .max_by(|a, b| a.predicted_secs.total_cmp(&b.predicted_secs))
+                    .filter(|l| l.predicted_secs > total / (m.max(1) as f64) && !l.parallel_safe)
+                {
+                    Some(l) => log::warn!(
+                        "apply --pool --split: '{}' dominates the pool floor but is HEAVY (not \
+                         parallel_safe) — its split units would inherit the heavy flag and still \
+                         serialize (the C3 floor), so splitting cannot lower the wall. Mark it \
+                         `parallel_safe: true` if its rows are independent; running it whole.",
+                        l.name
+                    ),
+                    None => log::info!(
+                        "apply --pool --split: no export dominates the pool floor — nothing to \
+                         split."
+                    ),
+                }
+            }
         }
     } else if let Some((giant, n, broken)) = &advise {
         let giant_secs = items

--- a/tests/live/live_density_probe.rs
+++ b/tests/live/live_density_probe.rs
@@ -149,6 +149,66 @@ fn pg_density_probe_corrects_a_never_analyzed_table() {
     let _ = c.execute(&format!("DROP TABLE IF EXISTS {table}"), &[]);
 }
 
+/// PG density probe on a never-analyzed table with a NON-INTEGER (uuid) PK: the
+/// integer-only density path is skipped (best_indexed_chunk_column requires an
+/// integer key), so before the COUNT(*) fallback the probe trusted `reltuples`
+/// clamped to 0 and init scaffolded `mode: full` on a possibly-huge just-restored
+/// table (the exact restore/migrate moment init is run). Now, matching MySQL's
+/// leg, a small/unknown catalog triggers an honest COUNT(*) so the real size wins.
+#[test]
+#[ignore = "live: requires docker compose up -d postgres"]
+fn pg_density_probe_counts_a_never_analyzed_non_integer_pk_table() {
+    require_alive(LiveService::Postgres);
+    let table = unique_name("pg_probe_uuid");
+    let mut c = pg_connect();
+    c.batch_execute(&format!(
+        "DROP TABLE IF EXISTS {table};
+         CREATE TABLE {table} (id UUID PRIMARY KEY, payload INT NOT NULL);
+         INSERT INTO {table} SELECT gen_random_uuid(), g FROM generate_series(1, 150000) g;"
+    ))
+    .unwrap();
+    let reltuples: f32 = c
+        .query_one(
+            "SELECT reltuples FROM pg_class WHERE relname = $1",
+            &[&table],
+        )
+        .unwrap()
+        .get(0);
+    assert!(
+        reltuples <= 0.0,
+        "fixture must be un-analyzed (reltuples {reltuples} should be -1/0)"
+    );
+
+    let dir = tempfile::tempdir().unwrap();
+    let out_yaml = dir.path().join("probe.yaml");
+    let out = run_rivet_env(
+        &[
+            "init",
+            "--source",
+            POSTGRES_URL,
+            "--table",
+            &format!("public.{table}"),
+            "-o",
+            out_yaml.to_str().unwrap(),
+        ],
+        &[],
+    );
+    assert!(
+        out.status.success(),
+        "init: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let yaml = std::fs::read_to_string(&out_yaml).unwrap();
+    // The COUNT(*) fallback corrects row_estimate 0 → 150000, so init must NOT scaffold the
+    // small-table `mode: full`. Before the fallback it trusted 0 and wrote `mode: full`.
+    assert!(
+        !yaml.contains("mode: full"),
+        "a never-analyzed 150k uuid-PK table must not scaffold `mode: full` (COUNT(*) fallback \
+         should overrule reltuples=0):\n{yaml}"
+    );
+    let _ = c.execute(&format!("DROP TABLE IF EXISTS {table}"), &[]);
+}
+
 /// #148 (roast 2026-08-10, gate exit 101): the MySQL density probe read
 /// MIN/MAX as (Option<i64>, Option<i64>); a BIGINT UNSIGNED key past i64::MAX
 /// made the mysql crate's FromRow PANIC (not a catchable Err), crashing


### PR DESCRIPTION
## What

Two of the three architecture-MEDIUM findings from the post-0.24.3 review. The third (governor runner-side wiring copy-pasted chunked↔keyset, drifted twice) is a ~80-line cross-runner refactor and is recommended as its own focused pass — not batched here.

### PG density probe — COUNT(*) fallback on a non-integer-PK never-analyzed table (diagnostic-bypass)
`density_probe` resolves its subject via `best_indexed_chunk_column` (integer-only), so a keysettable-but-non-integer PK (uuid/text) took the else arm and — when the catalog was `reltuples` clamped to 0 (the just-restored/migrated moment init is run) — kept `row_estimate = 0` / Unverified and `init` scaffolded `mode: full` on a possibly-huge table. MySQL's leg already ran an honest `COUNT(*)` here; PG degraded fast-but-wrong. Now PG matches: a small/unknown catalog (< 1M) triggers `COUNT(*)`; a genuinely large catalog (≥ 5M) is trusted as-is. **RED-proven (live):** `pg_density_probe_counts_a_never_analyzed_non_integer_pk_table`.

### Pool — honest, visible message when a HEAVY giant dominates but can't be split
`advise_split` correctly refuses a dominating-but-heavy giant (its units still serialize under C3), but the `--split` None arm logged "no export dominates — nothing to split" at INFO — misattributed and invisible. Now warns (visible) with the real reason + the actionable fix (`parallel_safe: true`). Message-only.

lib + offline green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)