### PR TITLE
test(load): --rivet-bin must resolve to THIS executable, never a $PATH lookup

### DIFF
--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -1912,3 +1912,41 @@ mod init_tls_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod rivet_bin_tests {
+    use super::resolve_rivet_bin;
+
+    /// `rivet load` shells out to a rivet subprocess for the type report, and
+    /// WHICH binary that is decides whether the types it resolves match the
+    /// version doing the load. The default must therefore be THIS executable, not
+    /// the name `rivet` — a `rivet` on `$PATH` may be an older, skewed build, and
+    /// a type report from a skewed build is wrong in exactly the way nobody
+    /// checks: it still parses, still loads, and describes different columns.
+    ///
+    /// `--rivet-bin` had no test of any kind, and this is its whole contract:
+    /// honour an explicit path, and otherwise resolve to self rather than to a
+    /// bare name the shell would look up.
+    #[test]
+    fn rivet_bin_defaults_to_this_executable_never_a_path_lookup() {
+        let explicit = resolve_rivet_bin(Some("/opt/pinned/rivet".to_string()));
+        assert_eq!(
+            explicit, "/opt/pinned/rivet",
+            "an explicit --rivet-bin must be used verbatim — the flag exists to PIN a build"
+        );
+
+        let default = resolve_rivet_bin(None);
+        assert_ne!(
+            default, "rivet",
+            "the default must not be the bare name `rivet`: that is a $PATH lookup, and the \
+             binary it finds may be a different version than the one running the load"
+        );
+        let me = std::env::current_exe().expect("current_exe");
+        assert_eq!(
+            std::path::Path::new(&default),
+            me.as_path(),
+            "the default must be THIS executable, so the type-report subprocess resolves \
+             types with the same version as the load"
+        );
+    }
+}


### PR DESCRIPTION
The last flag from the derived sweep with no test of any kind. Its contract is
small and load-bearing: `rivet load` shells out to a rivet subprocess for the
type report, so WHICH binary that is decides whether the types it resolves match
the version doing the load. Defaulting to the bare name `rivet` would be a $PATH
lookup, and an older build there produces a report that still parses, still
loads, and describes different columns — wrong in the way nobody checks.

Pins both halves: an explicit path is used verbatim (the flag exists to PIN a
build), and the default equals `current_exe()` rather than any name a shell
would resolve.

Lives in the BIN crate, so it runs under `cargo test --bin rivet` — which is why
`--lib` reported zero tests for it at first, and worth stating: half this crate's
CLI code is in the binary target, and a lib-only run grades none of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168uwctCn3W1rP4Kt4kZXvE