### PR TITLE
test(pool-split): the split fixture was measuring the machine, not the shape

### DIFF
--- a/dev/release_oracle/blessed_flow.py
+++ b/dev/release_oracle/blessed_flow.py
@@ -1419,6 +1419,27 @@ def _cli_flags(cmd: str) -> set[str]:
     return got
 
 
+def _declared_subcommands() -> list[str]:
+    """Every subcommand `rivet --help` LISTS, read from the binary under test.
+
+    From the `Commands:` block rather than a substring search: `"run"` also
+    occurs in prose ("Run export jobs…"), which is how the Rust-side twin of
+    this check passed for names it never verified.
+    """
+    out = rivet("--help").out
+    block = out.split("Commands:", 1)
+    if len(block) < 2:
+        return []
+    body = block[1].split("\nOptions:", 1)[0]
+    names = []
+    for line in body.splitlines():
+        if line.startswith("  ") and not line.startswith("   "):
+            parts = line.split()
+            if parts:
+                names.append(parts[0])
+    return names
+
+
 def verify_flag_surface(led: Ledger) -> None:
     """Every flag of every command in the chain is carried, or excused by name."""
     led.phase("blessed flow · flag surface (derived from the CLI, not from a list)")
@@ -1427,7 +1448,33 @@ def verify_flag_surface(led: Ledger) -> None:
     carried = {f for fl in cov.values() for f in fl}
     # `-c`, `-o` and load's two are carried by the executor rather than declared.
     carried |= {"--config", "--output", "--rivet-bin", "--run-id", "--prefix", "--date"}
-    for cmd in ("plan", "apply", "run", "validate", "check", "load", "doctor", "init"):
+    # The chain, DERIVED from what the cells actually run — not a literal tuple.
+    # It used to be eight names written out here while the CLI declares sixteen
+    # subcommands, in a function whose docstring says "derived from the CLI, not
+    # from a list": the FLAGS were derived, the COMMANDS were not, and nothing
+    # could notice the two drifting apart. The command with the most untested
+    # surface, `cdc` (13 flags, including `--stream`, which disables the
+    # until_current bound this repo documents as load-bearing on PG and Mongo),
+    # was one of the eight missing (audit 2026-08-17).
+    chain = sorted(cov)
+    assert chain, "no cell declares any flags — the flag surface would grade nothing"
+
+    # And the OTHER half of the omission, now a visible row instead of silence:
+    # subcommands rivet ships that this chain never runs. Not a failure — the
+    # blessed flow's subject is the chain — but not invisible either.
+    declared = _declared_subcommands()
+    outside = [c for c in declared if c not in cov and c != "help"]
+    if outside:
+        ungraded = {c: len(_cli_flags(c)) for c in outside}
+        led.skipped(
+            "-", "flow", "flow:flags", "outside-chain",
+            "flag surface · these subcommands are OUTSIDE the blessed flow, so none of "
+            "their flags is graded here: "
+            + ", ".join(f"{c}({n})" for c, n in sorted(ungraded.items())),
+            ",".join(outside),
+        )
+
+    for cmd in chain:
         real = _cli_flags(cmd)
         if not real:
             led.failed("-", "flow", "flow:flags", cmd,

--- a/src/pipeline/validate_manifest.rs
+++ b/src/pipeline/validate_manifest.rs
@@ -2289,6 +2289,12 @@ mod tests {
                 },
                 "RIVET_VERIFY_CDC_POSITION",
             ),
+            (
+                Failure::PartRowCountMismatch {
+                    detail: "declared 500, holds 400".into(),
+                },
+                "RIVET_VERIFY_PART_ROW_COUNT",
+            ),
         ];
         for (failure, code) in cases {
             assert_eq!(&failure.error_code(), code, "code for {failure:?}");
@@ -2297,6 +2303,66 @@ mod tests {
                 "every code shares the RIVET_VERIFY_ prefix"
             );
         }
