### PR TITLE
test(cdc): the independent per-column oracle for MSSQL, and its schemaless twin for Mongo

### DIFF
--- a/tests/common/mongo.rs
+++ b/tests/common/mongo.rs
@@ -185,6 +185,19 @@ impl MongoTest {
         })
     }
 
+    /// How many documents actually CARRY `field` — MongoDB's own answer, for a
+    /// per-field presence profile against a captured CDC change log. `$exists`
+    /// rather than a non-null test: the question is whether the key is there at
+    /// all, which is exactly what a renderer that drops a field would change.
+    pub fn count_field_present(&self, name: &str, field: &str) -> u64 {
+        self.rt.block_on(async {
+            self.coll(name)
+                .count_documents(doc! { field: { "$exists": true } })
+                .await
+                .expect("mongo: count field present")
+        })
+    }
+
     /// Current `_id → field` state (integer `_id`) — the oracle a dedup of the
     /// captured CDC change log must reproduce exactly.
     pub fn current_state_i64(&self, name: &str, field: &str) -> BTreeMap<i64, String> {

--- a/tests/common/mssql.rs
+++ b/tests/common/mssql.rs
@@ -396,3 +396,28 @@ fn split_go(sql: &str) -> Vec<String> {
     }
     out
 }
+
+/// Every row's first column as a `String`, against the CDC `mssql-cdc` (`:1434`).
+///
+/// For DERIVING an enumeration from the catalog rather than re-typing it in a
+/// test — a hand-written column list grades only what its author remembered, and
+/// silently stops covering a column the fixture gains later.
+pub fn mssql_cdc_query_strings(sql: &str) -> Vec<String> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("mssql: tokio runtime");
+    rt.block_on(async {
+        let mut client = connect_at(1434).await;
+        let rows = client
+            .simple_query(sql)
+            .await
+            .expect("mssql: query")
+            .into_first_result()
+            .await
+            .expect("mssql: rows");
+        rows.iter()
+            .filter_map(|r| r.get::<&str, _>(0).map(String::from))
+            .collect()
+    })
+}

--- a/tests/live/live_cdc_mongo.rs
+++ b/tests/live/live_cdc_mongo.rs
@@ -636,3 +636,93 @@ fn mongo_cdc_change_stream_renders_tricky_bson_verbatim_like_batch() {
         );
     }
 }
