### PR TITLE
fix(keyset): part names no longer double the export name

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -88,6 +88,20 @@ exclude_re = [
     # rest of the loop — the whole live_suite runs through it.
     "replace pg_run_export ->",
     " in pg_run_export",
+    # run_keyset / run_keyset_parallel (pipeline/keyset.rs) are the keyset export
+    # RUNNERS — each opens a real source, drives the seek-paged FETCH loop and
+    # streams parts to the sink. Unkillable OFFLINE (the --in-diff gate has no
+    # DB). They entered in-diff scope via a one-line `run_tag = run_scoped_tag(..)`
+    # change (PR #253); cargo-mutants then generated the whole-function `-> Ok(())`
+    # stub, which `--lib` cannot reach (the "--lib on a live-only path" class).
+    # The value logic that actually changed is `run_scoped_tag`, unit-tested and
+    # 4/4 mutants CAUGHT. Both runner stubs proven live-killed by hand: `Ok(())`
+    # produces ZERO parts, so run_keyset_parallel fails
+    # keyset_part_names_do_not_double_the_export_name and run_keyset fails
+    # keyset_varchar_pk_roundtrips_full_keyset_across_pages (both RED-verified
+    # 2026-08-20, then reverted). The whole live_keyset suite guards the bodies.
+    "replace run_keyset ->",
+    "replace run_keyset_parallel ->",
     # introspect_all (init/mod.rs) is the whole-schema scan: every arm opens a
     # live engine connection, so its dispatch mutants (delete match arm
     # "postgres"/"mysql"/"mssql") are unkillable OFFLINE. The DECISION logic was

--- a/docs/runner-coverage-matrix.yaml
+++ b/docs/runner-coverage-matrix.yaml
@@ -258,6 +258,14 @@ scenarios:
     keyset:         { test: parallel_keyset_two_full_runs_into_same_prefix_no_clobber_postgres }
     mongo_parallel: { test: mongo_parallel_two_rapid_runs_into_same_prefix_do_not_clobber }
 
+  - id: part_name_not_export_doubled
+    what: "a part filename carries the export name EXACTLY ONCE. The keyset part-name format prepends `<export>_` AND used the run_id for run-uniqueness — but the production run_id is itself `<export>_<stamp>` (job.rs), so real runs wrote `<export>_<export>_<stamp>_pk_w…` (field-run, 0.24.5). The chunked/mongo/single siblings key their middle segment off a FRESH Utc stamp, not the run_id, so they never doubled; keyset was the odd one out. Fix: `run_scoped_tag` strips a redundant leading `<export>_` from the run tag."
+    single:         { na: "keys off a fresh `%Y%m%d_%H%M%S_%3f` Utc stamp (single.rs), never the run_id — the export name cannot appear twice by construction" }
+    chunked:        { na: "shared seam `chunk_part_filename` (chunked/mod.rs:64) keys off a fresh `%Y%m%d_%H%M%S` Utc stamp, not the run_id — no double; every chunked variant derives from it" }
+    chunked_checkpoint: { na: "same `chunk_part_filename` seam as `chunked` — a fresh stamp, not the run_id" }
+    keyset:         { test: keyset_part_names_do_not_double_the_export_name }
+    mongo_parallel: { na: "keys off a fresh `%Y%m%d_%H%M%S_%3f` stamp (mongo_parallel.rs:63), not the run_id — no double" }
+
   - id: durable_manifest_before_advance
     what: "the destination manifest covering a run's parts is durable BEFORE the delivery position advances past them (the silent-loss ordering) — cross-references docs/durability-ordering-matrix.yaml."
     single:         { test: f2_crash_window_manifest_written_cursor_absent }

--- a/src/pipeline/keyset.rs
+++ b/src/pipeline/keyset.rs
@@ -244,6 +244,22 @@ fn sanitize_run_id(s: &str) -> String {
         .collect()
 }
 
+/// The run-unique tag used INSIDE a keyset part name — the sanitized run_id
+/// with a redundant leading `<export>_` stripped.
+///
+/// The production run_id is `<export>_<ms-stamp>` (job.rs), and the part-name
+/// format already prepends `<export>_`, so using the raw run_id produced
+/// `<export>_<export>_<stamp>_pk_w...` — the export name TWICE (field-run
+/// observation). The chunked and mongo-parallel siblings key their middle
+/// segment off a fresh stamp, not the run_id, so they never doubled; keyset was
+/// the odd one out. Stripping only a PRESENT `<export>_` prefix keeps run-
+/// uniqueness (the ms stamp survives) and leaves a bare/custom run_id (e.g. a
+/// synthetic `run-1`) untouched.
+fn run_scoped_tag(run_id: &str, export_name: &str) -> String {
+    let tag = sanitize_run_id(run_id);
+    let prefix = format!("{}_", sanitize_run_id(export_name));
+    tag.strip_prefix(&prefix).unwrap_or(&tag).to_string()
+}
 /// Sample the N ROW-percentile ranges for a FRESH parallel keyset run:
 /// `(range_index, lo_exclusive, hi_inclusive, done=false)`. The N−1 boundaries
 /// partition the key into half-open intervals whose union is the whole key space.
@@ -464,7 +480,7 @@ fn run_keyset_parallel(
     // Part names key off the run_id, not a wall-clock stamp: unique per fresh run
     // AND stable across a resume, so a re-run range's parts OVERWRITE its crashed
     // partial parts (idempotent) instead of accumulating duplicates.
-    let run_tag = sanitize_run_id(&summary.run_id);
+    let run_tag = run_scoped_tag(&summary.run_id, &plan.export_name);
     let run_id = summary.run_id.clone();
     // Workers commit to keyset_range + file_log ONLY on a checkpoint run — a
     // non-checkpoint run persists no ranges (the `_ =>` sample arm), so letting its
@@ -1050,7 +1066,7 @@ pub(crate) fn run_keyset(
     // rows on a live mysql keyset resume; convergence round-1 HIGH). Matches the parallel path.
     let frame = super::frame::RunnerFrame::open(plan)?;
     let (dest, ext) = (frame.dest, frame.ext);
-    let run_tag = sanitize_run_id(&summary.run_id);
+    let run_tag = run_scoped_tag(&summary.run_id, &plan.export_name);
 
     loop {
         // Name the part by the SEEK cursor (`last`), not the per-invocation page counter: a
@@ -1339,6 +1355,29 @@ mod tests {
     }
 
     // ── sanitize_run_id: filename-safe token for part names ──────────────────
+    #[test]
+    fn run_scoped_tag_strips_a_redundant_export_prefix_but_keeps_a_bare_run_id() {
+        // Production run_id is `<export>_<stamp>`; the part-name format prepends
+        // `<export>_`, so the raw run_id doubled the export name in the file
+        // (field-run: `aa_bonus_conversions_usd_aa_bonus_conversions_usd_...`).
+        assert_eq!(
+            run_scoped_tag(
+                "aa_bonus_conversions_usd_20260820T104554088",
+                "aa_bonus_conversions_usd"
+            ),
+            "20260820T104554088",
+            "the leading <export>_ must be stripped so the part name is not <export>_<export>_<stamp>"
+        );
+        // A bare / custom run_id (no export prefix) is left untouched — the
+        // synthetic keyset_range fixtures rely on `exp_run-1_pk_w1_0`.
+        assert_eq!(run_scoped_tag("run-1", "exp"), "run-1");
+        // Uniqueness survives: two runs -> two stamps -> two tags.
+        assert_ne!(
+            run_scoped_tag("e_20260820T104554088", "e"),
+            run_scoped_tag("e_20260820T104554090", "e")
+        );
+    }
+
     #[test]
     fn sanitize_run_id_keeps_safe_chars_and_replaces_the_rest() {
         // alnum, '-', '_' survive; everything else becomes '_'.

--- a/tests/live/live_keyset.rs
+++ b/tests/live/live_keyset.rs
@@ -2262,3 +2262,52 @@ fn validate_depth_full_rereads_the_parts_the_lighter_depths_never_open() {
         String::from_utf8_lossy(&full.stderr)
     );
 }
+
+/// PART-NAME NON-DOUBLING (field-run finding). The keyset part-name format
+/// prepends the export name, and the run_id it used for run-uniqueness is
+/// itself `<export>_<stamp>` — so real runs wrote `<export>_<export>_<stamp>_
+/// pk_w…`, the export name TWICE (the chunked/mongo siblings key off a fresh
+/// stamp and never doubled). Through the rig: a PARALLEL keyset export (the
+/// pk_w path, keyset.rs:605) whose part basenames must carry the export name
+/// exactly ONCE. RED before run_scoped_tag stripped the redundant prefix.
+#[test]
+#[ignore = "live: requires docker compose up -d postgres"]
+fn keyset_part_names_do_not_double_the_export_name() {
+    require_alive(LiveService::Postgres);
+    let table = seed_pg_numeric_table(2000);
+    let out = tempfile::tempdir().unwrap();
+    let rig = Rig::pg_batch(table.name())
+        .mode("chunked")
+        .export_line("chunk_by_key: id")
+        .export_line("chunk_size: 200")
+        .export_line("parallel: 4")
+        .dest_path(out.path().to_path_buf());
+    assert!(
+        rig.run_args(&[]).status.success(),
+        "keyset export must succeed before its part names can be checked"
+    );
+
+    let parts = files_with_extension(out.path(), "parquet");
+    assert!(!parts.is_empty(), "keyset run produced no parts to name");
+
+    let doubled = format!("{}_{}", table.name(), table.name());
+    for p in &parts {
+        let name = p.file_name().unwrap().to_string_lossy().into_owned();
+        // The part is a parallel-keyset part (proves we exercised the pk_w path).
+        assert!(
+            name.contains("_pk_w"),
+            "expected parallel-keyset (pk_w) parts; got {name}"
+        );
+        assert!(
+            !name.contains(&doubled),
+            "part name doubles the export name — '{doubled}' appears in '{name}' \
+             (the run_id-carries-the-export bug; run_scoped_tag must strip it)"
+        );
+        // ...and the export name is still present exactly once (dir + name both
+        // carry it, so a reader can attribute a stray file to its export).
+        assert!(
+            name.starts_with(&format!("{}_", table.name())),
+            "part name must still lead with the export name once: {name}"
+        );
+    }
+}


### PR DESCRIPTION
## The field-run finding
0.24.5 pool run — keyset parts landed as
`exports/<export>/<export>_<export>_<stamp>_pk_w3_2.parquet`: the export name **twice**.

## Root cause
The keyset part-name format prepends `<export>_` (keyset.rs:605 parallel, :1061 sequential) **and** used the run_id for run-uniqueness — but the production run_id is itself `<export>_<stamp>` (job.rs:732). The chunked, mongo-parallel and single siblings key their middle segment off a **fresh Utc stamp**, not the run_id, so they never doubled. Keyset was the odd one out.

## Fix
`run_scoped_tag(run_id, export_name)` strips a redundant leading `<export>_` from the sanitized run tag. Run-uniqueness survives (the ms stamp remains), retry-overwrite survives (the tag is stable within a run), and a bare/custom run_id is left untouched. No product code parses the prefix — the `_pk_w`/`_keyset_` suffix readers key off is unchanged.

## Proven three ways
- **lib unit** `run_scoped_tag_…` — RED against a no-strip mutant.
- **LIVE through the rig** `keyset_part_names_do_not_double_the_export_name` — a parallel keyset export (the pk_w path); part basenames must carry the export name exactly once. RED-proven (showed `rivet_qa_tbl_..._rivet_qa_tbl_..._pk_w1_2`).
- **runner-coverage-matrix** row `part_name_not_export_doubled` (keyset=test; the fresh-stamp siblings=na with the reason); the matrix guard RED-proven to see the cell.

Cosmetic on-disk change only (no data-loss, no manifest/parser impact); old runs' names remain valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168uwctCn3W1rP4Kt4kZXvE