### PR TITLE
fix(nightly): start the governor instance — and a guard so the two stacks cannot drift silently

### DIFF
--- a/.github/workflows/nightly-live.yml
+++ b/.github/workflows/nightly-live.yml
@@ -76,7 +76,7 @@ jobs:
           # it every test that writes a shared workdir EACCESes — the first
           # nightly after the cdc-oracle suite landed failed exactly there.
           mkdir -p tests/.live-tmp
-          docker compose --profile pool --profile loaders --profile cdc --profile replica up -d postgres mysql mssql minio fake-gcs azurite toxiproxy pgbouncer proxysql duckdb clickhouse postgres-cdc mysql-cdc mssql-cdc mysql-primary mysql-replica
+          docker compose --profile pool --profile loaders --profile cdc --profile replica --profile governor up -d postgres mysql mssql mssql-governor minio fake-gcs azurite toxiproxy pgbouncer proxysql duckdb clickhouse postgres-cdc mysql-cdc mssql-cdc mysql-primary mysql-replica
           sudo chmod -R 0777 tests/.live-tmp
 
       - name: Wait for services
@@ -114,6 +114,16 @@ jobs:
           for i in $(seq 1 30); do docker compose exec -T mysql-cdc mysqladmin ping -h localhost -uroot -privet 2>/dev/null && break || sleep 2; done
           for i in $(seq 1 40); do docker compose exec -T mssql-cdc /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'Rivet_Passw0rd!' -C -Q 'SELECT 1' >/dev/null 2>&1 && break || sleep 2; done
           docker compose exec -T mssql-cdc /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'Rivet_Passw0rd!' -C -Q "IF DB_ID('rivet') IS NULL CREATE DATABASE rivet;"
+          echo "Waiting for SQL Server (governor instance)..."
+          # The dedicated governor instance (`mssql-governor`, :1435) was added to
+          # ci.yml's E2E stack on 2026-08-17 and MISSED here — the runner-bypass
+          # class, in workflow YAML: two hand-maintained service lists, and the
+          # nightly's fell behind on the first change. Both governor canaries then
+          # failed the 08-19 nightly with "requires MssqlGovernor reachable on
+          # :1435". Same wait + same database seed as ci.yml; its two canaries
+          # seed their own tables.
+          for i in $(seq 1 40); do docker compose exec -T mssql-governor /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'Rivet_Passw0rd!' -C -Q 'SELECT 1' >/dev/null 2>&1 && break || sleep 2; done
+          docker compose exec -T mssql-governor /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'Rivet_Passw0rd!' -C -Q "IF DB_ID('rivet') IS NULL CREATE DATABASE rivet;"
 
       - name: Build release (rivet + seed)
         # `--bin seed` builds the auxiliary src/bin/seed.rs target on top of

--- a/tests/offline/workflow_stack_guard.rs
+++ b/tests/offline/workflow_stack_guard.rs
@@ -1,0 +1,78 @@
+//! The two CI workflows each hand-maintain a `docker compose … up -d` service
+//! list, and hand-maintained twins drift: `mssql-governor` was added to
+//! ci.yml's E2E stack on 2026-08-17 and missed in nightly-live.yml, so both
+//! governor canaries failed the 08-19 nightly with "requires MssqlGovernor
+//! reachable on :1435" — the runner-bypass class, in workflow YAML.
+//!
+//! The invariant is directional, not equality: the NIGHTLY runs the full live
+//! suite (a superset of the E2E matrix), so every service the E2E stack starts
+//! must be started by the nightly too. The nightly may start MORE (loaders,
+//! mongo variants); the E2E matrix may not need those.
+
+use std::collections::BTreeSet;
+
+/// Every service named across all `docker compose … up -d …` lines of one
+/// workflow file — flags (`--wait`, `--profile x`) stripped, the union taken
+/// because both files start services across several steps/jobs.
+fn compose_services(path: &str) -> BTreeSet<String> {
+    let text = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("read {path}: {e} (run from the repo root)"));
+    let mut out = BTreeSet::new();
+    for line in text.lines() {
+        let Some(idx) = line.find("up -d") else {
+            continue;
+        };
+        if !line.contains("docker compose") {
+            continue;
+        }
+        let mut words = line[idx + "up -d".len()..].split_whitespace().peekable();
+        while let Some(w) = words.next() {
+            if w == "--wait" {
+                continue;
+            }
+            if w == "--profile" {
+                words.next(); // the profile name is not a service
+                continue;
+            }
+            if w.starts_with("--") || w.starts_with('#') {
+                continue;
+            }
+            out.insert(w.trim_end_matches(&['"', '\''][..]).to_string());
+        }
+    }
+    assert!(
+        !out.is_empty(),
+        "{path}: no `docker compose … up -d` service lists found — if the startup moved to \
+         a script, point this guard at it rather than letting it pass on an empty set"
+    );
+    out
+}
+
+#[test]
+fn the_nightly_stack_covers_every_service_the_e2e_stack_starts() {
+    let e2e = compose_services(".github/workflows/ci.yml");
+    let nightly = compose_services(".github/workflows/nightly-live.yml");
+    let missing: Vec<&String> = e2e.difference(&nightly).collect();
+    assert!(
+        missing.is_empty(),
+        "nightly-live.yml does not start {missing:?}, which ci.yml's E2E stack does. The \
+         nightly runs the FULL live suite — a superset of the E2E matrix — so a service the \
+         E2E tests need is a service the nightly needs too. Add it to the nightly's \
+         `docker compose … up -d` line (and its wait/seed steps if ci.yml has them); this \
+         exact drift is how both governor canaries failed the 2026-08-19 nightly."
+    );
+}
+
+#[test]
+fn the_guard_reads_real_lists_not_an_empty_parse() {
+    // Self-check: the parser must actually extract the services this repo is
+    // known to start, or the subset assertion above is vacuously green.
+    let e2e = compose_services(".github/workflows/ci.yml");
+    for known in ["postgres", "mysql", "mssql", "mssql-governor", "minio"] {
+        assert!(
+            e2e.contains(known),
+            "parser lost `{known}` from ci.yml — the subset check above is grading a \
+             truncated list; parsed: {e2e:?}"
+        );
+    }
+}

--- a/tests/offline_suite.rs
+++ b/tests/offline_suite.rs
@@ -79,3 +79,5 @@ mod trust_artifacts_integration;
 mod validate_historical;
 #[path = "offline/validate_regression.rs"]
 mod validate_regression;
+#[path = "offline/workflow_stack_guard.rs"]
+mod workflow_stack_guard;


### PR DESCRIPTION
The 08-19 nightly failed both governor canaries with "requires MssqlGovernor
reachable on :1435". The dedicated instance was added to ci.yml's E2E stack on
2026-08-17 (the fix for the dominant E2E flake) and missed in nightly-live.yml —
the runner-bypass class, in workflow YAML: two hand-maintained service lists,
and the nightly's fell behind on the first change.

nightly now starts `mssql-governor` with the `governor` profile and mirrors
ci.yml's wait + database seed (the two canaries seed their own tables).

The structural half is `tests/offline/workflow_stack_guard.rs`: the nightly runs
the FULL live suite — a superset of the E2E matrix — so every service ci.yml's
E2E stack starts must be started by the nightly too (directional, not equality:
the nightly legitimately starts more). The guard parses every `docker compose …
up -d` line in both files, and a self-check pins that the parser really extracts
the known services, so the subset assertion cannot go vacuously green on a
truncated parse. RED-proven against yesterday's exact drift: removing
`mssql-governor` from the nightly line fails it with a message naming the service
and the incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168uwctCn3W1rP4Kt4kZXvE