### PR TITLE
fix: both red-main failures — a fuzz panic on a foreign checkpoint, and a fixture that wasn't idle

### DIFF
--- a/src/source/mongo/cdc.rs
+++ b/src/source/mongo/cdc.rs
@@ -175,8 +175,15 @@ pub(crate) fn decode_resume_token(
     // handed to the `ResumeToken`/bson deserializer, which PANICS (not `Err`s)
     // on a type mismatch. The release build is `panic = "abort"`, so an unguarded
     // deserialize would abort the whole run on a corrupt/foreign checkpoint.
-    if v.get("_data").and_then(|x| x.as_str()).is_some() {
-        return Ok(serde_json::from_value(v.clone())?);
+    // Deserialize a document built from `_data` ALONE, never `v` itself: a file
+    // carrying `_data` beside foreign keys panicked the bson visitor rather than
+    // erroring (fuzz crash 1c53b95b, 2026-08-17), so passing `v` through checked
+    // one key and then trusted the whole object. A resume token's meaning is
+    // entirely in `_data`; anything else in the file is noise to drop.
+    if let Some(data) = v.get("_data").and_then(|x| x.as_str()) {
+        return Ok(serde_json::from_value(
+            serde_json::json!({ "_data": data }),
+        )?);
     }
     anyhow::bail!(
         "mongodb cdc: unrecognized resume-token checkpoint shape \
@@ -563,6 +570,45 @@ mod tests {
     // in the release profile that aborts the whole run on a corrupt/foreign
     // checkpoint. The decoder must return a clean error for any unrecognized
     // shape. (RED before the shape-guard: `decode_resume_token` panics here.)
+
+    /// The exact input libFuzzer crashed on (nightly Fuzz, run 31998520492,
+    /// 2026-08-17): a `_data` STRING sitting beside a dozen unrelated keys, one
+    /// of them deeply nested. The guard below checked that `_data` was a string
+    /// and then handed the WHOLE object to the deserializer, which PANICS
+    /// (`unreachable!` in bson's seeded visitor) instead of erroring — so the
+    /// precondition its own comment claimed ("Deserialize ONLY that exact
+    /// shape") was named but never established. `panic = "abort"` in release
+    /// makes that an aborted run on a foreign checkpoint file.
+    #[test]
+    fn decode_resume_token_survives_foreign_keys_beside_data() {
+        let raw = r##"{"rz~tt":"t'" ,    "/":{"":{"":{"":{"t":{}}}}},   " t":"t'" ,    "RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR   ~vrtt":"t'" ,    "_data":"8" ,    " jjjjjjjjjjjr~tt":    "_data'" ,    "   rt":" E" }"##;
+        let v: serde_json::Value = serde_json::from_str(raw).expect("corpus input is valid JSON");
+        let token = decode_resume_token(&v)
+            .expect("a `_data` string is a resume token whatever else the file carries");
+        // Non-inert: the token really is the one `_data` named, not a default.
+        let round: serde_json::Value = serde_json::to_value(&token).unwrap();
+        assert_eq!(round.get("_data").and_then(|d| d.as_str()), Some("8"));
+    }
+
+    /// The `rt` branch is the SIBLING of the `_data` one and was never fuzzed
+    /// past the hex gate — libFuzzer cannot readily synthesise valid BSON, so a
+    /// well-formed document of the WRONG SHAPE is a hole the corpus cannot
+    /// reach. Probed directly with real BSON: it does NOT panic, because
+    /// `from_bson` decodes a `ResumeToken` as an opaque raw document rather than
+    /// through the serde_json visitor that blew up on the `_data` path. It is
+    /// ACCEPTED and rejected later by the server (`Bad resume token`, 40648) —
+    /// loud and lossless, which is why this asserts no-panic rather than `Err`.
+    #[test]
+    fn decode_resume_token_does_not_panic_on_wellformed_bson_of_the_wrong_shape() {
+        let mut doc = Document::new();
+        doc.insert("x", mongodb::bson::doc! { "y": 1i32 });
+        let mut buf = Vec::new();
+        doc.to_writer(&mut buf).unwrap();
+        let hex: String = buf.iter().map(|b| format!("{b:02x}")).collect();
+        // The point of the test is that this returns at all.
+        let _ = decode_resume_token(&json!({ "rt": hex }));
+    }
+
     #[test]
     fn decode_resume_token_rejects_malformed_shapes_without_panicking() {
         for bad in [

--- a/tests/common/mssql.rs
+++ b/tests/common/mssql.rs
@@ -187,6 +187,63 @@ pub fn mssql_governor_query_i64(sql: &str) -> i64 {
     query_i64_at(1435, sql)
 }
 
+/// Block until the governor instance's transaction log has stopped accumulating
+/// flush waits, so an "idle source" assertion grades the RUN rather than the
+/// fixture's own seed still draining.
+///
+/// Despite the name, `Log Flush Waits/sec` is a CUMULATIVE counter — two equal
+/// consecutive reads mean no wait was recorded in between, which is exactly the
+/// condition the no-shed canaries assert holds during their runs. Seeding 40k
+/// rows in 1000-row batches leaves the log draining for as long as the host's
+/// disk needs: under a second on a laptop, but long enough on CI's disk that the
+/// governor (correctly) shed for pressure the test itself had created. Giving
+/// the shared instance its own container fixed the SIBLING half of that; this
+/// fixes the half the fixture creates for itself.
+///
+/// Panics rather than proceeding when the log never settles: a bounded wait that
+/// gives up quietly is a `sleep` wearing a loop, and would hand the caller the
+/// same unestablished precondition it was called to establish.
+pub fn wait_for_quiet_mssql_governor_log() {
+    const FLUSH_WAITS: &str = "SELECT cntr_value FROM sys.dm_os_performance_counters \
+                               WHERE counter_name LIKE 'Log Flush Waits%' \
+                               AND instance_name = '_Total'";
+    /// Equal reads required in a row (i.e. two consecutive quiet intervals).
+    const SETTLED_READS: usize = 3;
+    const INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
+    const MAX_ATTEMPTS: usize = 60; // ~30s ceiling
+
+    let started = std::time::Instant::now();
+    let mut last = mssql_governor_query_i64(FLUSH_WAITS);
+    let mut equal_runs = 1usize;
+    for _ in 0..MAX_ATTEMPTS {
+        std::thread::sleep(INTERVAL);
+        let now = mssql_governor_query_i64(FLUSH_WAITS);
+        if now == last {
+            equal_runs += 1;
+            if equal_runs >= SETTLED_READS {
+                // Report the wait: on a fast disk the log is already quiet and
+                // this returns at the floor, which is exactly why the CI-only
+                // failure was invisible locally. Printing it means a future
+                // reader can tell a firing wait from an inert one.
+                eprintln!(
+                    "governor log settled after {:.1}s (flush waits steady at {last})",
+                    started.elapsed().as_secs_f64()
+                );
+                return;
+            }
+        } else {
+            equal_runs = 1;
+        }
+        last = now;
+    }
+    panic!(
+        "the governor instance's log never went quiet within {}s (Log Flush Waits still \
+         advancing, last={last}) — an idle-source assertion taken now would grade the \
+         fixture's own seed, not the run",
+        (MAX_ATTEMPTS as u64 * INTERVAL.as_millis() as u64) / 1000
+    );
+}
+
 /// As [`mssql_query_i64`], but against `mssql-cdc` (`:1434`) — e.g. polling a CDC
 /// change table's row count while the capture job catches up.
 pub fn mssql_cdc_query_i64(sql: &str) -> i64 {

--- a/tests/live/chunking_stand.rs
+++ b/tests/live/chunking_stand.rs
@@ -108,6 +108,48 @@ impl Eng {
     }
 }
 
+/// As [`insert_dense_range`], but also fills the `pad` column — for the SEEDING
+/// leg of a split fixture, whose giant must carry bytes across its whole span.
+/// The grow leg deliberately keeps using the narrow twin: `pad` is NULLable, and
+/// the width is only needed for the PRIMING run that sets the split ratio.
+fn insert_dense_range_padded(eng: Eng, table: &str, lo: i64, hi: i64, pad_bytes: usize) {
+    let (pg, my, ms) = (
+        format!("repeat('x', {pad_bytes})"),
+        format!("REPEAT('x', {pad_bytes})"),
+        format!("REPLICATE('x', {pad_bytes})"),
+    );
+    match eng {
+        Eng::Pg => {
+            let mut c = pg_connect();
+            c.batch_execute(&format!(
+                "INSERT INTO {table} (id, payload, pad) \
+                 SELECT g, g, {pg} FROM generate_series({lo}, {hi}) g"
+            ))
+            .unwrap();
+        }
+        Eng::My => {
+            let mut c = mysql_connect();
+            c.query_drop(format!(
+                "SET SESSION cte_max_recursion_depth = {}",
+                hi - lo + 10
+            ))
+            .unwrap();
+            c.query_drop(format!(
+                "INSERT INTO {table} (id, payload, pad) \
+                 WITH RECURSIVE seq AS (SELECT {lo} n UNION ALL SELECT n+1 FROM seq WHERE n < {hi}) \
+                 SELECT n, n, {my} FROM seq"
+            ))
+            .unwrap();
+        }
+        Eng::Ms => {
+            mssql_exec(&format!(
+                "INSERT INTO {table} (id, payload, pad) \
+                 SELECT value, value, {ms} FROM GENERATE_SERIES(CAST({lo} AS BIGINT), CAST({hi} AS BIGINT))"
+            ));
+        }
+    }
+}
+
 /// Append `id`s `lo..=hi` (payload = id) to a `(id BIGINT PK, payload INT)` stand
 /// table — the source-GROWTH leg of the split-resume scenario, per engine.
 fn insert_dense_range(eng: Eng, table: &str, lo: i64, hi: i64) {
@@ -153,8 +195,15 @@ fn seed_gappy_split(
     eng: Eng,
     block: i64,
 ) -> (String, StandCleanup, std::collections::BTreeSet<i64>) {
-    let (table, guard) = seed_dense(eng, block); // 1..=block
-    insert_dense_range(eng, &table, 2 * block + 1, 3 * block); // the far block, past the hole
+    // WIDE, for the same reason the dense split fixture is (see `seed_dense_wide`):
+    // this is a `_split_` fixture, and a narrow giant does not beat the sibling's
+    // fixed connect+plan floor by R=3.0. Widening the dense fixture on 08-17 left
+    // this one narrow — and `stand_pool_split_gappy_key_mssql` was one of the four
+    // nightly failures the next morning (giant 612 ms vs sibling 403 ms, ratio
+    // 1.52). Both blocks are padded, so the giant carries the bytes across the
+    // whole span rather than only its first half.
+    let (table, guard) = seed_dense_wide(eng, block, SPLIT_PAD_BYTES); // 1..=block
+    insert_dense_range_padded(eng, &table, 2 * block + 1, 3 * block, SPLIT_PAD_BYTES);
     let ids: std::collections::BTreeSet<i64> =
         (1..=block).chain(2 * block + 1..=3 * block).collect();
     (table, guard, ids)
@@ -251,7 +300,7 @@ fn run_pool_split_resume_with(
         // ANY status: this run crashes its units on purpose, so a unit that did
         // its job records a FAILED row, not a successful one.
         let units = runs.iter().filter(|(n, ..)| n.contains('#')).count();
-        if units < 2 {
+        {
             // The priming run's successes are what the advisor predicted from.
             // ONE entry per export NAME (its longest run): the advisor compares
             // the longest export to the next-longest OTHER export, so a list
@@ -278,7 +327,16 @@ fn run_pool_split_resume_with(
                 [(_, a, _), (_, b, _), ..] if *b > 0 => *a as f64 / *b as f64,
                 _ => f64::NAN,
             };
-            panic!(
+            // Report the MARGIN on every run, not only on the failing one. The
+            // ratio is a property of the machine as much as the fixture (local
+            // 15x, CI 1.52), so a nightly that passes at 3.1 is one slow disk
+            // away from the failure this guard exists to explain — and without
+            // this line the log says nothing until it is already red.
+            eprintln!(
+                "split fixture margin: ratio {ratio:.2} vs R=3.0, {units} unit(s), primed {primed:?}"
+            );
+            assert!(
+                units >= 2,
                 "FIXTURE INERT, not a product failure: `--split` produced {units} unit(s), so no \
                  unit could error and run 1 was always going to succeed — the assertion below \
                  would blame the product for the fixture's own failure to set up. \
@@ -632,8 +690,13 @@ fn seed_dense(eng: Eng, rows: i64) -> (String, StandCleanup) {
 /// it. The width is the only thing that changes: the id space, `dense_ids`, the
 /// grow ranges and every caller stay exactly as they were.
 fn seed_dense_wide_for_split(eng: Eng, rows: i64) -> (String, StandCleanup) {
-    seed_dense_wide(eng, rows, 200)
+    seed_dense_wide(eng, rows, SPLIT_PAD_BYTES)
 }
+
+/// One width for every split fixture. Named rather than repeated so widening it
+/// again (if a future runner still lands under R=3.0) is one edit, and so a
+/// reader can see the dense and gappy fixtures are deliberately the same shape.
+const SPLIT_PAD_BYTES: usize = 200;
 
 /// `seed_dense` with a `pad` column of `pad_bytes` characters.
 ///

--- a/tests/live/live_governor.rs
+++ b/tests/live/live_governor.rs
@@ -814,6 +814,18 @@ fn mssql_adaptive_never_loses_to_its_own_baseline_on_an_idle_source() {
     let _quiet = quiet_window_guard();
     const ROWS: i64 = 40_000;
     let table = seed_mssql_governor_numeric_table(ROWS);
+    // ...and the OTHER half of "idle", which the dedicated instance did NOT fix:
+    // this fixture's own seed. It failed again on main at 07:40 with the
+    // dedicated container up (job 95318036698), and the shed pattern names the
+    // cause — parallelism dropped ONE SECOND into the adaptive run and recovered
+    // immediately after ("source pressure rising" → "source pressure eased"),
+    // which is SQL Server's automatic CHECKPOINT flushing the 40k-row seed on a
+    // slower disk, not a busy server. (The sibling that deliberately creates
+    // flush pressure did not overlap: it finished at 07:51:11, this test at
+    // 07:51:05 — `quiet_window_guard` held.) Force that deferred work to happen
+    // NOW and wait for the counter to go flat, so the run measures the run.
+    mssql_governor_exec("CHECKPOINT");
+    wait_for_quiet_mssql_governor_log();
     let run = |adaptive: bool| -> (f64, String) {
         let rig = Rig::mssql_governor_batch(table.name())
             .mode("chunked")
@@ -840,11 +852,37 @@ fn mssql_adaptive_never_loses_to_its_own_baseline_on_an_idle_source() {
         (wall, stderr)
     };
     let (wall_off, _) = run(false);
+    // Bracket the graded run with the EXACT counter the governor samples, so a
+    // failure says which of the two things broke instead of costing another
+    // session of inference. The 07:40 failure had no such evidence: "nothing to
+    // shed for" is a product accusation, and the product was innocent.
+    const FLUSH_WAITS: &str = "SELECT cntr_value FROM sys.dm_os_performance_counters \
+                               WHERE counter_name LIKE 'Log Flush Waits%' \
+                               AND instance_name = '_Total'";
+    let waits_before = mssql_governor_query_i64(FLUSH_WAITS);
     let (wall_on, stderr_on) = run(true);
+    let flush_waits = mssql_governor_query_i64(FLUSH_WAITS) - waits_before;
     assert_governor_awake(&stderr_on, "mssql");
+    // A quiet stand measures a delta of 1 across a read-only run (2026-08-14);
+    // the sibling pressure test needs THOUSANDS to shed. Anything past this
+    // floor means the source genuinely was not idle.
+    const IDLE_CEILING: i64 = 50;
     assert!(
         !stderr_on.contains("backed off"),
-        "idle source: the MSSQL governor has nothing to shed for; stderr:\n{stderr_on}"
+        "{}",
+        if flush_waits > IDLE_CEILING {
+            format!(
+                "FIXTURE, not product: the source was NOT idle during the graded run \
+                 (+{flush_waits} log flush waits, ceiling {IDLE_CEILING}) — the governor \
+                 shed for real pressure and was RIGHT. Something is still writing to \
+                 :1435, or the seed's deferred work outlived the CHECKPOINT above.\n{stderr_on}"
+            )
+        } else {
+            format!(
+                "idle source (+{flush_waits} log flush waits, genuinely quiet): the MSSQL \
+                 governor has nothing to shed for; stderr:\n{stderr_on}"
+            )
+        }
     );
     assert!(
         wall_on <= wall_off * 1.6 + 1.0,


### PR DESCRIPTION
`main` was red on two independent jobs. Neither was a flake.

**Fuzz (mongo_resume_token)** — libFuzzer found a real panic: a checkpoint
carrying `_data` BESIDE foreign keys reached `unreachable!()` in bson's seeded
visitor. The guard checked that `_data` was a string and then handed the WHOLE
object to the deserializer, so its own comment ("Deserialize ONLY that exact
shape") named a precondition the code never established. With `panic = "abort"`
in release that aborts the run on a foreign/corrupt checkpoint file. Fixed by
deserializing a document built from `_data` alone. RED-proven locally on the
exact corpus bytes, which now live in a unit test — `fuzz/corpus` is gitignored,
so the lib suite is the durable home for the regression.

Probed the sibling `rt` branch rather than assuming it safe: it does NOT panic
(`from_bson` decodes opaquely), it accepts and lets the server reject with 40648
— loud and lossless. Test asserts that, not a stricter claim than the truth.

**E2E (mssql idle governor canary)** — the dedicated `:1435` instance fixed the
sibling half of "idle"; this is the half the fixture creates for itself. The
shed pattern names the cause: parallelism dropped one second into the graded run
and recovered immediately ("pressure rising" → "pressure eased"), the signature
of SQL Server's automatic CHECKPOINT flushing the 40k-row seed on a slower disk.
The governor was right; the precondition was false. An explicit `CHECKPOINT` plus
a wait on the counter going flat moves that work before the measurement.

The wait fails loudly if the log never settles — a bounded wait that gives up
quietly is a sleep wearing a loop — and reports how long it waited, because at
the floor it is inert, which is exactly why this was invisible locally (1.1s
here, and the local pass is therefore NOT proof the CI failure is closed).

Also brackets the graded run with the exact counter the governor samples and
classifies the failure: past the idle ceiling it reads "FIXTURE, not product —
the governor shed for real pressure and was RIGHT". The 07:40 failure carried no
such evidence, and "nothing to shed for" accused a product that was innocent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168uwctCn3W1rP4Kt4kZXvE