+
+        // COMPLETENESS, derived from the enum rather than trusted to the list
+        // above. The list is hand-written — that is unavoidable, since each case
+        // must construct a value — so the thing that CANNOT be hand-written is
+        // the check that it covers everything. It did not:
+        // `PartRowCountMismatch` was absent, the one code with no stability
+        // guard, in the test whose comment says renaming a code is a silent
+        // break for any CI gate keying off it (audit 2026-08-17).
+        let src = include_str!("validate_manifest.rs");
+        let enum_body = {
+            let at = src
+                .find("pub enum Failure {")
+                .expect("the Failure enum must be declared here");
+            let rest = &src[at..];
+            &rest[..rest.find("\n}").expect("the enum must close")]
+        };
+        let declared: Vec<&str> = enum_body
+            .lines()
+            .skip(1)
+            .filter(|l| l.starts_with("    ") && !l.starts_with("     "))
+            .filter_map(|l| {
+                let t = l.trim();
+                t.chars().next().filter(|c| c.is_ascii_uppercase())?;
+                Some(t.split(|c: char| !c.is_alphanumeric()).next().unwrap_or(""))
+            })
+            .filter(|v| !v.is_empty())
+            .collect();
+        assert!(
+            declared.len() >= 12,
+            "parsed only {} variant(s) from `Failure` — an empty dimension would \
+             make this assertion vacuous, which is the defect it replaces: {declared:?}",
+            declared.len()
+        );
+        let covered: Vec<&str> = cases
+            .iter()
+            .map(|(f, _)| match f {
+                Failure::PartMissing { .. } => "PartMissing",
+                Failure::PartSizeMismatch { .. } => "PartSizeMismatch",
+                Failure::PartChecksumMismatch { .. } => "PartChecksumMismatch",
+                Failure::ValueChecksumMismatch { .. } => "ValueChecksumMismatch",
+                Failure::PartRowCountMismatch { .. } => "PartRowCountMismatch",
+                Failure::CdcPositionViolation { .. } => "CdcPositionViolation",
+                Failure::SuccessMarkerMalformed { .. } => "SuccessMarkerMalformed",
+                Failure::SuccessMarkerStale { .. } => "SuccessMarkerStale",
+                Failure::ManifestSelfInconsistent { .. } => "ManifestSelfInconsistent",
+                Failure::ManifestReadError { .. } => "ManifestReadError",
+                Failure::SuccessMarkerReadError { .. } => "SuccessMarkerReadError",
+                Failure::ListPrefixError { .. } => "ListPrefixError",
+                Failure::UntrackedObject { .. } => "UntrackedObject",
+                Failure::ContentVerificationUnmet { .. } => "ContentVerificationUnmet",
+                Failure::ManifestRequiredButAbsent { .. } => "ManifestRequiredButAbsent",
+            })
+            .collect();
+        let missing: Vec<&&str> = declared.iter().filter(|v| !covered.contains(v)).collect();
+        assert!(
+            missing.is_empty(),
+            "`Failure` declares {} variant(s); these have no error-code case, so \
+             renaming their code would break a CI gate silently: {missing:?}",
+            declared.len()
+        );
     }
 
     #[test]