+
+/// Per-FIELD presence profile against MONGODB ITSELF — the schemaless analogue
+/// of the per-column NULL profile the SQL engines carry.
+///
+/// Mongo's CDC image is a JSON BLOB (`_id` + `document`), so "a column silently
+/// became NULL" has no direct shape here. The equivalent silent loss is a FIELD
+/// vanishing from the rendered document while every count still balances: the
+/// change count matches, `_id`s all present, and one key is simply gone from the
+/// post-images. The existing oracles cannot see it — the soak test deduplicates
+/// on ONE field (`v`) and the tricky-BSON test reads a SINGLE document, so a
+/// fault that drops a different field, or drops it in only some documents, is
+/// invisible to both.
+///
+/// The oracle is MongoDB's own per-field presence count, compared against
+/// DuckDB's `json_extract` over the captured `document` column — two readers
+/// that share no code with rivet's renderer.
+#[test]
+#[ignore = "live: requires docker compose up -d mongo-rs"]
+fn mongo_cdc_per_field_presence_matches_the_source() {
+    require_alive(LiveService::MongoRs);
+    require_alive(LiveService::DuckDb);
+    use mongodb::bson::doc;
+    let db = unique_name("cdc_fields");
+    let m = MongoTest::connect(PORT, &db);
+    m.drop_collection("f");
+
+    let rig = cdc(&db, "f");
+    rig.run_ok(); // anchor over the empty collection
+
+    // A POPULATION, not one document: a fault that drops a field in only some
+    // renderings needs more than one to be distinguishable from a fixture typo.
+    // `opt` is deliberately present on only half the documents, so the profile
+    // has to match a NON-TRIVIAL number on at least one field — a check where
+    // every field is present everywhere passes just as well when the extraction
+    // is broken and returns everything.
+    const DOCS: i64 = 24;
+    let docs: Vec<_> = (1..=DOCS)
+        .map(|i| {
+            let mut d = doc! { "_id": i, "always": format!("a{i}"), "nested": doc!{ "k": i } };
+            if i % 2 == 0 {
+                d.insert("opt", format!("o{i}"));
+            }
+            d
+        })
+        .collect();
+    m.insert_many("f", docs);
+    for _ in 0..3 {
+        rig.run_ok();
+    }
+
+    let captured = read_mongo_cdc_changes(&rig.out_dir()).len() as i64;
+    assert!(
+        captured >= DOCS,
+        "fixture inert: only {captured} change(s) captured for {DOCS} inserted documents"
+    );
+
+    // Every post-image must CARRY its document. A delete has none by design, so
+    // the profile is taken over the non-delete ops only.
+    let missing_doc = duckdb_dir_scalar(
+        &rig.out_dir(),
+        "count(*) - count(\"document\")",
+        Some("__op <> 'delete'"),
+    );
+    assert_eq!(
+        missing_doc, 0,
+        "{missing_doc} captured post-image(s) carry no document at all — a blob that \
+         degrades to NULL is this model's whole-row silent loss"
+    );
+
+    for (field, expected) in [("always", DOCS), ("opt", DOCS / 2), ("nested", DOCS)] {
+        // MongoDB's own answer, not a number this test assumes.
+        let src = m.count_field_present("f", field) as i64;
+        assert_eq!(
+            src, expected,
+            "fixture drifted: MongoDB reports {src} document(s) with '{field}', the fixture \
+             builds {expected} — the comparison below would then grade the wrong population"
+        );
+        let dst = duckdb_dir_scalar(
+            &rig.out_dir(),
+            &format!("count(json_extract(\"document\", '$.{field}'))"),
+            Some("__op <> 'delete'"),
+        );
+        assert_eq!(
+            src, dst,
+            "field '{field}': presence parity against MongoDB itself — source {src}, \
+             captured {dst}. A renderer that drops a field moves this and nothing else; \
+             the change count, the `_id` set and a single-field dedup all still balance."
+        );
+    }
+}

--- a/tests/live/live_cdc_mssql.rs
+++ b/tests/live/live_cdc_mssql.rs
@@ -989,6 +989,79 @@ fn mssql_cdc_full_type_matrix_matches_batch() {
     }
     // CDC adds its change-metadata columns the batch export doesn't have.
     assert!(cdc.schema().index_of("__op").is_ok() && cdc.schema().index_of("__pos").is_ok());
