### PR TITLE
fix(test): a pause hook makes the reconcile-mismatch window deterministic

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -27,6 +27,20 @@
 # point (2026-08-17).
 exclude_globs = [
     "src/fuzz.rs",
+    # src/test_hook.rs is TEST INSTRUMENTATION: every primitive is env-gated
+    # (RIVET_TEST_PANIC_AT / _ERROR_AT / _PAUSE_AT) and a no-op in production,
+    # and the code that READS the env is exercised only by the LIVE
+    # fault-injection suites — not by the `--lib --bins` run this gate does, so
+    # every mutant here is born MISSED (maybe_pause_at scored 4/4 on PR #246).
+    # Live oracle proven by hand before excluding: stubbing maybe_pause_at and
+    # flipping its point comparison EACH fail run_reconcile_reports_mismatch_
+    # when_source_grows_after_snapshot loudly at the marker wait (the second
+    # after first catching a vacuous probe — the identical comparison exists in
+    # maybe_panic_at, and a blind replace mutated the wrong fn and passed).
+    # The panic/exit/error primitives are guarded the same way by the whole
+    # crash-injection suite: a hook that stops firing leaves those tests unable
+    # to construct their crash and they fail on "the run succeeded".
+    "src/test_hook.rs",
     "src/bin/seed/main.rs",
     "src/bin/seed/args.rs",
     "src/bin/seed/insert.rs",

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -59,6 +59,21 @@ exclude_re = [
     # RED-proven); the dispatch itself is live-guarded (query_scalar feeds
     # min/max bounds exercised by the live planner suites).
     "replace scalar_to_string -> Option<String>",
+    # pg_run_export (source/postgres/mod.rs) is the PG batch export loop: it
+    # opens a real connection, BEGINs, declares the server-side cursor and
+    # drives the FETCH loop — unkillable OFFLINE end to end. It entered the
+    # in-diff scope via a three-line pause-hook insertion (PR #246) and scored
+    # 14/14 MISSED, which per the scope-honesty rule reads "no unit test
+    # executes this", not "14 gaps". Live oracle proven by hand on both
+    # representative shapes before excluding: the body stub `Ok((0, false))`
+    # fails run_reconcile_implies_validate_produces_manifest_verdict (an export
+    # that reads nothing has nothing to validate), and `delete !` on the hook's
+    # first-fetch flag fails run_reconcile_reports_mismatch_when_source_grows_
+    # after_snapshot (the marker never appears on the first fetch and the
+    # writer aborts loudly). Every PG batch live test transitively guards the
+    # rest of the loop — the whole live_suite runs through it.
+    "replace pg_run_export ->",
+    " in pg_run_export",
     # introspect_all (init/mod.rs) is the whole-schema scan: every arm opens a
     # live engine connection, so its dispatch mutants (delete match arm
     # "postgres"/"mysql"/"mssql") are unkillable OFFLINE. The DECISION logic was

--- a/src/source/postgres/mod.rs
+++ b/src/source/postgres/mod.rs
@@ -611,10 +611,21 @@ fn pg_run_export(
     // the buffer. Same source of truth as the sink's backstop guard.
     let max_value_bytes = tuning.max_value_bytes();
 
+    let mut first_fetch_done = false;
     loop {
         let requested = ctl.target();
         let fetch_sql = format!("FETCH {} FROM _rivet", requested);
         let rows = guard.client_mut().query(&fetch_sql, &[])?;
+        if !first_fetch_done {
+            first_fetch_done = true;
+            // The cursor's snapshot is pinned as of the FIRST FETCH, not the
+            // DECLARE — measured, not assumed: with the pause placed after
+            // DECLARE, a row committed during it was VISIBLE to the export
+            // (250 of 200). A paused window here is the race-free way for a
+            // test to commit writes strictly invisible to this read but
+            // visible to anything after it (the reconcile recount).
+            crate::test_hook::maybe_pause_at("pg_after_snapshot_open");
+        }
         if rows.is_empty() {
             break;
         }

--- a/src/test_hook.rs
+++ b/src/test_hook.rs
@@ -80,6 +80,38 @@ pub(crate) fn maybe_exit_at_index(point: &str, index: i64) {
     }
 }
 
+/// PAUSE for the configured milliseconds if `RIVET_TEST_PAUSE_AT` names this
+/// point (`"{point}:{millis}"`). The fourth primitive beside panic / hard-exit /
+/// returned-error: some tests need to construct a CONCURRENCY WINDOW — "a
+/// writer commits AFTER the snapshot opens and BEFORE the read finishes" — and
+/// without a pause the only tool is a sleep in the TEST racing rivet's own
+/// startup. That race is exactly how the reconcile-mismatch fixture flaked both
+/// ways (a 600 ms sleep lost to startup on a loaded box; a pg_stat_activity
+/// wait turned a CI-green test red, cause never identified, reverted). A pause
+/// at the product's own sequence point does not race anything: the window IS
+/// open when the point is reached.
+#[inline]
+pub(crate) fn maybe_pause_at(point: &str) {
+    if let Ok(p) = std::env::var("RIVET_TEST_PAUSE_AT")
+        && let Some((configured, ms)) = p.rsplit_once(':')
+        && configured == point
+        && let Ok(ms) = ms.parse::<u64>()
+    {
+        eprintln!("rivet test-hook: pausing {ms}ms at '{point}' (RIVET_TEST_PAUSE_AT)");
+        // Announce the window to the TEST before sleeping: the pause opens a
+        // concurrency window, but the test's writer has no way to know it
+        // opened — a writer on its own clock races rivet's startup, which is
+        // the exact defect this hook exists to remove (measured: an immediate
+        // writer landed its rows BEFORE the snapshot and the window was
+        // pause-shaped but empty). Touching a file turns "the window is open"
+        // into a pollable condition instead of a guess.
+        if let Ok(marker) = std::env::var("RIVET_TEST_PAUSE_MARKER") {
+            let _ = std::fs::write(&marker, point);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(ms));
+    }
+}
+
 /// Return an `Err` if `RIVET_TEST_ERROR_AT` matches `"{point}:{index}"` — simulates a
 /// per-worker SQL error (connection drop / statement timeout) MID-RANGE, distinct from
 /// the hard-exit crash: the worker RETURNS an error (not process death), the parallel

--- a/tests/live/live_cli_flags.rs
+++ b/tests/live/live_cli_flags.rs
@@ -536,11 +536,19 @@ fn run_reconcile_reports_mismatch_when_source_grows_after_snapshot() {
     // `run --reconcile` reconciles what it exported (a consistent source
     // snapshot) against a *fresh* source COUNT(*). There is no deterministic
     // single-snapshot mismatch — by construction the export and the recount read
-    // the same source moments apart — so a real mismatch is a concurrency event.
-    // We construct it deterministically: full mode holds one snapshot for the
-    // whole read; a throttle keeps the run alive while a writer inserts 50 rows
-    // *after* the snapshot opens but *before* the end-of-run recount. The export
-    // therefore sees 200 and reconcile sees 250 → MISMATCH.
+    // the same source moments apart — so a real mismatch is a concurrency event:
+    // 50 rows must land AFTER the snapshot opens and BEFORE the end-of-run
+    // recount.
+    //
+    // The window is constructed by the PRODUCT's own pause hook
+    // (`pg_after_snapshot_open`, src/source/postgres/mod.rs), not by racing it.
+    // This fixture's history is the argument for the hook: a 600 ms sleep in the
+    // writer lost to rivet's startup on a loaded box (rows landed BEFORE the
+    // snapshot, export read 250, no mismatch); the pg_stat_activity rewrite that
+    // replaced it turned a CI-green test red for a cause never identified and
+    // was reverted. A pause at the sequence point does not race anything: when
+    // the hook fires, the snapshot IS open, and the writer gets the whole pause
+    // to commit inside the window.
     require_alive(LiveService::Postgres);
     let table = seed_pg_numeric_table(200);
     let out = tempfile::tempdir().unwrap();
@@ -550,7 +558,6 @@ fn run_reconcile_reports_mismatch_when_source_grows_after_snapshot() {
 source:
   type: postgres
   url: "{POSTGRES_URL}"
-  tuning: {{batch_size: 10, throttle_ms: 60}}
 exports:
   - name: {name}
     query: "SELECT id, name FROM {name}"
@@ -563,47 +570,66 @@ exports:
     );
     let cfg = write_config(&cfg_dir, &yaml);
 
-    // Writer: after the snapshot has opened (and while the throttled export is
-    // still running), commit 50 new rows the export's snapshot can't see.
-    //
-    // The 600 ms is a clock, and a clock is the wrong shape here — but the
-    // replacement was WORSE and is recorded so nobody repeats it. On 2026-08-18
-    // this was rewritten to wait on `pg_stat_activity` (an `application_name`
-    // marker on this export's connection, plus the `_rivet` cursor present in the
-    // backend's current statement). Locally that fixed a failure this machine sees
-    // in isolation, 3 runs of 3. In CI it turned a GREEN test RED — E2E passed on
-    // main at 19:04 and 19:23 and failed at 21:01, on this test alone — and the
-    // cause was never identified, so it was reverted rather than iterated on main.
-    //
-    // If this is revisited: the sleep is sufficient in CI and insufficient on a
-    // loaded dev box, so the failure to reproduce is environmental, and the fix
-    // has to be verified THERE, not here. A pause hook in the export (there is
-    // none today) would remove the race instead of racing it better.
+    // Writer: waits for the hook's MARKER FILE — the product touches it at the
+    // sequence point, right as the pause begins — then inserts inside the
+    // window. The first draft fired the writer immediately and re-created the
+    // startup race from the other side (rows landed BEFORE the snapshot; the
+    // window was pause-shaped but empty). The marker is a condition, not a
+    // clock: it appears exactly when the snapshot is pinned, and the insert
+    // takes milliseconds against a 5 s pause.
+    let marker = cfg_dir.path().join("snapshot_open.marker");
     let table_name = table.name().to_string();
+    let marker_for_writer = marker.clone();
     let writer = std::thread::spawn(move || {
-        std::thread::sleep(std::time::Duration::from_millis(600));
+        let waited = (0..500).any(|_| {
+            if marker_for_writer.exists() {
+                return true;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            false
+        });
+        assert!(
+            waited,
+            "the pause marker never appeared within 10s — the hook did not fire, so the \
+             insert would race startup and the mismatch would be a coin flip"
+        );
         let mut c = pg_connect();
-        let _ = c.batch_execute(&format!(
+        c.batch_execute(&format!(
             "INSERT INTO {table_name} (id, name, amount) \
              SELECT g, 'late', 1.0 FROM generate_series(201, 250) g"
-        ));
+        ))
+        .expect("late insert");
     });
 
-    let result = run_rivet(&[
-        "run",
-        "--config",
-        cfg.to_str().unwrap(),
-        "--export",
-        table.name(),
-        "--reconcile",
-    ]);
-    let _ = writer.join();
+    let result = run_rivet_env(
+        &[
+            "run",
+            "--config",
+            cfg.to_str().unwrap(),
+            "--export",
+            table.name(),
+            "--reconcile",
+        ],
+        &[
+            ("RIVET_TEST_PAUSE_AT", "pg_after_snapshot_open:5000"),
+            ("RIVET_TEST_PAUSE_MARKER", marker.to_str().unwrap()),
+        ],
+    );
+    writer.join().expect("writer thread");
 
     let stderr = String::from_utf8_lossy(&result.stderr);
     assert!(
         stderr.contains("MISMATCH"),
         "run --reconcile must report MISMATCH when the source grew (250) past what \
          was exported (200); stderr:\n{stderr}"
+    );
+    // And the export itself must still be the SNAPSHOT's 200 rows — if the late
+    // rows are in the parquet, the pause fired before the snapshot opened and
+    // the MISMATCH above is measuring a different event than this test claims.
+    assert_eq!(
+        total_parquet_rows(out.path()),
+        200,
+        "the exported parquet must hold the snapshot's 200 rows, not the late 50"
     );
 }
 


### PR DESCRIPTION
The honest next step recorded in the #243 revert: "a pause hook in the export
would remove the race instead of racing it better." Done, and the road there
disproved two assumptions by measurement.

The fixture needs 50 rows committed AFTER the export's snapshot opens and BEFORE
the recount. Its history: a 600 ms writer sleep lost to rivet's startup on a
loaded box; a pg_stat_activity wait turned a CI-green test red (cause never
found, reverted). Both raced the window instead of being told about it.

`maybe_pause_at` is the fourth test-hook primitive beside panic / hard-exit /
returned-error: `RIVET_TEST_PAUSE_AT=point:millis` pauses the product at its own
sequence point. Two measurements shaped its placement and shape:

  * The snapshot is NOT pinned at DECLARE. With the pause right after the
    cursor's DECLARE, a row committed during it was visible to the export (250
    of 200): under plain BEGIN (READ COMMITTED) the cursor's snapshot fixes at
    the FIRST FETCH. The hook sits after that fetch, where pausing really is
    pausing inside a pinned snapshot.
  * A window nobody announces is still a race. The first rewrite fired the
    writer immediately and re-created the startup race from the other side —
    rows landed BEFORE the snapshot; the window was pause-shaped but empty. The
    hook now touches a MARKER file (RIVET_TEST_PAUSE_MARKER) as the pause
    begins, so "the window is open" is a pollable condition, not a guess.

Verified: 5/5 green sequentially, 39/39 with the whole file at --test-threads=4
(where the old fixture flaked), and the no-hook control fails LOUDLY at the
marker wait — naming the missing hook, never flipping a coin on the race. The
test also pins the parquet at the snapshot's 200 rows, so a pause that fired
before the snapshot cannot masquerade as the concurrency event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168uwctCn3W1rP4Kt4kZXvE