### PR TITLE
test: a rig-adoption ratchet, banked with the first migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,8 +502,11 @@ jobs:
       # discriminator: zero mutants is the CORRECT answer for a diff that
       # changes no mutable source (tests-only, docs+tests, a comment-only edit
       # inside src/**.rs — all routine here, and the previous version of this
-      # check fired a red `::error::` on every one of them). Only "the diff HAS
-      # mutants and the config removes them all" is the defect.
+      # check fired a red `::error::` on every one of them). The defect is
+      # narrower than "the config removes them all": it is the SELF-EXCUSING
+      # case, where the same diff edits the exclusions that swallow its own
+      # mutants. All-excluded under PRE-EXISTING exclusions is a live-only diff,
+      # reported loudly rather than failed — see the split below.
       - name: The PR diff is actually graded
         id: graded
         if: steps.scope.outputs.code == 'true'
@@ -526,10 +529,35 @@ jobs:
             exit 0
           fi
           if [ "$graded" -eq 0 ]; then
-            echo "::error::the mutation gate would grade NOTHING: this diff yields \
-          $all mutants, and .cargo/mutants.toml's exclude_re removes every one of \
-          them. That is the vacuous-gate failure (#227/#229/#230), not a pass."
-            exit 1
+            # All-excluded has TWO honest readings, split by one observable: did
+            # THIS diff edit the exclusions it benefits from?
+            #
+            #  * mutants.toml touched in-diff — a SELF-EXCUSING PR: the same
+            #    change that adds code adds the entries that exempt it from the
+            #    gate. That is the vacuous-gate shape (#227/#229/#230) and stays
+            #    a hard failure: a human must review the exclusions' proofs
+            #    before anything rides on them (PR #246 sat exactly here — its
+            #    triage was honest, live-proven, and still the reviewer's call,
+            #    not this script's).
+            #  * mutants.toml untouched — a LIVE-ONLY diff riding exclusions a
+            #    reviewer already accepted: every mutant it yields lands in code
+            #    the --lib --bins run cannot execute, triaged before this PR
+            #    existed. Failing that forever would teach people to stop
+            #    touching live-only files, or worse, to pad diffs with mutable
+            #    noise. It passes, LOUDLY: the notice says outright that offline
+            #    mutation says nothing about this diff.
+            if git diff --name-only "origin/$BASE_REF"...HEAD | grep -qx '.cargo/mutants.toml'; then
+              echo "::error::the mutation gate would grade NOTHING: this diff yields \
+          $all mutants, .cargo/mutants.toml removes every one — and this SAME diff \
+          edits mutants.toml. A PR must not excuse itself from the gate unreviewed \
+          (#227/#229/#230): a human confirms the exclusions' live-oracle proofs, \
+          then the merge proceeds over this red or the triage merges separately."
+              exit 1
+            fi
+            echo "::notice::live-only diff: all $all in-diff mutants land in code \
+          the offline gate cannot execute, under exclusions reviewed before this \
+          PR (mutants.toml untouched here). Offline mutation testing says NOTHING \
+          about this diff — its oracle is the live suite named in each exclusion."
           fi
           echo "$graded" > graded-count.txt
           echo "::notice::$graded of $all in-diff mutants pass the exclusions ($((all - graded)) excluded as triaged-equivalent) — whether they are all RUN is the budget question the next step audits."

--- a/tests/live/live_metrics_persist.rs
+++ b/tests/live/live_metrics_persist.rs
@@ -27,7 +27,6 @@
 //! completions post-scope and yields `None`).
 
 use crate::common::*;
-use std::process::Command;
 
 /// The complete set of harm counters each engine's probe reads. The probe
 /// queries a fixed column list and both snapshots see the same columns, so