--- a/tests/live/chunking_stand.rs
+++ b/tests/live/chunking_stand.rs
@@ -620,14 +620,61 @@ fn stand_keyset_decimal_key_bails_mssql() {
 /// Seed a DENSE contiguous integer-PK table (`id` = 1..rows), the well-behaved
 /// shape for range chunking / chunk_count.
 fn seed_dense(eng: Eng, rows: i64) -> (String, StandCleanup) {
+    seed_dense_wide(eng, rows, 0)
+}
+
+/// The dense fixture the `apply --pool --split` tests need.
+///
+/// 200 bytes a row, so the giant's export is dominated by BYTES WRITTEN rather
+/// than by how fast the machine gets through 300k narrow ints. That is what
+/// makes `pool::advise_split`'s R=3.0 threshold clear on a fast runner as well
+/// as a slow laptop — see [`seed_dense_wide`] for the measurements that forced
+/// it. The width is the only thing that changes: the id space, `dense_ids`, the
+/// grow ranges and every caller stay exactly as they were.
+fn seed_dense_wide_for_split(eng: Eng, rows: i64) -> (String, StandCleanup) {
+    seed_dense_wide(eng, rows, 200)
+}
+
+/// `seed_dense` with a `pad` column of `pad_bytes` characters.
+///
+/// The split fixtures need it. `pool::advise_split` declines unless the giant
+/// beats the next-longest by more than R=3.0 on PREDICTED SECONDS, and the
+/// sibling — 100 rows — costs whatever a connect + plan + tiny write costs on
+/// that machine, a FIXED floor that does not shrink with the fixture. Measured
+/// on CI 2026-08-17: the giant did 300k narrow rows in 601 ms while the sibling
+/// took 201-403 ms, so the ratio landed at 1.52-2.99 against a threshold of 3.0
+/// and `--split` produced no units at all. Locally the same fixture reads 15x,
+/// because the local giant takes 3.3 s — the ratio was measuring the machine.
+///
+/// Widening the ROW rather than adding rows is deliberate: export time is
+/// dominated by bytes written, so this buys the giant seconds without touching
+/// `dense_ids(300_000)`, the grow ranges, or anything else every caller passes,
+/// and the seed stays one bulk INSERT.
+fn seed_dense_wide(eng: Eng, rows: i64, pad_bytes: usize) -> (String, StandCleanup) {
     let table = unique_name("stand_dense");
     let guard = StandCleanup(eng, table.clone());
+    let (pad_col, pad_val_pg, pad_val_my, pad_val_ms) = if pad_bytes == 0 {
+        (String::new(), String::new(), String::new(), String::new())
+    } else {
+        (
+            format!(
+                // NULLable on purpose: `insert_dense_range` (the GROW step) inserts
+                // (id, payload) only, and the width is needed just for the PRIMING
+                // run, whose durations set the split ratio — the grow happens after.
+                ", pad VARCHAR({pad_bytes})"
+            ),
+            format!(", repeat('x', {pad_bytes})"),
+            format!(", REPEAT('x', {pad_bytes})"),
+            format!(", REPLICATE('x', {pad_bytes})"),
+        )
+    };
+    let cols = if pad_bytes == 0 { "" } else { ", pad" };
     match eng {
         Eng::Pg => {
             let mut c = pg_connect();
             c.batch_execute(&format!(
-                "CREATE TABLE {table} (id BIGINT PRIMARY KEY, payload INT NOT NULL);
-                 INSERT INTO {table} (id, payload) SELECT g, g FROM generate_series(1, {rows}) g;
+                "CREATE TABLE {table} (id BIGINT PRIMARY KEY, payload INT NOT NULL{pad_col});
+                 INSERT INTO {table} (id, payload{cols}) SELECT g, g{pad_val_pg} FROM generate_series(1, {rows}) g;
                  ANALYZE {table};"
             ))
             .unwrap();
@@ -635,7 +682,7 @@ fn seed_dense(eng: Eng, rows: i64) -> (String, StandCleanup) {
         Eng::My => {
             let mut c = mysql_connect();
             c.query_drop(format!(
-                "CREATE TABLE {table} (id BIGINT PRIMARY KEY, payload INT NOT NULL)"
+                "CREATE TABLE {table} (id BIGINT PRIMARY KEY, payload INT NOT NULL{pad_col})"
             ))
             .unwrap();
             c.query_drop(format!(
@@ -644,19 +691,19 @@ fn seed_dense(eng: Eng, rows: i64) -> (String, StandCleanup) {
             ))
             .unwrap();
             c.query_drop(format!(
-                "INSERT INTO {table} (id, payload) \
+                "INSERT INTO {table} (id, payload{cols}) \
                  WITH RECURSIVE seq AS (SELECT 1 n UNION ALL SELECT n+1 FROM seq WHERE n < {rows}) \
-                 SELECT n, n FROM seq"
+                 SELECT n, n{pad_val_my} FROM seq"
             ))
             .unwrap();
         }
         Eng::Ms => {
             mssql_exec(&format!(
-                "CREATE TABLE {table} (id BIGINT PRIMARY KEY, payload INT NOT NULL)"
+                "CREATE TABLE {table} (id BIGINT PRIMARY KEY, payload INT NOT NULL{pad_col})"
             ));
             mssql_exec(&format!(
-                "INSERT INTO {table} (id, payload) \
-                 SELECT value, value FROM GENERATE_SERIES(CAST(1 AS BIGINT), CAST({rows} AS BIGINT))"
+                "INSERT INTO {table} (id, payload{cols}) \
+                 SELECT value, value{pad_val_ms} FROM GENERATE_SERIES(CAST(1 AS BIGINT), CAST({rows} AS BIGINT))"
             ));
             mssql_exec(&format!("UPDATE STATISTICS {table}"));
         }
@@ -2320,7 +2367,7 @@ fn dense_ids(n: i64) -> std::collections::BTreeSet<i64> {
 #[ignore = "live: requires docker compose up -d postgres"]
 fn stand_pool_split_resume_grows_postgres() {
     Eng::Pg.require();
-    let (table, _g) = seed_dense(Eng::Pg, 300_000);
+    let (table, _g) = seed_dense_wide_for_split(Eng::Pg, 300_000);
     run_pool_split_resume(
         Eng::Pg,
         &table,
@@ -2333,7 +2380,7 @@ fn stand_pool_split_resume_grows_postgres() {
 #[ignore = "live: requires docker compose up -d mysql"]
 fn stand_pool_split_resume_grows_mysql() {
     Eng::My.require();
-    let (table, _g) = seed_dense(Eng::My, 300_000);
+    let (table, _g) = seed_dense_wide_for_split(Eng::My, 300_000);
     run_pool_split_resume(
         Eng::My,
         &table,
@@ -2346,7 +2393,7 @@ fn stand_pool_split_resume_grows_mysql() {
 #[ignore = "live: requires docker compose up -d mssql"]
 fn stand_pool_split_resume_grows_mssql() {
     Eng::Ms.require();
-    let (table, _g) = seed_dense(Eng::Ms, 300_000);
+    let (table, _g) = seed_dense_wide_for_split(Eng::Ms, 300_000);
     run_pool_split_resume(
         Eng::Ms,
         &table,
@@ -2414,7 +2461,7 @@ fn stand_pool_split_gappy_key_mssql() {
 #[ignore = "live: requires docker compose up -d postgres"]
 fn stand_pool_split_keyset_recovers_a_crash_postgres() {
     Eng::Pg.require();
-    let (table, _g) = seed_dense(Eng::Pg, 300_000);
+    let (table, _g) = seed_dense_wide_for_split(Eng::Pg, 300_000);
     run_pool_split_resume_with(
         Eng::Pg,
         &table,
@@ -2429,7 +2476,7 @@ fn stand_pool_split_keyset_recovers_a_crash_postgres() {
 #[ignore = "live: requires docker compose up -d mysql"]
 fn stand_pool_split_keyset_recovers_a_crash_mysql() {
     Eng::My.require();
-    let (table, _g) = seed_dense(Eng::My, 300_000);
+    let (table, _g) = seed_dense_wide_for_split(Eng::My, 300_000);
     run_pool_split_resume_with(
         Eng::My,
         &table,
@@ -2444,7 +2491,7 @@ fn stand_pool_split_keyset_recovers_a_crash_mysql() {
 #[ignore = "live: requires docker compose up -d mssql"]
 fn stand_pool_split_keyset_recovers_a_crash_mssql() {
     Eng::Ms.require();
-    let (table, _g) = seed_dense(Eng::Ms, 300_000);
+    let (table, _g) = seed_dense_wide_for_split(Eng::Ms, 300_000);
     run_pool_split_resume_with(
         Eng::Ms,
         &table,

--- a/tests/offline/cli_contract.rs
+++ b/tests/offline/cli_contract.rs
@@ -43,27 +43,76 @@ fn run(args: &[&str]) -> (i32, String, String) {
 
 // ─── --help / --version shape ────────────────────────────────
 
+/// Every variant of `Commands`, lowercased — clap's default rename for a
+/// subcommand name, and this enum declares no `command(name = ..)` override.
+///
+/// DERIVED, not typed. The list used to be eleven names written out by hand
+/// while `Commands` had sixteen variants: `cdc`, `load`, `validate`, `schema`
+/// and `journal` were missing, in a test called
+/// `root_help_lists_every_top_level_subcommand` inside a file called
+/// `cli_contract.rs`. A hand-written dimension cannot notice its own omission —
+/// the defect this repo has now paid for in five separate places (audit
+/// 2026-08-17).
+fn declared_subcommands() -> Vec<String> {
+    let src = include_str!("../../src/cli/args.rs");
+    let start = src
+        .find("pub enum Commands {")
+        .expect("src/cli/args.rs must declare `pub enum Commands`");
+    let body = &src[start..];
+    let end = body.find("\n}").expect("the enum must close");
+    let mut out = Vec::new();
+    for line in body[..end].lines().skip(1) {
+        let t = line.trim();
+        // Variants sit at one indent level and start with an uppercase letter;
+        // attributes, doc comments and nested field lines do not.
+        if line.starts_with("    ")
+            && !line.starts_with("     ")
+            && t.chars().next().is_some_and(|c| c.is_ascii_uppercase())
+        {
+            let name: String = t
+                .chars()
+                .take_while(|c| c.is_alphanumeric())
+                .collect::<String>()
+                .to_lowercase();
+            if !name.is_empty() {
+                out.push(name);
+            }
+        }
+    }
+    assert!(
+        out.len() >= 12,
+        "parsed only {} subcommand(s) from `Commands` — the parser lost the enum, \
+         and an empty dimension is exactly the failure this derivation replaces: {out:?}",
+        out.len()
+    );
+    out
+}
+
 #[test]
 fn root_help_lists_every_top_level_subcommand() {
     let (code, stdout, _stderr) = run(&["--help"]);
     assert_eq!(code, 0, "`rivet --help` must exit 0");
 
-    for sub in [
-        "run",
-        "check",
-        "doctor",
-        "state",
-        "plan",
-        "apply",
-        "repair",
-        "reconcile",
-        "metrics",
-        "init",
-        "completions",
-    ] {
+    // The `Commands:` block only — `stdout.contains("run")` also matches prose
+    // ("Run export jobs…", "run `doctor` first"), so the old check passed for
+    // names that were never listed.
+    let block = stdout
+        .split("Commands:")
+        .nth(1)
+        .and_then(|s| s.split("\nOptions:").next())
+        .expect("`rivet --help` must have a Commands: block");
+    let listed: Vec<&str> = block
+        .lines()
+        .filter_map(|l| l.strip_prefix("  "))
+        .filter(|l| !l.starts_with(' '))
+        .filter_map(|l| l.split_whitespace().next())
+        .collect();
+
+    for sub in declared_subcommands() {
         assert!(
-            stdout.contains(sub),
-            "root --help must mention subcommand '{sub}'; got:\n{stdout}"
+            listed.contains(&sub.as_str()),
+            "`Commands` declares `{sub}` but root --help does not LIST it \
+             (listed: {listed:?})"
         );
     }
 }


### PR DESCRIPTION
The `FIXTURE INERT` guard from #232 did its job on the first nightly that ran it,
and printed what the old assertion never could:

```
keyset_mssql     giant 601ms  sibling 201ms  ratio 2.99
gappy_key_mssql  giant 612ms  sibling 403ms  ratio 1.52
keyset_mysql     giant 302ms  sibling 101ms  ratio 2.99
```

against `pool::advise_split`'s R=3.0. Locally the same fixture reads 15x.

**The difference is not the product.** CI gets through 300k narrow ints in ~600ms
where this laptop takes 3.3s, while the sibling — 100 rows — costs whatever a
connect plus a plan plus a tiny write costs: a FIXED floor that does not shrink
with the machine. So the ratio was measuring how fast the runner is, and on a
fast one it collapsed onto the threshold. Two of the three landed on 2.99.

Before the guard, this same condition read as `run 1 must fail (a unit errored
mid-split)` — a product accusation.

## The fix

Widen the ROW rather than add rows. Export time is dominated by bytes written,
so 200 bytes a row takes the giant from ~3.6 MB to ~63 MB and into seconds on
any machine, while the seed stays one bulk INSERT and — the reason for this
shape — `dense_ids(300_000)`, the grow ranges and every caller stay untouched.

`pad` is NULLable deliberately: `insert_dense_range` (the GROW step) inserts
(id, payload) only, and the width is needed just for the PRIMING run whose
durations set the ratio; the grow happens two runs later. Found by widening it
NOT NULL first and watching exactly the six growing tests fail.

## Honest limit

I cannot reproduce CI's speed locally, so the margin is argued from bytes (~17x
the write, against a floor that does not move) rather than measured on the
machine that failed. If it stops holding, the guard says so with the numbers —
which is how this was found in the first place.

9 pool-split tests green, 94s (was 57s).