### PR TITLE
fix(reconcile): record the source COUNT the run already paid for

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,19 @@ name: CI
 # `Gate scripts (self-tests)` and `Mutants (coverage verdict)`. Two things
 # follow, and neither can be fixed from this file:
 #
-#  * `Mutants (changed lines)` IS required and is `continue-on-error: true`,
-#    which makes the job's CONCLUSION success even when its run fails. A
-#    required check that cannot report failure blocks nothing — that is how the
-#    vacuous gate survived eight runs. The evidence about what it actually
-#    graded is now published as job OUTPUTS and asserted by
-#    `Mutants (coverage verdict)`.
+#  * `Mutants (changed lines)` IS required and is `continue-on-error: true`.
+#    CORRECTED 2026-08-17 by observation, having been asserted the other way
+#    here and at the budget guard below: job-level `continue-on-error` does NOT
+#    launder the conclusion. A run whose mutate step exits 2 reports
+#    `conclusion: failure`, the check shows `fail`, and with the context in
+#    branch protection the PR is BLOCKED. Measured on PR #233, whose four missed
+#    mutants held the merge. So the requirement is load-bearing after all, and
+#    the practical consequence is the one the previous note missed: this gate
+#    does NOT consult `docs/mutants-baseline.txt` (that ledger is the NIGHTLY
+#    job's), so "live-guarded, see the baseline" is not an answer it accepts —
+#    a live-only path touched by a PR must grow a unit-level oracle or the PR
+#    cannot merge. The evidence about what it actually graded is published as
+#    job OUTPUTS and asserted by `Mutants (coverage verdict)` regardless.
 #  * `Mutants (coverage verdict)` is the one check that has to be ADDED to
 #    branch protection for the mutation gate to block anything: it runs with
 #    `if: always()` and fails unless `Mutants (gate sanity)`,
@@ -320,11 +327,13 @@ jobs:
           # at the ceiling having graded a fraction of the diff and reported
           # nothing about the rest. `Mutants (changed lines)` IS a required check
           # (verified against the API — see the ledger at the top of this file),
-          # but `continue-on-error: true` makes its conclusion success no matter
-          # how it ends, so the requirement blocks nothing; what a timeout really
-          # costs is a diff nobody graded. The blocking `Mutants (coverage
-          # verdict)` job fails on the "no verdict recorded" case, which is what
-          # a timeout looks like from outside.
+          # and — corrected 2026-08-17 — it DOES block: `continue-on-error` does
+          # not launder the conclusion, so a failed mutate step holds the merge
+          # (measured on PR #233). What a timeout costs is therefore worse than a
+          # diff nobody graded: it is a diff nobody graded AND a merge nobody can
+          # complete. The blocking `Mutants (coverage verdict)` job fails on the
+          # "no verdict recorded" case, which is what a timeout looks like from
+          # outside.
           #
           # What the guard hands the work to is CHECKED, not claimed. The first
           # version of this notice said "these modules are covered by the nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1036,7 +1036,13 @@ jobs:
           # Same bind-mount dance as the round-trip job: pre-create the shared
           # dir runner-owned (the daemon would root-own a missing mount source)…
           mkdir -p tests/.live-tmp
-          docker compose --profile pool --profile cdc --profile replica up -d postgres mysql mssql minio fake-gcs azurite toxiproxy pgbouncer proxysql postgres-cdc mysql-cdc mssql-cdc mysql-primary mysql-replica duckdb clickhouse
+          # `mssql-governor` is a SECOND SQL Server, on purpose: the concurrency-governor
+          # canaries read `Log Flush Waits/sec` with the `_Total` instance, which is
+          # server-wide, and 72 of the 74 SQL Server live tests do not take the
+          # quiet-window lock. On the shared instance the two canaries failed in
+          # OPPOSITE directions and both blamed the product for the schedule; they were
+          # the dominant E2E flake through 2026-08-16/17.
+          docker compose --profile pool --profile cdc --profile replica --profile governor up -d postgres mysql mssql mssql-governor minio fake-gcs azurite toxiproxy pgbouncer proxysql postgres-cdc mysql-cdc mssql-cdc mysql-primary mysql-replica duckdb clickhouse
           # …then re-open it after ClickHouse chowns /work to uid 101 on boot,
           # which propagates to the host on Linux and EACCESes the test writer.
           sudo chmod -R 0777 tests/.live-tmp
@@ -1059,8 +1065,12 @@ jobs:
           for i in $(seq 1 30); do (exec 3<>/dev/tcp/127.0.0.1/10000) 2>/dev/null && break || sleep 1; done
           echo "Waiting for SQL Server..."
           # mssql has a sqlcmd SELECT-1 healthcheck (start_period 30s); wait on it
-          # so the live_mssql_* suites can connect + seed.
+          # so the live_mssql_* suites can connect + seed. The governor instance
+          # gets the same wait AND its `rivet` database created — the canaries
+          # seed into it, and an unwaited second SQL Server is exactly the
+          # "enabled is not ready" trap this repo already paid for once.
           for i in $(seq 1 40); do [ "$(docker inspect -f '{{.State.Health.Status}}' rivet-mssql 2>/dev/null)" = "healthy" ] && break || sleep 2; done
+          for i in $(seq 1 40); do docker compose exec -T mssql-governor /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'Rivet_Passw0rd!' -C -Q 'SELECT 1' >/dev/null 2>&1 && break || sleep 2; done
           echo "Waiting for CDC services (cdc profile)..."
           # Dedicated CDC instances: logical WAL (PostgreSQL :5434), a REPLICATION
           # grant (MySQL :3307), the SQL Server Agent (MSSQL :1434).
@@ -1094,6 +1104,14 @@ jobs:
           docker compose cp dev/mssql/init.sql mssql:/tmp/init.sql
           docker compose exec -T mssql /opt/mssql-tools18/bin/sqlcmd \
             -S localhost -U sa -P 'Rivet_Passw0rd!' -C -i /tmp/init.sql
+
+      - name: Seed MSSQL-governor database
+        # The dedicated governor instance has no init hook either. Its two
+        # canaries seed their own tables; this just gives them a database.
+        run: |
+          docker compose exec -T mssql-governor /opt/mssql-tools18/bin/sqlcmd \
+            -S localhost -U sa -P 'Rivet_Passw0rd!' -C \
+            -Q "IF DB_ID('rivet') IS NULL CREATE DATABASE rivet;"
 
       - name: Seed MSSQL-CDC database
         # The mssql-cdc instance (Agent on) also has no init hook; just create the

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -298,6 +298,44 @@ services:
       timeout: 5s
       retries: 20
 
