### PR TITLE
fix(init): a broken view failed every schema-wide MySQL init — plus two derived guards over hand-typed twins

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -59,6 +59,24 @@ exclude_re = [
     # RED-proven); the dispatch itself is live-guarded (query_scalar feeds
     # min/max bounds exercised by the live planner suites).
     "replace scalar_to_string -> Option<String>",
+    # introspect_all (init/mod.rs) is the whole-schema scan: every arm opens a
+    # live engine connection, so its dispatch mutants (delete match arm
+    # "postgres"/"mysql"/"mssql") are unkillable OFFLINE. The DECISION logic was
+    # extracted into `scan_step` (unit-tested, both guard mutants RED-proven);
+    # the dispatch itself is live-guarded, one schema-wide init test per arm:
+    # init_schema_flag_filters_to_schema (pg), init_mysql_schema_wide_discovers_
+    # seeded_table (mysql), init_mssql_schema_wide_discovers_seeded_table (mssql
+    # — added 2026-08-19 after THIS exclusion's first draft found the arm had no
+    # test at all: deleting it left 15 init tests green). Each proven by deleting
+    # the arm and watching its test go RED.
+    # The body stubs (`-> Ok(vec![])` / `Ok(vec![Default::default()])`) share the
+    # same live oracle: an empty scan scaffolds no exports, and the schema-wide
+    # init tests assert the seeded table APPEARS. Stub proven live-killed by hand
+    # (init_schema_flag_filters_to_schema goes RED on `return Ok(vec![])`).
+    "replace introspect_all -> Result<Vec<TableInfo>>",
+    "delete match arm \"postgres\" in introspect_all",
+    "delete match arm \"mysql\" in introspect_all",
+    "delete match arm \"mssql\" in introspect_all",
     # density_probe (init/mysql.rs, init/postgres.rs) takes a live DB connection
     # (mysql::PooledConn / postgres::Client) to run MIN/MAX + the windowed COUNTs
     # — unkillable OFFLINE (the --in-diff gate has no DB). Its DECISION logic is

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -968,6 +968,28 @@ fn table_discovery(info: &TableInfo) -> TableDiscovery {
     }
 }
 
