### PR TITLE
test(pool-split): check the fixture's own precondition before blaming the product

### DIFF
--- a/tests/common/state.rs
+++ b/tests/common/state.rs
@@ -138,4 +138,37 @@ impl StateDb {
             .expect("query export_harm");
         rows.filter_map(|r| r.ok()).collect()
     }
+
+    /// Every export-run `(name, status, duration_ms, total_rows)`, oldest first.
+    ///
+    /// Deliberately UNFILTERED by status. The pool's split advisor predicts from
+    /// these durations, so a test whose fixture depends on one export DOMINATING
+    /// another must be able to read them — and a test that then CRASHES the
+    /// split's units must still be able to see that the units EXISTED. Filtering
+    /// to `status = 'success'` hides exactly that: a run whose every unit errors
+    /// records no successful unit row, so a fixture check written against
+    /// successes alone reports "no split happened" for a split that happened and
+    /// did its job. (Measured 2026-08-16: the first draft of
+    /// `run_pool_split_resume_with`'s precondition did this and failed on
+    /// postgres, which passes in CI.)
+    pub fn export_runs(&self) -> Vec<(String, String, i64, i64)> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT export_name, status, duration_ms, total_rows \
+                 FROM export_metrics ORDER BY id",
+            )
+            .expect("prepare export_metrics read");
+        let rows = stmt
+            .query_map([], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1).unwrap_or_default(),
+                    r.get::<_, i64>(2).unwrap_or(0),
+                    r.get::<_, i64>(3).unwrap_or(0),
+                ))
+            })
+            .expect("query export_metrics");
+        rows.filter_map(|r| r.ok()).collect()
+    }
 }

--- a/tests/live/chunking_stand.rs
+++ b/tests/live/chunking_stand.rs
@@ -231,6 +231,66 @@ fn run_pool_split_resume_with(
         &["apply", cfg.to_str().unwrap(), "--pool", "2", "--split"],
         &[crash],
     );
+    // PRECONDITION before the product assertion. `--split` is purely ADVISORY:
+    // `pool::advise_split` declines unless the giant beats the next-longest by
+    // more than R (3.0 at the `apply --pool --split` call site in run.rs) on
+    // PREDICTED seconds, which come from the priming run's recorded durations.
+    // The sibling is 100 rows but still pays a full connect + plan + write, so
+    // on a fast engine or a loaded runner the ratio can fall under 3 and NO
+    // units are produced — nothing to error, run 1 succeeds, and the assertion
+    // below then blames the product for an inert fixture. That is exactly how
+    // this read in CI (`stand_pool_split_gappy_key_{mysql,mssql}` and
+    // `..._resume_grows_mssql`, red on the 2026-08-16 nightly while green
+    // locally, and green on postgres in the same run — a ratio, not a bug).
+    //
+    // So: check the fixture FIRST, and when it is inert say so with the numbers
+    // the advisor actually used, rather than reporting a product failure.
+    {
+        let db = StateDb::next_to_config(&cfg);
+        let runs = db.export_runs();
+        // ANY status: this run crashes its units on purpose, so a unit that did
+        // its job records a FAILED row, not a successful one.
+        let units = runs.iter().filter(|(n, ..)| n.contains('#')).count();
+        if units < 2 {
+            // The priming run's successes are what the advisor predicted from.
+            // ONE entry per export NAME (its longest run): the advisor compares
+            // the longest export to the next-longest OTHER export, so a list
+            // that repeats one name would report it dominating ITSELF — ratio
+            // 1.00 on a giant that in fact dominates 15x (caught RED-proving
+            // this guard, 2026-08-16).
+            let mut best: std::collections::BTreeMap<String, (i64, i64)> =
+                std::collections::BTreeMap::new();
+            for (n, st, ms, rows) in &runs {
+                if n.contains('#') || st != "success" {
+                    continue;
+                }
+                let e = best.entry(n.clone()).or_insert((0, 0));
+                if *ms > e.0 {
+                    *e = (*ms, *rows);
+                }
+            }
+            let mut primed: Vec<_> = best
+                .into_iter()
+                .map(|(n, (ms, rows))| (n, ms, rows))
+                .collect();
+            primed.sort_by_key(|(_, ms, _)| -*ms);
+            let ratio = match primed.as_slice() {
+                [(_, a, _), (_, b, _), ..] if *b > 0 => *a as f64 / *b as f64,
+                _ => f64::NAN,
+            };
+            panic!(
+                "FIXTURE INERT, not a product failure: `--split` produced {units} unit(s), so no \
+                 unit could error and run 1 was always going to succeed — the assertion below \
+                 would blame the product for the fixture's own failure to set up. \
+                 `pool::advise_split` declines unless the giant beats the next-longest by more \
+                 than R=3.0 on PREDICTED seconds (from the priming run) AND the split lowers the \
+                 predicted wall. The priming run measured {primed:?} (ratio {ratio:.2} vs R=3.0). \
+                 If the ratio is comfortably past 3, the decline came from another gate — read \
+                 `pool::advise_split`. Do not relax the assertion below."
+            );
+        }
+    }
+
     assert!(
         !crashed.status.success(),
         "run 1 must fail (a unit errored mid-split):\n{}",


### PR DESCRIPTION
`stand_pool_split_gappy_key_{mysql,mssql}` and `..._resume_grows_mssql` have been
failing the nightly on `run 1 must fail (a unit errored mid-split)` while passing
locally — and passing on **postgres in the same CI run**. That assertion is about
the product; the thing that varies is the fixture.

`--split` is purely ADVISORY. `pool::advise_split` declines unless the giant beats
the next-longest by more than R (3.0 at the `apply --pool --split` call site) on
PREDICTED seconds — taken from the priming run's recorded durations — and unless
the split lowers the predicted wall. When it declines there are no units, so no
unit can error, so run 1 succeeds, and the assertion blames the product for a
fixture that never set itself up.

This checks the precondition first and fails with the numbers the advisor actually
used. **It does not fix the CI failures** — locally the ratio is 15-16x, well past
R, so the decline in CI comes from somewhere else and the next nightly will print
which.

Two bugs in the guard that RED-proving caught before it shipped, both worth
knowing because each would have produced a *more* convincing false failure:

* counting units via `status = 'success'` — this run crashes its units on purpose
  (`chunk_export:1` fires in both, each unit having two chunks), so a working
  split records no successful unit row. The guard reported "no split happened" for
  a split that happened and did its job, and failed on postgres, which passes in
  CI. `StateDb::export_runs` is deliberately unfiltered by status and says why.
* computing the ratio over the top two ROWS, so a giant that ran twice was
  compared to ITSELF: `ratio 1.00` on an export that dominates 16x. Now one entry
  per export NAME, its longest run.

RED-proven by dropping `parallel_safe: true` from the giant (tripping
advise_split's heavy-giant gate): the guard fires with `ratio 16.06 vs R=3.0` and
points at the remaining gates.

Third instance of this shape today, after both MSSQL governor canaries: a test
that names a precondition and does not establish it.

All nine pool-split tests pass locally; `cargo test --lib` 2493; clippy clean.