+  # ---- SQL Server for the CONCURRENCY GOVERNOR canaries ----------------------
+  # A dedicated instance, not a convenience. The governor samples SQL Server's
+  # `Log Flush Waits/sec` with the `_Total` instance — an INSTANCE-WIDE counter,
+  # summed across every database on the server. Its two canaries assert opposite
+  # things about it (`..._never_loses_to_its_own_baseline_on_an_idle_source`:
+  # no shed on a quiet source; `..._backs_off_under_real_log_flush_pressure`: a
+  # shed under real pressure), and on the SHARED `mssql` service both were
+  # unreliable in opposite directions, because 72 of the 74 SQL Server live tests
+  # do not take the quiet-window lock and any of their commits move that counter.
+  #
+  # Measured 2026-08-16: the idle canary passes alone (12.98s) and FAILS under a
+  # concurrent commit driver with the identical CI message and shed pattern
+  # (4 -> 3 -> 2 -> 1); the pressure canary fails the other way, its own writer
+  # unable to reach 5 of 5 batches on a loaded runner — and it says so honestly
+  # ("fixture went inert ... any counter movement below belongs to a concurrent
+  # sibling"). Between them they were the dominant E2E flake.
+  #
+  # No Agent here: these tests do not use CDC, and a capture job would be one
+  # more thing moving the log.
+  mssql-governor:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    profiles: ["governor"]
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: "Rivet_Passw0rd!"
+      MSSQL_PID: Developer
+    ports:
+      - "1435:1433"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"$$MSSQL_SA_PASSWORD\" -C -Q 'SELECT 1' || exit 1",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+
   # ---- MySQL primary → replica (replica profile) ----------------------------
   # Proves CDC can read a *replica's* binlog (the "no master access" case): the
   # replica re-logs replicated changes into its own binlog via log_replica_updates,

--- a/docs/chunking-matrix.yaml
+++ b/docs/chunking-matrix.yaml
@@ -104,7 +104,7 @@ scenarios:
 
   - id: chunk_count_n
     what: "chunk_count: N divides the key range into exactly N windows"
-    postgres: { test: roast_small_table_escape_respects_explicit_chunk_count }
+    postgres: { test: stand_chunk_count_postgres }
     mysql:    { test: stand_chunk_count_mysql }
     mssql:    { test: stand_chunk_count_mssql }
     mongo:    { na: "Mongo has no chunk_count knob; the analogue is parallel: N _id-range fan-out, covered by mongo_batch_parallel_integer_id_no_loss_or_dup" }

--- a/src/pipeline/finalize.rs
+++ b/src/pipeline/finalize.rs
@@ -325,9 +325,19 @@ pub(super) fn finalize_manifest(
             None, // cursor_type: follow-up (needs source-type plumbing)
             summary.cursor_low.clone(),
             summary.cursor_high.clone(),
-            None, // source_row_count: follow-up (needs a source COUNT)
+            None, // set below, for every strategy — not just cursored ones
         );
     }
