### PR TITLE
fix(nightly): unbreak the nightly (two typos) + close the corrupt-manifest gap

### DIFF
--- a/.github/workflows/nightly-live.yml
+++ b/.github/workflows/nightly-live.yml
@@ -232,7 +232,14 @@ jobs:
         # audit found all four cells never ran in any CI job).
         run: |
           mkdir -p tests/.live-tmp
-          docker compose up -d --wait mongo mongo-rs mongo-auth toxiproxy minio fake-gcs
+          # `duckdb` is the CDC readback ORACLE (rivet-duckdb; tests/common/env.rs
+          # DUCKDB_CONTAINER), not a source — an independent reader, so the CDC
+          # tests do not grade rivet's output with rivet. It has no compose
+          # profile, so a bare `up -d` would start it and an EXPLICIT service list
+          # silently does not: every live_cdc_mongo test died on
+          # `docker inspect failed: No such object: rivet-duckdb`, red on all five
+          # matrix cells for at least ten consecutive nights (2026-08-16).
+          docker compose up -d --wait mongo mongo-rs mongo-auth toxiproxy minio fake-gcs duckdb
           sudo chmod -R 0777 tests/.live-tmp
 
       - name: Run Mongo live tests
@@ -441,8 +448,15 @@ jobs:
           PREV=$(gh release list --limit 20 --json tagName,isPrerelease \
                    --jq '[.[] | select(.isPrerelease == false) | .tagName][0]')
           echo "baseline release: $PREV"
+          # The asset is `rivet-<tag>-<triple>.tar.gz` — the VERSION sits between
+          # the name and the triple, so the old `rivet-x86_64-...` glob matched
+          # NOTHING and `gh release download` failed under `set -e` before a
+          # single test ran. This job was red 10 of 10 nights, i.e. the
+          # cross-version artifact contract was never once checked. The Makefile's
+          # release-oracle-prev-bin target spells the same pattern correctly
+          # (`rivet-$$tag-$$triple.tar.gz`); this copy had drifted.
           gh release download "$PREV" \
-            --pattern 'rivet-x86_64-unknown-linux-gnu*' --dir baseline --clobber
+            --pattern "rivet-$PREV-x86_64-unknown-linux-gnu.tar.gz" --dir baseline --clobber
           cd baseline
           for f in *; do case "$f" in *.tar.gz) tar xzf "$f";; esac; done
           BIN=$(find . -type f -name rivet | head -1)

--- a/src/pipeline/validate_manifest.rs
+++ b/src/pipeline/validate_manifest.rs
@@ -1473,6 +1473,78 @@ mod tests {
         );
     }
 
+    /// A `manifest.json` that is not valid JSON at all.
+    ///
+    /// The branch above this one — `self_inconsistent_manifest_is_flagged_but_
+    /// part_check_still_runs` — writes a manifest that PARSES cleanly and then
+    /// lies (`row_count = 9999`); that is the self-consistency check far below.
+    /// The branch here is the one where `serde_json::from_slice` itself FAILS,
+    /// and until now nothing reached it: the 2026-08-16 nightly rotation caught
+    /// `delete field manifest_found` and `delete field failures` from this very
+    /// struct expression, both surviving the whole lib suite.
+    ///
+    /// Two halves of the operator-facing contract, both ungraded:
+    ///  * the verdict must still say a manifest was FOUND — reading a corrupt
+    ///    manifest as ABSENT routes the reader to the ADR-0012 M6 legacy-run
+    ///    explanation, a different and wrong story about their destination;
+    ///  * it must carry a FAILURE naming why — without it `rivet validate`
+    ///    reports a destination that did not pass with an EMPTY `failures`
+    ///    list: a red verdict and no reason on it.
+    ///
+    /// (The third survivor from the same report, `delete field passed`, is
+    /// EQUIVALENT — every exit from the main body calls `recompute_passed()`,
+    /// so that literal is unobservable. It has been in `.cargo/mutants.toml`
+    /// with that reason since 2026-07-14 and needs no test.)
+    #[test]
+    fn an_unparseable_manifest_is_found_and_carries_a_reason() {
+        let dir = tempfile::tempdir().unwrap();
+        // Present on disk so the fixture is not inert: if this early return
+        // ever stopped happening we would fall through to the part check
+        // rather than silently do nothing at all.
+        std::fs::write(dir.path().join("part-000001.parquet"), b"AAAA").unwrap();
+        std::fs::write(dir.path().join(MANIFEST_FILENAME), b"{ this is not json").unwrap();
+        let dest = local_dest(dir.path());
+
+        let v = verify_at_destination(&dest, "", ValidateDepth::Full).unwrap();
+
+        assert!(
+            v.manifest_found,
+            "an unreadable manifest.json is still a manifest that EXISTS — \
+             reporting it absent sends the operator to the legacy-run path \
+             instead of at the corruption: {v:?}"
+        );
+        assert!(
+            !v.legacy_run,
+            "a corrupt manifest is not a legacy run: {v:?}"
+        );
+        assert!(
+            v.failures
+                .iter()
+                .any(|f| matches!(f, Failure::ManifestSelfInconsistent { .. })),
+            "a parse failure must be RECORDED as a failure — a red verdict with \
+             an empty `failures` gives the operator no reason at all: {v:?}"
+        );
+        assert!(
+            !v.passed,
+            "a destination whose manifest cannot be parsed has not passed: {v:?}"
+        );
+
+        // The reason must name the artifact, not just the kind: the operator
+        // reads this line, never the enum variant.
+        let detail = v
+            .failures
+            .iter()
+            .find_map(|f| match f {
+                Failure::ManifestSelfInconsistent { detail } => Some(detail.clone()),
+                _ => None,
+            })
+            .expect("asserted present above");
+        assert!(
+            detail.contains("manifest.json"),
+            "the reason must name the file it is about: {detail}"
+        );
+    }
+
     // ── untracked objects ───────────────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
Two small, independent commits — read them separately.

**`adbabb5` — the nightly has been red 8 of 8 runs, and it is not slowness.**
The longest job is 54 minutes against a 360-minute ceiling. Two of the five root
causes are one-liners:

* the Mongo matrix job's explicit service list omitted `duckdb` — the CDC
  readback ORACLE, which carries no compose profile, so a bare `up -d` starts it
  and an explicit list silently does not. All five matrix cells died on
  `No such object: rivet-duckdb`, ~70 minutes of runner time a night.
* the cross-version job's asset glob omitted the version segment
  (`rivet-<tag>-x86_64-...`), so `gh release download` matched nothing and the
  job died under `set -e` before any test ran — red 10 of 10 nights, meaning the
  cross-version artifact contract has never once been checked.

The Makefile spells the same asset name correctly. One fact, two spellings, and
only the unread one drifted.

**`484b89a` — `verify_at_destination`'s parse-failure branch had no test.**
A corrupt `manifest.json` must still report `manifest_found: true` (else the
reader is sent to the legacy-run explanation) and must carry a failure saying
why (else `rivet validate` returns a red verdict with an EMPTY `failures` list).
RED-proven against both mutants; under the `failures` mutant 36 of the module's
37 tests stay green and only the new one bites.

The third survivor from the same report is EQUIVALENT (`recompute_passed()`
overwrites it on every exit path) and has been excluded with that reason since
2026-07-14 — no new exclusion here.

Scope honesty: the report that prompted this came from a nightly run against a
main that predates the mutation-gate fixes, so its list is not authoritative.
The two gaps closed here were confirmed by reading the branch, not by trusting
it. Tonight's nightly is the first trustworthy one.