+/// Classify one table's introspection result during a WHOLE-SCHEMA scan: keep
+/// it, skip it, or abort the scan.
+///
+/// Skip covers exactly the "listed but not introspectable" shape every engine
+/// can produce — a table dropped between `list_tables` and `introspect` (the
+/// live suite's parallelism does this constantly), and MySQL's broken VIEW,
+/// which stays listed with zero columns after its base table is gone. Any OTHER
+/// error must abort: a scan that shrugged off a connection drop or a permission
+/// error would emit a silently truncated scaffold that reads as a small schema.
+///
+/// Pure and shared by all three engine arms, so the tolerance cannot drift
+/// per-engine again (MySQL shipped without it — one stale view failed every
+/// schema-wide init) and so both mutants of the guard (`skip everything` /
+/// `skip nothing`) die in a unit test rather than surviving on a live-only path.
+fn scan_step(res: Result<TableInfo>) -> Result<Option<TableInfo>> {
+    match res {
+        Ok(info) => Ok(Some(info)),
+        Err(e) if e.to_string().contains("not found or has no columns") => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
 fn introspect_all(
     tls: Option<&crate::config::TlsConfig>,
     source_url: &str,
@@ -986,15 +1008,9 @@ fn introspect_all(
             let names = retain_filtered(postgres::list_tables(&mut client, sch)?, filter);
             let mut out = Vec::with_capacity(names.len());
             for n in names {
-                match postgres::introspect(&mut client, sch, &n) {
-                    Ok(mut info) => {
-                        postgres::density_probe(&mut client, &mut info);
-                        out.push(info)
-                    }
-                    // Table may have been dropped between list_tables and introspect.
-                    // Skip it rather than aborting the whole schema scan.
-                    Err(e) if e.to_string().contains("not found or has no columns") => {}
-                    Err(e) => return Err(e),
+                if let Some(mut info) = scan_step(postgres::introspect(&mut client, sch, &n))? {
+                    postgres::density_probe(&mut client, &mut info);
+                    out.push(info)
                 }
             }
             Ok(out)
@@ -1026,21 +1042,12 @@ fn introspect_all(
             let names = retain_filtered(mysql::list_tables(&mut conn, &db)?, filter);
             let mut out = Vec::with_capacity(names.len());
             for n in names {
-                match mysql::introspect(&mut conn, &n) {
-                    Ok(mut info) => {
-                        mysql::density_probe(&mut conn, &mut info);
-                        out.push(info);
-                    }
-                    // Same tolerance as the PG and MSSQL arms above/below — MySQL
-                    // was the one arm that aborted the whole scan instead. Two
-                    // real inputs hit it: a table dropped between list_tables and
-                    // introspect (the parallel suite does this constantly), and a
-                    // BROKEN VIEW — list_tables includes views, and a view whose
-                    // base table is gone stays listed in information_schema.tables
-                    // with ZERO columns, so ONE stale view made every schema-wide
-                    // `rivet init` fail, deterministically, no race required.
-                    Err(e) if e.to_string().contains("not found or has no columns") => {}
-                    Err(e) => return Err(e),
+                // MySQL was the one arm WITHOUT the vanished-table tolerance: a
+                // BROKEN VIEW (listed, zero columns once its base is dropped)
+                // made every schema-wide init fail — see scan_step.
+                if let Some(mut info) = scan_step(mysql::introspect(&mut conn, &n))? {
+                    mysql::density_probe(&mut conn, &mut info);
+                    out.push(info);
                 }
             }
             Ok(out)
@@ -1056,14 +1063,9 @@ fn introspect_all(
             let names = retain_filtered(mssql::list_tables(&mut conn, sch)?, filter);
             let mut out = Vec::with_capacity(names.len());
             for n in names {
-                match mssql::introspect(&mut conn, sch, &n) {
-                    Ok(mut info) => {
-                        mark_mssql_catalog_exact(&mut info);
-                        out.push(info)
-                    }
-                    // Dropped between list and introspect — skip, don't abort.
-                    Err(e) if e.to_string().contains("not found or has no columns") => {}
-                    Err(e) => return Err(e),
+                if let Some(mut info) = scan_step(mssql::introspect(&mut conn, sch, &n))? {
+                    mark_mssql_catalog_exact(&mut info);
+                    out.push(info)
                 }
             }
             Ok(out)
@@ -1160,6 +1162,43 @@ fn record_strategy_snapshots(config_path: &str, snapshots: &[crate::state::Strat
 
 #[cfg(test)]
 mod tests {
+    /// Both mutants of `scan_step`'s guard, killed where the CI gate can see
+    /// them: the whole-schema scan is a live-only path, so `guard -> true` and
+    /// `guard -> false` survived `cargo mutants -- --lib --bins` on PR #245
+    /// until the decision was extracted into this pure function.
+    #[test]
+    fn scan_step_skips_only_the_vanished_table_shape() {
+        // The real message every engine's introspect emits for the shape.
+        let vanished = Err(anyhow::anyhow!(
+            "Table 'qa_broken_v' not found or has no columns. Check the table name \
+             and that the user has SELECT privilege."
+        ));
+        assert!(
+            matches!(scan_step(vanished), Ok(None)),
+            "a listed-but-vanished table (dropped mid-scan, or a broken view) must be \
+             SKIPPED — aborting on it is how one stale view failed every schema-wide init"
+        );
+
+        // `guard -> true` makes EVERY error a skip; this is what kills it.
+        let real = Err(anyhow::anyhow!("connection refused (os error 61)"));
+        assert!(
+            scan_step(real).is_err(),
+            "any other error must ABORT the scan — swallowing a connection drop emits a \
+             silently truncated scaffold that reads as a small schema"
+        );
+
+        // And the pass-through, so the extraction cannot quietly drop tables.
+        let info = TableInfo {
+            schema: "s".into(),
+            table: "t".into(),
+            row_estimate: 1,
+            total_bytes: None,
+            columns: Vec::new(),
+            density: None,
+        };
+        assert!(matches!(scan_step(Ok(info)), Ok(Some(i)) if i.table == "t"));
+    }
+
     use super::*;
 
     fn col(name: &str, ty: &str, pk: bool) -> ColumnInfo {

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -1026,9 +1026,22 @@ fn introspect_all(
             let names = retain_filtered(mysql::list_tables(&mut conn, &db)?, filter);
             let mut out = Vec::with_capacity(names.len());
             for n in names {
-                let mut info = mysql::introspect(&mut conn, &n)?;
-                mysql::density_probe(&mut conn, &mut info);
-                out.push(info);
+                match mysql::introspect(&mut conn, &n) {
+                    Ok(mut info) => {
+                        mysql::density_probe(&mut conn, &mut info);
+                        out.push(info);
+                    }
+                    // Same tolerance as the PG and MSSQL arms above/below — MySQL
+                    // was the one arm that aborted the whole scan instead. Two
+                    // real inputs hit it: a table dropped between list_tables and
+                    // introspect (the parallel suite does this constantly), and a
+                    // BROKEN VIEW — list_tables includes views, and a view whose
+                    // base table is gone stays listed in information_schema.tables
+                    // with ZERO columns, so ONE stale view made every schema-wide
+                    // `rivet init` fail, deterministically, no race required.
+                    Err(e) if e.to_string().contains("not found or has no columns") => {}
+                    Err(e) => return Err(e),
+                }
             }
             Ok(out)
         }

--- a/tests/live/live_init.rs
+++ b/tests/live/live_init.rs
@@ -316,3 +316,38 @@ impl Drop for MysqlViewGuard {
         }
     }
 }
+
+// ─── I9: schema-wide MSSQL init — the arm no test entered ─────────────────────
+
+/// Schema-wide `rivet init` against SQL Server had NO test at any level: the
+/// only MSSQL init test is single-table (`--table dbo.…`, audit_init_deferred),
+/// which never enters `introspect_all`'s engine dispatch. Found by the mutation
+/// gate on PR #245 and then PROVEN empirically — with the whole `"mssql"` match
+/// arm DELETED, all 15 init live tests stayed green. Its PG twin
+/// (`init_schema_flag_filters_to_schema`) goes RED on the same mutation of its
+/// own arm, which is the difference between a live-guarded arm and an unguarded
+/// one.
+#[test]
+#[ignore = "live: requires docker compose mssql"]
+fn init_mssql_schema_wide_discovers_seeded_table() {
+    require_alive(LiveService::Mssql);
+
+    let table = seed_mssql_numeric_table(10);
+
+    let out = run_rivet(&["init", "--source", MSSQL_URL]);
+    assert!(
+        out.status.success(),
+        "schema-wide rivet init (mssql) must exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let yaml = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        yaml.contains("type: mssql"),
+        "emitted YAML must declare the mssql source; got:\n{yaml}"
+    );
+    assert!(
+        yaml.contains(table.name()),
+        "seeded table '{}' must be discovered by the schema-wide scan; got:\n{yaml}",
+        table.name()
+    );
+}

--- a/tests/live/live_init.rs
+++ b/tests/live/live_init.rs
@@ -248,3 +248,71 @@ fn init_unreachable_url_exits_nonzero_with_actionable_message() {
         "stderr must contain an actionable message; got:\n{stderr}"
     );
 }
+
+// ─── I8: a broken view must not abort the whole schema-wide MySQL init ────────
+
+/// The MySQL arm of the schema scan was the ONE of three that aborted on a
+/// table it could list but not introspect — PG and MSSQL already skipped those
+/// ("dropped between list and introspect"). Two real inputs hit the MySQL gap:
+/// the suite's own parallelism (a sibling's RAII drop mid-scan — how
+/// `init_mysql_schema_wide_discovers_seeded_table` flaked on 2026-08-18), and
+/// this test's deterministic shape: `list_tables` includes VIEWs, and a view
+/// whose base table is gone stays listed in `information_schema.tables` with
+/// ZERO columns. One stale view therefore failed every schema-wide `rivet init`
+/// against that database — no race required.
+///
+/// RED against the pre-fix arm: exit non-zero with "not found or has no
+/// columns" before the seeded table is ever reached.
+#[test]
+#[ignore = "live: requires docker compose mysql"]
+fn init_mysql_schema_wide_survives_a_broken_view() {
+    require_alive(LiveService::Mysql);
+
+    let table = seed_mysql_numeric_table(10);
+    // A view over a base table that then disappears — listed, zero columns.
+    let base = unique_name("rivet_qa_vbase");
+    let view = unique_name("rivet_qa_vbroken");
+    {
+        use mysql::prelude::Queryable as _;
+        let mut c = mysql_connect();
+        for stmt in [
+            format!("DROP VIEW IF EXISTS {view}"),
+            format!("DROP TABLE IF EXISTS {base}"),
+            format!("CREATE TABLE {base} (id INT)"),
+            format!("CREATE VIEW {view} AS SELECT * FROM {base}"),
+            format!("DROP TABLE {base}"),
+        ] {
+            c.query_drop(stmt).expect("seed broken view");
+        }
+    }
+    let _cleanup = MysqlViewGuard(view.clone());
+
+    let out = run_rivet(&["init", "--source", MYSQL_URL]);
+    assert!(
+        out.status.success(),
+        "schema-wide init must SKIP the broken view, not abort the scan; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let yaml = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        yaml.contains(table.name()),
+        "the seeded table must still be discovered around the broken view; got:\n{yaml}"
+    );
+    assert!(
+        !yaml.contains(&view),
+        "the zero-column view must be skipped, not scaffolded as an export; got:\n{yaml}"
+    );
+}
+
+/// RAII for the broken view — a bare trailing DROP is skipped by every panic
+/// path, and a stale broken view then fails EVERY later schema-wide init test
+/// on the shared server (exactly the failure this test exists to prevent).
+struct MysqlViewGuard(String);
+impl Drop for MysqlViewGuard {
+    fn drop(&mut self) {
+        use mysql::prelude::Queryable as _;
+        if let Ok(mut c) = std::panic::catch_unwind(mysql_connect) {
+            let _ = c.query_drop(format!("DROP VIEW IF EXISTS {}", self.0));
+        }
+    }
+}

--- a/tests/offline/cli_flag_coverage_guard.rs
+++ b/tests/offline/cli_flag_coverage_guard.rs
@@ -1,0 +1,135 @@
+//! Every long CLI flag must be exercised somewhere in the test tree — or carry
+//! a named exemption with the reason.
+//!
+//! This was a ONE-OFF sweep on 2026-08-18: deriving the flag list from
+//! `src/cli/args.rs` (instead of the list anyone remembered) found EIGHT flags
+//! with zero references anywhere, among them `--json-errors` (the machine
+//! contract a wrapper parses), `--rollover` (part naming on the CDC CLI, the
+//! clobber class), and four init cloud-destination flags. A sweep that found
+//! that much is a gate, not a script; this is the sweep, permanent.
+//!
+//! The exemptions are judgments, not coverage — each carries WHY, and the guard
+//! fails if an exempt flag disappears from args.rs (a stale exemption is a list
+//! drifting in the other direction).
+
+use std::collections::BTreeSet;
+
+/// Flags deliberately not referenced by the test tree, each with its reason.
+const EXEMPT: &[(&str, &str)] = &[
+    (
+        "tls",
+        "needs a TLS-enabled source to mean anything — passing it at a plaintext server \
+         proves only that clap accepted the argument (recorded 2026-08-18)",
+    ),
+    (
+        "tls-ca",
+        "same fixture gap as --tls: a CA file against a plaintext server exercises nothing",
+    ),
+    (
+        "rivet-bin",
+        "contract pinned by `rivet_bin_defaults_to_this_executable_never_a_path_lookup` \
+         (src/cli/dispatch.rs, bin crate) on `resolve_rivet_bin` directly; the literal \
+         flag only reaches code on a real warehouse load",
+    ),
+];
+
+/// Every long flag `src/cli/args.rs` declares: `long = "name"` when named,
+/// else the kebab-cased field under a bare `long`.
+fn declared_long_flags() -> BTreeSet<String> {
+    let src = std::fs::read_to_string("src/cli/args.rs").expect("read src/cli/args.rs");
+    let mut flags = BTreeSet::new();
+    for (start, _) in src.match_indices("#[arg(") {
+        let Some(close) = src[start..].find(")]") else {
+            continue;
+        };
+        let attrs = &src[start..start + close];
+        if !attrs.contains("long") {
+            continue;
+        }
+        let after = &src[start + close..];
+        let name = if let Some(named) = attrs.split("long = \"").nth(1) {
+            named.split('"').next().unwrap_or_default().to_string()
+        } else {
+            // The field name is the first `ident:` after the attribute.
+            after
+                .lines()
+                .map(str::trim)
+                .find_map(|l| {
+                    let l = l.strip_prefix("pub ").unwrap_or(l);
+                    let (ident, _) = l.split_once(':')?;
+                    ident
+                        .chars()
+                        .all(|c| c.is_ascii_lowercase() || c == '_' || c.is_ascii_digit())
+                        .then(|| ident.replace('_', "-"))
+                })
+                .unwrap_or_default()
+        };
+        if !name.is_empty() {
+            flags.insert(name);
+        }
+    }
+    flags
+}
+
+/// Does `--flag` occur, with a boundary, anywhere under `tests/`? Boundary
+/// matters: `--source` must not be satisfied by `--source-env`.
+fn referenced_in_tests(haystack: &str, flag: &str) -> bool {
+    let needle = format!("--{flag}");
+    haystack.match_indices(&needle).any(|(i, _)| {
+        haystack[i + needle.len()..]
+            .chars()
+            .next()
+            .is_none_or(|c| !(c.is_ascii_alphanumeric() || c == '-'))
+    })
+}
+
+fn test_tree_text() -> String {
+    let mut out = String::new();
+    let mut stack = vec![std::path::PathBuf::from("tests")];
+    while let Some(dir) = stack.pop() {
+        if dir.ends_with(".live-tmp") {
+            continue;
+        }
+        for e in std::fs::read_dir(&dir).expect("read tests dir").flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                stack.push(p);
+            } else if p.extension().is_some_and(|x| x == "rs") {
+                out.push_str(&std::fs::read_to_string(&p).unwrap_or_default());
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn every_declared_long_flag_is_tested_or_exempted_with_a_reason() {
+    let flags = declared_long_flags();
+    assert!(
+        flags.len() >= 40,
+        "parsed only {} long flags from args.rs — the sweep below is grading a truncated \
+         list: {flags:?}",
+        flags.len()
+    );
+    let tests = test_tree_text();
+    let exempt: BTreeSet<&str> = EXEMPT.iter().map(|(f, _)| *f).collect();
+
+    let unreferenced: Vec<&String> = flags
+        .iter()
+        .filter(|f| !exempt.contains(f.as_str()) && !referenced_in_tests(&tests, f))
+        .collect();
+    assert!(
+        unreferenced.is_empty(),
+        "long flags with no reference anywhere under tests/ and no exemption: \
+         {unreferenced:?}. Either add a test (the 2026-08-18 sweep found a wedge, a \
+         clobber and a broken machine contract behind exactly such flags) or add an \
+         EXEMPT entry with the reason a test cannot be written."
+    );
+
+    // Stale exemptions are the same defect pointed the other way.
+    let stale: Vec<&&str> = exempt.iter().filter(|f| !flags.contains(**f)).collect();
+    assert!(
+        stale.is_empty(),
+        "EXEMPT names flags args.rs no longer declares: {stale:?} — delete the entries"
+    );
+}

--- a/tests/offline/live_service_ports_guard.rs
+++ b/tests/offline/live_service_ports_guard.rs
@@ -1,0 +1,106 @@
+//! `LiveService::addr()` hand-types every service's host port, and
+//! `docker-compose.yaml` hand-types the same ports as mappings — twin lists in
+//! two files, the exact shape that has already produced false "verified" claims
+//! twice when a hand-drifted container disagreed with the declared stand
+//! (PRs 139/142), and the workflow-stack drift the 08-19 nightly paid for.
+//!
+//! Derivation direction: every port a `LiveService` arm claims must exist as a
+//! HOST port mapping in docker-compose.yaml (or the dev stand's compose). The
+//! reverse is deliberately not asserted — compose maps many ports no test
+//! probes (admin consoles, replica internals), and requiring an arm per mapping
+//! would just breed dead enum variants.
+
+use std::collections::BTreeSet;
+
+/// Host ports mapped by a compose file: the left side of `- "HOST:CONTAINER"`.
+fn compose_host_ports(path: &str) -> BTreeSet<u16> {
+    let text = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("read {path}: {e} (run from the repo root)"));
+    text.lines()
+        .filter_map(|l| {
+            let t = l.trim();
+            let t = t.strip_prefix("- \"")?;
+            let (host, _rest) = t.split_once(':')?;
+            host.parse::<u16>().ok()
+        })
+        .collect()
+}
+
+/// Every `(name, port)` the LiveService enum claims, parsed from the SOURCE of
+/// `tests/common/env.rs` — the same read-the-source technique the runner-frame
+/// and workflow-stack guards use. Parsing the source rather than linking the
+/// enum keeps this an offline test with no live-test feature plumbing; the
+/// self-check below pins that the parse is not truncated.
+fn live_service_ports() -> Vec<(String, u16)> {
+    let text = std::fs::read_to_string("tests/common/env.rs").expect("read tests/common/env.rs");
+    let addr_fn = text
+        .split("fn addr(self)")
+        .nth(1)
+        .expect("env.rs must contain LiveService::addr");
+    let mut out = Vec::new();
+    for arm in addr_fn.split("LiveService::").skip(1) {
+        let Some(name) = arm.split(|c: char| !c.is_alphanumeric()).next() else {
+            continue;
+        };
+        // The port is the second tuple field after the host literal.
+        if let Some(rest) = arm.split("\"127.0.0.1\",").nth(1)
+            && let Some(port) = rest
+                .split(|c: char| !c.is_ascii_digit())
+                .find(|s| !s.is_empty())
+                .and_then(|s| s.parse::<u16>().ok())
+        {
+            out.push((name.to_string(), port));
+        }
+        // Stop at the end of the match block — later LiveService:: mentions in
+        // the file (require_alive etc.) are not addr arms.
+        if arm.contains("\n    }\n") {
+            break;
+        }
+    }
+    out
+}
+
+#[test]
+fn every_live_service_port_is_mapped_by_a_compose_file() {
+    let mut mapped = compose_host_ports("docker-compose.yaml");
+    // The optional dev stand maps the engine-version matrix ports (pg18 etc.).
+    if std::path::Path::new("dev/stand/docker-compose.yaml").exists() {
+        mapped.extend(compose_host_ports("dev/stand/docker-compose.yaml"));
+    }
+    let services = live_service_ports();
+    let orphans: Vec<&(String, u16)> = services
+        .iter()
+        // Port 0 is the documented "not reached via TCP" sentinel: DuckDb is
+        // probed through `docker exec` container health (env.rs says so at the
+        // require_alive early-return), so there is no host mapping to demand.
+        .filter(|(_, p)| *p != 0 && !mapped.contains(p))
+        .collect();
+    assert!(
+        orphans.is_empty(),
+        "LiveService arms claim ports no compose file maps: {orphans:?}. Either the \
+         service moved in docker-compose.yaml and env.rs was not updated (every \
+         require_alive for it now probes a dead port and reports the service down), or \
+         the arm was added ahead of the compose service (its tests can never run). \
+         Hand-drifted twins here have produced false 'verified' claims before."
+    );
+}
+
+#[test]
+fn the_port_parse_is_not_truncated() {
+    // Self-check, same reason as the workflow-stack guard's: a parser that loses
+    // arms makes the assertion above vacuously green. 17 arms today; assert a
+    // floor rather than equality so adding a service does not touch this test.
+    let services = live_service_ports();
+    assert!(
+        services.len() >= 15,
+        "parsed only {} LiveService port arms from env.rs — the guard above is grading a \
+         truncated list: {services:?}",
+        services.len()
+    );
+    for known in ["Postgres", "Mysql", "MssqlGovernor", "Minio"] {
+        assert!(
+            services.iter().any(|(n, _)| n == known),
+            "parser lost `{known}`; parsed: {services:?}"
+        );
+    }
+}

--- a/tests/offline_suite.rs
+++ b/tests/offline_suite.rs
@@ -61,6 +61,10 @@ mod retry_integration;
 #[path = "offline/run_summary_contract.rs"]
 mod run_summary_contract;
 
+#[path = "offline/cli_flag_coverage_guard.rs"]
+mod cli_flag_coverage_guard;
+#[path = "offline/live_service_ports_guard.rs"]
+mod live_service_ports_guard;
 #[path = "offline/runner_frame_gate.rs"]
 mod runner_frame_gate;
 #[path = "offline/scenario_artifact_matrix_guard.rs"]


### PR DESCRIPTION
Chasing the one remaining flake (init_mysql_schema_wide, red under local
parallelism) led to a real product defect of the engine-bypass class: the PG and
MSSQL arms of the schema scan already SKIP a table they can list but not
introspect ("dropped between list_tables and introspect"), and MySQL — the one
arm without the tolerance — aborted the whole scan.

Two real inputs hit it. The suite's own parallelism (a sibling's RAII drop
mid-scan — the flake). And the deterministic one, which makes this a production
failure with no race required: `list_tables` includes VIEWs, and a view whose
base table is gone stays listed in information_schema.tables with ZERO columns —
measured on the stand — so ONE stale view failed every schema-wide `rivet init`
against that database. RED-proven: the pre-fix arm exits with the exact
production error before the seeded table is ever reached; the fixed arm skips
the view, discovers the table, and does not scaffold the zero-column view.

The hand-typed-list audit closes with two new derived guards (the rest of the
lists are judgment/exemption lists with reasons, which is their correct form):

  * live_service_ports_guard — every port a LiveService arm claims must be
    mapped by a compose file (docker-compose.yaml or the dev stand). Twin
    hand-typed lists across two files are how false 'verified' claims happened
    before (PRs 139/142) and how the nightly stack drifted. Port 0 is the
    documented docker-exec sentinel (DuckDb). RED-proven by moving the governor
    port in env.rs only — after first catching a vacuous mutation that hit a
    comment instead of the arm.
  * cli_flag_coverage_guard — the 2026-08-18 one-off sweep (derive every long
    flag from args.rs, find those with zero test references) found a wedge, a
    clobber and a broken machine contract; a sweep that productive is a gate.
    Exemptions carry reasons and go stale loudly when args.rs drops a flag.
    RED-proven with an unreferenced probe flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168uwctCn3W1rP4Kt4kZXvE