### PR TITLE
docs(matrix): classify the session's split bugs into pool-split-matrix as a regression ledger

### DIFF
--- a/docs/pool-split-matrix.yaml
+++ b/docs/pool-split-matrix.yaml
@@ -56,3 +56,58 @@ scenarios:
     mysql:    { test: stand_pool_split_keyset_recovers_a_crash_mysql }
     mssql:    { test: stand_pool_split_keyset_recovers_a_crash_mssql }
     mongo:    { na: "no inline SQL range literal (inline_literal is unreachable for Mongo) — source_type_supports_split leaves a Mongo giant WHOLE; it fans out via its own keyset/parallel path, never a range split" }
+
+  # ── Engine-AGNOSTIC split merge-back / reconstruct guarantees (post-0.24.3 review) ──
+  # These operate on the run-unique manifest copies, not per-engine SQL, so every engine cell is
+  # `na` (proven ONCE by the RED-proven test named in `what` — the na-shared-seam convention, like
+  # runner-coverage-matrix). Added so pool-split-matrix is the full regression ledger for the split
+  # bugs this session found: each class here had a silent data bug (loss/dup) and now a guard test.
+
+  - id: reconstruct_survives_adjacent_crashes
+    what: "TWO adjacent units hard-crash (no manifest): reconstruct must rebuild the FULL partition, never truncate. RED: reconstruct_covers_a_leading_adjacent_crash_instead_of_re_sampling (leading gap → NOT None→re-sample→silent LOSS) + reconstruct_fills_an_interior_adjacent_crash_without_overlapping_a_survivor (interior gap → NOT a coarse open-ended unit that re-covers a survivor → silent DUP)."
+    postgres: { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+    mysql:    { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+    mssql:    { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+    mongo:    { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+
+  - id: fill_synthesized_unit_runs_fresh_not_stale_checkpoint
+    what: "A unit whose window was SYNTHESIZED by the adjacent-crash fill must run FRESH, never resume its stale per-unit checkpoint against the changed window (keyset would silently dup/lose; chunked would loudly bail). RED: reconstruct_fills_an_interior_adjacent_crash_* asserts chunk_checkpoint=[true,false,false,true] + reconstruct_keeps_checkpoint_for_an_exactly_recovered_single_crash (single-crash exact recovery still resumes)."
+    postgres: { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+    mysql:    { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+    mssql:    { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+    mongo:    { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+
+  - id: validate_presence_covers_every_split_unit
+    what: "rivet validate must presence/size-check EVERY split unit's parts, not just the canonical (last-writer) manifest — else a missing part of a non-last unit is invisible (silent loss, trust-oracle passes). RED: verify_over_a_split_prefix_catches_a_missing_non_last_unit_part (merge_split_unit_parts folds same-family split-window siblings)."
+    postgres: { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+    mysql:    { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+    mssql:    { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+    mongo:    { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+
+  - id: validate_value_checksum_covers_every_split_unit
+    what: "Form-B value-checksum + per-part row-count re-read must cover EVERY split unit, not just the canonical — else a value corruption / row mis-count in a non-last unit silently PASSES. RED: split_unit_manifests_folds_every_same_family_split_sibling (value_checksum.rs folds split-window siblings, excludes foreign/plain)."
+    postgres: { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+    mysql:    { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+    mssql:    { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+    mongo:    { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+
+  - id: load_full_selects_every_split_unit
+    what: "rivet load in Full (replace) mode must select ALL units of the split snapshot, not the single latest manifest — else N-1 units are silently dropped. RED: latest_full_over_a_split_family_selects_every_unit_not_just_the_last + latest_full_over_a_split_family_takes_the_newest_run_per_unit (group by export_name, latest per group)."
+    postgres: { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+    mysql:    { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+    mssql:    { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+    mongo:    { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+
+  - id: load_full_refuses_a_mixed_generation_prefix
+    what: "A Full load whose selection mixes TWO split generations (a reused prefix, a changed unit count, an unsplit↔split toggle) would DUPLICATE rows and the count gate can't catch it; with no generation id, select_runs REFUSES loudly rather than silently dup. RED: select_runs_full_refuses_a_mixed_generation_split_prefix (+ _accepts_one_coherent_split_generation)."
+    postgres: { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+    mysql:    { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+    mssql:    { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+    mongo:    { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+
+  - id: split_refuses_an_unsplittable_export_loudly
+    what: "Split must REFUSE what it cannot do correctly — incremental (cursor_column), keyset_incremental (append-only), CDC (a stream), Mongo (no inline range literal) — on the FRESH path AND on resume (reconstruct must not resurrect a now-unsplittable split). RED: incremental_and_cdc_exports_are_not_splittable + reconstruct_refuses_to_resurrect_a_now_unsplittable_export_on_resume + mongo_source_is_not_range_split_capable."
+    postgres: { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+    mysql:    { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+    mssql:    { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }
+    mongo:    { na: "engine-agnostic — the split fold/selection/reconstruct operates on the run-unique manifests, not per-engine SQL; proven once by the test in `what`" }

--- a/tests/offline/chunking_matrix_guard.rs
+++ b/tests/offline/chunking_matrix_guard.rs
@@ -364,6 +364,46 @@ fn matrix_every_mapped_test_exists() {
     }
 }
 
+/// The engine-agnostic `na`-shared-seam scenarios in pool-split-matrix.yaml name their RED-proven
+/// regression test in `what` (not a `test:` cell, so [`matrix_every_mapped_test_exists`] does not
+/// reach them). Those tests ARE the regression barrier — the matrix only maps each split bug this
+/// session found to the guard that keeps it fixed. Assert every named test still EXISTS, so a
+/// renamed/deleted guard fails loud here instead of silently unmapping a bug's coverage.
+#[test]
+fn pool_split_shared_seam_scenarios_name_existing_regression_tests() {
+    let fns = all_fn_names();
+    // The regression tests the pool-split-matrix na-shared-seam `what` fields cite, one per split
+    // bug found in the post-0.24.3 review + the #217/#218 bughunts. Keep in sync with the matrix.
+    const NAMED: &[&str] = &[
+        "reconstruct_covers_a_leading_adjacent_crash_instead_of_re_sampling",
+        "reconstruct_fills_an_interior_adjacent_crash_without_overlapping_a_survivor",
+        "reconstruct_keeps_checkpoint_for_an_exactly_recovered_single_crash",
+        "verify_over_a_split_prefix_catches_a_missing_non_last_unit_part",
+        "split_unit_manifests_folds_every_same_family_split_sibling",
+        "latest_full_over_a_split_family_selects_every_unit_not_just_the_last",
+        "latest_full_over_a_split_family_takes_the_newest_run_per_unit",
+        "select_runs_full_refuses_a_mixed_generation_split_prefix",
+        "incremental_and_cdc_exports_are_not_splittable",
+        "reconstruct_refuses_to_resurrect_a_now_unsplittable_export_on_resume",
+        "mongo_source_is_not_range_split_capable",
+    ];
+    // Cross-check the list against the matrix text so a `what` that stops naming a test (or names a
+    // new one) is caught — the list must not drift from the ledger it guards.
+    let matrix_text = std::fs::read_to_string("docs/pool-split-matrix.yaml").unwrap();
+    for name in NAMED {
+        assert!(
+            fns.contains(*name),
+            "pool-split-matrix names regression test `{name}` in a `what` field, but no `fn {name}` \
+             exists under src/ or tests/ — a renamed/deleted split-bug guard unmapped its coverage"
+        );
+        assert!(
+            matrix_text.contains(name),
+            "regression test `{name}` is in the guard list but no longer cited by any \
+             pool-split-matrix `what` — drop it here or re-cite it there"
+        );
+    }
+}
+
 #[test]
 fn matrix_gaps_do_not_exceed_ratchet() {
     for (path, ceiling) in MATRICES {


### PR DESCRIPTION
## What

Applies the CLAUDE.md "pattern → matrix" discipline to every bug the split+pool bughunts (#217/#218) and the post-0.24.3 review (#219/#220/#221) found. They cluster into one dominant class — **split merge-back / reconstruct** — so pool-split-matrix.yaml becomes their regression ledger.

### Classification
| Pattern class | Bugs | Where |
|---|---|---|
| **A** consumer reads only the canonical manifest | validate presence (F1), value-checksum Form-B, load Full one-unit | pool-split (new rows) |
| **B** reconstruct correctness | leading-gap loss, interior-gap dup, keyset stale-checkpoint | pool-split (new rows) |
| **C** split refuse-loudly | keyset_incremental leak, mixed-generation load, resume-resurrect | pool-split (new rows) |
| **D** diagnostic-bypass / per-engine parity | PG density no COUNT-fallback, Mongo db_max_connections | *no matrix yet* — follow-up |

### Change
Seven engine-AGNOSTIC scenarios added to pool-split-matrix as `na`-shared-seam cells (they operate on the run-unique manifests, not per-engine SQL), each naming its RED-proven guard test in `what`. A new guard `pool_split_shared_seam_scenarios_name_existing_regression_tests` gives them teeth — it asserts every named test still exists (na cells escape `matrix_every_mapped_test_exists`) AND is still cited by the matrix; a renamed/deleted guard or a dropped citation fails loud (RED-proven with a typo). 30 matrix guards green.

### Follow-up (not here)
Class D (diagnostic-bypass) has no matrix; a preflight/init-parity matrix (engine × probe-property) would house it — the PG density fix has a test to cite, the Mongo db_max_connections fix needs one first.

Offline suite green. Docs + offline-guard only (no product/live behaviour), so the live release gate is not exercised for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)