### PR TITLE
feat(pipeline): ADR-0028 — one finalize seam for the export tail (CommitLedger)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -117,6 +117,27 @@ exclude_re = [
     # 2026-08-20, then reverted). The whole live_keyset suite guards the bodies.
     "replace run_keyset ->",
     "replace run_keyset_parallel ->",
+    # run_with_reconnect / run_mongo_parallel (ADR-0028 seam cut-over, PR: the
+    # finalize-export-seam branch) are live-only export runners: the first wraps
+    # run_single_export's retry loop over a real source connection, the second
+    # fans _id-range workers over a real MongoDB. Their whole-fn `Ok(())` stubs
+    # export nothing and are unkillable under `--lib --bins`. Both proven
+    # live-killed by hand 2026-08-21 (stub applied, test run, stub reverted):
+    # run_with_reconnect fails keyset_export_records_form_b_checksums_and_
+    # validate_passes; run_mongo_parallel fails mongo_parallel_export_records_
+    # form_b_checksum. The tail DECISION logic the cut-over moved is unit-killed
+    # (CommitLedger 4/4, finalize_export + shape guard, drain_tail_into).
+    "replace run_with_reconnect ->",
+    "replace run_mongo_parallel ->",
+    # run_export_job_with_chunk_source is the plan-ARTIFACT apply orchestration
+    # (apply_cmd.rs:215 is its only caller) — a real StateStore + source per
+    # export, live-only. Its stub `(Ok(()), Default::default())` is proven
+    # live-killed by hand 2026-08-21: plan_and_apply_full_export_round_trip
+    # FAILS (no export happens). Honest scope note: the .yaml wave-apply live
+    # test (resume_skips_completed_exports) stays GREEN under this stub — that
+    # path goes through run_export_job, not this fn; the artifact round-trip
+    # test is the one that owns it.
+    "replace run_export_job_with_chunk_source ->",
     # introspect_all (init/mod.rs) is the whole-schema scan: every arm opens a
     # live engine connection, so its dispatch mutants (delete match arm
     # "postgres"/"mysql"/"mssql") are unkillable OFFLINE. The DECISION logic was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- **ADR-0028: one finalize seam for the export tail.** The post-write tail
+  (manifest schema-fingerprint pin, `on_schema_drift` gate, Form-B checksum
+  harvest, shape-drift warn) is now applied exactly once, at
+  `finalize::finalize_export` — called by the dispatcher between the runner
+  returning and `finalize_manifest` — from a `CommitLedger` the runners feed as
+  they commit. Previously every export runner re-assembled that tail by hand,
+  which is how a feature wired into one runner ended up silently absent on the
+  others (the recurring runner-bypass class: the keyset/mongo drift-gate miss,
+  Form-B computed-then-discarded on the large-table runners). Runners now only
+  feed the ledger; the ordering constraints live in one place. Behavior is
+  unchanged except keyset/mongo manifests now also carry the dest-schema
+  fingerprint single mode always recorded (uniform pin at the seam).
+
 - **`rivet plan` is now READ-ONLY without `--annotate-waves`.** It computes and
   prints the advisory schedule (and the reviewable plan artifact) but no longer
   touches your config file unless you pass `--annotate-waves`. Previously, plan

--- a/docs/adr/0028-finalize-export-seam.md
+++ b/docs/adr/0028-finalize-export-seam.md
@@ -1,0 +1,142 @@
+# ADR-0028: One finalize seam for the export tail — retiring the runner-bypass class by construction
+
+**Status**: Proposed (design accepted, migration not started)
+**Date**: 2026-08
+**Relates to**: ADR-0012 (manifest durability ordering), ADR-0021 (chunked drift pre-chunk), `docs/runner-coverage-matrix.yaml` (the ledger this ADR aims to shrink)
+
+---
+
+## Context
+
+`run_export_job` (`src/pipeline/job.rs:896`) dispatches on `plan.strategy` to
+one of several execution loops — four runner families (`single`, `chunked` +
+its checkpoint twin, `keyset`, `mongo_parallel`), ~eight real commit loops
+counting sequential/parallel variants. Each loop owns its own **tail**: after
+the last batch it must harvest per-column checksums, run the schema-drift
+gate, capture the incremental cursor range, clear the resume anchor, and hand
+back to the dispatcher for `finalize_manifest`.
+
+That tail is **re-assembled by hand in every runner**. The primitives are
+already shared (`commit::record_part`, `commit::harvest_column_checksums`,
+`schema_drift::check_from_sink_schema`, `finalize::finalize_manifest`); the
+**orchestration** is not. The result is the *runner-bypass class*: a
+per-export feature wired into one runner is silently absent on the others,
+and every count/sum/oracle stays green because the missing piece (a gate, an
+integrity record, a run-unique stamp) is orthogonal to row correctness.
+
+The class is recurrent, not incidental — it has surfaced across eight bughunt
+rounds because it is a property of the shape: a dispatcher fanning out to N
+re-implementations of one sequence gives **N places to forget**. Documented
+bites, each with its comment still in the tree:
+
+* `on_schema_drift: fail` silently returned exit 0 on keyset and
+  mongo_parallel (`keyset.rs:1266` says so verbatim) — round 8 found two
+  misses in one round.
+* Form-B value-checksum harvest was absent on all three large-table runners:
+  the sink *computed* the checksums for every runner, but only `single`
+  harvested them into the summary.
+* The keyset part-name stamp doubled the export name (#253) because keyset
+  alone derived its stamp from `run_id` while its three siblings used a fresh
+  Utc stamp — a divergence in a tail step no test compared across runners.
+
+Current defenses, and their limits:
+
+1. **`docs/runner-coverage-matrix.yaml`** (59 `na` / 39 `test` / 4 `gap` as
+   of this writing) — a map, not a guard. It catches gaps after the fact and
+   collapses ~8 loops into 4 columns, so `test` on `keyset` may be proven
+   only on keyset_sequential.
+2. **`RunSummary::check_post_run_invariants`** (`summary.rs:795`, called
+   inside `finalize_manifest`) — a genuine structural backstop for the two
+   telltale-bearing features (drift verdict, Form-B), but it asserts the
+   summary is *coherent*, not that every tail step *ran*.
+3. **Per-variant audit** (2026-08-04, recorded in the matrix header) — all 8
+   loops × 13 scenarios read by hand, adversarially refuted. A snapshot, not
+   a mechanism.
+
+The load-bearing observation: `finalize_manifest` and the invariant check are
+**already centralized in the dispatcher** (`job.rs:1221`, `job.rs:1493`). The
+whole surface of the class is the stretch **between the last batch and
+`finalize_manifest`** — the pre-finalize tail the dispatcher does not yet
+own.
+
+## Decision
+
+Funnel the pre-finalize tail through **one seam**, `finalize_export`, called
+by the dispatcher; and fill that seam's input **as a side effect of the one
+call every runner already makes** (`commit::record_part`), so no runner can
+bypass what it never touches.
+
+Two contract shapes were designed (design-it-twice):
+
+* **Option A — collect struct.** Each runner returns an
+  `ExportTail { drift_schema, checksums+key, cursor, shape }`; the dispatcher
+  passes it to `finalize_export`. This moves the *ordering* into one place
+  but converts "forget to call" into "forget to fill" — a runner can still
+  leave `drift_schema = None` and the gate quietly no-ops.
+* **Option B — the sink/commit path owns the tail (CHOSEN).**
+  `commit::record_part` is already the single drain point every runner —
+  including parallel workers (`mongo_parallel.rs:19`) — must call to write.
+  Extend it to accumulate, per part, the drift schema, the checksum XOR, the
+  cursor high-water, and shape bytes into a `CommitLedger`. The tail input is
+  then captured **by construction of committing**, exactly the mechanism that
+  already makes `record_part` itself an `na` cell. `finalize_export` reads a
+  ledger it did nothing special to fill.
+
+The seam encodes, once, the ordering constraints each runner currently
+re-derives by hand:
+
+* drift gate + checksum harvest **before** `finalize_manifest` — the manifest
+  must record the checksums, and a drift `fail` must abort before a manifest
+  exists;
+* cursor commit + *incremental* checkpoint clear **after** the manifest is
+  durable (ADR-0012: a crash in the advance→manifest window strands committed
+  parts the manifest-authoritative loader silently drops);
+* *non-incremental* checkpoint clear at data-complete, **before** the gates —
+  a gate failure must not leave a resume anchor that turns an intended full
+  re-run into a crash-recovery skip (`keyset.rs:1228` hand-codes this today).
+
+**What stays apart, deliberately**: the reads. A keyset seek, a chunked
+`BETWEEN`, a single cursor scan and a Mongo `$sample` split are genuinely
+different access patterns — folding them behind one interface would be a
+shallow abstraction over real difference, the opposite mistake. Only the tail
+funnels. ADR-0025 made the same call for CDC adapters' refill loops: shared
+seams for the invariants, per-adapter loops where the engines truly differ.
+
+## Migration (one runner at a time, each cut RED-proven)
+
+1. Land `finalize_export` against `single` — the reference tail, lowest-risk
+   cut; prove parity on its live suite.
+2. Extend `record_part` to fill the `CommitLedger` (concurrency-safe — it is
+   already the parallel drain point).
+3. Cut over `keyset` → `mongo_parallel` → `chunked`(+checkpoint): delete each
+   runner's tail block; the deleted block is the RED mutant.
+4. Collapse the matrix rows (drift / checksum / cursor flip from N× `test` to
+   one `na`) and strengthen `check_post_run_invariants` from "summary is
+   coherent" to "the ledger was populated" — the backstop graduates to
+   asserting the feature *ran*.
+
+## Consequences
+
+* A new per-export feature has exactly **one** home and is born `na`. The
+  places-to-forget count drops from N to 1; the recurring bughunt find ends
+  because there is no longer an *other runner* to forget.
+* The deletion test passes in the right direction: removing the per-runner
+  tail blocks **concentrates** complexity into one ordering-correct,
+  tested-once seam rather than moving it around.
+* The runner-coverage matrix shrinks toward what it should be: a ledger of
+  genuinely per-runner concerns (part naming, read-side semantics), not a
+  guard against re-assembly drift.
+* Cost: `record_part`'s signature/state widens, and the migration touches
+  every runner — hence the one-at-a-time, RED-proven schedule rather than a
+  big-bang cut.
+* Until the migration completes, the matrix + invariant backstop remain the
+  defense; this ADR does not retire them, it names their replacement.
+
+## Sibling class, recorded for the next reader
+
+The same fan-out shape one layer up is the *diagnostic-bypass* class: a
+preflight that resolves its subject from a **subset** of strategy fields (an
+`.or()` chain shorter than the strategy enum, a `?` placeholder surfacing in
+output). The cure rhymes: resolve through the one function that enumerates
+every strategy. Wherever a fan-out re-implements a decision its dispatcher
+could own, this class is waiting.

--- a/docs/adr/0028-finalize-export-seam.md
+++ b/docs/adr/0028-finalize-export-seam.md
@@ -1,6 +1,14 @@
 # ADR-0028: One finalize seam for the export tail — retiring the runner-bypass class by construction
 
-**Status**: Proposed (design accepted, migration not started)
+**Status**: Accepted — implemented 2026-08-21. `finalize::finalize_export` +
+`CommitLedger` landed in one pass: the tail blocks were deleted from all seven
+commit loops (single, keyset sequential + parallel, mongo_parallel, chunked
+sequential + parallel, both checkpoint twins); each runner now only feeds the
+ledger. RED-proven both ways — seam call removed → two live tests FAIL and the
+finalize telltale panics; a runner's feed removed → the telltale names the
+runner-bypass class in its message. The retry boundary (`run_with_reconnect`)
+resets the ledger so a failed attempt's partial feed never double-merges into
+the retry's.
 **Date**: 2026-08
 **Relates to**: ADR-0012 (manifest durability ordering), ADR-0021 (chunked drift pre-chunk), `docs/runner-coverage-matrix.yaml` (the ledger this ADR aims to shrink)
 

--- a/docs/runner-coverage-matrix.yaml
+++ b/docs/runner-coverage-matrix.yaml
@@ -9,6 +9,18 @@
 # of parallel-keyset shipped exactly that: the drift gate, wired into keyset_sequential,
 # was absent on keyset_parallel; a human caught it, not this ledger — see below).
 #
+# ADR-0028 (2026-08-21): the tail APPLICATION is now ONE seam. `finalize::
+# finalize_export`, called by the dispatcher between the runner returning and
+# `finalize_manifest`, applies the fingerprint pin, the on_schema_drift gate,
+# the Form-B harvest and the shape-drift warn from `summary.ledger` — the
+# CommitLedger the runners FEED as they commit. No runner applies any of those
+# itself any more, so the drift/Form-B rows below grade the runner's FEED (and
+# the seam end-to-end), not a per-runner re-application; the class this ledger
+# exists to catch is structurally reduced to "a runner fed nothing", which the
+# telltale backstop below turns RED (proven 2026-08-21: seam call removed ->
+# 2 live tests FAIL + the finalize panic fires; keyset feed removed -> the
+# telltale names the runner-bypass class in its message).
+#
 # STRUCTURAL BACKSTOP (feat/parallel-keyset, candidate A): two of the recurring
 # scenarios below — `schema_drift_gate` and value-checksum Form B — are now guarded
 # STRUCTURALLY by `RunSummary::check_post_run_invariants` (a debug/test panic in
@@ -179,7 +191,7 @@ scenarios:
     mongo_parallel: { na: "mongo_parallel spawns one thread per _id range with NO shared permit ceiling — the governor's resize target does not exist there. The reader-level adaptive batch sizing (engine pressure counters) still applies; the concurrency governor is a permit-ceiling mechanism and mongo_parallel has no ceiling to shrink. A future ceiling would take a `test` cell here." }
 
   - id: schema_drift_gate
-    what: "on_schema_drift enforcement — a drifted schema under `fail` aborts (exit 4). Each runner bypasses run_single_export, so each must re-apply the gate (check_from_sink_schema / check_from_type_mappings). Round-8: keyset + mongo_parallel had SILENTLY dropped it (exit 0 on drift)."
+    what: "on_schema_drift enforcement — a drifted schema under `fail` aborts (exit 4). Round-8: keyset + mongo_parallel had SILENTLY dropped it (exit 0 on drift) — each runner re-applied the gate by hand then. Since ADR-0028 the gate runs ONCE at the finalize_export seam from the ledger's drift schema; runners only FEED the schema they resolved (chunked feeds none — its gate is pre-chunk via check_from_type_mappings, ADR-0021). The test cells grade the feed + seam end-to-end."
     single:         { test: schema_drift_removed_column_is_detected }
     chunked:        { test: chunked_range_export_enforces_on_schema_drift_fail }
     chunked_checkpoint: { na: "shared CHUNKED preamble, not per-runner: every chunked variant takes the gate through chunked/mod.rs — `prepare_chunk_plan` / `prepare_chunk_plan_fresh` on the Detect path and `check_drift_only(_fresh)` on the Precomputed (apply/resume) path. Call sites: sequential_checkpoint.rs:245/249 and parallel_checkpoint.rs:61/68, the same two functions exec.rs:31/36 and :203/210 call, so the checkpoint runners cannot diverge from the cell to the left. Backstopped structurally as well — check_post_run_invariants rejects a state_backed success that committed parts with schema_changed = None (summary.rs), and finalize.rs panics on it under debug_assertions, the build every live test runs" }
@@ -195,7 +207,7 @@ scenarios:
     mongo_parallel: { na: "runs UNDER `ExtractionStrategy::Keyset` (single.rs: a Mongo keyset export with parallel > 1 fans _id-range workers), so it takes the Keyset arm of the same match — the cell to the left is the same code. A separate strategy variant would need its own `test` cell here." }
 
   - id: shape_drift_warn
-    what: "detect_shape_drift — advisory warning when a string/binary column's max byte length grows past the factor. Needs the run-wide per-column max-bytes aggregate."
+    what: "detect_shape_drift — advisory warning when a string/binary column's max byte length grows past the factor. Needs the run-wide per-column max-bytes aggregate. Since ADR-0028 the warn is applied at the finalize_export seam wherever a runner fed shape bytes into the ledger (merge_shape, max-merge) — today only the single sink drains them, so the na cells below still hold; a runner that starts feeding gets the warn for free (born na)."
     single:         { test: growth_above_threshold_warns }
     chunked:        { na: "advisory, single-batch-only by design (documented on shape_drift_warn_factor): the multi-part runners write through several sinks and never aggregate the run-wide per-column max bytes, so there is nothing to compare" }
     chunked_checkpoint: { na: "advisory, single-batch-only by design — same reason as the plain chunked cell (several sinks, no run-wide max-bytes aggregate)" }
@@ -203,14 +215,15 @@ scenarios:
     mongo_parallel: { na: "advisory, single-batch-only by design — no run-wide max-bytes aggregate across workers" }
 
   - id: value_checksum_form_b
-    what: "Form B — the sink's per-column value checksums are harvested into summary.column_checksums so finalize_manifest RECORDS them and `rivet validate` can re-read the parts and verify the Arrow→Parquet encode. The sink COMPUTES them for every runner (track_checksum in on_batch); the multi-part runners XOR-combine per part run-wide through the shared commit::{accumulate,harvest}_column_checksums seam (round-9 fix — previously computed then discarded)."
+    what: "Form B — the sink's per-column value checksums are harvested into summary.column_checksums so finalize_manifest RECORDS them and `rivet validate` can re-read the parts and verify the Arrow→Parquet encode. The sink COMPUTES them for every runner (track_checksum in on_batch); since ADR-0028 every runner FEEDS them into summary.ledger (merge_checksums, order-independent) and the HARVEST happens once at the finalize_export seam — no runner calls harvest itself (round-9 had fixed the computed-then-discarded bug per runner; the seam removes the per-runner call entirely). The test cells grade the feed + seam end-to-end."
     single:         { test: pg_type_matrix_value_checksum_guard }
     chunked:        { test: chunked_export_records_form_b_checksums_and_validate_passes }
     # The load-bearing half is that test's BASELINE arm: a clean parallel-checkpoint
     # run (parallel: 4, chunk_checkpoint: true) must record Form B in the destination
     # manifest AND `rivet validate` (Full) must re-read it — the test says so in its
     # own body ("so the suppression below is not vacuous"). The SEQUENTIAL checkpoint
-    # runner harvests at sequential_checkpoint.rs:409 with no dedicated live cell; its
+    # runner feeds the ledger inside its per-chunk loop (sequential_checkpoint.rs,
+    # merge_checksums) with no dedicated live cell; its
     # backstop is structural (check_post_run_invariants rejects a state_backed parquet
     # success with empty, un-flagged column_checksums; finalize.rs panics on it under
     # debug_assertions, which is the build live tests run).

--- a/src/pipeline/chunked/exec.rs
+++ b/src/pipeline/chunked/exec.rs
@@ -51,9 +51,6 @@ pub(crate) fn run_chunked_sequential(
     let streamed_rows = std::sync::Arc::new(std::sync::atomic::AtomicI64::new(0));
     // Form B: XOR-combine each chunk's per-column checksums run-wide, harvest once
     // after the loop — so the finalize manifest records Form B for chunked exports.
-    let mut checksums_acc: std::collections::BTreeMap<String, u64> =
-        std::collections::BTreeMap::new();
-    let mut checksum_key_column: Option<String> = None;
 
     // Run the cross-shape manifest guard ONCE, at run start — the answer cannot
     // change mid-run, and re-running it per chunk cost one remote GET per chunk
@@ -168,18 +165,20 @@ pub(crate) fn run_chunked_sequential(
                 file_name: None,
             });
         }
-        // Fold this chunk's Form B checksums into the run-wide accumulator (empty
-        // for a zero-row chunk — a no-op).
-        super::super::commit::accumulate_column_checksums(
-            &mut checksums_acc,
-            &sink.column_checksums,
-        );
-        if checksum_key_column.is_none() {
-            checksum_key_column = sink.checksum_key_col.and(sink.cursor_column.clone());
-        }
+        // ADR-0028: feed this chunk's Form-B checksums into the run ledger (empty
+        // for a zero-row chunk — a no-op); the seam harvests once, at the
+        // dispatcher. Deliberately NOT the full sink drain: chunked runs its
+        // drift gate PRE-chunk from type_mappings (ADR-0021), so feeding the
+        // sink schema here would make the seam re-check post-run and overwrite
+        // the pre-chunk verdict.
+        summary
+            .ledger
+            .merge_checksums(&std::mem::take(&mut sink.column_checksums));
+        summary
+            .ledger
+            .note_key_column(sink.checksum_key_col.and(sink.cursor_column.clone()));
     }
 