+    // The source COUNT(*) `--reconcile` already ran. Recording it is what makes
+    // `load::reconcile`'s source→file leg executable: without it that check,
+    // `LoadIntegrity.source_rows` and `--allow-source-drift` are unreachable,
+    // and the only "did the extract drop rows" evidence a loader ever sees is
+    // rivet's own part-row arithmetic compared against itself.
+    //
+    // UNCONDITIONAL by strategy, deliberately: the count belongs to the run,
+    // not to the cursor. It stays `None` unless the run probed the source, so
+    // this adds no query — it stops discarding one already paid for.
+    builder.set_source_row_count(summary.source_count);
     let manifest = builder.finalize(status);
 
     let dest = match crate::destination::create_destination(&plan.destination) {

--- a/src/pipeline/manifest_writer.rs
+++ b/src/pipeline/manifest_writer.rs
@@ -177,6 +177,30 @@ impl ManifestBuilder {
     ///
     /// `status` reflects the overall run outcome — `Success` is the only
     /// status that licenses the `_SUCCESS` marker (M2).
+    /// Record the source-side `COUNT(*)` this run probed, so the load side can
+    /// check the **source→file** leg (`load::reconcile` bails when
+    /// `source_row_count != row_count` — the extract silently dropped rows).
+    ///
+    /// Separate from [`set_cursor_range`] on purpose. The field used to be one
+    /// of that method's parameters, and that method is only called when the run
+    /// has a CURSOR — so on a `full` or `chunked` export the count could not
+    /// reach the manifest even if a caller had one to give. Combined with all
+    /// three production writers passing `None` there, the effect was that
+    /// `load::reconcile`'s source→file bail, its `LoadIntegrity.source_rows`
+    /// field and the whole `--allow-source-drift` flag were unreachable code:
+    /// the chain of custody always ended at "rivet says it wrote N" (audit
+    /// 2026-08-17).
+    ///
+    /// Still `None` unless the run actually probed the source — the field's
+    /// contract is "when cheaply known", and a blanket `COUNT(*)` on every
+    /// export is a scan nobody asked for. Today the probe is `--reconcile`,
+    /// which already runs the count and, before this, threw it away.
+    pub fn set_source_row_count(&mut self, source_row_count: Option<i64>) {
+        if let Some(ex) = self.source.extraction.as_mut() {
+            ex.source_row_count = source_row_count;
+        }
+    }
+
     /// Record the cursor range this run covered (incremental strategies) so
     /// the warehouse can prove continuity across runs. `low` is the prior
     /// run's high (or the min seen this run); `high` is the value the next run

--- a/src/pipeline/manifest_writer.rs
+++ b/src/pipeline/manifest_writer.rs
@@ -830,6 +830,74 @@ mod tests {
         assert_eq!(ex.source_row_count, Some(123));
     }
 
+    /// The source count must reach the extraction section WITHOUT a cursor.
+    ///
+    /// It used to be a parameter of `set_cursor_range`, which `finalize` calls
+    /// only when the run has one — so on a `full` or `chunked` export the count
+    /// could not have reached the manifest even with a caller willing to supply
+    /// it. That is half of why `load::reconcile`'s source→file bail had never
+    /// executed; the other half was all three writers passing `None`.
+    ///
+    /// Written because the mutation gate caught `set_source_row_count with ()`
+    /// surviving: the setter's only coverage was a LIVE test
+    /// (`run_reconcile_flag_exits_zero_when_counts_match`), which the `--lib`
+    /// run cannot see. The live test stays — it observes the value at the
+    /// boundary, out of the artifact the real producer wrote — and this pins the
+    /// cursor-independence the live fixture happens not to exercise.
+    #[test]
+    fn builder_carries_the_source_row_count_without_a_cursor() {
+        let mut b = ManifestBuilder::new(
+            &plan_snapshot(),
+            "e",
+            "run_src",
+            chrono::Utc::now(),
+            "xxh3:0".into(),
+            "postgres",
+            None,
+            None,
+            "file:///tmp/out/".into(),
+        );
+        // No `set_cursor_range` call at all — the `full`/`chunked` shape.
+        b.set_source_row_count(Some(4242));
+        let m = b.finalize(ManifestStatus::Success);
+        let ex = m.source.extraction.expect("extraction section present");
+        assert_eq!(
+            ex.source_row_count,
+            Some(4242),
+            "a run with no cursor must still record the source count — otherwise \
+             load::reconcile's source→file leg stays unreachable on every \
+             non-incremental export"
+        );
+        assert_eq!(
+            ex.cursor_column, None,
+            "and it must not fabricate a cursor to carry it"
+        );
+    }
+
+    /// `None` must survive as absent, not become 0.
+    ///
+    /// `load::reconcile` branches on `if let Some(src)`, so a `Some(0)` where no
+    /// probe ran would compare a real `row_count` against zero and bail on every
+    /// export that did not use `--reconcile`.
+    #[test]
+    fn an_unprobed_run_records_no_source_row_count() {
+        let mut b = ManifestBuilder::new(
+            &plan_snapshot(),
+            "e",
+            "run_none",
+            chrono::Utc::now(),
+            "xxh3:0".into(),
+            "postgres",
+            None,
+            None,
+            "file:///tmp/out/".into(),
+        );
+        b.set_source_row_count(None);
+        let m = b.finalize(ManifestStatus::Success);
+        let ex = m.source.extraction.expect("extraction section present");
+        assert_eq!(ex.source_row_count, None);
+    }
+
     #[test]
     fn record_committed_part_assigns_max_plus_one_over_id_gaps() {
         // Mutants killed: `m + 1` → `m - 1` / `m * 1` in the part-id

--- a/src/pipeline/reconcile_cmd.rs
+++ b/src/pipeline/reconcile_cmd.rs
@@ -281,6 +281,19 @@ fn print_report_pretty(report: &ReconcileReport) {
         report.summary.total_source_rows, report.summary.total_exported_rows,
     );
 
+    // Say what the right-hand number IS. `exported` is `chunk_task.rows_written`
+    // — the count rivet RECORDED for each window, not a re-read of the parts. So
+    // "all partitions match" means the source agrees with rivet's own ledger; a
+    // part that was recorded at 500 rows and holds 400 reconciles clean. Naming
+    // the evidence is the difference between a report and a reassurance, and it
+    // is the same rule the preflight already follows: a diagnostic must not
+    // claim more than it checked (audit 2026-08-17).
+    println!(
+        "  Evidence  : source COUNT(*) per window vs the per-chunk counts rivet \
+         RECORDED (state DB), not a re-read of the parts"
+    );
+    println!("              to check the files themselves: rivet validate --depth full");
+
     let repair = report.repair_candidates();
     if repair.is_empty() {
         println!("  Status    : all partitions match");

--- a/src/pipeline/reconcile_cmd.rs
+++ b/src/pipeline/reconcile_cmd.rs
@@ -537,6 +537,44 @@ mod tests {
         assert!(enforce_reconcile_exit(&summary(0, 1, 2)).is_err());
     }
 
+    /// `emit_report` must actually EMIT — the dispatcher, not just the writer.
+    ///
+    /// `replace emit_report -> Result<()> with Ok(())` survived even after
+    /// `write_report_pretty` got its own unit test: stubbing the CALLER makes
+    /// every format silently produce nothing while the command still exits 0.
+    /// That is the layer-boundary shape this repo keeps paying for — a correct
+    /// test of correct logic, one layer below the thing that decides whether the
+    /// logic runs at all.
+    ///
+    /// Driven through the `Json(Some(path))` arm because its effect is a FILE,
+    /// readable without capturing stdout; the pretty arm is covered by the test
+    /// below and by the live reconcile suites.
+    #[test]
+    fn emit_report_actually_writes_the_json_report() {
+        let report = ReconcileReport::new(
+            "orders".into(),
+            "run_j".into(),
+            "chunked".into(),
+            Vec::new(),
+        );
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("report.json");
+        emit_report(
+            &report,
+            &ReconcileOutputFormat::Json(Some(path.to_string_lossy().into_owned())),
+        )
+        .expect("emit_report must succeed");
+
+        let body = std::fs::read_to_string(&path)
+            .expect("emit_report must have WRITTEN the file, not merely returned Ok");
+        let v: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        assert_eq!(
+            v["export_name"].as_str(),
+            Some("orders"),
+            "the emitted document must be this report; got:\n{body}"
+        );
+    }
+
     /// The report must reach the operator, and must NAME its evidence.
     ///
     /// `replace print_report_pretty with ()` — the whole report silently gone —

--- a/src/pipeline/reconcile_cmd.rs
+++ b/src/pipeline/reconcile_cmd.rs
@@ -249,7 +249,7 @@ where
 fn emit_report(report: &ReconcileReport, format: &ReconcileOutputFormat) -> Result<()> {
     match format {
         ReconcileOutputFormat::Pretty => {
-            print_report_pretty(report);
+            write_report_pretty(&mut std::io::stdout(), report);
         }
         ReconcileOutputFormat::Json(None) => {
             println!("{}", report.to_json_pretty()?);
@@ -264,19 +264,30 @@ fn emit_report(report: &ReconcileReport, format: &ReconcileOutputFormat) -> Resu
     Ok(())
 }
 
-fn print_report_pretty(report: &ReconcileReport) {
-    println!();
-    println!("  Export    : {}", report.export_name);
-    println!("  Run       : {}", report.run_id);
-    println!("  Strategy  : {}", report.strategy);
-    println!(
+/// Render the human report to `w`.
+///
+/// Takes a writer rather than calling `println!` so a unit test can read what an
+/// operator would see. It used to print directly, and `replace
+/// print_report_pretty with ()` — the whole report silently gone — survived the
+/// lib suite: its only coverage was a live test, which the `--lib` mutation run
+/// cannot execute. The per-diff gate does not consult
+/// `docs/mutants-baseline.txt` either, so "live-guarded" is not an answer it
+/// accepts (2026-08-17).
+fn write_report_pretty(w: &mut impl std::io::Write, report: &ReconcileReport) {
+    let _ = writeln!(w);
+    let _ = writeln!(w, "  Export    : {}", report.export_name);
+    let _ = writeln!(w, "  Run       : {}", report.run_id);
+    let _ = writeln!(w, "  Strategy  : {}", report.strategy);
+    let _ = writeln!(
+        w,
         "  Partitions: {} ({} match, {} mismatch, {} unknown)",
         report.summary.total_partitions,
         report.summary.matches,
         report.summary.mismatches,
         report.summary.unknown,
     );
-    println!(
+    let _ = writeln!(
+        w,
         "  Rows      : source {} / exported {}",
         report.summary.total_source_rows, report.summary.total_exported_rows,
     );
@@ -288,22 +299,26 @@ fn print_report_pretty(report: &ReconcileReport) {
     // the evidence is the difference between a report and a reassurance, and it
     // is the same rule the preflight already follows: a diagnostic must not
     // claim more than it checked (audit 2026-08-17).
-    println!(
+    let _ = writeln!(
+        w,
         "  Evidence  : source COUNT(*) per window vs the per-chunk counts rivet \
          RECORDED (state DB), not a re-read of the parts"
     );
-    println!("              to check the files themselves: rivet validate --depth full");
+    let _ = writeln!(
+        w,
+        "              to check the files themselves: rivet validate --depth full"
+    );
 
     let repair = report.repair_candidates();
     if repair.is_empty() {
-        println!("  Status    : all partitions match");
+        let _ = writeln!(w, "  Status    : all partitions match");
     } else {
-        println!("  Repair candidates:");
+        let _ = writeln!(w, "  Repair candidates:");
         for p in repair {
-            println!("    • {} — {}", p.identifier, format_status_note(p));
+            let _ = writeln!(w, "    • {} — {}", p.identifier, format_status_note(p));
         }
     }
-    println!();
+    let _ = writeln!(w);
 }
 
 fn format_status_note(p: &PartitionResult) -> String {
@@ -520,5 +535,49 @@ mod tests {
     fn reconcile_exit_fails_when_mismatch_and_unknown_coexist() {
         // A real mismatch still gates even when other partitions are unverifiable.
         assert!(enforce_reconcile_exit(&summary(0, 1, 2)).is_err());
+    }
+
+    /// The report must reach the operator, and must NAME its evidence.
+    ///
+    /// `replace print_report_pretty with ()` — the whole report silently gone —
+    /// survived the lib suite: the only coverage was a live test, which the
+    /// `--lib` mutation run cannot execute, and the per-diff gate does not read
+    /// `docs/mutants-baseline.txt`. Taking a writer is what makes the operator's
+    /// view readable from a unit test at all.
+    ///
+    /// The evidence line is load-bearing, not decoration: `exported` is
+    /// `chunk_task.rows_written`, the count rivet RECORDED per window, never a
+    /// re-read of the parts — so "all partitions match" means the source agrees
+    /// with rivet's own ledger, and a chunk recorded at 500 rows whose file holds
+    /// 400 reconciles clean.
+    #[test]
+    fn the_pretty_report_names_what_it_compared() {
+        let report = ReconcileReport::new(
+            "orders".into(),
+            "run_x".into(),
+            "chunked".into(),
+            Vec::new(),
+        );
+        let mut buf: Vec<u8> = Vec::new();
+        write_report_pretty(&mut buf, &report);
+        let out = String::from_utf8(buf).expect("the report is utf-8");
+
+        assert!(
+            out.contains("Export    : orders") && out.contains("Run       : run_x"),
+            "the report must reach the operator at all; got:\n{out}"
+        );
+        assert!(
+            out.contains("Evidence"),
+            "the report must name what it compared; got:\n{out}"
+        );
+        assert!(
+            out.contains("RECORDED") && out.contains("not a re-read"),
+            "and must say the right-hand number is rivet's own record rather than \
+             a re-read of the parts — that distinction is the whole point; got:\n{out}"
+        );
+        assert!(
+            out.contains("rivet validate --depth full"),
+            "and must point at the check that DOES read the files; got:\n{out}"
+        );
     }
 }

--- a/tests/cdc_conformance_gate.rs
+++ b/tests/cdc_conformance_gate.rs
@@ -407,6 +407,14 @@ fn every_live_cdc_test_asserts_an_outcome() {
             // destination listing, or the state DB) — not merely that the
             // process exited 0.
             let asserts_outcome = chunk.contains("manifest_rows")
+                // `cdc_id_ops` (-> `read_cdc_changes`, arrow straight off the
+                // parquet) is the STRONGEST marker in this list and was missing
+                // from it: a test asserting only that — i.e. reading the
+                // delivered rows and nothing else — was reported as asserting no
+                // outcome, while `manifest_rows` alone (rivet's own summary of
+                // its own writes) counted. Found when the first test to use the
+                // independent reader ALONE was rejected here (2026-08-17).
+                || chunk.contains("cdc_id_ops")
                 || chunk.contains("assert_cdc_matches_batch")
                 || chunk.contains("read_one_batch")
                 || chunk.contains("parquet_")

--- a/tests/common/env.rs
+++ b/tests/common/env.rs
@@ -59,6 +59,20 @@ pub const POSTGRES_CDC_URL: &str = "postgresql://rivet:rivet@127.0.0.1:5434/rive
 pub const MYSQL_CDC_URL: &str = "mysql://rivet:rivet@127.0.0.1:3307/rivet";
 pub const MSSQL_CDC_URL: &str = "sqlserver://sa:Rivet_Passw0rd!@127.0.0.1:1434/rivet";
 
+/// SQL Server for the CONCURRENCY GOVERNOR canaries (`service: mssql-governor`,
+/// port :1435, `governor` profile).
+///
+/// Dedicated because the governor's SQL Server signal is `Log Flush Waits/sec`
+/// read with the `_Total` instance — INSTANCE-WIDE, across every database on the
+/// server. On the shared `mssql` service the two canaries failed in OPPOSITE
+/// directions and both were wrong about the product: the idle one blamed the
+/// governor for a shed a sibling's commits had genuinely earned, and the
+/// pressure one could not get its own writer enough of the machine to move the
+/// counter at all. 72 of the 74 SQL Server live tests do not take the
+/// quiet-window lock, so "idle" was never a property of the fixture — only of
+/// the schedule (audit 2026-08-16).
+pub const MSSQL_GOVERNOR_URL: &str = "sqlserver://sa:Rivet_Passw0rd!@127.0.0.1:1435/rivet";
+
 /// ProxySQL in transaction-persistent mode, port :6033.
 /// Opt in: docker compose --profile pool up -d proxysql
 /// Backend forwards to the same `mysql` service used by `MYSQL_URL`.
@@ -287,6 +301,9 @@ pub enum LiveService {
     MysqlToxi,
     /// SQL Server source engine. TCP :1433.
     Mssql,
+    /// SQL Server dedicated to the concurrency-governor canaries. TCP :1435.
+    /// See [`MSSQL_GOVERNOR_URL`] for why it is not the shared instance.
+    MssqlGovernor,
     /// MongoDB standalone source engine (batch JSON-blob). TCP :27017.
     Mongo,
     /// MongoDB single-node replica set (change-stream CDC). TCP :27018.
@@ -327,6 +344,11 @@ impl LiveService {
             ),
             LiveService::Mysql => ("127.0.0.1", 3306, "service `mysql` in docker-compose.yaml"),
             LiveService::Mssql => ("127.0.0.1", 1433, "service `mssql` in docker-compose.yaml"),
+            LiveService::MssqlGovernor => (
+                "127.0.0.1",
+                1435,
+                "service `mssql-governor` — run: docker compose --profile governor up -d mssql-governor",
+            ),
             LiveService::Mongo => ("127.0.0.1", 27017, "service `mongo` in docker-compose.yaml"),
             LiveService::MongoRs => (
                 "127.0.0.1",

--- a/tests/common/mssql.rs
+++ b/tests/common/mssql.rs
@@ -171,6 +171,22 @@ pub fn mssql_query_i64(sql: &str) -> i64 {
     query_i64_at(1433, sql)
 }
 
+/// The governor instance's twins (`mssql-governor`, :1435). Kept beside their
+/// `:1433` siblings so a reader sees the two servers are DIFFERENT servers, not
+/// two spellings of one — the whole point of the split is that
+/// `Log Flush Waits/sec (_Total)` is server-wide.
+pub fn mssql_governor_exec(sql: &str) {
+    exec_at(1435, sql)
+}
+
+pub fn mssql_governor_try_exec(sql: &str) -> bool {
+    soft_exec_at(1435, sql)
+}
+
+pub fn mssql_governor_query_i64(sql: &str) -> i64 {
+    query_i64_at(1435, sql)
+}
+
 /// As [`mssql_query_i64`], but against `mssql-cdc` (`:1434`) — e.g. polling a CDC
 /// change table's row count while the capture job catches up.
 pub fn mssql_cdc_query_i64(sql: &str) -> i64 {
@@ -253,16 +269,35 @@ impl Drop for MssqlTable {
 /// `created_at`, matching the MySQL/PG seeders so the same export queries and
 /// row-count assertions hold across engines.
 pub fn seed_mssql_numeric_table(row_count: i64) -> MssqlTable {
+    seed_mssql_numeric_table_at(1433, row_count)
+}
+
+/// Seed the same fixture on the GOVERNOR instance (`mssql-governor`, :1435).
+///
+/// The concurrency-governor canaries need a SQL Server nobody else is writing
+/// to: the signal they assert on is `Log Flush Waits/sec` with the `_Total`
+/// instance, which is server-wide. See `env::MSSQL_GOVERNOR_URL`.
+pub fn seed_mssql_governor_numeric_table(row_count: i64) -> MssqlTable {
+    seed_mssql_numeric_table_at(1435, row_count)
+}
+
+fn seed_mssql_numeric_table_at(port: u16, row_count: i64) -> MssqlTable {
     let name = unique_name("rivet_qa_tbl");
-    mssql_drop_table(&name);
-    mssql_exec(&format!(
-        "CREATE TABLE {name} (
+    exec_at(
+        port,
+        &format!("IF OBJECT_ID('{name}','U') IS NOT NULL DROP TABLE {name}"),
+    );
+    exec_at(
+        port,
+        &format!(
+            "CREATE TABLE {name} (
             id BIGINT PRIMARY KEY,
             name NVARCHAR(100) NOT NULL,
             amount DECIMAL(12,2) NOT NULL,
             created_at DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME()
         );"
-    ));
+        ),
+    );
     if row_count > 0 {
         // T-SQL caps a multi-row VALUES clause at 1000 rows per INSERT — chunk.
         let mut start = 0;
@@ -279,7 +314,7 @@ pub fn seed_mssql_numeric_table(row_count: i64) -> MssqlTable {
                     row_count - i
                 ));
             }
-            mssql_exec(&sql);
+            exec_at(port, &sql);
             start = end;
         }
     }

--- a/tests/common/rig.rs
+++ b/tests/common/rig.rs
@@ -50,7 +50,16 @@ pub struct Rig {
 #[derive(Clone)]
 struct SecondaryExport {
     name: String,
+    /// A secondary declared by QUERY (the batch shape). Mutually exclusive with
+    /// `table` — CDC exports address a table, not a query.
     query: String,
+    /// A secondary declared by TABLE, with its own `cdc:` block. SQL Server CDC
+    /// needs this: the product REFUSES `tables:` on that engine ("its capture
+    /// instances are per-table; use one cdc export per table"), so a multi-table
+    /// SQL Server capture is N exports in one config, not one export over N
+    /// tables — and `query:` cannot express any of them.
+    table: Option<String>,
+    cdc_lines: Vec<String>,
     mode: String,
     lines: Vec<String>,
 }
@@ -259,7 +268,38 @@ impl Rig {
         self.extra_exports.push(SecondaryExport {
             name: name.to_string(),
             query: query.to_string(),
+            table: None,
+            cdc_lines: Vec::new(),
             mode: "full".to_string(),
+            lines: Vec::new(),
+        });
+        self
+    }
+
+    /// A second CDC export over its OWN table, with its own `cdc:` block and its
+    /// own checkpoint file.
+    ///
+    /// Exists because SQL Server cannot express a multi-table capture any other
+    /// way: `Config` bails with "`tables:` is not yet supported for SQL Server —
+    /// its capture instances are per-table; use one cdc export per table
+    /// (capture_instance each)". Every routing question on that engine therefore
+    /// needs TWO exports, and until now the suite had none — the whole
+    /// multi-table SQL Server CDC surface was untested, including the routing
+    /// bug that once dropped 100% of events for 6 of 8 tables (audit 2026-08-17).
+    ///
+    /// `cdc` lines are rendered verbatim into the map; `checkpoint:` is supplied
+    /// here rather than by the caller, because two CDC exports sharing one
+    /// checkpoint file would silently overwrite each other's position.
+    pub fn also_cdc_export(mut self, name: &str, table: &str, cdc: &[&str]) -> Self {
+        let ckpt = self.dir.path().join(format!("cdc_{name}.ckpt"));
+        let mut cdc_lines: Vec<String> = cdc.iter().map(|l| l.to_string()).collect();
+        cdc_lines.push(format!("checkpoint: \"{}\"", ckpt.display()));
+        self.extra_exports.push(SecondaryExport {
+            name: name.to_string(),
+            query: String::new(),
+            table: Some(table.to_string()),
+            cdc_lines,
+            mode: "cdc".to_string(),
             lines: Vec::new(),
         });
         self
@@ -580,10 +620,18 @@ impl Rig {
             .iter()
             .map(|e| {
                 let lines: String = e.lines.iter().map(|l| format!("    {l}\n")).collect();
+                let subject = match &e.table {
+                    Some(t) => format!("table: {t}"),
+                    None => format!("query: \"{}\"", e.query),
+                };
+                let cdc = if e.cdc_lines.is_empty() {
+                    String::new()
+                } else {
+                    format!("    cdc: {{ {} }}\n", e.cdc_lines.join(", "))
+                };
                 format!(
-                    "  - name: {n}\n    query: \"{q}\"\n    mode: {m}\n    format: {f}\n{lines}    destination: {{ type: local, path: \"{o}\" }}\n",
+                    "  - name: {n}\n    {subject}\n    mode: {m}\n    format: {f}\n{cdc}{lines}    destination: {{ type: local, path: \"{o}\" }}\n",
                     n = e.name,
-                    q = e.query,
                     m = e.mode,
                     f = self.format,
                     o = self.out_dir_for(&e.name).display(),

--- a/tests/common/rig.rs
+++ b/tests/common/rig.rs
@@ -124,6 +124,19 @@ impl Rig {
         Self::new("postgres", super::env::POSTGRES_URL, table)
     }
 
+    /// SQL Server batch against the GOVERNOR instance (:1435).
+    ///
+    /// For the two concurrency-governor canaries only. They assert opposite
+    /// things about `Log Flush Waits/sec (_Total)` — a server-wide counter — so
+    /// on the shared `mssql` service both were decided by whichever sibling test
+    /// happened to be committing. See `env::MSSQL_GOVERNOR_URL`.
+    pub fn mssql_governor_batch(table: &str) -> Self {
+        let mut r = Self::new("mssql", super::env::MSSQL_GOVERNOR_URL, table);
+        r.source_lines.push("tls:".into());
+        r.source_lines.push("  accept_invalid_certs: true".into());
+        r
+    }
+
     pub fn mssql_batch(table: &str) -> Self {
         let mut r = Self::new("mssql", super::env::MSSQL_URL, table);
         // The test stack's SQL Server runs a self-signed cert — every mssql

--- a/tests/live/batch_memory_policy.rs
+++ b/tests/live/batch_memory_policy.rs
@@ -149,7 +149,8 @@ fn auto_shrink_parquet_output_is_complete_and_readable() {
     // auto_shrink splits oversized batches recursively and writes sub-batches.
     // Definition of done: export succeeds, parquet file is non-empty.
     require_alive(LiveService::Postgres);
-    let table = seed_pg_wide_table(2000, 0);
+    const ROWS: usize = 2000;
+    let table = seed_pg_wide_table(ROWS as i64, 0);
     let out = tempfile::tempdir().unwrap();
     let export_name = unique_name("bmp_shrink_pq");
 
@@ -178,21 +179,29 @@ fn auto_shrink_parquet_output_is_complete_and_readable() {
         !files.is_empty(),
         "auto_shrink must produce at least one parquet file"
     );
-    for f in &files {
-        let size = std::fs::metadata(f).unwrap().len();
-        assert!(
-            size > 0,
-            "parquet output must be non-empty: {}",
-            f.display()
-        );
-    }
+    // The rows are the point, and until 2026-08-17 nothing read them: the test
+    // was named `..._is_complete_and_readable` and its body never opened a file
+    // (`metadata(f).len() > 0`). `auto_shrink` SPLITS an oversized batch
+    // recursively, so its failure mode is a sub-batch that never gets written —
+    // and a splitter that drops one leaves every remaining file non-empty. The
+    // name promised what the body could not check.
+    //
+    // DuckDB, not the parquet crate rivet writes with: a symmetric encode/decode
+    // fault cancels out in the shared path.
+    assert_eq!(
+        duckdb_total_parquet_rows(out.path()),
+        ROWS,
+        "auto_shrink must deliver every source row — a dropped sub-batch leaves \
+         the remaining files non-empty and this is the only assertion that sees it"
+    );
 }
 
 #[test]
 #[ignore = "live: requires docker compose postgres"]
 fn auto_shrink_csv_output_is_complete_and_valid() {
     require_alive(LiveService::Postgres);
-    let table = seed_pg_wide_table(2000, 0);
+    const ROWS: usize = 2000;
+    let table = seed_pg_wide_table(ROWS as i64, 0);
     let out = tempfile::tempdir().unwrap();
     let export_name = unique_name("bmp_shrink_csv");
 
@@ -221,6 +230,24 @@ fn auto_shrink_csv_output_is_complete_and_valid() {
     assert!(
         !files.is_empty(),
         "auto_shrink CSV must produce at least one file"
+    );
+    // `lines.len() >= 2` per file passes when 2000 rows deliver ONE. Count the
+    // data rows across every part and compare to what was seeded — the CSV
+    // splitter drops a sub-batch the same way the parquet one does.
+    let delivered: usize = files
+        .iter()
+        .map(|f| {
+            let content = std::fs::read_to_string(f).expect("read csv");
+            // A header-only part (the splitter's failure signature) is 1 line.
+            content.lines().count().saturating_sub(1)
+        })
+        .sum();
+    assert_eq!(
+        delivered,
+        ROWS,
+        "auto_shrink CSV must deliver every source row across its parts; got \
+         {delivered} data rows in {} file(s)",
+        files.len()
     );
     for f in &files {
         let content = std::fs::read_to_string(f).expect("read csv");

--- a/tests/live/chunking_stand.rs
+++ b/tests/live/chunking_stand.rs
@@ -703,9 +703,11 @@ fn seed_mysql_unsigned_key(rows: i64) -> (String, StandCleanup) {
 /// on a dense key. Assert the run succeeds and emits exactly N parquet parts.
 fn run_chunk_count(eng: Eng, n: usize) {
     eng.require();
-    let (table, _guard) = seed_dense(eng, 4000);
+    const ROWS: i64 = 4000;
+    let (table, _guard) = seed_dense(eng, ROWS);
     let rig = eng
         .rig(&table)
+        .duckdb_oracle()
         .mode("chunked")
         .export_line("chunk_column: id")
         .export_line(&format!("chunk_count: {n}"));
@@ -726,6 +728,17 @@ fn run_chunk_count(eng: Eng, n: usize) {
         "chunk_count: {n} must emit exactly {n} part files on a dense key; got {}: {files:?}",
         files.len()
     );
+    // The file COUNT is the shape; the ROWS are the point. `chunk_count` divides
+    // the key range into N windows, so the failure this knob can produce is a
+    // divisor that drops or double-covers a boundary — and that leaves the part
+    // count untouched. Until 2026-08-17 nothing anywhere in the tree read a row
+    // from a `chunk_count` export, on any engine (audit).
+    //
+    // DuckDB, not `count_parquet_rows`: the arrow helper decodes with the same
+    // crate rivet encodes with, so a fault in that shared path cancels out.
+    // Distinct-on-`id` is what separates the two failures — a lost window and a
+    // double-covered one can both leave the row total looking plausible.
+    rig.assert_complete("id", ROWS, "chunk_count over a dense key");
 }
 
 /// Seed a table keyed by a DATE column `d` spanning `days` distinct days
@@ -793,9 +806,11 @@ fn seed_dated(eng: Eng, rows: i64, days: i64, recent: bool) -> (String, StandCle
 /// the run succeeds and emits exactly 5 parts on every engine.
 fn run_chunk_by_days(eng: Eng) {
     eng.require();
-    let (table, _guard) = seed_dated(eng, 350, 35, false);
+    const ROWS: i64 = 350;
+    let (table, _guard) = seed_dated(eng, ROWS, 35, false);
     let rig = eng
         .rig(&table)
+        .duckdb_oracle()
         .mode("chunked")
         .export_line("chunk_column: d")
         .export_line("chunk_by_days: 7");
@@ -816,6 +831,15 @@ fn run_chunk_by_days(eng: Eng) {
         "chunk_by_days: 7 over a 35-day span must emit 5 weekly parts; got {}: {files:?}",
         files.len()
     );
+    // Five files is the shape; the rows are the point. Date windows are the
+    // likeliest place in the tree for an off-by-one — an inclusive/exclusive
+    // slip at a week boundary loses a day's rows or emits them twice, and both
+    // leave FIVE parts sitting there looking correct. Until 2026-08-17 no test
+    // on any engine read a row out of a `chunk_by_days` export (audit).
+    //
+    // Distinct-on-`id` separates the two: a dropped boundary day shows up in the
+    // row total, a double-covered one only in the distinct count.
+    rig.assert_complete("id", ROWS, "chunk_by_days over a 35-day span");
 }
 
 /// `mode: time_window` — a bounded date scan (`time_column` + `days_window`)
@@ -1191,6 +1215,18 @@ fn stand_chunked_nondefault_schema_probe_degrades_and_exports_all_postgres() {
         40,
         "all 40 rows must export via the degrade fast-path"
     );
+}
+
+/// PostgreSQL was the one engine with no `chunk_count` EXPORT at all. The
+/// chunking matrix pointed its `chunk_count_n x postgres` cell at
+/// `roast_small_table_escape_respects_explicit_chunk_count`, which runs `rivet
+/// plan` and asserts the resolved strategy — planning, not data. So the knob's
+/// row-level behaviour was unproven on PG in both directions: no export ran, and
+/// the cell read `test` (audit 2026-08-17).
+#[test]
+#[ignore = "live: requires docker compose up -d postgres"]
+fn stand_chunk_count_postgres() {
+    run_chunk_count(Eng::Pg, 4);
 }
 
 #[test]

--- a/tests/live/live_cdc_mssql.rs
+++ b/tests/live/live_cdc_mssql.rs
@@ -651,6 +651,91 @@ fn mssql_cdc_capture_instance_name_must_not_decide_the_table() {
     );
 }
 
+/// The routing bug's actual SHAPE needs two tables — the test above cannot
+/// express it.
+///
+/// The field failure was events for 6 of 8 tables landing under the WRONG table
+/// (the capture-instance name was split on `_`, so `product_catalog` became
+/// schema `product` / table `catalog`), while every run reported success. With
+/// ONE table a mis-route can only drop to zero, which `manifest_rows == 2`
+/// catches. With two, a swap keeps BOTH counts at 2 and only the CONTENT
+/// differs — and nothing in the suite looked at content, on this engine, until
+/// now (audit 2026-08-17). Its own rule: a guard against confusing two things
+/// needs two of the thing.
+///
+/// SQL Server cannot do this in one export — `Config` refuses `tables:` there
+/// because capture instances are per-table — so this is two CDC exports over one
+/// config, which is what `Rig::also_cdc_export` was added for.
+///
+/// The ids are deliberately DISJOINT (10,11 vs 20,21): identical ids in both
+/// tables would make a perfect swap invisible even to a content check, which is
+/// how the PG/MySQL uncaptured-table fixtures are shaped today (both insert
+/// `id = 1`).
+///
+/// HONEST LIMIT, stated because a reader will otherwise assume more. I could not
+/// build a mutant where this test bites and the single-table one above does not.
+/// Four were tried: ignore the catalog and split the instance name; the same with
+/// the identity guard disabled; resolve without `WHERE capture_instance`; and both
+/// together. The first and third fail LOUDLY in `rig.run_ok()` — the identity
+/// guard (`table_matches` against the catalog's spelling) refuses before any event
+/// moves. With the guard disabled the routing filter is byte-exact, so a
+/// mis-resolved export matches NOTHING and the prefix comes back EMPTY (`left:
+/// []`) rather than holding the other table's rows. Drop-to-zero is what the count
+/// assertion above already catches.
+///
+/// So what this adds is coverage, not proven sensitivity: multi-table SQL Server
+/// CDC had NO test at all before it (`Rig::also_cdc_export` had to be written for
+/// it), and per-prefix CONTENT is the assertion PG and MySQL already make and this
+/// engine did not. If someone later makes routing tolerant enough to place a row
+/// under the wrong prefix instead of dropping it, this is the test that sees it —
+/// but that is an argument from shape, and it has not been demonstrated.
+#[test]
+#[ignore = "live: requires docker compose mssql with SQL Server Agent + CDC"]
+fn mssql_cdc_two_underscored_tables_do_not_cross_route() {
+    let _serial = CDC_SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    let d = tempfile::tempdir().unwrap();
+
+    let t1 = unique_name("rivet_cdc_ord");
+    let t2 = unique_name("rivet_cdc_inv");
+    let (ci1, ci2) = (t1.clone(), t2.clone());
+    for (t, ci) in [(&t1, &ci1), (&t2, &ci2)] {
+        mssql_cdc_drop_table(&format!("dbo.{t}"));
+        mssql_cdc_exec(&format!("CREATE TABLE dbo.{t}(id INT PRIMARY KEY, v INT)"));
+        enable_cdc(t, ci);
+    }
+    let _g1 = MssqlCdcTable {
+        table: t1.clone(),
+        ci: ci1.clone(),
+    };
+    let _g2 = MssqlCdcTable {
+        table: t2.clone(),
+        ci: ci2.clone(),
+    };
+
+    mssql_cdc_exec(&format!("INSERT INTO dbo.{t1} VALUES (10,1),(11,1)"));
+    mssql_cdc_exec(&format!("INSERT INTO dbo.{t2} VALUES (20,2),(21,2)"));
+    wait_for_capture(&ci1, 2);
+    wait_for_capture(&ci2, 2);
+
+    let rig = Rig::mssql_cdc(&t1, &ci1)
+        .checkpoint_path(d.path().join("cdc1.ckpt"))
+        .also_cdc_export(&t2, &t2, &[&format!("capture_instance: {ci2}")]);
+    rig.run_ok();
+
+    // Content, per export prefix. A swap leaves both counts at 2.
+    assert_eq!(
+        cdc_id_ops(&rig.out_dir()),
+        vec![(10, "insert".to_string()), (11, "insert".to_string())],
+        "export '{t1}' must hold ONLY its own rows — a cross-route keeps the count \
+         at 2 and swaps the ids, which is the shape the field failure had"
+    );
+    assert_eq!(
+        cdc_id_ops(&rig.out_dir_for(&t2)),
+        vec![(20, "insert".to_string()), (21, "insert".to_string())],
+        "export '{t2}' must hold ONLY its own rows"
+    );
+}
+
 #[test]
 #[ignore = "live: requires docker compose mssql with SQL Server Agent + CDC"]
 fn mssql_cdc_crash_before_checkpoint_re_reads_on_resume() {

--- a/tests/live/live_cli_flags.rs
+++ b/tests/live/live_cli_flags.rs
@@ -458,6 +458,76 @@ fn run_reconcile_flag_exits_zero_when_counts_match() {
         25,
         "destination must physically hold all 25 rows"
     );
+
+    // The COUNT(*) this run just paid for must be RECORDED, not discarded.
+    // `load::reconcile` checks the source→file leg only `if let Some(src) =
+    // …source_row_count`, and until 2026-08-17 every production writer passed
+    // `None` — so that bail, `LoadIntegrity.source_rows` and the whole
+    // `--allow-source-drift` flag were unreachable, and a loader's only
+    // evidence about the extract was rivet's own part arithmetic compared
+    // against itself. This asserts the value AT THE BOUNDARY, read out of the
+    // artifact the real producer wrote — not handed to a decider by a test.
+    let manifest: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(out.path().join("manifest.json"))
+            .expect("run --reconcile must leave a manifest"),
+    )
+    .expect("manifest.json must parse");
+    assert_eq!(
+        manifest["source"]["extraction"]["source_row_count"].as_i64(),
+        Some(25),
+        "the source COUNT(*) --reconcile ran must reach the manifest, so the LOAD \
+         side can check source→file; manifest:\n{manifest:#}"
+    );
+}
+
+/// A run WITHOUT `--reconcile` must leave `source_row_count` absent.
+///
+/// The field's contract is "when cheaply known" — recording anything else would
+/// mean either a `COUNT(*)` nobody asked for on every export, or (worse) copying
+/// rivet's own extracted-row counter into the field the load side treats as the
+/// INDEPENDENT source number, which would make `load::reconcile`'s source→file
+/// leg compare rivet to itself while reading as a real check.
+#[test]
+#[ignore = "live: requires docker compose postgres"]
+fn a_run_without_reconcile_records_no_source_row_count() {
+    require_alive(LiveService::Postgres);
+
+    let table = seed_pg_numeric_table(25);
+    let out = tempfile::tempdir().unwrap();
+    let cfg_dir = tempfile::tempdir().unwrap();
+    let cfg = write_config(&cfg_dir, &simple_config(table.name(), out.path()));
+
+    let result = std::process::Command::new(RIVET_BIN)
+        .args([
+            "run",
+            "--config",
+            cfg.to_str().unwrap(),
+            "--export",
+            table.name(),
+        ])
+        .output()
+        .expect("spawn rivet run");
+    assert!(result.status.success(), "the plain run must succeed");
+
+    // Not inert: the run really did export, so an absent field is a decision,
+    // not a missing manifest.
+    assert_eq!(
+        duckdb_total_parquet_rows(out.path()),
+        25,
+        "the fixture must actually export before absence means anything"
+    );
+
+    let manifest: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(out.path().join("manifest.json")).expect("a manifest"),
+    )
+    .expect("manifest.json must parse");
+    assert_eq!(
+        manifest["source"]["extraction"]["source_row_count"].as_i64(),
+        None,
+        "no probe ran, so there is no independent source number to record — \
+         recording one anyway would hand the load side rivet's own counter \
+         dressed as the source's; manifest:\n{manifest:#}"
+    );
 }
 
 #[test]

--- a/tests/live/live_governor.rs
+++ b/tests/live/live_governor.rs
@@ -802,13 +802,20 @@ fn pg_adaptive_never_loses_to_its_own_baseline_on_an_idle_source() {
 #[test]
 #[ignore = "live: requires docker-compose mssql"]
 fn mssql_adaptive_never_loses_to_its_own_baseline_on_an_idle_source() {
-    require_alive(LiveService::Mssql);
+    // The GOVERNOR instance, not the shared `mssql`. "Idle" is the whole
+    // assertion, and on :1433 it was never a property of this fixture — 72 of
+    // the 74 SQL Server live tests do not take the quiet-window lock, and
+    // `Log Flush Waits/sec` is read with the `_Total` instance, i.e. server-wide.
+    // Reproduced 2026-08-16: alone it passes in 12.98s; under a concurrent
+    // commit driver it fails with CI's exact message and shed pattern
+    // (4 -> 3 -> 2 -> 1). The governor was RIGHT both times; the fixture was not.
+    require_alive(LiveService::MssqlGovernor);
     // Quiet window: the no-shed and ratio gates need no sibling pressure/CPU.
     let _quiet = quiet_window_guard();
     const ROWS: i64 = 40_000;
-    let table = seed_mssql_numeric_table(ROWS);
+    let table = seed_mssql_governor_numeric_table(ROWS);
     let run = |adaptive: bool| -> (f64, String) {
-        let rig = Rig::mssql_batch(table.name())
+        let rig = Rig::mssql_governor_batch(table.name())
             .mode("chunked")
             .source_line("tuning:")
             .source_line(&format!("  adaptive: {adaptive}"))
@@ -1330,7 +1337,11 @@ fn governor_pressure_fixtures_are_reaped_by_a_panicking_run() {
 #[test]
 #[ignore = "live: requires docker compose mssql"]
 fn mssql_governor_backs_off_under_real_log_flush_pressure() {
-    require_alive(LiveService::Mssql);
+    // Same dedicated instance, opposite direction: this one needs its OWN
+    // writer to be the thing moving the counter. On the shared server it failed
+    // by going inert — "committed 3 40-transaction batches (needs >= 5)" — a
+    // loaded runner starving the fixture rather than the product misbehaving.
+    require_alive(LiveService::MssqlGovernor);
     let _quiet = quiet_window_guard();
 
     // The exact counter `MssqlSource::sample_governor_pressure` reads — the
@@ -1341,9 +1352,9 @@ fn mssql_governor_backs_off_under_real_log_flush_pressure() {
                                AND instance_name = '_Total'";
 
     const ROWS: i64 = 20_000;
-    let table = seed_mssql_numeric_table(ROWS);
+    let table = seed_mssql_governor_numeric_table(ROWS);
     let scratch = format!("{}_flush", table.name());
-    mssql_exec(&format!(
+    mssql_governor_exec(&format!(
         "IF OBJECT_ID('dbo.{scratch}') IS NOT NULL DROP TABLE dbo.{scratch}; \
          CREATE TABLE dbo.{scratch} (id INT IDENTITY PRIMARY KEY, payload VARBINARY(MAX))"
     ));
@@ -1370,7 +1381,7 @@ fn mssql_governor_backs_off_under_real_log_flush_pressure() {
             while !stop.load(Ordering::Relaxed) {
                 // 40 committed transactions per batch keeps the round-trip
                 // count low while the commit RATE stays high.
-                if mssql_try_exec(&format!(
+                if mssql_governor_try_exec(&format!(
                     "SET NOCOUNT ON; \
                      DECLARE @i INT = 0; \
                      WHILE @i < 40 \
@@ -1392,9 +1403,9 @@ fn mssql_governor_backs_off_under_real_log_flush_pressure() {
     // Let the writer drive the counter before rivet starts, so the governor's
     // first sample PAIR already spans rising pressure.
     std::thread::sleep(Duration::from_millis(500));
-    let waits_before = mssql_query_i64(FLUSH_WAITS);
+    let waits_before = mssql_governor_query_i64(FLUSH_WAITS);
 
-    let rig = Rig::mssql_batch(table.name())
+    let rig = Rig::mssql_governor_batch(table.name())
         .mode("chunked")
         .source_line("tuning:")
         .source_line("  adaptive: true")
@@ -1413,7 +1424,7 @@ fn mssql_governor_backs_off_under_real_log_flush_pressure() {
         Duration::from_secs(120),
     );
 
-    let waits_after = mssql_query_i64(FLUSH_WAITS);
+    let waits_after = mssql_governor_query_i64(FLUSH_WAITS);
     let writer_panicked = writer.reap();
     let batches = writer_batches.load(Ordering::Relaxed);
 

--- a/tests/live/live_mysql_reconcile_repair.rs
+++ b/tests/live/live_mysql_reconcile_repair.rs
@@ -80,6 +80,28 @@ fn mysql_reconcile_all_match_exits_zero_with_pretty_output() {
         100,
         "destination parquet must physically hold every source row, independent of the reconcile verdict"
     );
+
+    // The report must NAME its evidence. `exported` is `chunk_task.rows_written`
+    // — what rivet RECORDED per window, never a re-read of the parts — so
+    // "all partitions match" means the source agrees with rivet's own ledger.
+    // A chunk recorded at 500 rows whose file holds 400 reconciles clean, and
+    // the assertion above is the only thing in this test that would notice.
+    // Without this line an operator reads a clean reconcile as proof the files
+    // are right; the line is what makes the report honest about its own reach
+    // (audit 2026-08-17), so it is pinned rather than left to drift.
+    assert!(
+        stdout.contains("Evidence"),
+        "the reconcile report must name what it compared; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("RECORDED") && stdout.contains("not a re-read"),
+        "the evidence line must say the right-hand number is rivet's own record, \
+         not a re-read of the parts — that distinction is the whole point; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("rivet validate --depth full"),
+        "and must point at the check that DOES read the files; got:\n{stdout}"
+    );
 }
 
 // ─── RR2: reconcile --format json ────────────────────────────────────────────


### PR DESCRIPTION
`load::reconcile` has a **source→file** leg — the only check in the product that can
say *"the extract silently dropped rows"*:

```rust
if let Some(src) = m.source.extraction.as_ref().and_then(|x| x.source_row_count) {
    bail!("source→file mismatch … source had {src} rows but {rows} were extracted")
```

**It has never executed.** All three production writers passed `None` (`finalize.rs:328`,
`manifest_writer.rs:117`, `cdc/sink.rs:913`); the only `Some(..)` in the tree is a test
fixture. So `LoadIntegrity.source_rows` was always `None`, `chain_prefix()` always
rendered `source ? → files N`, and `--allow-source-drift` gated an unreachable branch.

## Why it matters beyond one dead field

Both of rivet's own verification commands compare the source to a number **rivet
recorded**, never to the delivered data:

| command | source side | "delivered" side |
|---|---|---|
| `rivet reconcile` | `COUNT(*)` | `chunk_task.rows_written` (`reconcile_cmd.rs:208`) |
| `rivet load --reconcile` | `COUNT(*)` | sum of manifest part rows (`job.rs:683`) |

An operator who runs `rivet reconcile` and reads "match" has learned that two of
rivet's counters agree with each other. The leg that would close the chain is the one
that never ran.

## No new query

When `--reconcile` is set, `reconcile_source_count` **already** issues the COUNT and
stores it on the summary (`job.rs:1163`), compares it, and discards it;
`finalize_manifest` runs after it (`job.rs:1221`). This stops discarding it.

## Two changes, not one

`source_row_count` was a *parameter of* `set_cursor_range`, which finalize calls only
when the run has a cursor — so on a `full` or `chunked` export the count could not have
reached the manifest even with a caller willing to supply it. It gets its own setter,
applied for every strategy.

## Deliberately still `None` without a probe

The field's contract is *"when cheaply known"*. Both alternatives are wrong: a blanket
`COUNT(*)` is a scan nobody asked for, and copying rivet's own extracted-row counter
into the field the load side treats as the **independent** source number would make the
source→file leg compare rivet to itself *while reading as a real check* — the exact
failure mode this commit exists to end. A second test pins that absence as deliberate.

## Proof

Both tests observe the value **at the boundary**, read out of the artifact the real
producer wrote — not handed to a decider by the test, which CLAUDE.md records as the
shape mutation testing cannot see. RED-proven by restoring the `None`:
`left: None, right: Some(25)`.

Found by a five-axis read-only audit of the harness asking, per path, what verifies the
delivered data. The harness itself came out well — 4/4 CDC engines read the parquet back
on resume/idle/crash, batch runners use DuckDB on the clean and crash paths. The gap was
in the shipped product, not the tests.