@@ -86,44 +85,22 @@ fn pg_chunked_run_persists_extended_metric_columns() {
 
     let table = seed_pg_numeric_table(ROWS);
     let export = unique_name("metrics_persist");
-    let cfg_dir = tempfile::tempdir().unwrap();
-    let out = tempfile::tempdir().unwrap();
-    let yaml = format!(
-        r#"source: {{type: postgres, url: "{POSTGRES_URL}"}}
-exports:
-  - name: {export}
-    query: "SELECT id, name FROM {table_name}"
-    mode: chunked
-    chunk_column: id
-    chunk_size: {CHUNK}
-    parallel: 1
-    format: parquet
-    compression: none
-    destination: {{type: local, path: {dir}}}
-"#,
-        table_name = table.name(),
-        dir = out.path().display(),
-    );
-    let cfg = write_config(&cfg_dir, &yaml);
-
-    let run = Command::new(RIVET_BIN)
-        .args([
-            "run",
-            "--config",
-            cfg.to_str().unwrap(),
-            "--export",
-            &export,
-            "--reconcile",
-        ])
-        .output()
-        .expect("spawn rivet run");
+    let rig = Rig::pg_batch(table.name())
+        .query(&format!("SELECT id, name FROM {}", table.name()))
+        .export_named(&export)
+        .mode("chunked")
+        .export_line("chunk_column: id")
+        .export_line(&format!("chunk_size: {CHUNK}"))
+        .export_line("parallel: 1")
+        .export_line("compression: none");
+    let run = rig.run_args(&["--export", &export, "--reconcile"]);
     assert!(
         run.status.success(),
         "chunked --reconcile run must succeed; stderr:\n{}",
         String::from_utf8_lossy(&run.stderr)
     );
 
-    let db = StateDb::next_to_config(&cfg);
+    let db = StateDb::next_to_config(&rig.config_path());
     let run_id = db.latest_run_id(&export);
     let m = db.metrics_row(&run_id);
 
@@ -198,60 +175,28 @@ fn pg_apply_persists_metric_row() {
     // source must reference the URL via env (`url_env`) to stay re-resolvable.
     const ROWS: i64 = 30;
     let table = seed_pg_numeric_table(ROWS);
-    let cfg_dir = tempfile::tempdir().unwrap();
-    let out = tempfile::tempdir().unwrap();
-    let yaml = format!(
-        r#"source:
-  type: postgres
-  url_env: DATABASE_URL
-exports:
-  - name: {export}
-    query: "SELECT id, name FROM {export}"
-    mode: full
-    format: parquet
-    compression: none
-    destination: {{type: local, path: {dir}}}
-"#,
-        export = table.name(),
-        dir = out.path().display(),
-    );
-    let cfg = write_config(&cfg_dir, &yaml);
-    let plan_path = cfg_dir.path().join("plan.json");
+    let rig = Rig::pg_batch(table.name())
+        .query(&format!("SELECT id, name FROM {}", table.name()))
+        .source_url_env("DATABASE_URL")
+        .export_line("compression: none");
+    let plan_path = rig.config_path().with_file_name("plan.json");
 
-    let plan = Command::new(RIVET_BIN)
-        .args([
-            "plan",
-            "--config",
-            cfg.to_str().unwrap(),
-            "--export",
-            table.name(),
-            "--format",
-            "json",
-            "--output",
-            plan_path.to_str().unwrap(),
-        ])
-        .env("DATABASE_URL", POSTGRES_URL)
-        .output()
-        .expect("spawn rivet plan");
+    let plan = rig.plan_json_env(&plan_path, &[], &[("DATABASE_URL", POSTGRES_URL)]);
     assert!(
         plan.status.success(),
         "rivet plan must exit 0; stderr:\n{}",
         String::from_utf8_lossy(&plan.stderr)
     );
 
-    let apply = Command::new(RIVET_BIN)
-        .args(["apply", plan_path.to_str().unwrap()])
-        .env("DATABASE_URL", POSTGRES_URL)
-        .output()
-        .expect("spawn rivet apply");
+    let apply = rig.apply_env(&plan_path, &[], &[("DATABASE_URL", POSTGRES_URL)]);
     assert!(
         apply.status.success(),
         "rivet apply must exit 0; stderr:\n{}",
         String::from_utf8_lossy(&apply.stderr)
     );
 
-    // apply opens state next to the original config dir (still present here).
-    let db = StateDb::next_to_config(&cfg);
+    // apply opens state next to the original config dir (the rig owns it).
+    let db = StateDb::next_to_config(&rig.config_path());
     let run_id = db.latest_run_id(table.name());
     let m = db.metrics_row(&run_id);
 
@@ -282,11 +227,14 @@ fn pg_run_persists_source_harm_rows() {
 
     let table = seed_pg_numeric_table(200);
     let export = unique_name("metrics_harm_pg");
-    let out = tempfile::tempdir().unwrap();
-    let yaml = pg_full_yaml(&export, table.name(), out.path());
-    let (cfg, _cfg_dir, run_id) = run_full_export_capture(&yaml, &export);
+    let rig = harm_rig(Rig::pg_batch(table.name()), table.name(), &export);
+    let run_id = run_and_latest_run_id(&rig, &export);
 
-    assert_harm_contract(&StateDb::next_to_config(&cfg), &run_id, PG_HARM_COUNTERS);
+    assert_harm_contract(
+        &StateDb::next_to_config(&rig.config_path()),
+        &run_id,
+        PG_HARM_COUNTERS,
+    );
 
     // `table`, `out`, `cfg_dir` are guards bound for the whole function; Rust
     // keeps Drop types to scope end, so they outlive every read above.
@@ -299,23 +247,14 @@ fn mysql_run_persists_source_harm_rows() {
 
     let table = seed_mysql_numeric_table(200);
     let export = unique_name("metrics_harm_mysql");
-    let out = tempfile::tempdir().unwrap();
-    let yaml = format!(
-        r#"source: {{type: mysql, url: "{MYSQL_URL}"}}
-exports:
-  - name: {export}
-    query: "SELECT id, name FROM {table_name}"
-    mode: full
-    format: parquet
-    compression: none
-    destination: {{type: local, path: {dir}}}
-"#,
-        table_name = table.name(),
-        dir = out.path().display(),
-    );
-    let (cfg, _cfg_dir, run_id) = run_full_export_capture(&yaml, &export);
+    let rig = harm_rig(Rig::mysql_batch(table.name()), table.name(), &export);
+    let run_id = run_and_latest_run_id(&rig, &export);
 
-    assert_harm_contract(&StateDb::next_to_config(&cfg), &run_id, MYSQL_HARM_COUNTERS);
+    assert_harm_contract(
+        &StateDb::next_to_config(&rig.config_path()),
+        &run_id,
+        MYSQL_HARM_COUNTERS,
+    );
 
     // `table`, `out`, `cfg_dir` are guards bound for the whole function; Rust
     // keeps Drop types to scope end, so they outlive every read above.
@@ -328,30 +267,18 @@ fn mssql_run_persists_source_harm_rows() {
 
     let table = seed_mssql_numeric_table(200);
     let export = unique_name("metrics_harm_mssql");
-    let out = tempfile::tempdir().unwrap();
     // The harm probe reads sys.dm_os_wait_stats, which needs VIEW SERVER STATE;
     // the `sa` test login is sysadmin, so the LCK% aggregate always returns one
     // row and both counters persist (delta may be 0 with no contention).
-    let yaml = format!(
-        r#"source:
-  type: mssql
-  url: "{MSSQL_URL}"
-  tls:
-    accept_invalid_certs: true
-exports:
-  - name: {export}
-    query: "SELECT id, name FROM {table_name}"
-    mode: full
-    format: parquet
-    compression: none
-    destination: {{type: local, path: {dir}}}
-"#,
-        table_name = table.name(),
-        dir = out.path().display(),
-    );
-    let (cfg, _cfg_dir, run_id) = run_full_export_capture(&yaml, &export);
+    // (`Rig::mssql_batch` already declares the accept_invalid_certs TLS block.)
+    let rig = harm_rig(Rig::mssql_batch(table.name()), table.name(), &export);
+    let run_id = run_and_latest_run_id(&rig, &export);
 
-    assert_harm_contract(&StateDb::next_to_config(&cfg), &run_id, MSSQL_HARM_COUNTERS);
+    assert_harm_contract(
+        &StateDb::next_to_config(&rig.config_path()),
+        &run_id,
+        MSSQL_HARM_COUNTERS,
+    );
 
     // `table`, `out`, `cfg_dir` are guards bound for the whole function; Rust
     // keeps Drop types to scope end, so they outlive every read above.
@@ -359,39 +286,23 @@ exports:
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
-fn pg_full_yaml(export: &str, table: &str, out: &std::path::Path) -> String {
-    format!(
-        r#"source: {{type: postgres, url: "{POSTGRES_URL}"}}
-exports:
-  - name: {export}
-    query: "SELECT id, name FROM {table}"
-    mode: full
-    format: parquet
-    compression: none
-    destination: {{type: local, path: {dir}}}
-"#,
-        dir = out.display(),
-    )
+/// One shape for every engine's harm test: the seeded table read back by a
+/// simple query, full mode, no compression — through the canonical Rig rather
+/// than the per-file YAML builder + raw binary invocation pair this file
+/// carried (the exact smell the rig replaced; rig-adoption ratchet, 2026-08-19).
+fn harm_rig(base: Rig, table: &str, export: &str) -> Rig {
+    base.query(&format!("SELECT id, name FROM {table}"))
+        .export_named(export)
+        .export_line("compression: none")
 }
 
-/// Run a single export from an already-rendered `yaml` (no `--reconcile`) and
-/// return `(cfg path, cfg TempDir guard, run_id)`. The caller owns the source
-/// table guard and the destination TempDir.
-fn run_full_export_capture(
-    yaml: &str,
-    export: &str,
-) -> (std::path::PathBuf, tempfile::TempDir, String) {
-    let cfg_dir = tempfile::tempdir().unwrap();
-    let cfg = write_config(&cfg_dir, yaml);
-    let run = Command::new(RIVET_BIN)
-        .args(["run", "--config", cfg.to_str().unwrap(), "--export", export])
-        .output()
-        .expect("spawn rivet run");
+/// Run the rig's single export and return the run_id the state DB recorded.
+fn run_and_latest_run_id(rig: &Rig, export: &str) -> String {
+    let run = rig.run_args(&["--export", export]);
     assert!(
         run.status.success(),
         "run must succeed; stderr:\n{}",
         String::from_utf8_lossy(&run.stderr)
     );
-    let run_id = StateDb::next_to_config(&cfg).latest_run_id(export);
-    (cfg, cfg_dir, run_id)
+    StateDb::next_to_config(&rig.config_path()).latest_run_id(export)
 }

--- a/tests/offline/rig_adoption_guard.rs
+++ b/tests/offline/rig_adoption_guard.rs
@@ -1,0 +1,151 @@
+//! The Rig exists because ~250 hand-rolled YAML templates and ~240 inline
+//! `Command::new(RIVET_BIN)` sites drifted apart; it re-converged them. But
+//! nothing STOPPED the drift from re-accumulating — new tests kept minting
+//! bespoke config builders and raw binary invocations one file at a time,
+//! because no gate ever asked. This is that gate: a shrink-only ratchet over
+//! every live file's count of bespoke sites (raw `Command::new(RIVET_BIN)` +
+//! `write_config(`), the same ledger shape as `docs/mutants-baseline.txt`.
+//!
+//! The ratchet does NOT demand migration — some files are legitimately bespoke
+//! (`rivet init` produces configs, so a config-owning rig is the wrong tool;
+//! signal tests kill a live child). It demands that bespokeness never GROWS
+//! silently: a new bespoke site either migrates to a `Rig::*` affordance, or
+//! raises its file's ceiling here in a reviewed diff that says why.
+
+use std::collections::BTreeMap;
+
+/// (file, bespoke-site ceiling) — regenerate a line by counting
+/// `Command::new(RIVET_BIN)` + `write_config(` in the file. Shrink freely;
+/// grow only with a reason in the PR.
+const BASELINE: &[(&str, usize)] = &[
+    ("audit_cli_dispatch.rs", 4),
+    ("audit_cloud_multipart.rs", 3),
+    ("audit_column_validation.rs", 5),
+    ("audit_doctor_fastfail.rs", 2),
+    ("audit_doctor_probe.rs", 2),
+    ("audit_init_deferred.rs", 4),
+    ("audit_maxfile.rs", 2),
+    ("audit_observability.rs", 4),
+    ("audit_plan_apply.rs", 4),
+    ("audit_preflight_table.rs", 7),
+    ("audit_repair.rs", 6),
+    ("audit_repair_chunk_index.rs", 3),
+    ("audit_rerun.rs", 4),
+    ("audit_state.rs", 4),
+    ("audit_target_typo.rs", 3),
+    ("batch_memory_policy.rs", 1),
+    ("chunking_stand.rs", 6),
+    ("gremlin.rs", 4),
+    ("gremlin_cdc.rs", 4),
+    ("live_azure_multipart.rs", 2),
+    ("live_batch_switch_golden.rs", 3),
+    ("live_catalog_hints.rs", 9),
+    ("live_cdc.rs", 33),
+    ("live_cdc_mbt.rs", 4),
+    ("live_cdc_mssql.rs", 7),
+    ("live_cdc_oracle.rs", 4),
+    ("live_cdc_property.rs", 2),
+    ("live_cdc_replica.rs", 2),
+    ("live_chaos.rs", 8),
+    ("live_chunked_dense.rs", 2),
+    ("live_chunked_recovery.rs", 1),
+    ("live_cli_flags.rs", 76),
+    ("live_crash_recovery.rs", 1),
+    ("live_crash_soak.rs", 2),
+    ("live_cross_db_parity.rs", 5),
+    ("live_destination_parity.rs", 2),
+    ("live_init_extended.rs", 6),
+    ("live_keyset.rs", 14),
+    ("live_mssql_chunked.rs", 3),
+    ("live_mssql_crash_recovery.rs", 6),
+    ("live_mssql_harm_permission.rs", 2),
+    ("live_mssql_resume.rs", 1),
+    ("live_mysql_chunked.rs", 2),
+    ("live_mysql_crash_recovery.rs", 6),
+    ("live_mysql_resume.rs", 1),
+    ("live_mysql_retry_and_faults.rs", 5),
+    ("live_mysql_schema_drift.rs", 3),
+    ("live_parallel_ux.rs", 2),
+    ("live_parquet_roundtrip.rs", 4),
+    ("live_partition_by.rs", 4),
+    ("live_partition_cloud.rs", 2),
+    ("live_performance_smoke.rs", 3),
+    ("live_plan_output_ux.rs", 6),
+    ("live_resume.rs", 2),
+    ("live_retry_and_faults.rs", 5),
+    ("live_schema_drift.rs", 6),
+    ("live_temp_spill.rs", 1),
+    ("live_wave_apply.rs", 9),
+    ("preflight_missing_table.rs", 2),
+    ("preflight_target_fail_note.rs", 2),
+    ("quality_live.rs", 1),
+    ("roast_metric_validated_ordering.rs", 2),
+    ("roast_mssql_decimal_scale.rs", 2),
+    ("roast_part_loss.rs", 3),
+    ("roast_pg_json_fidelity.rs", 1),
+    ("roast_small_table_escape.rs", 3),
+    ("roast_validate_exit.rs", 1),
+    ("sec_exit_codes.rs", 1),
+    ("sec_preflight_sqli.rs", 3),
+    ("sec_terminal_inject.rs", 2),
+    ("sec_tls_defaults.rs", 2),
+];
+
+fn bespoke_sites(path: &std::path::Path) -> usize {
+    let text = std::fs::read_to_string(path).unwrap_or_default();
+    text.matches("Command::new(RIVET_BIN)").count() + text.matches("write_config(").count()
+}
+
+#[test]
+fn bespoke_runner_sites_never_grow_per_file() {
+    let baseline: BTreeMap<&str, usize> = BASELINE.iter().copied().collect();
+    let mut over: Vec<String> = Vec::new();
+    let mut unknown: Vec<String> = Vec::new();
+    for e in std::fs::read_dir("tests/live")
+        .expect("read tests/live")
+        .flatten()
+    {
+        let p = e.path();
+        if p.extension().is_none_or(|x| x != "rs") {
+            continue;
+        }
+        let name = p.file_name().unwrap().to_string_lossy().to_string();
+        let n = bespoke_sites(&p);
+        match baseline.get(name.as_str()) {
+            Some(&cap) if n > cap => over.push(format!("{name}: {n} > {cap}")),
+            None if n > 0 => unknown.push(format!("{name}: {n}")),
+            _ => {}
+        }
+    }
+    assert!(
+        over.is_empty() && unknown.is_empty(),
+        "bespoke rivet-runner sites grew past the ratchet: over {over:?}; new files with \
+         bespoke sites {unknown:?}. Use a `Rig::*` constructor (`Rig::cli` for non-run \
+         subcommands, `spawn_args_env` for a killable child, `also_export` for \
+         multi-export configs), or raise this file's ceiling in a reviewed diff that \
+         says why the rig cannot express the case."
+    );
+}
+
+#[test]
+fn the_baseline_matches_reality_downward_too() {
+    // A shrink-only ratchet must RECORD its wins, or the slack it leaves is a
+    // future silent growth allowance exactly as wide as every past migration.
+    let baseline: BTreeMap<&str, usize> = BASELINE.iter().copied().collect();
+    let mut slack: Vec<String> = Vec::new();
+    for (name, &cap) in &baseline {
+        let p = std::path::Path::new("tests/live").join(name);
+        if !p.exists() {
+            slack.push(format!("{name}: listed but deleted — drop the entry"));
+            continue;
+        }
+        let n = bespoke_sites(&p);
+        if n < cap {
+            slack.push(format!("{name}: {n} actual < {cap} ceiling — lower it"));
+        }
+    }
+    assert!(
+        slack.is_empty(),
+        "the ratchet has slack; tighten it so migrations stay banked: {slack:?}"
+    );
+}

--- a/tests/offline_suite.rs
+++ b/tests/offline_suite.rs
@@ -65,6 +65,8 @@ mod run_summary_contract;
 mod cli_flag_coverage_guard;
 #[path = "offline/live_service_ports_guard.rs"]
 mod live_service_ports_guard;
+#[path = "offline/rig_adoption_guard.rs"]
+mod rig_adoption_guard;
 #[path = "offline/runner_frame_gate.rs"]
 mod runner_frame_gate;
 #[path = "offline/scenario_artifact_matrix_guard.rs"]


### PR DESCRIPTION
The Rig exists because ~250 hand-rolled YAML templates and ~240 raw binary
invocations drifted apart; it re-converged them — and nothing has stopped the
drift from re-accumulating since. Counted today: 72 live files still carry
bespoke sites (`Command::new(RIVET_BIN)` + `write_config(`), from 76 in
live_cli_flags.rs down to singletons. New tests kept minting them because no
gate ever asked.

`rig_adoption_guard` is that gate, the same ledger shape as the mutants
baseline: a per-file shrink-only ratchet. It does NOT demand migration — some
files are legitimately bespoke (`rivet init` PRODUCES configs, so a config-owning
rig is the wrong tool) — it demands that bespokeness never grows silently. Two
sides, both proven: growth fails (RED with a probe site), and slack fails too —
a shrink-only ratchet must record its wins, or the slack it leaves is a future
growth allowance exactly as wide as every past migration. The slack side fired
its first five findings against MY OWN hand-typed first draft of the baseline,
which had drifted from reality in both directions before the guard ever ran in
CI — the baseline is now generated by the same counter the guard measures with.

Banked migration: live_metrics_persist.rs, 7 bespoke sites -> 0. All five tests
through Rig constructors (`export_named`, `query`, `plan_json_env`/`apply_env`
for the apply path, one shared `harm_rig` for the three engine harm tests),
5/5 green live. One honest note: the first migration attempt silently DELETED
all five tests — a helper-removal slice cut through them, the build stayed green
(dead helpers compile fine), and only `grep -c '#[test]'` caught it. The redo
asserts the removed span contains no `#[test]` before writing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168uwctCn3W1rP4Kt4kZXvE