-    super::super::commit::harvest_column_checksums(summary, checksums_acc, checksum_key_column);
     pb.finish(summary.total_rows);
     log::info!("export '{}': all chunks completed", plan.export_name);
     Ok(())
@@ -478,18 +477,12 @@ pub(crate) fn run_chunked_parallel(
         );
     }
 
-    // Form B: XOR-combine every worker's chunk checksums run-wide + harvest once
-    // (order-independent, so worker completion order does not matter).
-    let mut checksums_acc: std::collections::BTreeMap<String, u64> =
-        std::collections::BTreeMap::new();
-    let mut checksum_key_column: Option<String> = None;
+    // ADR-0028: feed every worker's chunk checksums into the run ledger
+    // (order-independent merge); the seam harvests once, at the dispatcher.
     for (part, key) in poison::into_recover(checksums_shared) {
-        super::super::commit::accumulate_column_checksums(&mut checksums_acc, &part);
-        if checksum_key_column.is_none() {
-            checksum_key_column = key;
-        }
+        summary.ledger.merge_checksums(&part);
+        summary.ledger.note_key_column(key);
     }
-    super::super::commit::harvest_column_checksums(summary, checksums_acc, checksum_key_column);
 
     log::info!(
         "export '{}': all {} chunks completed",

--- a/src/pipeline/chunked/parallel_checkpoint.rs
+++ b/src/pipeline/chunked/parallel_checkpoint.rs
@@ -606,18 +606,12 @@ pub(crate) fn run_chunked_parallel_checkpoint(
         );
     }
 
