### PR TITLE
refactor(governor): extract runner-side wiring into one GovernorHarness seam (arch-MED #3)

### DIFF
--- a/src/pipeline/chunked/exec.rs
+++ b/src/pipeline/chunked/exec.rs
@@ -15,7 +15,6 @@ use crate::journal::RunEvent;
 use crate::plan::ResolvedRunPlan;
 use crate::source::{self, Source};
 use crate::state::StateStore;
-use crate::tuning::Governor;
 use crate::{destination, format, resource};
 
 pub(crate) fn run_chunked_sequential(
@@ -265,47 +264,9 @@ pub(crate) fn run_chunked_parallel(
     let pb = ChunkProgress::new(&plan.export_name, total_chunks);
     let pb_handle = pb.handle();
 
-    // OPT-2 adaptive concurrency governor. Armed only when the user opted into
-    // adaptation (`tuning.adaptive`) and there is real parallelism to govern
-    // (`parallel > 1`). Floor defaults to 1; ceiling is the configured
-    // `parallel`. A failed monitoring connection degrades gracefully to static
-    // parallelism rather than failing the export.
-    // `parallel` can be 0 when there are no chunks; `.max(1)` keeps `clamp`'s
-    // bounds valid (the governor is off in that case anyway).
-    let governor_floor = plan
-        .tuning
-        .min_parallel
-        .unwrap_or(1)
-        .clamp(1, parallel.max(1));
-    let governor_on = plan.tuning.adaptive && parallel > 1;
-    let governor_monitor: Option<Box<dyn Source>> = if governor_on {
-        match source::create_source(&plan.source) {
-            Ok(s) => {
-                log::info!(
-                    "export '{}': adaptive concurrency governor active (parallel {}..{})",
-                    plan.export_name,
-                    governor_floor,
-                    parallel
-                );
-                Some(s)
-            }
-            Err(e) => {
-                log::warn!(
-                    "export '{}': governor monitoring connection failed; parallelism stays static at {}: {:#}",
-                    plan.export_name,
-                    parallel,
-                    e
-                );
-                None
-            }
-        }
-    } else {
-        None
-    };
-    // Governor decisions buffered here (the journal is not thread-shared) and
-    // drained into `summary.journal` after the scope joins.
-    let governor_log: std::sync::Mutex<Vec<(usize, usize, String)>> =
-        std::sync::Mutex::new(Vec::new());
+    // OPT-2 adaptive concurrency governor — armed, spawned, and drained through the shared
+    // GovernorHarness (identical wiring in the keyset runner; #152).
+    let governor = crate::pipeline::governor::GovernorHarness::arm(plan, parallel);
 
     // One destination (GCS/S3) instance for the whole export: `create_destination` wires a
     // dedicated Tokio runtime; creating one per chunk caused runtime shutdown races under load
@@ -319,54 +280,10 @@ pub(crate) fn run_chunked_parallel(
     );
 
     std::thread::scope(|s| {
-        // Governor thread: samples source pressure on its own monitoring
-        // connection and resizes the semaphore within [floor, parallel]. It
-        // self-terminates once every chunk worker has finished (success OR
-        // failure) — keyed on `finished`, not `completed`, so a failing chunk
-        // can't strand it and deadlock the scope. Holds parallelism flat
-        // whenever the engine can't sample (`sample_pressure` → None).
-        if let Some(mut monitor) = governor_monitor {
-            let semaphore = &semaphore;
-            let finished = &finished;
-            let governor_log = &governor_log;
-            let total = total_chunks;
-            let ceiling = parallel;
-            let floor = governor_floor;
-            let export_name = plan.export_name.as_str();
-            s.spawn(move || {
-                // The decision loop lives in [`tuning::Governor`]; the
-                // callback below is the only runner-specific binding
-                // (resize the kernel-park semaphore, log the transition,
-                // append it to the off-thread decision log so the parent
-                // can drain it into the run journal post-scope).
-                //
-                // `RIVET_GOVERNOR_INTERVAL_MS` is read inside
-                // [`Governor::new`]; the poll interval is clamped to the
-                // sample interval so a tiny override (deterministic live
-                // tests) actually polls that fast.
-                let mut gov = Governor::new(ceiling, floor, ceiling);
-                gov.run(
-                    &mut monitor,
-                    || finished.load(Ordering::Relaxed) >= total,
-                    |from, to| {
-                        semaphore.resize(to);
-                        let reason = if to < from {
-                            "source pressure rising: backed off"
-                        } else {
-                            "source pressure eased: recovered"
-                        };
-                        log::info!(
-                            "export '{}': governor parallelism {} → {} ({})",
-                            export_name,
-                            from,
-                            to,
-                            reason
-                        );
-                        poison::lock_recover(governor_log).push((from, to, reason.to_string()));
-                    },
-                );
-            });
-        }
+        // Governor thread (shared seam): samples source pressure on its own monitoring connection
+        // and resizes the semaphore within [floor, ceiling], self-terminating once every chunk
+        // worker has FINISHED (success OR failure) so a failing chunk can't strand it.
+        governor.spawn_into(s, &semaphore, &finished, total_chunks, &plan.export_name);
 
         for (i, (start, end)) in chunks.iter().enumerate() {
             // Block (kernel-park) until a worker slot frees up.
@@ -509,12 +426,9 @@ pub(crate) fn run_chunked_parallel(
     super::super::commit::accumulate_run_rows(summary, agg_rows.load(Ordering::Relaxed));
     pb.finish(summary.total_rows);
 
-    // Drain governor decisions (recorded off-thread) into the run journal.
-    for (from, to, reason) in poison::into_recover(governor_log) {
-        summary
-            .journal
-            .record(RunEvent::ParallelismAdjusted { from, to, reason });
-    }
+    // Drain governor decisions (recorded off-thread) into the run journal — BEFORE any error
+    // check, so a failed run still journals its ParallelismAdjusted events.
+    governor.drain_into(summary);
     if plan.validate {
         summary.validated = Some(true);
     }

--- a/src/pipeline/governor.rs
+++ b/src/pipeline/governor.rs
@@ -1,0 +1,135 @@
+//! Shared runner-side wiring for the OPT-2 adaptive concurrency governor (#152).
+//!
+//! The DECISION loop lives in [`crate::tuning::Governor`]; this is the per-runner scaffolding both
+//! the chunked and keyset parallel runners need — arm a monitoring connection, spawn the governor
+//! thread that resizes the permit semaphore, and drain its decisions into the run journal. It was
+//! copy-pasted between the two runners and drifted twice: (1) the log mutex was poison-recovered in
+//! chunked but plain-`unwrap()`ed in keyset (a panicked worker would then also take down the drain),
+//! and (2) keyset once drained AFTER its error check, losing every `ParallelismAdjusted` event on a
+//! failed run (roast 2026-08-10). One seam, one behaviour.
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::journal::RunEvent;
+use crate::plan::ResolvedRunPlan;
+use crate::resource::Semaphore;
+use crate::source::{self, Source};
+use crate::tuning::Governor;
+
+use super::summary::RunSummary;
+
+/// Recover a poisoned lock instead of panicking: a worker that panicked mid-run must not also take
+/// down the governor's decision log — those decisions are still valid to journal.
+fn recover<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// The armed governor for one parallel runner invocation. Owns the monitoring connection and the
+/// off-thread decision log; [`spawn_into`](Self::spawn_into) runs the governor thread and
+/// [`drain_into`](Self::drain_into) records its decisions. Unarmed (adaptation off / no real
+/// parallelism / monitor connect failed) → spawn is a no-op and drain records nothing.
+pub(crate) struct GovernorHarness {
+    floor: usize,
+    ceiling: usize,
+    monitor: Mutex<Option<Box<dyn Source>>>,
+    log: Mutex<Vec<(usize, usize, String)>>,
+}
+
+impl GovernorHarness {
+    /// Arm the governor for `plan` at `parallel` slots: compute `[floor, ceiling]` and, when the
+    /// user opted into adaptation (`tuning.adaptive`) with real parallelism (`parallel > 1`), open a
+    /// DEDICATED monitoring source connection. A failed monitor connection degrades gracefully to
+    /// static parallelism (logged), never fails the export. `parallel` may be 0 (no work); `.max(1)`
+    /// keeps `clamp`'s bounds valid (the governor is off then anyway).
+    pub(crate) fn arm(plan: &ResolvedRunPlan, parallel: usize) -> Self {
+        let floor = plan
+            .tuning
+            .min_parallel
+            .unwrap_or(1)
+            .clamp(1, parallel.max(1));
+        let on = plan.tuning.adaptive && parallel > 1;
+        let monitor: Option<Box<dyn Source>> = if on {
+            match source::create_source(&plan.source) {
+                Ok(s) => {
+                    log::info!(
+                        "export '{}': adaptive concurrency governor active (parallel {floor}..{parallel})",
+                        plan.export_name
+                    );
+                    Some(s)
+                }
+                Err(e) => {
+                    log::warn!(
+                        "export '{}': governor monitoring connection failed; parallelism stays \
+                         static at {parallel}: {e:#}",
+                        plan.export_name
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        Self {
+            floor,
+            ceiling: parallel,
+            monitor: Mutex::new(monitor),
+            log: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Spawn the governor thread into `scope` (no-op when unarmed). It samples source pressure on
+    /// its own monitoring connection and resizes `semaphore` within `[floor, ceiling]`,
+    /// self-terminating once `finished` reaches `total` — keyed on FINISHED (success OR failure),
+    /// not completed, so a failing worker can't strand it and deadlock the scope. Decisions are
+    /// buffered in `self.log` (the journal is not thread-shared) and recorded by
+    /// [`drain_into`](Self::drain_into) after the scope joins.
+    pub(crate) fn spawn_into<'s>(
+        &'s self,
+        scope: &'s std::thread::Scope<'s, '_>,
+        semaphore: &'s Semaphore,
+        finished: &'s AtomicUsize,
+        total: usize,
+        export_name: &'s str,
+    ) {
+        let Some(mut monitor) = recover(&self.monitor).take() else {
+            return;
+        };
+        let (floor, ceiling) = (self.floor, self.ceiling);
+        let log = &self.log;
+        scope.spawn(move || {
+            // The decision loop is [`tuning::Governor`]; this callback is the only runner-specific
+            // binding — resize the kernel-park semaphore, log the transition, and append it to the
+            // off-thread log for the post-scope drain. `RIVET_GOVERNOR_INTERVAL_MS` is read inside
+            // `Governor::new`.
+            let mut gov = Governor::new(ceiling, floor, ceiling);
+            gov.run(
+                &mut monitor,
+                || finished.load(Ordering::Relaxed) >= total,
+                |from, to| {
+                    semaphore.resize(to);
+                    let reason = if to < from {
+                        "source pressure rising: backed off"
+                    } else {
+                        "source pressure eased: recovered"
+                    };
+                    log::info!(
+                        "export '{export_name}': governor parallelism {from} → {to} ({reason})"
+                    );
+                    recover(log).push((from, to, reason.to_string()));
+                },
+            );
+        });
+    }
+
+    /// Record the buffered governor decisions into the run journal. MUST be called BEFORE the
+    /// runner's error/bail check so a FAILED run still journals its `ParallelismAdjusted` events
+    /// (the drift the keyset copy re-introduced). Consumes the harness; poison-recovers the log.
+    pub(crate) fn drain_into(self, summary: &mut RunSummary) {
+        for (from, to, reason) in recover(&self.log).drain(..) {
+            summary
+                .journal
+                .record(RunEvent::ParallelismAdjusted { from, to, reason });
+        }
+    }
+}

--- a/src/pipeline/keyset.rs
+++ b/src/pipeline/keyset.rs
@@ -483,77 +483,20 @@ fn run_keyset_parallel(
     // predicate can't be stranded by a failing worker.
     let semaphore = crate::resource::Semaphore::new(parallel.max(1));
     let finished = std::sync::atomic::AtomicUsize::new(0);
-    let governor_floor = plan
-        .tuning
-        .min_parallel
-        .unwrap_or(1)
-        .clamp(1, parallel.max(1));
-    let governor_on = plan.tuning.adaptive && parallel > 1;
-    let governor_monitor: Option<Box<dyn Source>> = if governor_on {
-        match source::create_source(&plan.source) {
-            Ok(s) => {
-                log::info!(
-                    "export '{}': adaptive concurrency governor active on keyset (parallel {}..{})",
-                    plan.export_name,
-                    governor_floor,
-                    parallel
-                );
-                Some(s)
-            }
-            Err(e) => {
-                log::warn!(
-                    "export '{}': keyset governor monitoring connection failed; parallelism stays static at {}: {:#}",
-                    plan.export_name,
-                    parallel,
-                    e
-                );
-                None
-            }
-        }
-    } else {
-        None
-    };
-    let governor_log: Mutex<Vec<(usize, usize, String)>> = Mutex::new(Vec::new());
+    // OPT-2 adaptive concurrency governor — the SHARED seam (identical wiring in the chunked
+    // runner; #152). arm → spawn_into (in the scope) → drain_into (post-scope, before any bail).
+    let governor = crate::pipeline::governor::GovernorHarness::arm(plan, parallel);
 
     std::thread::scope(|scope| {
-        // Governor thread — mirrors chunked/exec.rs: samples source pressure on
-        // its own monitoring connection and resizes the permit semaphore within
-        // [floor, parallel], self-terminating once every worker has finished.
-        if let Some(mut monitor) = governor_monitor {
-            let semaphore = &semaphore;
-            let finished = &finished;
-            let governor_log = &governor_log;
-            let total = pending.len();
-            let ceiling = parallel;
-            let floor = governor_floor;
-            let export_name = plan.export_name.as_str();
-            scope.spawn(move || {
-                let mut gov = crate::tuning::Governor::new(ceiling, floor, ceiling);
-                gov.run(
-                    &mut monitor,
-                    || finished.load(Ordering::Relaxed) >= total,
-                    |from, to| {
-                        semaphore.resize(to);
-                        let reason = if to < from {
-                            "source pressure rising: backed off"
-                        } else {
-                            "source pressure eased: recovered"
-                        };
-                        log::info!(
-                            "export '{}': keyset governor parallelism {} → {} ({})",
-                            export_name,
-                            from,
-                            to,
-                            reason
-                        );
-                        governor_log
-                            .lock()
-                            .unwrap()
-                            .push((from, to, reason.to_string()));
-                    },
-                );
-            });
-        }
+        // Governor thread (shared seam): resizes the permit semaphore within [floor, ceiling],
+        // self-terminating once every worker has FINISHED (success OR failure).
+        governor.spawn_into(
+            scope,
+            &semaphore,
+            &finished,
+            pending.len(),
+            &plan.export_name,
+        );
 
         for (ridx, lo, hi) in pending.iter().cloned() {
             let dest = std::sync::Arc::clone(&dest);
@@ -817,16 +760,11 @@ fn run_keyset_parallel(
     }
     summary.total_rows += rows.into_inner();
 
-    // #152 (roast 2026-08-10): drain the governor's decisions into the journal
-    // BEFORE the error bail — the failure path is EXACTLY where the back-off
-    // forensics matter (was the source under pressure when it failed?). Draining
-    // after the bail lost every ParallelismAdjusted event on a failed run, unlike
-    // chunked/exec.rs which drains before its error check.
-    for (from, to, reason) in governor_log.into_inner().unwrap() {
-        summary
-            .journal
-            .record(crate::journal::RunEvent::ParallelismAdjusted { from, to, reason });
-    }
+    // #152: drain the governor's decisions into the journal BEFORE the error bail — the failure
+    // path is EXACTLY where the back-off forensics matter (was the source under pressure when it
+    // failed?). The shared drain_into (which poison-recovers, unlike the old into_inner().unwrap()
+    // here) makes this identical to the chunked runner — the drift the copy re-introduced twice.
+    governor.drain_into(summary);
 
     if !errs.is_empty() {
         anyhow::bail!(

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -17,6 +17,7 @@ mod cli;
 pub(crate) mod commit;
 mod finalize;
 pub(crate) mod frame;
+mod governor;
 pub(crate) mod ipc;
 mod job;
 mod keyset;

--- a/tests/live/live_governor.rs
+++ b/tests/live/live_governor.rs
@@ -450,7 +450,10 @@ exports:
         "governed keyset run must complete; stderr:\n{stderr}"
     );
     assert!(
-        stderr.contains("adaptive concurrency governor active on keyset"),
+        // The chunked and keyset runners now share one GovernorHarness seam, so both log the
+        // SAME arm message (the old "on keyset" suffix is gone); this being a keyset run, its
+        // presence proves the governor armed on the keyset path.
+        stderr.contains("adaptive concurrency governor active"),
         "the KEYSET governor must arm for adaptive + parallel>1; stderr:\n{stderr}"
     );
     assert!(


### PR DESCRIPTION
## What

The third architecture-MEDIUM finding from the post-0.24.3 review. The OPT-2 concurrency governor's runner-side scaffolding (#152) was copy-pasted ~80 lines between `chunked/exec.rs` and `keyset.rs` — only the decision loop (`tuning::Governor`) was shared. It had **drifted twice**:
- the decision-log mutex was poison-recovered in chunked but plain-`unwrap()`ed in keyset;
- keyset once drained AFTER its error bail, losing every `ParallelismAdjusted` event on a failed run (the forensics the failure path most needs).

## Fix

One `GovernorHarness` (`src/pipeline/governor.rs`): `arm(plan, parallel)` → `spawn_into(scope, &semaphore, &finished, total, export_name)` → `drain_into(summary)`. Both runners call it; both now poison-recover the log and drain BEFORE their bail **by construction** — the drift can't recur. Behaviour-preserving; the unified arm message drops the keyset-only "on keyset" suffix (the keyset governor live test now asserts the shared text).

## Validation

All four governor live tests green through the shared seam (`governor_activates_and_run_completes`, `governor_backs_off_under_concurrent_write_pressure`, `governor_does_not_deadlock_when_chunks_fail`, `keyset_governor_backs_off_under_concurrent_write_pressure` — verified locally: the log shows 8→7→…→2→3 back-off/recover through the harness). lib (2402) + offline green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)