+
+    // ─── Per-column NULL profile against SQL SERVER ITSELF ────────────────────
+    //
+    // HONEST LIMIT, first, because it changes how to read what follows: no mutant
+    // was found where THIS assertion is the one that bites. Two were tried.
+    // (1) `ColumnData::Guid(Some(g))` → `RivetValue::Null` in the MSSQL CDC
+    // decoder — the exact degrade-to-NULL shape — is caught FIRST by the
+    // ArrayData comparison above (`column u: CDC differs from the batch export`),
+    // because only the CDC side degrades. (2) The shared decision point, where a
+    // fault WOULD be symmetric — `RivetType::Uuid => FixedSizeBinary(16)` in
+    // `types/mapping.rs`, which both paths read — narrowed to `(8)` never runs:
+    // the product rejects it at `mapping.rs:294` ("Uuid extension only valid on
+    // FixedSizeBinary(16)"). That is a real result about the product, not a gap:
+    // the one place both paths could go wrong together is guarded by its own
+    // invariant.
+    //
+    // So this earns its place as defence in depth, not on a demonstrated kill —
+    // and the distinction is stated here rather than left for a reader to assume
+    // a kill. What it uniquely covers is the SYMMETRIC fault: the comparison
+    // above is differential (CDC against batch, both decoded by rivet), so a
+    // fault the two share passes its own inspection. This asks SQL Server.
+    //
+    // The class is not hypothetical on other engines: the `FixedSizeBinary(16)`
+    // builder nulled anything not exactly 16 bytes and `test_decoding` renders
+    // uuids as 36-char TEXT, so 100% of a PostgreSQL uuid column became NULL on a
+    // real bucket while every count and sum check passed.
+    //
+    // The column list is DERIVED from the catalog, never re-typed here: a
+    // hand-written list grades only the columns its author remembered and
+    // silently stops covering any the fixture gains later.
+    //
+    // INSERT images only — a CDC part holds one row per change, so the source's
+    // 2 rows are the 2 inserts; reading the whole part compares different
+    // populations.
+    let cols = mssql_cdc_query_strings(&format!(
+        "SELECT c.name FROM sys.columns c \
+         JOIN sys.tables t ON t.object_id = c.object_id \
+         WHERE t.name = '{table}' ORDER BY c.column_id"
+    ));
+    assert!(
+        cols.len() >= 20,
+        "the fixture must present a rich column set to profile; got {} — did the \
+         catalog query stop resolving the table?",
+        cols.len()
+    );
+    let mut columns_with_nulls = 0;
+    for col in &cols {
+        let src_nulls = mssql_cdc_query_i64(&format!(
+            "SELECT COUNT(*) - COUNT([{col}]) FROM dbo.{table}"
+        ));
+        columns_with_nulls += i32::from(src_nulls > 0);
+        let dst_nulls = duckdb_dir_scalar(
+            &cdc_out,
+            &format!("count(*) - count(\"{col}\")"),
+            Some("__op = 'insert'"),
+        );
+        assert_eq!(
+            src_nulls, dst_nulls,
+            "column '{col}': NULL-count parity against SQL Server itself — source \
+             {src_nulls}, captured {dst_nulls}. A per-cell decode that degrades to \
+             NULL moves this and nothing else."
+        );
+    }
+    // The fixture must actually LOAD this axis: row 2 sets only `id`, so every
+    // other column must show a source NULL. A column compared at 0-vs-0 is a
+    // green that proves nothing, and that is what this decays into if someone
+    // later simplifies the INSERTs.
+    assert!(
+        columns_with_nulls >= 15,
+        "only {columns_with_nulls} of {} columns carry a source NULL — the fixture \
+         stopped exercising the null axis, so the parity above is comparing zeros",
+        cols.len()
+    );
 }
 
 #[test]


### PR DESCRIPTION
Item 2 of the uncovered list: the CDC type matrices had the null-profile oracle
on PostgreSQL only. Both additions ask the ENGINE, not another rivet path.

MSSQL — per-column NULL profile against SQL Server itself, column list DERIVED
from `sys.columns` rather than re-typed (a hand-written list grades only what its
author remembered). Reported honestly in the test: no mutant was found where this
assertion is the one that bites. Two were tried. `ColumnData::Guid(Some(g))` →
`RivetValue::Null` — the exact degrade-to-NULL shape — is caught FIRST by the
existing ArrayData comparison, because only the CDC side degrades. The shared
decision point, where a fault WOULD be symmetric (`RivetType::Uuid =>
FixedSizeBinary(16)`, read by both paths), cannot be narrowed to (8) at all: the
product rejects it at `mapping.rs:294`. That is a real result about the product —
the one place both paths could go wrong together is guarded by its own invariant.
So this earns its place as defence in depth against the symmetric fault, and the
test says so where a reader will see it instead of implying a kill.

Mongo — the schemaless analogue, and this one IS RED-proven. Its image is a JSON
blob, so "a column became NULL" has no direct shape; the equivalent silent loss
is a FIELD vanishing while every count balances. Neither existing oracle can see
it: the soak test deduplicates on ONE field, the tricky-BSON test reads ONE
document. New test compares MongoDB's own `$exists` counts against DuckDB's
`json_extract` over the captured column — two readers sharing no code with
rivet's renderer — over a population of 24 documents, one field deliberately
present on only half so the profile matches a non-trivial number.

RED-proven against a renderer that drops a field: source 12, captured 0. The
claim that the other oracles cannot see it was VERIFIED, not asserted — the soak
and tricky-BSON tests both stay GREEN under the same mutant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168uwctCn3W1rP4Kt4kZXvE