-    // Form B: XOR-combine every worker's chunk checksums run-wide + harvest once,
-    // before finalize writes the manifest.
-    let mut checksums_acc: std::collections::BTreeMap<String, u64> =
-        std::collections::BTreeMap::new();
-    let mut checksum_key_column: Option<String> = None;
+    // ADR-0028: feed every worker's chunk checksums into the run ledger; the
+    // seam harvests once, at the dispatcher, before finalize writes the manifest.
     for (part, key) in poison::into_recover(checksums_shared) {
-        super::super::commit::accumulate_column_checksums(&mut checksums_acc, &part);
-        if checksum_key_column.is_none() {
-            checksum_key_column = key;
-        }
+        summary.ledger.merge_checksums(&part);
+        summary.ledger.note_key_column(key);
     }
-    super::super::commit::harvest_column_checksums(summary, checksums_acc, checksum_key_column);
 
     state.finalize_chunk_run_completed(&run_id)?;
     // ADR-0008 PG2 committed boundary via the shared finalize seam.

--- a/src/pipeline/chunked/sequential_checkpoint.rs
+++ b/src/pipeline/chunked/sequential_checkpoint.rs
@@ -271,9 +271,6 @@ pub(crate) fn run_chunked_sequential_checkpoint(
     let streamed_rows = std::sync::Arc::new(std::sync::atomic::AtomicI64::new(0));
     // Form B: XOR-combine each chunk's checksums run-wide (order-independent), then
     // harvest once — so the CHECKPOINT chunked path records Form B like exec.rs.
-    let mut checksums_acc: std::collections::BTreeMap<String, u64> =
-        std::collections::BTreeMap::new();
-    let mut checksum_key_column: Option<String> = None;
 
     if !plan.resume && !resource::check_memory(plan.tuning.memory_threshold_mb) {
         log::warn!("memory threshold exceeded before chunk export; pausing 5s");
@@ -332,13 +329,11 @@ pub(crate) fn run_chunked_sequential_checkpoint(
             Ok((rows, parts, chunk_checksums, key)) => {
                 summary.total_rows += rows as i64;
                 pb.inc(summary.total_rows);
-                super::super::commit::accumulate_column_checksums(
-                    &mut checksums_acc,
-                    &chunk_checksums,
-                );
-                if checksum_key_column.is_none() {
-                    checksum_key_column = key;
-                }
+                // ADR-0028: feed the run ledger; the seam harvests once, at
+                // the dispatcher (chunked's drift gate stays pre-chunk, ADR-0021,
+                // so no schema is fed here).
+                summary.ledger.merge_checksums(&chunk_checksums);
+                summary.ledger.note_key_column(key);
                 // Shared commit path for the non-empty branch (I2/M1 + counters
                 // + ChunkCompleted journal + I7 file-log + fault hooks).
                 // Empty chunks have no file to record but still need to journal
@@ -404,9 +399,6 @@ pub(crate) fn run_chunked_sequential_checkpoint(
             plan.export_name
         );
     }
-
-    // Form B: record the run-wide checksums before finalize writes the manifest.
-    super::super::commit::harvest_column_checksums(summary, checksums_acc, checksum_key_column);
 
     pb.finish(summary.total_rows);
     state.finalize_chunk_run_completed(&run_id)?;

--- a/src/pipeline/commit.rs
+++ b/src/pipeline/commit.rs
@@ -466,6 +466,44 @@ mod tests {
     /// shape. RED-proven against: note_schema last-wins (second schema
     /// overwrites), merge via overwrite-insert (second part clobbers), and
     /// merge_shape via min.
+    /// ADR-0028: `drain_tail_into` is the FEEDING leg every sink-based runner
+    /// relies on — stubbed to a no-op, no schema/checksums/shape ever reach the
+    /// ledger and the seam applies nothing (live: the Form-B telltale fires).
+    /// Unit-pinned here so the in-diff gate kills the stub without a stand:
+    /// populate a real sink's tail fields, drain, assert the ledger got all
+    /// four (schema, checksums, key, shape) and the sink was emptied.
+    #[test]
+    fn drain_tail_into_moves_schema_checksums_key_and_shape_to_the_ledger() {
+        use arrow::datatypes::{DataType, Field, Schema};
+        let plan = test_plan();
+        let mut sink = crate::pipeline::sink::ExportSink::new(&plan).expect("sink");
+        sink.dest_schema = Some(std::sync::Arc::new(Schema::new(vec![Field::new(
+            "id",
+            DataType::Int64,
+            false,
+        )])));
+        sink.column_checksums = [("id".to_string(), 41u64)].into();
+        sink.checksum_key_col = Some(0);
+        sink.cursor_column = Some("id".to_string());
+        sink.column_max_bytes = [("id".to_string(), 8u64)].into();
+
+        let mut led = CommitLedger::default();
+        sink.drain_tail_into(&mut led);
+
+        assert_eq!(
+            led.drift_schema.as_ref().map(|s| s.field(0).name().clone()),
+            Some("id".to_string()),
+            "the sink's dest schema must reach the ledger"
+        );
+        assert_eq!(led.column_checksums.get("id"), Some(&41u64));
+        assert_eq!(led.checksum_key_column.as_deref(), Some("id"));
+        assert_eq!(led.column_max_bytes.get("id"), Some(&8u64));
+        assert!(
+            sink.column_checksums.is_empty() && sink.column_max_bytes.is_empty(),
+            "drain must TAKE the sink's accumulators, not copy them"
+        );
+    }
+
     #[test]
     fn commit_ledger_first_wins_schema_and_key_and_commutative_merges() {
         use arrow::datatypes::{DataType, Field, Schema};

--- a/src/pipeline/commit.rs
+++ b/src/pipeline/commit.rs
@@ -66,6 +66,71 @@ pub(in crate::pipeline) fn accumulate_run_rows(summary: &mut RunSummary, this_ru
     summary.total_rows += this_run_rows;
 }
 
+/// ADR-0028: the run-wide tail ledger, filled by the runners as they commit and
+/// APPLIED once by [`crate::pipeline::finalize::finalize_export`] — the one seam
+/// the dispatcher calls between the runner returning and `finalize_manifest`.
+///
+/// This exists to retire the runner-bypass class: before it, every runner
+/// re-assembled the same post-write tail by hand (fingerprint pin → drift gate →
+/// Form-B harvest → shape warn), and a feature wired into one runner was
+/// silently absent on the others (`keyset.rs` said so verbatim; Form-B was
+/// computed-then-discarded on all three large-table runners). Runners now only
+/// FEED this ledger — what schema they saw, which checksums their sinks
+/// computed — and the APPLICATION lives in exactly one place, ordering encoded
+/// once. The telltale invariants in `check_post_run_invariants` (drift verdict
+/// present, Form-B harvested-or-flagged) go RED if a runner feeds nothing.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct CommitLedger {
+    /// Run-wide sum-combined per-column value checksums (Form B input).
+    pub(in crate::pipeline) column_checksums: std::collections::BTreeMap<String, u64>,
+    /// The key column the checksums are keyed to (first runner-reported wins).
+    pub(in crate::pipeline) checksum_key_column: Option<String>,
+    /// The run's dest schema (first non-empty page/sink wins) — drives the
+    /// manifest fingerprint pin and the post-run `on_schema_drift` gate.
+    /// `None` on runners whose drift gate runs elsewhere by design (chunked
+    /// checks pre-chunk via `check_from_type_mappings`, ADR-0021).
+    pub(in crate::pipeline) drift_schema: Option<arrow::datatypes::Schema>,
+    /// Max observed byte length per column (shape-drift warn input); merged
+    /// by max so worker/part order is irrelevant.
+    pub(in crate::pipeline) column_max_bytes: std::collections::HashMap<String, u64>,
+}
+
+impl CommitLedger {
+    /// First-wins schema note (idempotent run-wide, like the fingerprint pin).
+    pub(in crate::pipeline) fn note_schema(&mut self, schema: &arrow::datatypes::Schema) {
+        if self.drift_schema.is_none() {
+            self.drift_schema = Some(schema.clone());
+        }
+    }
+
+    /// Fold one part/page/worker's per-column checksums into the run-wide map
+    /// (commutative wrapping add — see [`accumulate_column_checksums`]).
+    pub(in crate::pipeline) fn merge_checksums(
+        &mut self,
+        part: &std::collections::BTreeMap<String, u64>,
+    ) {
+        accumulate_column_checksums(&mut self.column_checksums, part);
+    }
+
+    /// First-wins key-column note (all pages/workers of a run share one key).
+    pub(in crate::pipeline) fn note_key_column(&mut self, key: Option<String>) {
+        if self.checksum_key_column.is_none() {
+            self.checksum_key_column = key;
+        }
+    }
+
+    /// Max-merge one sink's observed per-column byte lengths.
+    pub(in crate::pipeline) fn merge_shape(
+        &mut self,
+        max_bytes: &std::collections::HashMap<String, u64>,
+    ) {
+        for (col, len) in max_bytes {
+            let e = self.column_max_bytes.entry(col.clone()).or_insert(0);
+            *e = (*e).max(*len);
+        }
+    }
+}
+
 /// XOR-accumulate one part/page/chunk sink's per-column value checksums into a
 /// run-wide map. Order-independent (XOR), so chunk/page/worker order and count do
 /// not change the result — the MULTI-PART runners (chunked / keyset / mongo_parallel)
@@ -394,6 +459,54 @@ mod tests {
     use crate::state::StateStore;
     use crate::tuning::SourceTuning;
     use std::io::Write;
+
+    /// ADR-0028 CommitLedger semantics, each of which a runner relies on:
+    /// first-wins schema/key (idempotent across pages/workers), commutative
+    /// wrapping-add checksum merge (worker order must not matter), max-merge
+    /// shape. RED-proven against: note_schema last-wins (second schema
+    /// overwrites), merge via overwrite-insert (second part clobbers), and
+    /// merge_shape via min.
+    #[test]
+    fn commit_ledger_first_wins_schema_and_key_and_commutative_merges() {
+        use arrow::datatypes::{DataType, Field, Schema};
+        let mut led = CommitLedger::default();
+
+        // first-wins schema: the second (drifted) schema must NOT replace it.
+        let a = Schema::new(vec![Field::new("id", DataType::Int64, false)]);
+        let b = Schema::new(vec![Field::new("other", DataType::Utf8, true)]);
+        led.note_schema(&a);
+        led.note_schema(&b);
+        assert_eq!(
+            led.drift_schema.as_ref().map(|s| s.field(0).name().clone()),
+            Some("id".to_string()),
+            "note_schema is first-wins — a later page/worker schema must not replace the run's"
+        );
+
+        // first-Some-wins key: a None feed leaves it open for a later Some.
+        led.note_key_column(None);
+        led.note_key_column(Some("id".into()));
+        led.note_key_column(Some("late".into()));
+        assert_eq!(led.checksum_key_column.as_deref(), Some("id"));
+
+        // commutative wrapping-add merge — two parts with the same column SUM,
+        // never overwrite (an overwrite would silently drop part 1's coverage).
+        let p1: std::collections::BTreeMap<String, u64> = [("v".to_string(), 7u64)].into();
+        let p2: std::collections::BTreeMap<String, u64> = [("v".to_string(), 5u64)].into();
+        led.merge_checksums(&p1);
+        led.merge_checksums(&p2);
+        assert_eq!(
+            led.column_checksums.get("v"),
+            Some(&12u64),
+            "checksum merge must fold (wrapping add), not overwrite"
+        );
+
+        // shape is max-merge: order-independent, the larger observation wins.
+        let s1: std::collections::HashMap<String, u64> = [("t".to_string(), 100u64)].into();
+        let s2: std::collections::HashMap<String, u64> = [("t".to_string(), 40u64)].into();
+        led.merge_shape(&s1);
+        led.merge_shape(&s2);
+        assert_eq!(led.column_max_bytes.get("t"), Some(&100u64));
+    }
 
     fn test_plan() -> ResolvedRunPlan {
         ResolvedRunPlan {

--- a/src/pipeline/finalize.rs
+++ b/src/pipeline/finalize.rs
@@ -1125,6 +1125,58 @@ mod tests {
         assert_eq!(summary.column_checksums.len(), 1);
     }
 
+    /// ADR-0028: the seam's shape-drift arm — the ONE guard deciding whether the
+    /// advisory warn runs. Positive: factor set + shape fed + a stored smaller
+    /// max → a `shape_drift:` Warning journal event. Negative: factor 0.0
+    /// (disabled — the config default is opt-in) with the SAME grown shape must
+    /// warn nothing. Together they pin every guard mutant: `>` → `<`/`==`
+    /// (positive stops warning), `>` → `>=` and `&&` → `||` (negative starts
+    /// warning while disabled), `delete !` (positive skips a non-empty ledger).
+    #[test]
+    fn finalize_export_shape_warn_fires_only_when_enabled_and_fed() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = crate::state::StateStore::open_in_memory().unwrap();
+
+        let shape_of = |bytes: u64| -> std::collections::HashMap<String, u64> {
+            [("payload".to_string(), bytes)].into()
+        };
+        let warned = |summary: &crate::pipeline::summary::RunSummary| {
+            summary.journal.warnings().iter().any(|e| {
+                matches!(&e.event, crate::journal::RunEvent::Warning { context, .. }
+                    if context.starts_with("shape_drift:"))
+            })
+        };
+
+        // Seed the stored high-water mark (first run: silently accepted).
+        state
+            .detect_shape_drift("public.orders", &shape_of(10), 2.0)
+            .unwrap();
+
+        // Positive: factor 2.0, 10 → 100 bytes (10×) must warn via the seam.
+        let mut plan = fin_plan(dir.path());
+        plan.shape_drift_warn_factor = 2.0;
+        let mut summary = crate::pipeline::summary::RunSummary::default();
+        summary.ledger.merge_shape(&shape_of(100));
+        finalize_export(&plan, Some(&state), &mut summary).unwrap();
+        assert!(
+            warned(&summary),
+            "a 10× column growth with warn_factor 2.0 must journal a shape_drift warning"
+        );
+
+        // Negative: factor 0.0 (disabled) — the same growth must warn NOTHING,
+        // and the guard must not even consult the state (a `>=`/`||` mutant
+        // enters the arm and warns).
+        let mut plan = fin_plan(dir.path());
+        plan.shape_drift_warn_factor = 0.0;
+        let mut summary = crate::pipeline::summary::RunSummary::default();
+        summary.ledger.merge_shape(&shape_of(100_000));
+        finalize_export(&plan, Some(&state), &mut summary).unwrap();
+        assert!(
+            !warned(&summary),
+            "shape_drift_warn_factor 0.0 means DISABLED — the seam must not warn"
+        );
+    }
+
     fn fin_plan(dest: &std::path::Path) -> crate::plan::ResolvedRunPlan {
         use crate::config::{SourceConfig, SourceType};
         crate::plan::ResolvedRunPlan {

--- a/src/pipeline/finalize.rs
+++ b/src/pipeline/finalize.rs
@@ -28,6 +28,106 @@ use crate::state::StateStore;
 
 use super::summary::RunSummary;
 
+/// ADR-0028: THE export tail — the one place the per-export post-write features
+/// are applied, called by the dispatcher (`job.rs`) on runner success, before
+/// `finalize_manifest`. Runners FEED `summary.ledger` as they commit (what
+/// schema they saw, which checksums their sinks computed); this seam APPLIES:
+///
+///   1. manifest schema-fingerprint pin (ADR-0012 M3),
+///   2. the `on_schema_drift` gate (post-run, from the run's resolved schema —
+///      chunked runs its gate pre-chunk via `check_from_type_mappings`
+///      (ADR-0021) and feeds no drift schema here, by design),
+///   3. Form-B value-checksum harvest into the summary/manifest,
+///   4. the shape-drift advisory warn.
+///
+/// Ordering is load-bearing and encoded HERE, once: the gate + harvest run
+/// before `finalize_manifest` (a drift `fail` must abort before a manifest
+/// exists; the manifest must record the checksums). Before this seam, every
+/// runner re-assembled this tail by hand and a feature wired into one runner
+/// was silently absent on the others — the runner-bypass class this seam
+/// retires (three documented bites: the keyset/mongo drift-gate miss, Form-B
+/// computed-then-discarded on all three large-table runners, and the keyset
+/// part-name divergence). The telltale invariants in
+/// `check_post_run_invariants` stay as the backstop: a runner that feeds
+/// nothing still fails the drift/Form-B telltales.
+pub(super) fn finalize_export(
+    plan: &ResolvedRunPlan,
+    state: Option<&StateStore>,
+    summary: &mut RunSummary,
+) -> Result<()> {
+    let ledger = std::mem::take(&mut summary.ledger);
+
+    if let Some(schema) = &ledger.drift_schema {
+        // Fingerprint pin is idempotent (first call wins) — uniform across
+        // runners now, so keyset/mongo manifests carry the fingerprint single
+        // mode always recorded.
+        super::manifest_writer::record_run_schema_fingerprint(summary, schema);
+        if let Some(st) = state {
+            super::schema_drift::check_from_sink_schema(
+                st,
+                &plan.export_name,
+                schema,
+                plan.schema_drift_policy,
+                summary,
+            )?;
+        }
+    }
+
+    // Form B: record the run-wide checksums so the manifest carries them.
+    // `harvest_column_checksums` itself suppresses on
+    // `column_checksums_incomplete` (checkpoint-resume hydration) — that
+    // decision stays in the harvest, not here.
+    super::commit::harvest_column_checksums(
+        summary,
+        ledger.column_checksums,
+        ledger.checksum_key_column,
+    );
+
+    // Epic 8: data shape drift — warn when string/binary columns grow beyond
+    // threshold. Applied wherever a runner fed shape bytes (today the single
+    // sink tracks them; a runner that starts feeding them gets the warn for
+    // free — born `na`, per ADR-0028).
+    if plan.shape_drift_warn_factor > 0.0
+        && !ledger.column_max_bytes.is_empty()
+        && let Some(st) = state
+    {
+        match st.detect_shape_drift(
+            &plan.export_name,
+            &ledger.column_max_bytes,
+            plan.shape_drift_warn_factor,
+        ) {
+            Ok(warnings) => {
+                for w in &warnings {
+                    log::warn!(
+                        "export '{}': shape drift in column '{}' — \
+                         max byte length grew {:.1}× ({} → {} bytes); \
+                         set `shape_drift_warn_factor` to a higher value to suppress",
+                        plan.export_name,
+                        w.column,
+                        w.growth_factor,
+                        w.stored_max_bytes,
+                        w.current_max_bytes,
+                    );
+                    summary.journal.record(crate::journal::RunEvent::Warning {
+                        context: format!("shape_drift:{}", w.column),
+                        message: format!(
+                            "column '{}' max byte length grew {:.1}× ({} → {} bytes)",
+                            w.column, w.growth_factor, w.stored_max_bytes, w.current_max_bytes
+                        ),
+                    });
+                }
+            }
+            Err(e) => log::warn!(
+                "export '{}': shape tracking error: {:#}",
+                plan.export_name,
+                e
+            ),
+        }
+    }
+
+    Ok(())
+}
+
 /// Write `.rivet/runs/<run_id>/{summary.md,summary.json}` and surface a
 /// stderr hint pointing at the report (plus a resume command, when
 /// applicable).
@@ -984,6 +1084,46 @@ mod tests {
     // finalize_manifest (18 missed) + the success gates (4) had NO driving
     // test: stubbing finalize_manifest to () — i.e. never writing the manifest
     // at end of run — survived the whole lib suite.
+
+    /// ADR-0028: the seam applies the ledger — Form-B checksums land on the
+    /// summary (keyed), and the ledger is TAKEN (emptied) so a hypothetical
+    /// second application cannot double-record. State-free half only (the drift
+    /// gate + shape warn need a StateStore; their end-to-end proof is the live
+    /// drift suite + the RED-proven telltale backstop). RED against a seam that
+    /// reads the ledger without applying (checksums stay empty) and against one
+    /// that clones instead of takes (second call re-harvests).
+    #[test]
+    fn finalize_export_harvests_the_ledger_and_takes_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let plan = fin_plan(dir.path());
+        let mut summary = crate::pipeline::summary::RunSummary::default();
+        summary
+            .ledger
+            .merge_checksums(&[("v".to_string(), 9u64)].into());
+        summary.ledger.note_key_column(Some("id".into()));
+
+        finalize_export(&plan, None, &mut summary).expect("state-free seam must succeed");
+
+        assert_eq!(
+            summary
+                .column_checksums
+                .iter()
+                .map(|c| (c.name.as_str(), c.checksum.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("v", "9")],
+            "the seam must harvest the ledger's Form-B checksums into the summary"
+        );
+        assert_eq!(summary.checksum_key_column.as_deref(), Some("id"));
+        assert!(
+            summary.ledger.column_checksums.is_empty(),
+            "the seam must TAKE the ledger — a second application must find nothing"
+        );
+
+        // Second call: no ledger left, the harvested record must survive untouched
+        // (harvest_column_checksums early-returns on an empty accumulator).
+        finalize_export(&plan, None, &mut summary).expect("idempotent on an empty ledger");
+        assert_eq!(summary.column_checksums.len(), 1);
+    }
 
     fn fin_plan(dest: &std::path::Path) -> crate::plan::ResolvedRunPlan {
         use crate::config::{SourceConfig, SourceType};

--- a/src/pipeline/finalize.rs
+++ b/src/pipeline/finalize.rs
@@ -57,22 +57,19 @@ pub(super) fn finalize_export(
 ) -> Result<()> {
     let ledger = std::mem::take(&mut summary.ledger);
 
+    // RECORDS before GATES (seam bughunt 2026-08-21): the fingerprint pin and
+    // the Form-B harvest describe the durable parts and must land on the
+    // summary even when the drift gate below ABORTS the run — the Failed
+    // manifest lists the debris, so it must describe it honestly ("recording
+    // first is the truthful thing", the rule mongo_parallel's pre-seam drain
+    // already followed). Pre-fix the gate's `?` skipped the harvest and a
+    // drift-FAILED keyset/mongo run wrote a Failed manifest with no Form-B.
     if let Some(schema) = &ledger.drift_schema {
         // Fingerprint pin is idempotent (first call wins) — uniform across
         // runners now, so keyset/mongo manifests carry the fingerprint single
         // mode always recorded.
         super::manifest_writer::record_run_schema_fingerprint(summary, schema);
-        if let Some(st) = state {
-            super::schema_drift::check_from_sink_schema(
-                st,
-                &plan.export_name,
-                schema,
-                plan.schema_drift_policy,
-                summary,
-            )?;
-        }
     }
-
     // Form B: record the run-wide checksums so the manifest carries them.
     // `harvest_column_checksums` itself suppresses on
     // `column_checksums_incomplete` (checkpoint-resume hydration) — that
@@ -82,6 +79,16 @@ pub(super) fn finalize_export(
         ledger.column_checksums,
         ledger.checksum_key_column,
     );
+
+    if let (Some(schema), Some(st)) = (&ledger.drift_schema, state) {
+        super::schema_drift::check_from_sink_schema(
+            st,
+            &plan.export_name,
+            schema,
+            plan.schema_drift_policy,
+            summary,
+        )?;
+    }
 
     // Epic 8: data shape drift — warn when string/binary columns grow beyond
     // threshold. Applied wherever a runner fed shape bytes (today the single
@@ -126,6 +133,27 @@ pub(super) fn finalize_export(
     }
 
     Ok(())
+}
+
+/// ADR-0028, the FAILURE half of the seam (bughunt 2026-08-21, MED): a run
+/// whose RUNNER errored still fed the ledger up to the failure, and its Failed
+/// manifest lists the durable debris — so the RECORDS (fingerprint pin, Form-B
+/// harvest) must still apply, or the manifest falls back to the STALE open
+/// baseline fingerprint while the durable parquet carries the observed schema
+/// (actively wrong forensics), and the checksums mongo/keyset recorded
+/// pre-seam vanish. GATES (drift policy, shape warn) are deliberately NOT run
+/// here: the run is already failing with the runner's own error, and a gate
+/// error would mask it.
+pub(super) fn finalize_export_records(summary: &mut RunSummary) {
+    let ledger = std::mem::take(&mut summary.ledger);
+    if let Some(schema) = &ledger.drift_schema {
+        super::manifest_writer::record_run_schema_fingerprint(summary, schema);
+    }
+    super::commit::harvest_column_checksums(
+        summary,
+        ledger.column_checksums,
+        ledger.checksum_key_column,
+    );
 }
 
 /// Write `.rivet/runs/<run_id>/{summary.md,summary.json}` and surface a
@@ -1092,6 +1120,43 @@ mod tests {
     /// drift suite + the RED-proven telltale backstop). RED against a seam that
     /// reads the ledger without applying (checksums stay empty) and against one
     /// that clones instead of takes (second call re-harvests).
+    /// The FAILURE half (seam bughunt 2026-08-21): a runner error must still
+    /// apply the RECORDS — fingerprint pinned from the fed schema, Form-B
+    /// harvested — with no state and no gates. RED against an Err arm that
+    /// skips the records call (fingerprint stays None, checksums empty).
+    #[test]
+    fn finalize_export_records_applies_pin_and_harvest_on_the_failure_path() {
+        use arrow::datatypes::{DataType, Field, Schema};
+        let mut summary = crate::pipeline::summary::RunSummary::default();
+        summary
+            .ledger
+            .note_schema(&Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+        summary
+            .ledger
+            .merge_checksums(&[("id".to_string(), 5u64)].into());
+        summary.ledger.note_key_column(Some("id".into()));
+
+        finalize_export_records(&mut summary);
+
+        assert!(
+            summary.schema_fingerprint.is_some(),
+            "a FAILED run must record the fingerprint it OBSERVED — the Failed              manifest otherwise falls back to the stale open baseline"
+        );
+        assert_eq!(
+            summary
+                .column_checksums
+                .iter()
+                .map(|c| c.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["id"],
+            "a FAILED run must still harvest Form-B for its durable parts"
+        );
+        assert!(
+            summary.ledger.column_checksums.is_empty(),
+            "ledger is taken"
+        );
+    }
+
     #[test]
     fn finalize_export_harvests_the_ledger_and_takes_it() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/pipeline/job.rs
+++ b/src/pipeline/job.rs
@@ -1087,12 +1087,20 @@ pub(super) fn run_export_job(
             chunked::ChunkSource::Detect,
         )
     };
-    // ADR-0028: THE export tail — apply the ledger the runner fed (fingerprint
-    // pin, drift gate, Form-B harvest, shape warn) exactly once, here, before
-    // anything downstream reads the summary. A drift `fail` folds into `result`
-    // and flows the same failed-status path a runner error does.
-    let result =
-        result.and_then(|()| super::finalize::finalize_export(&plan, Some(state), &mut summary));
+    // ADR-0028: THE export tail — apply the ledger the runner fed exactly once,
+    // here, before anything downstream reads the summary. On runner success the
+    // full seam runs (records + gates; a drift `fail` folds into `result` and
+    // flows the same failed-status path a runner error does). On runner FAILURE
+    // the records half still applies — the Failed manifest must describe the
+    // durable debris with the OBSERVED fingerprint + Form-B, never the stale
+    // baseline (seam bughunt 2026-08-21).
+    let result = match result {
+        Ok(()) => super::finalize::finalize_export(&plan, Some(state), &mut summary),
+        Err(e) => {
+            super::finalize::finalize_export_records(&mut summary);
+            Err(e)
+        }
+    };
 
     let rss_peak = rss_sampler.stop();
     let rss_after = crate::resource::get_rss_mb();
@@ -1391,12 +1399,16 @@ pub(crate) fn run_export_job_with_chunk_source(
     } else {
         run_with_reconnect(state, plan, &mut summary, "", chunk_source)
     };
-    // ADR-0028: THE export tail — apply the ledger the runner fed (fingerprint
-    // pin, drift gate, Form-B harvest, shape warn) exactly once, here, before
-    // anything downstream reads the summary. A drift `fail` folds into `result`
-    // and flows the same failed-status path a runner error does.
-    let result =
-        result.and_then(|()| super::finalize::finalize_export(plan, Some(state), &mut summary));
+    // ADR-0028: THE export tail — same contract as run_export_job's site: full
+    // seam on success, records half on failure (the Failed manifest must carry
+    // the OBSERVED fingerprint + Form-B, never the stale baseline).
+    let result = match result {
+        Ok(()) => super::finalize::finalize_export(plan, Some(state), &mut summary),
+        Err(e) => {
+            super::finalize::finalize_export_records(&mut summary);
+            Err(e)
+        }
+    };
 
     let rss_peak = rss_sampler.stop();
     let rss_after = crate::resource::get_rss_mb();

--- a/src/pipeline/job.rs
+++ b/src/pipeline/job.rs
@@ -737,6 +737,7 @@ pub(crate) fn synthetic_failed_summary(export_name: &str, err: &anyhow::Error) -
     let journal = crate::journal::RunJournal::new(&run_id, export_name);
     RunSummary {
         bytes_read: 0,
+        ledger: Default::default(),
         cursor_column: None,
         cursor_low: None,
         cursor_high: None,
@@ -1086,6 +1087,12 @@ pub(super) fn run_export_job(
             chunked::ChunkSource::Detect,
         )
     };
+    // ADR-0028: THE export tail — apply the ledger the runner fed (fingerprint
+    // pin, drift gate, Form-B harvest, shape warn) exactly once, here, before
+    // anything downstream reads the summary. A drift `fail` folds into `result`
+    // and flows the same failed-status path a runner error does.
+    let result =
+        result.and_then(|()| super::finalize::finalize_export(&plan, Some(state), &mut summary));
 
     let rss_peak = rss_sampler.stop();
     let rss_after = crate::resource::get_rss_mb();
@@ -1384,6 +1391,12 @@ pub(crate) fn run_export_job_with_chunk_source(
     } else {
         run_with_reconnect(state, plan, &mut summary, "", chunk_source)
     };
+    // ADR-0028: THE export tail — apply the ledger the runner fed (fingerprint
+    // pin, drift gate, Form-B harvest, shape warn) exactly once, here, before
+    // anything downstream reads the summary. A drift `fail` folds into `result`
+    // and flows the same failed-status path a runner error does.
+    let result =
+        result.and_then(|()| super::finalize::finalize_export(plan, Some(state), &mut summary));
 
     let rss_peak = rss_sampler.stop();
     let rss_after = crate::resource::get_rss_mb();

--- a/src/pipeline/keyset.rs
+++ b/src/pipeline/keyset.rs
@@ -19,7 +19,6 @@
 //! key in `last_cursor_value` (its `cursor_extract_column` resolves to the
 //! keyset key), which the loop reads to advance to the next page.
 
-use super::manifest_writer;
 use super::{RunSummary, sink::ExportSink};
 use crate::config::IncrementalCursorMode;
 use crate::destination;
@@ -819,8 +818,10 @@ fn run_keyset_parallel(
     if plan.validate {
         summary.validated = Some(true);
     }
+    // ADR-0028: the workers converged on ONE run schema; feed it to the ledger —
+    // the seam pins the fingerprint and runs the drift gate.
     if let Some(sc) = fingerprint.get() {
-        manifest_writer::record_run_schema_fingerprint(summary, sc);
+        summary.ledger.note_schema(sc);
     }
     // cursor_high = the highest populated range's max (forensics v18); see range_max.
     summary.cursor_high = highest_range_max(range_max.into_inner().unwrap());
@@ -838,16 +839,12 @@ fn run_keyset_parallel(
     {
         super::chunked::rehydrate_manifest_parts_from_file_log(st, &run_id, summary)?;
     }
-    // Form B: XOR-combine every worker's per-page column checksums run-wide.
-    let mut acc: std::collections::BTreeMap<String, u64> = std::collections::BTreeMap::new();
-    let mut ck_key: Option<String> = None;
+    // ADR-0028: feed every committed range's Form-B checksums to the ledger
+    // (commit-gated — a failed range published none). The seam harvests once.
     for (m, k) in checksums_mx.into_inner().unwrap() {
-        super::commit::accumulate_column_checksums(&mut acc, &m);
-        if ck_key.is_none() {
-            ck_key = k;
-        }
+        summary.ledger.merge_checksums(&m);
+        summary.ledger.note_key_column(k);
     }
-    super::commit::harvest_column_checksums(summary, acc, ck_key);
 
     log::info!(
         "export '{}': parallel keyset complete — {} range(s), {} parts, {} rows",
@@ -856,21 +853,6 @@ fn run_keyset_parallel(
         parts.len(),
         summary.total_rows
     );
-
-    // on_schema_drift gate — the SAME post-run check the sequential runner applies
-    // (mirror single mode). Without this, `on_schema_drift: fail` would silently
-    // return exit 0 on a drifted schema on the parallel path — the runner-bypass
-    // class. The workers converge on ONE run schema (fingerprint), so the check is
-    // run-wide, not per-worker.
-    if let (Some(sc), Some(st)) = (fingerprint.get(), state) {
-        super::schema_drift::check_from_sink_schema(
-            st,
-            &plan.export_name,
-            sc,
-            plan.schema_drift_policy,
-            summary,
-        )?;
-    }
 
     // Incremental (iteration 3): on CLEAN SUCCESS advance the persisted anchor to
     // this run's ceiling (the source max pinned at open), so the next run seeks
@@ -1046,16 +1028,6 @@ pub(crate) fn run_keyset(
     crate::test_hook::maybe_panic_at("keyset_after_open_before_first_page");
 
     let mut pages: usize = 0;
-    // Captured once from the first non-empty page for the post-run on_schema_drift
-    // gate: keyset owns its runner (run_single_export early-returns here), so the
-    // drift check single mode applies must be applied here too.
-    let mut drift_schema: Option<arrow::datatypes::Schema> = None;
-    // Form B: XOR-combine each page's per-column checksums run-wide (order-
-    // independent), then harvest once after the loop — so the finalize manifest
-    // records Form B and `rivet validate` can re-verify keyset exports too.
-    let mut checksums_acc: std::collections::BTreeMap<String, u64> =
-        std::collections::BTreeMap::new();
-    let mut checksum_key_column: Option<String> = None;
 
     // Destination + manifest-mode guard (Finding #44) fixed for the whole run — hoisted out of
     // the page loop. Part names key off the SANITIZED RUN_ID (stable across a resume, unique per
@@ -1108,19 +1080,16 @@ pub(crate) fn run_keyset(
             summary.cursor_low = page.first_cursor.clone();
         }
 
-        // ADR-0012 M3: capture the dest schema fingerprint from the first
-        // non-empty page; idempotent run-wide.
+        // ADR-0028: feed the run ledger from this page — the seam
+        // (`finalize::finalize_export`) pins the fingerprint, runs the drift
+        // gate and harvests Form B once, at the dispatcher. No application here.
         if let Some(sc) = &page.schema {
-            manifest_writer::record_run_schema_fingerprint(summary, sc);
-            if drift_schema.is_none() {
-                drift_schema = Some(sc.clone());
-            }
+            summary.ledger.note_schema(sc);
         }
-        // Form B: fold this page's checksums into the run-wide XOR accumulator.
-        super::commit::accumulate_column_checksums(&mut checksums_acc, &page.column_checksums);
-        if checksum_key_column.is_none() {
-            checksum_key_column = page.checksum_key_column.clone();
-        }
+        summary.ledger.merge_checksums(&page.column_checksums);
+        summary
+            .ledger
+            .note_key_column(page.checksum_key_column.clone());
         if plan.validate {
             summary.validated = Some(true);
         }
@@ -1220,9 +1189,6 @@ pub(crate) fn run_keyset(
         }
     }
 
-    // Form B: record the run-wide XOR-combined checksums so finalize writes them.
-    super::commit::harvest_column_checksums(summary, checksums_acc, checksum_key_column);
-
     // DATA COMPLETE: the page loop exhausted the key range, so there is no
     // uncommitted work left to resume — for a NON-INCREMENTAL run, clear the
     // in-progress run_id NOW, BEFORE the post-data gates (schema-drift below, and
@@ -1263,20 +1229,10 @@ pub(crate) fn run_keyset(
         summary.total_rows
     );
 
-    // on_schema_drift gate — run_single_export applies this, but keyset returns
-    // through its own runner and never reached it, so an opted-in
-    // `on_schema_drift: fail` silently returned exit 0 on a drifted schema for the
-    // headline large-table path. Mirror single mode: compare the run's resolved
-    // schema against the stored fingerprint once, post-run.
-    if let (Some(sc), Some(st)) = (&drift_schema, state) {
-        super::schema_drift::check_from_sink_schema(
-            st,
-            &plan.export_name,
-            sc,
-            plan.schema_drift_policy,
-            summary,
-        )?;
-    }
+    // ADR-0028: the on_schema_drift gate, Form-B harvest and fingerprint pin are
+    // applied by the ONE seam (`finalize::finalize_export`, at the dispatcher)
+    // from the ledger this loop fed — the runner-bypass class this runner
+    // twice re-introduced by hand-mirroring single mode is structurally gone.
     Ok(())
 }
 

--- a/src/pipeline/keyset.rs
+++ b/src/pipeline/keyset.rs
@@ -1191,7 +1191,7 @@ pub(crate) fn run_keyset(
 
     // DATA COMPLETE: the page loop exhausted the key range, so there is no
     // uncommitted work left to resume — for a NON-INCREMENTAL run, clear the
-    // in-progress run_id NOW, BEFORE the post-data gates (schema-drift below, and
+    // in-progress run_id NOW, BEFORE the post-data gates (schema-drift at the finalize_export seam, and
     // the quality gate in job.rs). A gate that fails AFTER all data is durable must
     // not leave a resume anchor, or the operator's intended full re-run would be
     // treated as a crash-recovery and continue from the high-water mark, silently

--- a/src/pipeline/mongo_parallel.rs
+++ b/src/pipeline/mongo_parallel.rs
@@ -114,13 +114,6 @@ pub(crate) fn run_mongo_parallel(
 
     // Drain on the main thread: sum rows + record every part through the shared
     // commit path (single-threaded → the counter/journal ordering is race-free).
-    let mut drift_schema: Option<arrow::datatypes::Schema> = None;
-    // Form B: fold each worker's XOR-combined checksums run-wide (order-independent
-    // across workers), then harvest once — so a parallel-Mongo manifest records
-    // Form B like every other runner.
-    let mut checksums_acc: std::collections::BTreeMap<String, u64> =
-        std::collections::BTreeMap::new();
-    let mut checksum_key_column: Option<String> = None;
     // Errors are COLLECTED, not propagated mid-drain. `let out = res?` used to sit
     // here, above the record_part calls below — so a worker failure abandoned both
     // its OWN durable pages and every later worker's, and handed
@@ -134,16 +127,14 @@ pub(crate) fn run_mongo_parallel(
             errs.push(format!("worker {w}: {e}"));
         }
         summary.total_rows += out.rows;
+        // ADR-0028: feed the run ledger per worker — the seam pins the
+        // fingerprint, runs the drift gate and harvests Form B once, at the
+        // dispatcher. No application in this runner.
         if let Some(sc) = &out.schema {
-            super::manifest_writer::record_run_schema_fingerprint(summary, sc);
-            if drift_schema.is_none() {
-                drift_schema = Some(sc.clone());
-            }
+            summary.ledger.note_schema(sc);
         }
-        super::commit::accumulate_column_checksums(&mut checksums_acc, &out.column_checksums);
-        if checksum_key_column.is_none() {
-            checksum_key_column = out.checksum_key_column;
-        }
+        summary.ledger.merge_checksums(&out.column_checksums);
+        summary.ledger.note_key_column(out.checksum_key_column);
         if plan.validate && out.rows > 0 {
             summary.validated = Some(true);
         }
@@ -159,8 +150,6 @@ pub(crate) fn run_mongo_parallel(
             );
         }
     }
-    super::commit::harvest_column_checksums(summary, checksums_acc, checksum_key_column);
-
     // Only now — every durable part is recorded and the counters are truthful.
     if !errs.is_empty() {
         anyhow::bail!(
@@ -178,18 +167,8 @@ pub(crate) fn run_mongo_parallel(
         summary.total_rows
     );
 
-    // on_schema_drift gate — mirror single/keyset: this runner also bypasses
-    // run_single_export, so without this an opted-in `on_schema_drift: fail`
-    // returned exit 0 on a drifted schema for a parallel Mongo export.
-    if let Some(sc) = &drift_schema {
-        super::schema_drift::check_from_sink_schema(
-            state,
-            &plan.export_name,
-            sc,
-            plan.schema_drift_policy,
-            summary,
-        )?;
-    }
+    // ADR-0028: fingerprint/drift/Form-B application lives in the ONE seam
+    // (`finalize::finalize_export`), fed from the ledger above.
     Ok(())
 }
 

--- a/src/pipeline/single.rs
+++ b/src/pipeline/single.rs
@@ -477,7 +477,11 @@ pub(super) fn run_single_export(
     // The application no longer lives in any runner.
     sink.drain_tail_into(&mut summary.ledger);
 
-    log::info!("export '{}' completed successfully", plan.export_name);
+    // "data phase complete", not "completed successfully": the post-run gates
+    // (drift policy, quality) run at the dispatcher AFTER this returns — a run
+    // they abort must not have already logged itself successful (seam bughunt
+    // 2026-08-21, LOW).
+    log::info!("export '{}': data phase complete", plan.export_name);
     Ok(())
 }
 

--- a/src/pipeline/single.rs
+++ b/src/pipeline/single.rs
@@ -29,6 +29,13 @@ pub(crate) fn run_with_reconnect(
     let mut last_err: Option<anyhow::Error> = None;
 
     for attempt in 0..=plan.tuning.max_retries {
+        // ADR-0028: the tail ledger accumulates ACROSS a runner invocation, and a
+        // retried attempt re-reads from scratch — carrying a failed attempt's
+        // partial checksums into the retry would double-merge them (the old
+        // runner-local accumulators got this for free by being re-declared per
+        // call). Reset at every attempt boundary; the successful attempt's feed
+        // is the only one the seam applies.
+        summary.ledger = Default::default();
         if attempt > 0 {
             summary.retries = attempt;
             let class = last_err
@@ -464,77 +471,11 @@ pub(super) fn run_single_export(
         summary.cursor_high = Some(last_val.clone());
     }
 
-    // ADR-0012 M3: pin the dest schema fingerprint on the summary so
-    // `finalize_manifest` does not have to round-trip through the state
-    // store (which is only populated by the drift-detect path below, and
-    // not at all in chunked mode).
-    if let Some(schema) = sink.dest_schema.as_deref() {
-        super::manifest_writer::record_run_schema_fingerprint(summary, schema);
-    }
-
-    if let (Some(schema), Some(st)) = (&sink.dest_schema, state) {
-        // Single mode: drift from the sink's resolved (data-derived) schema,
-        // post-write. Chunked runs the same facade pre-chunk via
-        // `check_from_type_mappings` (ADR-0021).
-        super::schema_drift::check_from_sink_schema(
-            st,
-            &plan.export_name,
-            schema,
-            plan.schema_drift_policy,
-            summary,
-        )?;
-    }
-
-    // Form B: harvest the per-column value checksums the sink accumulated into the
-    // summary, so the manifest records them. `validate` re-reads the parts to verify
-    // the Arrow→Parquet encode + post-write fault the in-process Form A cannot see.
-    // Single mode has one sink; the multi-part runners XOR-combine per part through
-    // the SAME seam (super::commit::{accumulate,harvest}_column_checksums).
-    let single_key = sink.checksum_key_col.and(sink.cursor_column.clone());
-    super::commit::harvest_column_checksums(
-        summary,
-        std::mem::take(&mut sink.column_checksums),
-        single_key,
-    );
-
-    // Epic 8: data shape drift — warn when string/binary columns grow beyond threshold.
-    if plan.shape_drift_warn_factor > 0.0
-        && !sink.column_max_bytes.is_empty()
-        && let Some(st) = state
-    {
-        match st.detect_shape_drift(
-            &plan.export_name,
-            &sink.column_max_bytes,
-            plan.shape_drift_warn_factor,
-        ) {
-            Ok(warnings) => {
-                for w in &warnings {
-                    log::warn!(
-                        "export '{}': shape drift in column '{}' — \
-                         max byte length grew {:.1}× ({} → {} bytes); \
-                         set `shape_drift_warn_factor` to a higher value to suppress",
-                        plan.export_name,
-                        w.column,
-                        w.growth_factor,
-                        w.stored_max_bytes,
-                        w.current_max_bytes,
-                    );
-                    summary.journal.record(RunEvent::Warning {
-                        context: format!("shape_drift:{}", w.column),
-                        message: format!(
-                            "column '{}' max byte length grew {:.1}× ({} → {} bytes)",
-                            w.column, w.growth_factor, w.stored_max_bytes, w.current_max_bytes
-                        ),
-                    });
-                }
-            }
-            Err(e) => log::warn!(
-                "export '{}': shape tracking error: {:#}",
-                plan.export_name,
-                e
-            ),
-        }
-    }
+    // ADR-0028: feed the run ledger — the seam (`finalize::finalize_export`,
+    // called by the dispatcher) applies the fingerprint pin, the
+    // `on_schema_drift` gate, the Form-B harvest and the shape-drift warn.
+    // The application no longer lives in any runner.
+    sink.drain_tail_into(&mut summary.ledger);
 
     log::info!("export '{}' completed successfully", plan.export_name);
     Ok(())

--- a/src/pipeline/sink/mod.rs
+++ b/src/pipeline/sink/mod.rs
@@ -126,6 +126,28 @@ pub(in crate::pipeline) struct RowProgress {
 }
 
 impl ExportSink {
+    /// ADR-0028: drain this sink's tail state into the run ledger — the dest
+    /// schema it resolved, the Form-B checksums it accumulated (keyed to the
+    /// cursor/key column when the key survived into the dest batch), and the
+    /// per-column shape bytes. Runners call this instead of applying the
+    /// fingerprint/drift/harvest/shape features themselves; the application
+    /// happens once, in `finalize::finalize_export`.
+    pub(in crate::pipeline) fn drain_tail_into(
+        &mut self,
+        ledger: &mut crate::pipeline::commit::CommitLedger,
+    ) {
+        if let Some(schema) = self.dest_schema.as_deref() {
+            ledger.note_schema(schema);
+        }
+        // Same keying rule the single tail used: the checksums are keyed only
+        // when the key column is present in the dest batch (`checksum_key_col`
+        // is its index there).
+        let key = self.checksum_key_col.and(self.cursor_column.clone());
+        ledger.note_key_column(key);
+        ledger.merge_checksums(&std::mem::take(&mut self.column_checksums));
+        ledger.merge_shape(&std::mem::take(&mut self.column_max_bytes));
+    }
+
     pub fn new(plan: &ResolvedRunPlan) -> Result<Self> {
         let tmp = tempfile::NamedTempFile::new()?;
         let exported_at_us = chrono::Utc::now().timestamp_micros();

--- a/src/pipeline/summary.rs
+++ b/src/pipeline/summary.rs
@@ -137,6 +137,13 @@ pub struct RunSummary {
     /// to a size-only check. An incomplete integrity record must be ABSENT, not
     /// partial-and-lying.
     pub column_checksums_incomplete: bool,
+    /// ADR-0028: the run-wide tail ledger the runners FEED as they commit
+    /// (schema seen, per-part checksums, shape bytes) and that
+    /// `finalize::finalize_export` — called once by the dispatcher — APPLIES:
+    /// fingerprint pin, drift gate, Form-B harvest, shape warn. Runners no
+    /// longer apply any of those themselves; forgetting to FEED is caught by
+    /// the telltale invariants in `check_post_run_invariants` below.
+    pub(crate) ledger: super::commit::CommitLedger,
     /// Cursor range this run covered (incremental strategies) — travels to the
     /// manifest's extraction section for warehouse-side continuity checks.
     /// v1 ships column + low + high; cursor_type / source_row_count are
@@ -297,6 +304,7 @@ impl RunSummary {
             apply_context: None,
             column_checksums: Vec::new(),
             column_checksums_incomplete: false,
+            ledger: Default::default(),
             checksum_key_column: None,
             cursor_column: None,
             cursor_low: None,
@@ -371,6 +379,7 @@ impl RunSummary {
             apply_context: None,
             column_checksums: Vec::new(),
             column_checksums_incomplete: false,
+            ledger: Default::default(),
             checksum_key_column: None,
             cursor_column: None,
             cursor_low: None,

--- a/tests/live/live_schema_drift.rs
+++ b/tests/live/live_schema_drift.rs
@@ -326,3 +326,96 @@ fn stable_schema_across_runs_reports_no_drift() {
         "stable schema across runs must record schema_changed = Some(false), not None"
     );
 }
+
+/// ADR-0028 bughunt (2026-08-21, MED): a run that FAILS must still RECORD what it
+/// observed — the seam's records half (fingerprint pin + Form-B harvest) applies
+/// on the failure path too; only the gates (drift policy, shape warn) are
+/// success-only. Pre-fix the seam ran only on runner Ok, so a drift-FAIL keyset
+/// run wrote a Failed manifest whose fingerprint fell back to the STALE open
+/// baseline (actively wrong: the durable parquet carries the new schema) and
+/// whose Form-B checksums — which mongo/keyset recorded pre-bail before the
+/// seam — were silently dropped. "Recording first is the truthful thing": the
+/// Failed manifest lists the durable debris, so it must describe it honestly.
+///
+/// Oracle is INDEPENDENT of the code under test: run 2's Failed manifest is
+/// compared against run 1's Success manifest (two artifacts on disk) — the
+/// fingerprint must DIFFER (run 2 observed the post-DROP schema) and the
+/// Form-B checksums must be present (the data phase completed; only the gate
+/// failed). RED pre-fix on both assertions.
+#[test]
+#[ignore = "live: requires docker compose postgres"]
+fn drift_failed_keyset_run_still_records_observed_fingerprint_and_form_b() {
+    require_alive(LiveService::Postgres);
+    let table_name = unique_name("keyset_drift_rec");
+    let mut c = pg_connect();
+    c.batch_execute(&format!(
+        "CREATE TABLE {table_name} (k TEXT PRIMARY KEY, name TEXT NOT NULL, tmp_col INT DEFAULT 0);
+         INSERT INTO {table_name} (k, name) VALUES ('a','x'), ('b','y'), ('c','z');"
+    ))
+    .unwrap();
+    let _guard = PgCleanup(table_name.clone());
+
+    let export_name = unique_name("keyset_drift_rec_exp");
+    let out = tempfile::tempdir().unwrap();
+    let rig = Rig::pg_batch(&table_name)
+        .export_named(&export_name)
+        .mode("chunked")
+        .export_line("chunk_by_key: k")
+        .export_line("chunk_size: 2")
+        .export_line("on_schema_drift: fail")
+        .dest_path(out.path().to_path_buf());
+
+    assert!(
+        rig.run_args(&["--export", &export_name]).status.success(),
+        "run 1 (records the schema baseline) must succeed"
+    );
+    let m1: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(out.path().join("manifest.json")).expect("run-1 manifest"),
+    )
+    .unwrap();
+    let fp1 = m1["schema_fingerprint"]
+        .as_str()
+        .expect("run-1 fingerprint")
+        .to_string();
+
+    c.batch_execute(&format!("ALTER TABLE {table_name} DROP COLUMN tmp_col;"))
+        .unwrap();
+
+    let r2 = rig.run_args(&["--export", &export_name]);
+    assert!(
+        !r2.status.success(),
+        "run 2 must FAIL on the drift gate (the fixture's premise)"
+    );
+
+    let m2: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(out.path().join("manifest.json")).expect("run-2 manifest"),
+    )
+    .unwrap();
+    assert_eq!(
+        m2["status"].as_str(),
+        Some("failed"),
+        "run 2 writes a Failed manifest"
+    );
+
+    // (a) the OBSERVED fingerprint, not the stale baseline: run 2 read the
+    // post-DROP schema, so its manifest fingerprint must differ from run 1's.
+    let fp2 = m2["schema_fingerprint"]
+        .as_str()
+        .expect("run-2 fingerprint");
+    assert_ne!(
+        fp2, fp1,
+        "a drift-FAILED run's manifest must record the fingerprint it OBSERVED \
+         (post-DROP), not fall back to the stale baseline run 1 stored — the \
+         durable parts carry the new schema and the manifest must describe them"
+    );
+
+    // (b) Form-B survives the gate: the data phase completed before the gate
+    // fired, so the Failed manifest must carry the run-wide column checksums.
+    let checks = m2["column_checksums"].as_array();
+    assert!(
+        checks.is_some_and(|c| !c.is_empty()),
+        "a drift-FAILED keyset run must still record Form-B checksums for its \
+         durable parts (it did before ADR-0028 unified the tail); got: {:?}",
+        m2["column_checksums"]
+    );
+}


### PR DESCRIPTION
## What

Implements ADR-0028 (included): the post-write export tail — schema-fingerprint pin, `on_schema_drift` gate, Form-B checksum harvest, shape-drift warn — is applied **exactly once**, at `finalize::finalize_export`, called by the dispatcher between the runner returning and `finalize_manifest`, from a `CommitLedger` the runners feed as they commit. All **seven commit loops** cut over in one pass; their hand-assembled tail blocks are deleted.

This retires the **runner-bypass class** (8 bughunt rounds of recurrence) by construction: a per-export feature now has one home and is born `na`.

## Key decisions

- **Runners only feed** (`summary.ledger`): single via `sink.drain_tail_into`; keyset/mongo per page/worker; **chunked feeds no schema** — its drift gate stays pre-chunk (ADR-0021); feeding the sink schema would overwrite the pre-chunk verdict.
- **Records before gates** + **records on the failure path** (`finalize_export_records` in the Err arm at both dispatcher sites): a FAILED run's manifest must describe its durable debris with the *observed* fingerprint + Form-B, never the stale open baseline. Found by the post-implementation multi-agent bughunt (13 agents, 8 findings → 1 root MED + 2 cosmetics, 0 refuted).
- **Retry boundary resets the ledger** (`run_with_reconnect`) — a failed attempt's partial feed never double-merges.
- Cursor capture deliberately stays per-runner (read-strategy semantics, not uniform tail).

## Proof

- **RED both ways** on the live stand: seam call removed → 2 live tests FAIL + the finalize telltale panics in-process; a runner's feed removed → the backstop fails the run naming the runner-bypass class.
- **New live regression**: `drift_failed_keyset_run_still_records_observed_fingerprint_and_form_b` — independent oracle (run-2 Failed manifest vs run-1 Success manifest on disk); RED pre-fix, GREEN post-fix.
- **Green**: 2506 lib · 265 offline (matrix guards) · 95+ live (drift ×7 incl. keyset seq/par + chunked, Form-B keyset/chunked/mongo, 63 chunked, mongo, plan/apply).
- **Mutants in-diff**: 42 tested — 38 caught, 4 unviable, 0 missed. New pure logic all unit-killed (CommitLedger ×4, finalize_export + shape guard positive/negative, drain_tail_into, records-on-failure). Three live-only whole-fn stubs excluded, each hand-proven live-killed first (stub → named live test FAILS → revert), reasons in `.cargo/mutants.toml`.

## Ledgers

`runner-coverage-matrix` header + drift/Form-B/shape rows now grade the FEED + seam; ADR-0028 → Accepted; CHANGELOG (Unreleased). Supersedes #255 (ADR text cherry-picked here; will close it).

## Behavior deltas (intended, documented)

- keyset/mongo manifests now carry the dest-schema fingerprint single mode always recorded.
- Failed manifests now carry observed fingerprint + Form-B (previously mongo-only, pre-bail).
- single's "completed successfully" info line → "data phase complete" (gates run later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)