### PR TITLE
refactor: god-module split, slice 1 — one job script + one waves/pool tail (arch-roast)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -103,6 +103,22 @@ exclude_re = [
     # suite (e.g. plan_is_read_only_without_annotate_waves, which asserts the
     # artifact/paths, and audit_plan_apply's plan.json reads).
     "replace run_plan_command ->",
+    # execute_resolved_plan (pipeline/job.rs) is THE post-plan execution script
+    # both orchestrator entry points route through (arch-roast 2026-08-21): it
+    # opens a real source, drives a runner, brackets source-harm, finalizes the
+    # manifest and writes the metric row — live-only end to end, so its
+    # whole-function stub `(Ok(()), Default::default())` is unkillable under
+    # `--lib --bins` (the documented "--lib on a live-only path" class; the two
+    # entry points it replaced were excluded for the same reason before it).
+    # Every DECISION it makes is extracted and unit-tested next door and each
+    # was RED-proven against the exact mutant the in-diff gate reported:
+    # should_reconcile (the reconcile leg's three operators),
+    # resume_success_gate_applies / rerun_warning_applies (the --resume/--force
+    # truth table), dispatches_to_cdc_runner, plan_rejection_error. Live oracle:
+    # the stub exports nothing and writes no manifest, so it fails every batch
+    # live test — proven by hand on run_with_reconnect and
+    # run_export_job_with_chunk_source, which stub the same way.
+    "replace execute_resolved_plan ->",
     # run_keyset / run_keyset_parallel (pipeline/keyset.rs) are the keyset export
     # RUNNERS — each opens a real source, drives the seek-paged FETCH loop and
     # streams parts to the sink. Unkillable OFFLINE (the --in-diff gate has no

--- a/src/pipeline/job.rs
+++ b/src/pipeline/job.rs
@@ -894,6 +894,339 @@ fn ledger_finish_run(state: &StateStore, export_name: &str, run_id: &str, status
     }
 }
 
+/// ADR-0028 follow-up (arch roast 2026-08-21, Strong #1): the policy divergences
+/// between the TWO orchestrator entry points — `run_export_job` (config-driven
+/// `rivet run`) and `run_export_job_with_chunk_source` (artifact-driven
+/// `rivet apply`). Everything else about the post-plan execution script is ONE
+/// sequence, and it used to be written twice (~250 lines each): this session
+/// alone paid that two-sites tax twice (the finalize seam call, then its
+/// records-on-failure fix — each wired at both bodies). The policy is data;
+/// the script lives once in [`execute_resolved_plan`].
+struct TailPolicy<'a> {
+    /// "export" | "apply" — log prefixes, manifest kind, report kind.
+    kind: &'static str,
+    /// Ledger/manifest family: `export.family()` on the run path (the CDC
+    /// snapshot leg differs from the export name), the export name on apply
+    /// (a sealed artifact has no ExportConfig — correctly, see the manifest
+    /// call's comment in git history).
+    family: &'a str,
+    /// Where the run report lands.
+    config_path: &'a str,
+    /// What the runners receive as their config-path argument: the real path
+    /// on the run path (chunk-checkpoint resume reads it), "" on apply (which
+    /// does not support checkpoint-parallel resume).
+    runner_config_path: &'a str,
+    chunk_source: chunked::ChunkSource,
+    /// Apply-only provenance recorded on the summary.
+    apply_context: Option<crate::pipeline::summary::ApplyContext>,
+    /// The reconcile leg exists only on the run path; apply folds `Ok(())`.
+    allow_reconcile: bool,
+    /// Run-path notifications; apply sends none.
+    notifications: Option<&'a crate::config::NotificationsConfig>,
+    /// Plan (rule, message) warnings the run path journals as `PlanWarning`
+    /// events; apply logs them at validate time and journals none (existing
+    /// behavior, preserved).
+    plan_warnings: Vec<(String, String)>,
+}
+
+/// THE post-plan execution script, written once: rss/forensics/harm bracket →
+/// dispatch → ADR-0028 seam → bracket close → quality gate → status → diagnosis
+/// → [reconcile] → journal → ledger close → manifest → cursor → keyset anchor →
+/// validate → metrics → report → [notify] → final fold. Ordering comments are
+/// load-bearing and live HERE only. LIVE-ONLY BY CONSTRUCTION (real source +
+/// destination + StateStore) — the pure decisions are extracted and unit-tested
+/// next door ([`pg_temp_bytes_delta`], [`pg_temp_bytes_warning`],
+/// `run_diagnosis`, `resolve_final_result`, `keyset_anchor_survives`); the live
+/// oracles are the plan/apply round-trips and the whole live suite.
+fn execute_resolved_plan(
+    plan: &ResolvedRunPlan,
+    state: &StateStore,
+    tail: TailPolicy<'_>,
+) -> (Result<()>, RunSummary) {
+    let start = std::time::Instant::now();
+    let rss_before = crate::resource::get_rss_mb();
+    let rss_sampler = crate::resource::RssPeakSampler::start(rss_before, 100);
+    let mut summary = RunSummary::new(plan);
+    summary.apply_context = tail.apply_context;
+    // Record this run `running` BEFORE any part lands — in the ledger + a bucket
+    // marker manifest — the authority `gc_orphans` reads to spare a live extract's
+    // committed-but-not-yet-manifested parts. (finish_run transitions it below.)
+    ledger_begin_run(state, plan, tail.family, &summary.run_id);
+    // The id the LEDGER row was opened under. A chunk-checkpoint RESUME adopts the
+    // prior run's id (chunked/mod.rs) — `summary.run_id` changes AFTER this point —
+    // and `finish_run` is a bare UPDATE, so closing the run under the adopted id
+    // matched no row and left this one `running` forever.
+    //
+    // That leak is not cosmetic: `has_active_run_on_prefix` keeps answering true,
+    // so `gc_orphans` defers cleanup, and since the load now excludes active runs
+    // from the consumed set (dispatch.rs), every later load on that prefix
+    // re-appends instead of recording progress — until an unrelated newer run of
+    // the same export happens to supersede it.
+    let ledger_run_id = summary.run_id.clone();
+    // Failure forensics at open: source schema + server limits, so a run that fails
+    // before finalize still explains itself (export_schema is otherwise success-only).
+    capture_open_forensics(plan, state, &mut summary);
+
+    // PG cursor / sort spill probe — captured around the actual run window.
+    // Cluster-level counter, so this is a noisy upper bound on a shared host
+    // but accurate on the single-tenant test DBs pilots typically use.
+    let pg_temp_bytes_before = pg_temp_bytes_snapshot(plan);
+    // Tier 2: broader source-harm counters (locks, rows read, buffer misses,
+    // temp files) bracketed around the same run window; the per-counter delta is
+    // stored in export_harm. Best-effort — see `harm_snapshot`.
+    let harm_before = harm_snapshot(&plan.source);
+
+    // Record plan diagnostics the caller already logged at validate time.
+    for (rule, message) in &tail.plan_warnings {
+        summary.journal.record(RunEvent::PlanWarning {
+            rule: rule.clone(),
+            message: message.clone(),
+        });
+    }
+
+    let result = if plan.strategy.requires_parallel_execution() {
+        if plan.strategy.is_resumable() {
+            run_chunked_parallel_checkpoint(
+                tail.runner_config_path,
+                state,
+                plan,
+                &mut summary,
+                tail.chunk_source,
+            )
+        } else {
+            chunked::run_chunked_parallel(state, plan, &mut summary, tail.chunk_source)
+        }
+    } else {
+        run_with_reconnect(
+            state,
+            plan,
+            &mut summary,
+            tail.runner_config_path,
+            tail.chunk_source,
+        )
+    };
+    // ADR-0028: THE export tail — apply the ledger the runner fed exactly once,
+    // here, before anything downstream reads the summary. On runner success the
+    // full seam runs (records + gates; a drift `fail` folds into `result` and
+    // flows the same failed-status path a runner error does). On runner FAILURE
+    // the records half still applies — the Failed manifest must describe the
+    // durable debris with the OBSERVED fingerprint + Form-B, never the stale
+    // baseline (seam bughunt 2026-08-21).
+    let result = match result {
+        Ok(()) => super::finalize::finalize_export(plan, Some(state), &mut summary),
+        Err(e) => {
+            super::finalize::finalize_export_records(&mut summary);
+            Err(e)
+        }
+    };
+
+    let rss_peak = rss_sampler.stop();
+    let rss_after = crate::resource::get_rss_mb();
+    // Harvest the run's bytes-read counter ONCE — every sink (per chunk, per
+    // worker) incremented plan.bytes_read, so this single read covers every
+    // runner by construction (#175).
+    summary.bytes_read = plan.bytes_read.load(std::sync::atomic::Ordering::Relaxed);
+    summary.duration_ms = start.elapsed().as_millis() as i64;
+    summary.peak_rss_mb = rss_peak.max(rss_after).max(rss_before) as i64;
+
+    // Close the harm bracket on the SAME window the run occupied, before the
+    // status resolution below — the deltas are what the DIAGNOSIS reads.
+    // Compute the temp_bytes delta only when both snapshots succeeded — partial
+    // failures (e.g. dropped connection between runs) leave the field None so
+    // the summary card omits the line entirely.
+    if let Some(before) = pg_temp_bytes_before
+        && let Some(after) = pg_temp_bytes_snapshot(plan)
+    {
+        let delta = pg_temp_bytes_delta(before, after);
+        summary.pg_temp_bytes_delta = Some(delta);
+        if let Some(line) = pg_temp_bytes_warning(
+            &plan.export_name,
+            delta,
+            super::run::multi_export_concurrent(),
+        ) {
+            log::warn!("{line}");
+        }
+    }
+
+    // Tier 2: record the per-counter source-harm delta. A failed or absent probe
+    // (e.g. missing VIEW SERVER STATE on MSSQL) leaves no rows — never fatal.
+    let mut harm_delta_vec: Vec<(String, i64)> = Vec::new();
+    if let Some(before) = &harm_before
+        && let Some(after) = harm_snapshot(&plan.source)
+    {
+        harm_delta_vec = harm_deltas(before, &after);
+        if let Err(e) = state.record_harm(&summary.run_id, &summary.export_name, &harm_delta_vec) {
+            log::debug!(
+                "{} '{}': harm metrics write failed (informational): {:#}",
+                tail.kind,
+                summary.export_name,
+                e
+            );
+        }
+    }
+    let tuning_class = plan.tuning.profile_name().to_string();
+    let result = run_chunked_quality_gate(result, plan, &mut summary);
+    let failed = result.is_err();
+    match &result {
+        Ok(()) => {
+            if summary.status == "running" {
+                summary.status = "success".into();
+            }
+        }
+        Err(e) => {
+            summary.status = "failed".into();
+            let redacted = crate::redact::redact_error(e);
+            summary.error_message = Some(redacted.clone());
+            log::error!("{} '{}' failed: {}", tail.kind, plan.export_name, redacted);
+        }
+    }
+
+    // Self-diagnosing run-health line — makes a log the field team sends back
+    // readable at a glance (reconnects survived, a resume-hit, a source spill).
+    // Emitted AFTER the success/failed resolution above so the line reports the
+    // real terminal status, not the transient "running" it was built with (#18
+    // bughunt: it ran before the status was resolved, so it always said running).
+    if let Some(line) = run_diagnosis(
+        &summary,
+        &harm_delta_vec,
+        super::run::multi_export_concurrent(),
+    ) {
+        log::warn!("{line}");
+    }
+
+    let mut reconcile_gate: crate::error::Result<()> = Ok(());
+    if tail.allow_reconcile && plan.reconcile && !failed {
+        let could_not_verify = reconcile_source_count(plan, &mut summary);
+        if let (Some(source_count), Some(matched)) = (summary.source_count, summary.reconciled) {
+            summary.journal.record(RunEvent::ReconciliationResult {
+                source_count,
+                exported_rows: summary.total_rows,
+                matched,
+            });
+        }
+        // The reconcile verdict drives the EXIT CODE (folded into `final_result`):
+        // exit 3 on a mismatch, exit 1 on a could-not-verify. It does NOT flip
+        // `summary.status` to "failed" — that would make `finalize_manifest` write
+        // a Failed manifest with no _SUCCESS, so `rivet load` would REFUSE a
+        // COMPLETE, durable export because a post-hoc COUNT(*) raced a concurrent
+        // write on a live source (#2 bughunt). The export succeeded and stays
+        // loadable; the mismatch surfaces via `summary.reconciled` (report +
+        // metrics + the ReconciliationResult journal event) and the non-zero exit.
+        reconcile_gate = reconcile_run_gate(&summary, could_not_verify.as_deref());
+    }
+
+    // Terminal journal entry BEFORE the print, so a later `finalize_manifest`
+    // gap that flips the status is NOT in the journal on either entry point
+    // (one behaviour, not two — the round-5 apply-journal-bypass fix).
+    summary.journal.record(RunEvent::RunCompleted {
+        status: summary.status.clone(),
+        error_message: summary.error_message.clone(),
+        duration_ms: summary.duration_ms,
+    });
+
+    if let Err(e) = state.store_journal(&summary.journal) {
+        log::warn!(
+            "{} '{}': journal persist failed (run history not stored): {:#}",
+            tail.kind,
+            summary.export_name,
+            e
+        );
+    }
+
+    summary.print();
+    // Transition the run-status ledger to its terminal status — the manifest
+    // written just below is a PROJECTION of this record, so both carry the same
+    // status. A crash before here leaves the row `running`; supersession by a
+    // later run reconciles it (no age timer).
+    ledger_finish_owned_runs(state, &plan.export_name, &ledger_run_id, &summary);
+    // Order matters: write the manifest first, then run the manifest-aware
+    // `--validate` pass against the destination, then persist the metrics
+    // row, then write the run report.  The report sees the verification
+    // verdict only because we run it before `finalize_run_report`; the
+    // metrics row must also wait for `finalize_validate_manifest`, which can
+    // downgrade `summary.validated` — recording earlier left `rivet metrics`
+    // permanently saying validated=pass for a run whose report says it
+    // failed.  The notification fires last so it carries the most complete
+    // summary.
+    // A run whose manifest never landed is NOT a success, whatever its rows say.
+    // The parts are durable and the counts are right — and no manifest names them,
+    // so the loader will not read them. Reporting success there is a claim the
+    // artifacts do not support.
+    //
+    // The status has already been printed and the ledger row already closed by
+    // this point, so both are corrected: the metrics row is written below and
+    // picks up the new status, and the ledger row is re-closed. The manifest
+    // itself cannot be re-written to say `failed` — failing to write it is the
+    // problem.
+    let manifest_gap = finalize_manifest(plan, tail.family, state, &summary, tail.kind);
+    if let Some(why) = &manifest_gap {
+        summary.status = "failed".into();
+        summary.error_message = Some(why.clone());
+        ledger_finish_owned_runs(state, &plan.export_name, &ledger_run_id, &summary);
+    }
+    // Round-2 audit #12: advance the incremental cursor now that the destination
+    // manifest is durable — never before. A failure here is at-least-once safe (the
+    // data + manifest are durable; the next run re-exports from the prior cursor),
+    // so log loudly rather than fail a run whose write cycle already succeeded.
+    //
+    // "now that the manifest is durable" was a PREMISE, not a check: the cursor
+    // advanced even when the manifest write had just failed, so the next run
+    // started past data nothing described. Guarded now.
+    if manifest_gap.is_some() {
+        log::error!(
+            "{} '{}': incremental cursor NOT advanced — the manifest did not land, so the \
+             next run must re-export this window rather than skip past it",
+            tail.kind,
+            summary.export_name,
+        );
+    } else if let Err(e) = commit_incremental_cursor(state, plan, &summary) {
+        log::error!(
+            "{} '{}': cursor advance failed AFTER the manifest was written — the next run \
+             re-exports from the prior cursor (at-least-once, no loss): {:#}",
+            tail.kind,
+            summary.export_name,
+            e
+        );
+    }
+    // Round-5: a keyset checkpoint run has now finalized its COMPLETE destination
+    // manifest — clear the in-progress run_id (persisted for crash rehydration) so a
+    // later run isn't treated as a resume of this finished one. Clearing AFTER the
+    // manifest write is the same ordering as the cursor advance: a crash before here
+    // leaves resume_run_id set, so the next run rehydrates rather than orphans.
+    // EVERY entry point must clear it — a wrapper that skips it strands
+    // resume_run_id forever (round-3 wrapper-bypass regression), which is exactly
+    // why this script now exists once.
+    finalize_keyset_anchor(
+        state,
+        plan,
+        &summary.export_name,
+        keyset_anchor_survives(RunOutcome {
+            failed,
+            manifest_gap: &manifest_gap,
+        }),
+    );
+    if plan.validate {
+        finalize_validate_manifest(plan, &mut summary, tail.kind);
+    }
+    // After finalize_validate_manifest: it can downgrade summary.validated, and
+    // the metrics row must carry the final verdict.
+    if let Err(e) = state.record_metric_full(&build_metric_row(&summary, plan, &tuning_class)) {
+        log::warn!(
+            "{} '{}': metrics write failed (run outcome not stored): {:#}",
+            tail.kind,
+            summary.export_name,
+            e
+        );
+    }
+    finalize_run_report(tail.config_path, &summary, tail.kind);
+    crate::notify::maybe_send(tail.notifications, &summary);
+
+    // An export failure wins, otherwise an unwritten manifest fails the run;
+    // the reconcile leg is `Ok(())` where the policy disables it.
+    let final_result = resolve_final_result(failed, result, reconcile_gate, manifest_gap);
+    (final_result, summary)
+}
+
 pub(super) fn run_export_job(
     config_path: &str,
     config: &Config,
@@ -1021,275 +1354,34 @@ pub(super) fn run_export_job(
         plan.tuning
     );
 
-    let start = std::time::Instant::now();
-    let rss_before = crate::resource::get_rss_mb();
-    let rss_sampler = crate::resource::RssPeakSampler::start(rss_before, 100);
-    let mut summary = RunSummary::new(&plan);
-    // Record this run `running` BEFORE any part lands — in the ledger + a bucket
-    // marker manifest — the authority `gc_orphans` reads to spare a live extract's
-    // committed-but-not-yet-manifested parts. (finish_run transitions it below.)
-    ledger_begin_run(state, &plan, &export.family(), &summary.run_id);
-    // The id the LEDGER row was opened under. A chunk-checkpoint RESUME adopts the
-    // prior run's id (chunked/mod.rs) — `summary.run_id` changes AFTER this point —
-    // and `finish_run` is a bare UPDATE, so closing the run under the adopted id
-    // matched no row and left this one `running` forever.
-    //
-    // That leak is not cosmetic: `has_active_run_on_prefix` keeps answering true,
-    // so `gc_orphans` defers cleanup, and since the load now excludes active runs
-    // from the consumed set (dispatch.rs), every later load on that prefix
-    // re-appends instead of recording progress — until an unrelated newer run of
-    // the same export happens to supersede it.
-    let ledger_run_id = summary.run_id.clone();
-    // Failure forensics at open: source schema + server limits, so a run that fails
-    // before finalize still explains itself (export_schema is otherwise success-only).
-    capture_open_forensics(&plan, state, &mut summary);
-
-    // PG cursor / sort spill probe — captured around the actual run window.
-    // Cluster-level counter, so this is a noisy upper bound on a shared host
-    // but accurate on the single-tenant test DBs pilots typically use.
-    let pg_temp_bytes_before = pg_temp_bytes_snapshot(&plan);
-    // Tier 2: broader source-harm counters (locks, rows read, buffer misses,
-    // temp files) bracketed around the same run window; the per-counter delta is
-    // stored in export_harm. Best-effort — see `harm_snapshot`.
-    let harm_before = harm_snapshot(&plan.source);
-
-    // Record plan diagnostics that were already logged above.
-    for d in &diags {
-        if matches!(
-            d.level,
-            DiagnosticLevel::Warning | DiagnosticLevel::Degraded
-        ) {
-            summary.journal.record(RunEvent::PlanWarning {
-                rule: d.rule.to_string(),
-                message: d.message.clone(),
-            });
-        }
-    }
-
-    let result = if plan.strategy.requires_parallel_execution() {
-        if plan.strategy.is_resumable() {
-            run_chunked_parallel_checkpoint(
-                config_path,
-                state,
-                &plan,
-                &mut summary,
-                chunked::ChunkSource::Detect,
+    // The post-plan execution script lives ONCE in `execute_resolved_plan`;
+    // this entry point only supplies the run-path policy.
+    let plan_warnings: Vec<(String, String)> = diags
+        .iter()
+        .filter(|d| {
+            matches!(
+                d.level,
+                DiagnosticLevel::Warning | DiagnosticLevel::Degraded
             )
-        } else {
-            chunked::run_chunked_parallel(state, &plan, &mut summary, chunked::ChunkSource::Detect)
-        }
-    } else {
-        run_with_reconnect(
-            state,
-            &plan,
-            &mut summary,
-            config_path,
-            chunked::ChunkSource::Detect,
-        )
-    };
-    // ADR-0028: THE export tail — apply the ledger the runner fed exactly once,
-    // here, before anything downstream reads the summary. On runner success the
-    // full seam runs (records + gates; a drift `fail` folds into `result` and
-    // flows the same failed-status path a runner error does). On runner FAILURE
-    // the records half still applies — the Failed manifest must describe the
-    // durable debris with the OBSERVED fingerprint + Form-B, never the stale
-    // baseline (seam bughunt 2026-08-21).
-    let result = match result {
-        Ok(()) => super::finalize::finalize_export(&plan, Some(state), &mut summary),
-        Err(e) => {
-            super::finalize::finalize_export_records(&mut summary);
-            Err(e)
-        }
-    };
-
-    let rss_peak = rss_sampler.stop();
-    let rss_after = crate::resource::get_rss_mb();
-    // Harvest the run's bytes-read counter ONCE — every sink (per chunk, per
-    // worker) incremented plan.bytes_read, so this single read covers every
-    // runner by construction (#175).
-    summary.bytes_read = plan.bytes_read.load(std::sync::atomic::Ordering::Relaxed);
-    summary.duration_ms = start.elapsed().as_millis() as i64;
-    summary.peak_rss_mb = rss_peak.max(rss_after).max(rss_before) as i64;
-
-    // Compute the temp_bytes delta only when both snapshots succeeded — partial
-    // failures (e.g. dropped connection between runs) leave the field None so
-    // the summary card omits the line entirely.
-    if let Some(before) = pg_temp_bytes_before
-        && let Some(after) = pg_temp_bytes_snapshot(&plan)
-    {
-        let delta = pg_temp_bytes_delta(before, after);
-        summary.pg_temp_bytes_delta = Some(delta);
-        if let Some(line) = pg_temp_bytes_warning(
-            &plan.export_name,
-            delta,
-            super::run::multi_export_concurrent(),
-        ) {
-            log::warn!("{line}");
-        }
-    }
-
-    // Tier 2: record the per-counter source-harm delta. A failed or absent probe
-    // (e.g. missing VIEW SERVER STATE on MSSQL) leaves no rows — never fatal.
-    let mut harm_delta_vec: Vec<(String, i64)> = Vec::new();
-    if let Some(before) = &harm_before
-        && let Some(after) = harm_snapshot(&plan.source)
-    {
-        harm_delta_vec = harm_deltas(before, &after);
-        if let Err(e) = state.record_harm(&summary.run_id, &summary.export_name, &harm_delta_vec) {
-            log::debug!(
-                "export '{}': harm metrics write failed (informational): {:#}",
-                summary.export_name,
-                e
-            );
-        }
-    }
-    let tuning_class = plan.tuning.profile_name().to_string();
-    let result = run_chunked_quality_gate(result, &plan, &mut summary);
-    let failed = result.is_err();
-    match &result {
-        Ok(()) => {
-            if summary.status == "running" {
-                summary.status = "success".into();
-            }
-        }
-        Err(e) => {
-            summary.status = "failed".into();
-            let redacted = crate::redact::redact_error(e);
-            summary.error_message = Some(redacted.clone());
-            log::error!("export '{}' failed: {}", plan.export_name, redacted);
-        }
-    }
-
-    // Self-diagnosing run-health line — makes a log the field team sends back
-    // readable at a glance (reconnects survived, a resume-hit, a source spill).
-    // Emitted AFTER the success/failed resolution above so the line reports the
-    // real terminal status, not the transient "running" it was built with (#18
-    // bughunt: it ran before the status was resolved, so it always said running).
-    if let Some(line) = run_diagnosis(
-        &summary,
-        &harm_delta_vec,
-        super::run::multi_export_concurrent(),
-    ) {
-        log::warn!("{line}");
-    }
-
-    let mut reconcile_gate: crate::error::Result<()> = Ok(());
-    if plan.reconcile && !failed {
-        let could_not_verify = reconcile_source_count(&plan, &mut summary);
-        if let (Some(source_count), Some(matched)) = (summary.source_count, summary.reconciled) {
-            summary.journal.record(RunEvent::ReconciliationResult {
-                source_count,
-                exported_rows: summary.total_rows,
-                matched,
-            });
-        }
-        // The reconcile verdict drives the EXIT CODE (folded into `final_result`):
-        // exit 3 on a mismatch, exit 1 on a could-not-verify. It does NOT flip
-        // `summary.status` to "failed" — that would make `finalize_manifest` write
-        // a Failed manifest with no _SUCCESS, so `rivet load` would REFUSE a
-        // COMPLETE, durable export because a post-hoc COUNT(*) raced a concurrent
-        // write on a live source (#2 bughunt). The export succeeded and stays
-        // loadable; the mismatch surfaces via `summary.reconciled` (report +
-        // metrics + the ReconciliationResult journal event) and the non-zero exit.
-        reconcile_gate = reconcile_run_gate(&summary, could_not_verify.as_deref());
-    }
-
-    summary.journal.record(RunEvent::RunCompleted {
-        status: summary.status.clone(),
-        error_message: summary.error_message.clone(),
-        duration_ms: summary.duration_ms,
-    });
-
-    if let Err(e) = state.store_journal(&summary.journal) {
-        log::warn!(
-            "export '{}': journal persist failed (run history not stored): {:#}",
-            summary.export_name,
-            e
-        );
-    }
-
-    summary.print();
-    // Transition the run-status ledger to its terminal status — the manifest
-    // written just below is a PROJECTION of this record, so both carry the same
-    // status. A crash before here leaves the row `running`; supersession by a
-    // later run reconciles it (no age timer).
-    ledger_finish_owned_runs(state, &plan.export_name, &ledger_run_id, &summary);
-    // Order matters: write the manifest first, then run the manifest-aware
-    // `--validate` pass against the destination, then persist the metrics
-    // row, then write the run report.  The report sees the verification
-    // verdict only because we run it before `finalize_run_report`; the
-    // metrics row must also wait for `finalize_validate_manifest`, which can
-    // downgrade `summary.validated` — recording earlier left `rivet metrics`
-    // permanently saying validated=pass for a run whose report says it
-    // failed.  The notification fires last so it carries the most complete
-    // summary.
-    // A run whose manifest never landed is NOT a success, whatever its rows say.
-    // The parts are durable and the counts are right — and no manifest names them,
-    // so the loader will not read them. Reporting success there is a claim the
-    // artifacts do not support.
-    //
-    // The status has already been printed and the ledger row already closed by
-    // this point, so both are corrected: the metrics row is written below and
-    // picks up the new status, and the ledger row is re-closed. The manifest
-    // itself cannot be re-written to say `failed` — failing to write it is the
-    // problem.
-    let manifest_gap = finalize_manifest(&plan, &export.family(), state, &summary, "export");
-    if let Some(why) = &manifest_gap {
-        summary.status = "failed".into();
-        summary.error_message = Some(why.clone());
-        ledger_finish_owned_runs(state, &plan.export_name, &ledger_run_id, &summary);
-    }
-    // Round-2 audit #12: advance the incremental cursor now that the destination
-    // manifest is durable — never before. A failure here is at-least-once safe (the
-    // data + manifest are durable; the next run re-exports from the prior cursor),
-    // so log loudly rather than fail a run whose write cycle already succeeded.
-    //
-    // "now that the manifest is durable" was a PREMISE, not a check: the cursor
-    // advanced even when the manifest write had just failed, so the next run
-    // started past data nothing described. Guarded now.
-    if manifest_gap.is_some() {
-        log::error!(
-            "export '{}': incremental cursor NOT advanced — the manifest did not land, so the \
-             next run must re-export this window rather than skip past it",
-            summary.export_name,
-        );
-    } else if let Err(e) = commit_incremental_cursor(state, &plan, &summary) {
-        log::error!(
-            "export '{}': cursor advance failed AFTER the manifest was written — the next run \
-             re-exports from the prior cursor (at-least-once, no loss): {:#}",
-            summary.export_name,
-            e
-        );
-    }
-    // Round-5: a keyset checkpoint run has now finalized its COMPLETE destination
-    // manifest — clear the in-progress run_id (persisted for crash rehydration) so a
-    // later run isn't treated as a resume of this finished one. Clearing AFTER the
-    // manifest write is the same ordering as the cursor advance: a crash before here
-    // leaves resume_run_id set, so the next run rehydrates rather than orphans.
-    finalize_keyset_anchor(
-        state,
+        })
+        .map(|d| (d.rule.to_string(), d.message.clone()))
+        .collect();
+    let family = export.family();
+    execute_resolved_plan(
         &plan,
-        &summary.export_name,
-        keyset_anchor_survives(RunOutcome {
-            failed,
-            manifest_gap: &manifest_gap,
-        }),
-    );
-    if plan.validate {
-        finalize_validate_manifest(&plan, &mut summary, "export");
-    }
-    if let Err(e) = state.record_metric_full(&build_metric_row(&summary, &plan, &tuning_class)) {
-        log::warn!(
-            "export '{}': metrics write failed (run outcome not stored): {:#}",
-            summary.export_name,
-            e
-        );
-    }
-    finalize_run_report(config_path, &summary, "export");
-    crate::notify::maybe_send(config.notifications.as_ref(), &summary);
-
-    let final_result = resolve_final_result(failed, result, reconcile_gate, manifest_gap);
-    (final_result, summary)
+        state,
+        TailPolicy {
+            kind: "export",
+            family: &family,
+            config_path,
+            runner_config_path: config_path,
+            chunk_source: chunked::ChunkSource::Detect,
+            apply_context: None,
+            allow_reconcile: true,
+            notifications: config.notifications.as_ref(),
+            plan_warnings,
+        },
+    )
 }
 
 // `finalize_*` and the M8 success-gate live in `pipeline::finalize` so this
@@ -1364,214 +1456,25 @@ pub(crate) fn run_export_job_with_chunk_source(
         plan.tuning
     );
 
-    let start = std::time::Instant::now();
-    let rss_before = crate::resource::get_rss_mb();
-    let rss_sampler = crate::resource::RssPeakSampler::start(rss_before, 100);
-    let mut summary = RunSummary::new(plan);
-    summary.apply_context = apply_context;
-    ledger_begin_run(state, plan, &plan.export_name, &summary.run_id);
-    // The id the ledger row was opened under. A chunk-checkpoint resume — which
-    // THIS wrapper dispatches to — replaces `summary.run_id` with the crashed
-    // run's, so the opening row must be closed by name or it stays `running`
-    // forever.
-    let ledger_run_id = summary.run_id.clone();
-    // Runner parity: the apply/chunk-source path is a SEPARATE runner from
-    // run_export_job, so it must re-apply open forensics itself (server_context +
-    // schema-at-open) or an apply-run failure records neither — the runner-bypass
-    // class. See docs/runner-coverage-matrix.yaml.
-    capture_open_forensics(plan, state, &mut summary);
-    // Same runner-parity reason: the source-harm bracket and the DIAGNOSIS line
-    // it feeds are re-applied here, or an `apply` run records no `export_harm`
-    // rows and never says a word about a source it spilled to disk — while the
-    // identical plan under `rivet run` does both (round-3 bughunt: the doc on
-    // this fn claimed "everything else is identical to run_export_job", and the
-    // harm half was the exception).
-    let pg_temp_bytes_before = pg_temp_bytes_snapshot(plan);
-    let harm_before = harm_snapshot(&plan.source);
-
-    let result = if plan.strategy.requires_parallel_execution() {
-        if plan.strategy.is_resumable() {
-            // apply does not support checkpoint-parallel resume; use Detect fallback
-            run_chunked_parallel_checkpoint("", state, plan, &mut summary, chunk_source)
-        } else {
-            chunked::run_chunked_parallel(state, plan, &mut summary, chunk_source)
-        }
-    } else {
-        run_with_reconnect(state, plan, &mut summary, "", chunk_source)
-    };
-    // ADR-0028: THE export tail — same contract as run_export_job's site: full
-    // seam on success, records half on failure (the Failed manifest must carry
-    // the OBSERVED fingerprint + Form-B, never the stale baseline).
-    let result = match result {
-        Ok(()) => super::finalize::finalize_export(plan, Some(state), &mut summary),
-        Err(e) => {
-            super::finalize::finalize_export_records(&mut summary);
-            Err(e)
-        }
-    };
-
-    let rss_peak = rss_sampler.stop();
-    let rss_after = crate::resource::get_rss_mb();
-    // Harvest the run's bytes-read counter ONCE — every sink (per chunk, per
-    // worker) incremented plan.bytes_read, so this single read covers every
-    // runner by construction (#175).
-    summary.bytes_read = plan.bytes_read.load(std::sync::atomic::Ordering::Relaxed);
-    summary.duration_ms = start.elapsed().as_millis() as i64;
-    summary.peak_rss_mb = rss_peak.max(rss_after).max(rss_before) as i64;
-
-    // Close the harm bracket on the SAME window the run occupied, before the
-    // status resolution below — the deltas are what the DIAGNOSIS reads.
-    if let Some(before) = pg_temp_bytes_before
-        && let Some(after) = pg_temp_bytes_snapshot(plan)
-    {
-        let delta = pg_temp_bytes_delta(before, after);
-        summary.pg_temp_bytes_delta = Some(delta);
-        if let Some(line) = pg_temp_bytes_warning(
-            &plan.export_name,
-            delta,
-            super::run::multi_export_concurrent(),
-        ) {
-            log::warn!("{line}");
-        }
-    }
-    let mut harm_delta_vec: Vec<(String, i64)> = Vec::new();
-    if let Some(before) = &harm_before
-        && let Some(after) = harm_snapshot(&plan.source)
-    {
-        harm_delta_vec = harm_deltas(before, &after);
-        if let Err(e) = state.record_harm(&summary.run_id, &summary.export_name, &harm_delta_vec) {
-            log::debug!(
-                "apply '{}': harm metrics write failed (informational): {:#}",
-                summary.export_name,
-                e
-            );
-        }
-    }
-
-    let tuning_class = plan.tuning.profile_name().to_string();
-    let result = run_chunked_quality_gate(result, plan, &mut summary);
-    let failed = result.is_err();
-
-    match &result {
-        Ok(()) => {
-            if summary.status == "running" {
-                summary.status = "success".into();
-            }
-        }
-        Err(e) => {
-            summary.status = "failed".into();
-            let redacted = crate::redact::redact_error(e);
-            summary.error_message = Some(redacted.clone());
-            log::error!("apply '{}' failed: {}", plan.export_name, redacted);
-        }
-    }
-
-    // Emitted after the status resolution for the same reason `run_export_job`
-    // does it there: the line must report the terminal status, not "running".
-    if let Some(line) = run_diagnosis(
-        &summary,
-        &harm_delta_vec,
-        super::run::multi_export_concurrent(),
-    ) {
-        log::warn!("{line}");
-    }
-
-    // Runner parity, third facet: the run JOURNAL. Every runner this wrapper
-    // dispatches to records into `summary.journal` — `governor.drain_into`
-    // (`ParallelismAdjusted`, deliberately drained before the worker-error bail
-    // so a FAILED run still journals its sheds), `ChunkCompleted`/`FileWritten`
-    // from `commit.rs`, `SchemaChanged`, `RetryAttempted` — and apply then threw
-    // the whole thing away: no terminal `RunCompleted`, no `store_journal`, so
-    // `rivet journal -e X` answered "No journal entries" after a completed apply
-    // run while the byte-identical plan under `rivet run` had the full history
-    // (round-5 bughunt). An operator investigating a slow governed apply had no
-    // record that the governor shed at all.
-    //
-    // Same placement and same best-effort warn as `run_export_job`: before the
-    // print, so a later `finalize_manifest` gap that flips the status is NOT in
-    // the journal on either entry point (one behaviour, not two).
-    summary.journal.record(RunEvent::RunCompleted {
-        status: summary.status.clone(),
-        error_message: summary.error_message.clone(),
-        duration_ms: summary.duration_ms,
-    });
-    if let Err(e) = state.store_journal(&summary.journal) {
-        log::warn!(
-            "apply '{}': journal persist failed (run history not stored): {:#}",
-            summary.export_name,
-            e
-        );
-    }
-
-    summary.print();
-    ledger_finish_owned_runs(state, &plan.export_name, &ledger_run_id, &summary);
-    // Apply replays a SEALED artifact and has no ExportConfig — correctly:
-    // the family is the export's own name here. The one export whose family
-    // differs (the CDC snapshot leg) is synthesized by `cdc_job` at runtime and
-    // never reaches plan/apply, which refuses `mode: cdc` at build_plan entry.
-    // The manifest gap is handled EXACTLY as `run_export_job` handles it, and the
-    // duplication is the point: this wrapper reaches `run_with_reconnect` for a
-    // plain incremental plan, so it sets `cursor_high` and can advance the cursor
-    // just like the run path. Binding the verdict only there left `rivet apply`
-    // reporting success, advancing the cursor past a window no manifest names, and
-    // skipping it on the next run — the same defect, undone one runner over.
-    let manifest_gap = finalize_manifest(plan, &plan.export_name, state, &summary, "apply");
-    if let Some(why) = &manifest_gap {
-        summary.status = "failed".into();
-        summary.error_message = Some(why.clone());
-        ledger_finish_owned_runs(state, &plan.export_name, &ledger_run_id, &summary);
-    }
-    // Round-2 audit #12: incremental cursor advance AFTER the manifest is durable
-    // (see run_export_job) — and never when it did not land.
-    if manifest_gap.is_some() {
-        log::error!(
-            "apply '{}': incremental cursor NOT advanced — the manifest did not land, so the \
-             next run must re-export this window rather than skip past it",
-            summary.export_name,
-        );
-    } else if let Err(e) = commit_incremental_cursor(state, plan, &summary) {
-        log::error!(
-            "apply '{}': cursor advance failed AFTER the manifest was written — the next run \
-             re-exports from the prior cursor (at-least-once, no loss): {:#}",
-            summary.export_name,
-            e
-        );
-    }
-    // Clear the keyset in-progress anchor AFTER the manifest is durable — the SAME
-    // post-finalize clear run_export_job does (job.rs above). An INCREMENTAL keyset
-    // run no longer clears it in run_keyset (the clear must be post-finalize, or a
-    // crash orphans the pages — round-2 fix), so EVERY job wrapper must clear it
-    // here; a wrapper that skips it strands resume_run_id forever, so the next apply
-    // is misread as a resume, reuses the frozen run_id, and the run-unique manifest
-    // sidecar collides across runs (round-3 wrapper-bypass regression).
-    finalize_keyset_anchor(
-        state,
+    // Same script, apply-path policy: artifact family = export name, no
+    // checkpoint-parallel resume path (runner_config_path ""), no reconcile
+    // leg, no notifications, plan warnings logged above but not journaled
+    // (existing behavior, preserved).
+    execute_resolved_plan(
         plan,
-        &summary.export_name,
-        keyset_anchor_survives(RunOutcome {
-            failed,
-            manifest_gap: &manifest_gap,
-        }),
-    );
-    if plan.validate {
-        finalize_validate_manifest(plan, &mut summary, "apply");
-    }
-    // After finalize_validate_manifest: it can downgrade summary.validated,
-    // and the metrics row must carry the final verdict (same ordering as
-    // run_export_job).
-    if let Err(e) = state.record_metric_full(&build_metric_row(&summary, plan, &tuning_class)) {
-        log::warn!(
-            "apply '{}': metrics write failed: {:#}",
-            summary.export_name,
-            e
-        );
-    }
-    finalize_run_report(config_path, &summary, "apply");
-
-    // Same fold as the run path: an export failure wins, otherwise an unwritten
-    // manifest fails the run. `apply` has no reconcile flag, so that leg is `Ok`.
-    let final_result = resolve_final_result(failed, result, Ok(()), manifest_gap);
-    (final_result, summary)
+        state,
+        TailPolicy {
+            kind: "apply",
+            family: &plan.export_name,
+            config_path,
+            runner_config_path: "",
+            chunk_source,
+            apply_context,
+            allow_reconcile: false,
+            notifications: None,
+            plan_warnings: Vec::new(),
+        },
+    )
 }
 
 #[cfg(test)]

--- a/src/pipeline/job.rs
+++ b/src/pipeline/job.rs
@@ -1395,10 +1395,11 @@ use super::finalize::{
 /// Execute a pre-resolved plan with a caller-supplied `ChunkSource`.
 ///
 /// Used by `rivet apply`: the plan comes from a deserialized `PlanArtifact` so
-/// `build_plan` is skipped.  Everything else — quality gate, metrics, state
-/// persistence — is identical to `run_export_job` *except* the two runner-parity
-/// re-applications called out at their sites below (open forensics, the
-/// source-harm bracket).
+/// `build_plan` is skipped. Everything after validation routes through the ONE
+/// post-plan script (`execute_resolved_plan`) — open forensics, the source-harm
+/// bracket, the finalize seam, metrics, state persistence — so this entry point
+/// can no longer diverge from `run_export_job` by omission; its policy is the
+/// `TailPolicy` it passes.
 ///
 /// LIVE-ONLY BY CONSTRUCTION, and deliberately not unit-tested: it needs a real
 /// source, a real destination and a `StateStore`, so a body stub

--- a/src/pipeline/job.rs
+++ b/src/pipeline/job.rs
@@ -943,6 +943,51 @@ fn should_reconcile(allow_reconcile: bool, plan_reconcile: bool, failed: bool) -
     allow_reconcile && plan_reconcile && !failed
 }
 
+/// The plan-validation verdict, pure: `Some(err)` when the plan carries
+/// REJECTED diagnostics, `None` when it may run. Extracted because the
+/// `!rejected.is_empty()` gate sits in the live-only `run_export_job` body and
+/// its `!` survived the in-diff mutation gate — dropping it inverts the verdict,
+/// so a clean plan would be refused and a rejected one would RUN.
+fn plan_rejection_error(export_name: &str, rejected: &[String]) -> Option<anyhow::Error> {
+    if rejected.is_empty() {
+        return None;
+    }
+    Some(anyhow::anyhow!(
+        "export '{}': plan validation failed:\n  {}",
+        export_name,
+        rejected.join("\n  ")
+    ))
+}
+
+/// The two `--resume` / `--force` gates, pure. Both live inside `run_export_job`
+/// — a live-only body the in-diff mutation gate cannot reach, which is why its
+/// `&&` and both its `!`s survived (2026-08-21 run: 6 of the 16 misses were
+/// these three operators). The conditions are opposite halves of one policy, so
+/// they are stated together and unit-tested as one truth table.
+///
+/// `resume` asks to continue into a prefix; `force` is the audited override.
+/// A `--resume` into a COMPLETE prefix is refused unless forced (re-exporting a
+/// verified dataset is almost never meant); a FRESH run into a complete prefix
+/// is only warned about, because refusing or auto-deleting would destroy
+/// operator data.
+fn resume_success_gate_applies(resume: bool, force: bool) -> bool {
+    resume && !force
+}
+
+/// Sibling of [`resume_success_gate_applies`] — the fresh-run rerun-accumulation
+/// warning (audit findings #5/#19/#30).
+fn rerun_warning_applies(resume: bool, force: bool) -> bool {
+    !resume && !force
+}
+
+/// Does this export bypass the batch plan/strategy machinery for the dedicated
+/// CDC runner? Pure so the dispatch condition is graded offline — the `==`
+/// survived as a live-only mutant (flipping it to `!=` sends every BATCH export
+/// through the CDC runner and every CDC export through the batch planner).
+fn dispatches_to_cdc_runner(mode: crate::config::ExportMode) -> bool {
+    mode == crate::config::ExportMode::Cdc
+}
+
 /// THE post-plan execution script, written once: rss/forensics/harm bracket →
 /// dispatch → ADR-0028 seam → bracket close → quality gate → status → diagnosis
 /// → [reconcile] → journal → ledger close → manifest → cursor → keyset anchor →
@@ -1252,7 +1297,7 @@ pub(super) fn run_export_job(
     // CDC exports read the transaction log, not a query — they bypass the batch
     // plan/strategy machinery entirely and run through the dedicated CDC runner,
     // which produces the same (Result, RunSummary) contract + metric row.
-    if export.mode == crate::config::ExportMode::Cdc {
+    if dispatches_to_cdc_runner(export.mode) {
         // `initial: snapshot`: anchor first, then each pending table's full
         // snapshot (a recursive `mode: full` run into `…/snapshot/`, with its
         // own metric + journal), then the drain below. A failed snapshot fails
@@ -1327,12 +1372,7 @@ pub(super) fn run_export_job(
             }
         }
     }
-    if !rejected.is_empty() {
-        let err = anyhow::anyhow!(
-            "export '{}': plan validation failed:\n  {}",
-            plan.export_name,
-            rejected.join("\n  ")
-        );
+    if let Some(err) = plan_rejection_error(&plan.export_name, &rejected) {
         let summary = synthetic_failed_summary(&export.name, &err);
         return (Err(err), summary);
     }
@@ -1342,8 +1382,7 @@ pub(super) fn run_export_job(
     // overrode the gate with `--force`.  Re-exporting over a verified
     // dataset is almost never what the operator meant; the gate makes the
     // override an audited decision.
-    if opts.resume
-        && !opts.force
+    if resume_success_gate_applies(opts.resume, opts.force)
         && let Err(e) = check_success_gate_for_resume(&plan)
     {
         let summary = synthetic_failed_summary(&export.name, &e);
@@ -1358,7 +1397,7 @@ pub(super) fn run_export_job(
     // parts.  Refusing or auto-deleting would destroy operator data, so this
     // is a loud, non-fatal WARN instead (the `--resume` path above keeps its
     // refuse-without-`--force` gate).  `--force` is the explicit opt-out.
-    if !opts.resume && !opts.force {
+    if rerun_warning_applies(opts.resume, opts.force) {
         warn_if_prefix_has_completed_run(&plan);
     }
 
@@ -1650,6 +1689,79 @@ mod tests {
     /// no `&&`→`||` and no dropped `!` survives (the in-diff mutation gate found
     /// all three of those alive in the live-only script body; extracting the
     /// decision is what makes them killable offline).
+    /// The plan-validation verdict: a clean plan RUNS, a rejected one is
+    /// refused with every reason named. Kills the `delete !` mutant, which
+    /// inverts both halves — refusing valid plans and running rejected ones.
+    #[test]
+    fn plan_rejection_error_refuses_only_a_rejected_plan_and_names_every_reason() {
+        use super::plan_rejection_error;
+        assert!(
+            plan_rejection_error("orders", &[]).is_none(),
+            "a plan with no REJECTED diagnostics must run"
+        );
+        let err = plan_rejection_error(
+            "orders",
+            &[
+                "chunk key is nullable".to_string(),
+                "no primary key".to_string(),
+            ],
+        )
+        .expect("a rejected plan must not run");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("export 'orders'"),
+            "names the export; got {msg}"
+        );
+        assert!(
+            msg.contains("chunk key is nullable") && msg.contains("no primary key"),
+            "every rejection reason must reach the operator; got {msg}"
+        );
+    }
+
+    /// The resume/force policy as ONE truth table: the refuse-gate and the
+    /// warn-gate are opposite halves, and `--force` disables both. Kills the
+    /// `&&`→`||` and both `delete !` mutants the in-diff gate found alive in
+    /// `run_export_job`.
+    #[test]
+    fn resume_and_rerun_gates_are_opposite_halves_disabled_by_force() {
+        use super::{rerun_warning_applies, resume_success_gate_applies};
+        // --resume, no --force: refuse a complete prefix; do NOT warn (the
+        // resume path owns this case).
+        assert!(resume_success_gate_applies(true, false));
+        assert!(!rerun_warning_applies(true, false));
+        // fresh run, no --force: warn about accumulation; the refuse-gate is
+        // not this path's.
+        assert!(!resume_success_gate_applies(false, false));
+        assert!(rerun_warning_applies(false, false));
+        // --force is the audited override: BOTH gates go quiet, resumed or not.
+        for resume in [true, false] {
+            assert!(
+                !resume_success_gate_applies(resume, true),
+                "--force must disable the resume refusal (resume={resume})"
+            );
+            assert!(
+                !rerun_warning_applies(resume, true),
+                "--force must disable the rerun warning (resume={resume})"
+            );
+        }
+    }
+
+    /// The CDC dispatch fork: exactly one mode takes the CDC runner, every other
+    /// mode takes the batch planner. Kills the `==`→`!=` mutant (which would
+    /// invert the whole fork).
+    #[test]
+    fn only_cdc_mode_dispatches_to_the_cdc_runner() {
+        use super::dispatches_to_cdc_runner;
+        use crate::config::ExportMode;
+        assert!(dispatches_to_cdc_runner(ExportMode::Cdc));
+        for m in [ExportMode::Full, ExportMode::Incremental] {
+            assert!(
+                !dispatches_to_cdc_runner(m),
+                "{m:?} is a BATCH mode and must not reach the CDC runner"
+            );
+        }
+    }
+
     #[test]
     fn should_reconcile_requires_permission_request_and_success() {
         use super::should_reconcile;

--- a/src/pipeline/job.rs
+++ b/src/pipeline/job.rs
@@ -929,6 +929,20 @@ struct TailPolicy<'a> {
     plan_warnings: Vec<(String, String)>,
 }
 
+/// Does this run's reconcile leg run? Pure, because the three-input condition
+/// is the ONE piece of NEW logic the two-entry-point unification introduced
+/// (`allow_reconcile` is the policy bit; the other two already gated the leg on
+/// both sides), and a live-only script body cannot be graded by the in-diff
+/// mutation gate — its `&&`s and its `!` all survived on the first run.
+///
+/// All three must hold: the entry point ALLOWS a reconcile at all (apply does
+/// not — a sealed artifact has no reconcile flag), the plan ASKED for one, and
+/// the export did not already fail (reconciling a failed export compares a
+/// partial write against the source and reports a mismatch that is not one).
+fn should_reconcile(allow_reconcile: bool, plan_reconcile: bool, failed: bool) -> bool {
+    allow_reconcile && plan_reconcile && !failed
+}
+
 /// THE post-plan execution script, written once: rss/forensics/harm bracket →
 /// dispatch → ADR-0028 seam → bracket close → quality gate → status → diagnosis
 /// → [reconcile] → journal → ledger close → manifest → cursor → keyset anchor →
@@ -1095,7 +1109,7 @@ fn execute_resolved_plan(
     }
 
     let mut reconcile_gate: crate::error::Result<()> = Ok(());
-    if tail.allow_reconcile && plan.reconcile && !failed {
+    if should_reconcile(tail.allow_reconcile, plan.reconcile, failed) {
         let could_not_verify = reconcile_source_count(plan, &mut summary);
         if let (Some(source_count), Some(matched)) = (summary.source_count, summary.reconciled) {
             summary.journal.record(RunEvent::ReconciliationResult {
@@ -1630,6 +1644,45 @@ mod tests {
         s.reconciled = Some(false);
         let err = reconcile_run_gate(&s, Some("noise")).unwrap_err();
         assert_eq!(crate::error::classify_exit(&err), 3);
+    }
+
+    /// The reconcile gate's full truth table — three booleans, eight cases, so
+    /// no `&&`→`||` and no dropped `!` survives (the in-diff mutation gate found
+    /// all three of those alive in the live-only script body; extracting the
+    /// decision is what makes them killable offline).
+    #[test]
+    fn should_reconcile_requires_permission_request_and_success() {
+        use super::should_reconcile;
+        // The ONLY true case: allowed, asked for, and the export succeeded.
+        assert!(should_reconcile(true, true, false));
+
+        // Each input alone is decisive.
+        assert!(
+            !should_reconcile(false, true, false),
+            "apply does not allow a reconcile leg — a sealed artifact has no flag"
+        );
+        assert!(
+            !should_reconcile(true, false, false),
+            "the plan did not ask for one"
+        );
+        assert!(
+            !should_reconcile(true, true, true),
+            "a FAILED export must not reconcile: comparing a partial write against \
+             the source reports a mismatch that is not one"
+        );
+
+        // …and no combination of the remaining four is true.
+        for (a, r, f) in [
+            (false, false, false),
+            (false, false, true),
+            (false, true, true),
+            (true, false, true),
+        ] {
+            assert!(
+                !should_reconcile(a, r, f),
+                "({a},{r},{f}) must not reconcile"
+            );
+        }
     }
 
     #[test]

--- a/src/pipeline/run.rs
+++ b/src/pipeline/run.rs
@@ -3754,6 +3754,24 @@ mod run_tail_tests {
             "expected the gate at `finish_run_tail`'s two sites plus \
              `tail_plan` — found {sites}"
         );
+        // The floor dropped 5→3 because waves/pool no longer gate inline — so
+        // PIN that they still route through the shared tail, or an ungated
+        // revert (rebuilding an aggregate inline, printing unconditionally)
+        // would pass every remaining count (godsplit bughunt 2026-08-21, MED).
+        for tail_fn in ["fn run_waves", "fn run_pool"] {
+            let at = code.find(tail_fn).expect("orchestrator tail exists");
+            let body = &code[at..code[at..]
+                .find("\npub")
+                .or_else(|| code[at..].find("\nfn "))
+                .map(|o| at + o)
+                .unwrap_or(code.len())];
+            assert!(
+                body.contains("finish_run_tail("),
+                "{tail_fn} no longer routes through finish_run_tail — the \
+                 shared-tail invariant (one aggregate, gated card, ungated \
+                 self-check) is unenforced for it"
+            );
+        }
         // …and no tail may OVERWRITE the subject on its way to the gate, which
         // is the one way back to a re-derived count that still type-checks
         // (`agg.total_exports = total;` before the call). Reading it is the
@@ -4103,14 +4121,19 @@ mod run_tail_tests {
                 // owns the aggregate + self-check + persist sequence, and its
                 // own body is graded by this same loop (it builds an aggregate
                 // and must call the check directly).
-                let calls = body
+                let direct = body
                     .match_indices(seam)
                     .filter(|(i, _)| !body[..*i].ends_with("fn "))
-                    .count()
-                    + body
-                        .match_indices("finish_run_tail(")
-                        .filter(|(i, _)| !body[..*i].ends_with("fn "))
-                        .count();
+                    .count();
+                let routed = body
+                    .match_indices("finish_run_tail(")
+                    .filter(|(i, _)| !body[..*i].ends_with("fn "))
+                    .count();
+                // Routed credit is NOT fungible (godsplit bughunt 2026-08-21):
+                // a tail that builds its OWN aggregate must call the check on
+                // it directly — forwarding a different entries vec through
+                // finish_run_tail must not excuse the self-built one.
+                let calls = if builds == 0 { direct + routed } else { direct };
                 assert!(
                     calls >= builds.max(1),
                     "{rel}::{name} ends a run (it drives an export to completion \

--- a/src/pipeline/run.rs
+++ b/src/pipeline/run.rs
@@ -781,33 +781,7 @@ pub fn run(
         print_json_summary(&agg);
     }
 
-    if !failures.is_empty() {
-        // Carry a representative typed failure as the returned error so
-        // `error::classify_exit` downcasts the marker (DataIntegrityError=3,
-        // SchemaDriftError=4, transient=2) through anyhow's context chain. Pick
-        // the most "stop-worthy" class — data-integrity (possibly-wrong data)
-        // outranks schema-drift, which outranks retryable, which outranks
-        // generic — so a mixed batch exits on the scariest reason.
-        let primary_idx = representative_failure_idx(&failures).unwrap();
-        let primary = failures.remove(primary_idx);
-        if failures.is_empty() {
-            // Single failure — return it verbatim (its own message + marker).
-            return Err(primary);
-        }
-        // Multiple failures: list the others as higher-level context; `primary`
-        // (with its typed marker) rides underneath so the downcast still finds it.
-        let others = failures
-            .iter()
-            .map(|e| format!("{e:#}"))
-            .collect::<Vec<_>>()
-            .join("; ");
-        return Err(primary.context(format!(
-            "{} export(s) failed; representative error follows (also: {others})",
-            failures.len() + 1
-        )));
-    }
-
-    Ok(())
+    fold_failures(failures, "")
 }
 
 /// `rivet apply -c config.yaml` (plan→apply cycle): run every export of the
@@ -1054,50 +1028,94 @@ pub(crate) fn run_waves(
     // The mode label is decided from the concurrency the run ACHIEVED (the same
     // `peak_concurrency` the harm frame above reads), never from the flag — see
     // [`wave_mode_label`].
+    // The mode label + RunModes are the ONLY wave-specific inputs: waves is the
+    // one tail whose exports did NOT all run under the run's label
+    // ([`RunModes::per_export`]). Everything after is the shared tail.
+    let mode_label = wave_mode_label(peak_concurrency);
+    let modes = RunModes::per_export(mode_label, export_modes);
+    finish_run_tail(
+        &state,
+        entries,
+        started_at,
+        finished_at,
+        config_path,
+        mode_label,
+        &modes,
+        Some((&combined_stderr, &config_dir)),
+        failures,
+        " across waves",
+    )
+}
+
+/// Arch-roast follow-up (2026-08-21): the representative-failure fold, written
+/// once. Three orchestrator tails carried the identical block with only the
+/// context word differing — the exact per-copy drift the run-level tail keeps
+/// growing. Pure over its inputs.
+fn fold_failures(mut failures: Vec<anyhow::Error>, context: &str) -> crate::error::Result<()> {
+    if failures.is_empty() {
+        return Ok(());
+    }
+    // Carry a representative typed failure as the returned error so
+    // `error::classify_exit` downcasts the marker (DataIntegrityError=3,
+    // SchemaDriftError=4, transient=2) through anyhow's context chain. Pick
+    // the most "stop-worthy" class — data-integrity (possibly-wrong data)
+    // outranks schema-drift, which outranks retryable, which outranks
+    // generic — so a mixed batch exits on the scariest reason.
+    let primary_idx = representative_failure_idx(&failures).unwrap();
+    let primary = failures.remove(primary_idx);
+    if failures.is_empty() {
+        return Err(primary);
+    }
+    let others = failures
+        .iter()
+        .map(|e| format!("{e:#}"))
+        .collect::<Vec<_>>()
+        .join("; ");
+    Err(primary.context(format!(
+        "{} export(s) failed{}; representative error follows (also: {others})",
+        failures.len() + 1,
+        context,
+    )))
+}
+
+/// The waves/pool run tail, written once: ONE aggregate, then the shared
+/// routing — the card and the `run_aggregate` row are multi-export-only
+/// ([`reports_run_aggregate`]), the run-over-run self-check is not gated at
+/// all, and the failure fold picks the scariest class. The two machine-channel
+/// tails (`run()`'s process branch and in-process tail, which honour
+/// `--summary-output`/`--json`) are the tracked next slice — this seam unifies
+/// the two copies that were already byte-alike so a routing fix lands once.
+#[allow(clippy::too_many_arguments)]
+fn finish_run_tail(
+    state: &StateStore,
+    entries: Vec<crate::state::RunAggregateEntry>,
+    started_at: chrono::DateTime<chrono::Utc>,
+    finished_at: chrono::DateTime<chrono::Utc>,
+    config_path: &str,
+    mode_label: &str,
+    modes: &RunModes<'_>,
+    stderr_artifact: Option<(&str, &Path)>,
+    failures: Vec<anyhow::Error>,
+    failure_context: &str,
+) -> crate::error::Result<()> {
     let agg = aggregate::build(
         entries,
         started_at,
         finished_at,
         Some(config_path),
-        wave_mode_label(peak_concurrency),
+        mode_label,
     );
-    // The card + row gate is the SHARED rule (`run`'s tail asks the same
-    // question through `tail_plan`); the self-check between them is not gated at
-    // all — see [`reports_run_aggregate`].
     if reports_run_aggregate(&agg) {
         aggregate::print(&agg);
     }
-    self_check_throughput(
-        &state,
-        &agg.per_export,
-        // The ONE tail whose exports did NOT all run under the run's label —
-        // see [`RunModes`].
-        &RunModes::per_export(&agg.parallel_mode, export_modes),
-    );
+    self_check_throughput(state, &agg.per_export, modes);
     if reports_run_aggregate(&agg) {
-        aggregate::persist(&state, &agg, None);
+        aggregate::persist(state, &agg, None);
     }
-    // Captured child stderr (verbose per-export cards, parallel path only) goes
-    // to a file artifact beside the config, with a one-line console pointer.
-    emit_child_stderr(&combined_stderr, &config_dir);
-
-    if !failures.is_empty() {
-        let primary_idx = representative_failure_idx(&failures).unwrap();
-        let primary = failures.remove(primary_idx);
-        if failures.is_empty() {
-            return Err(primary);
-        }
-        let others = failures
-            .iter()
-            .map(|e| format!("{e:#}"))
-            .collect::<Vec<_>>()
-            .join("; ");
-        return Err(primary.context(format!(
-            "{} export(s) failed across waves; representative error follows (also: {others})",
-            failures.len() + 1
-        )));
+    if let Some((dump, dir)) = stderr_artifact {
+        emit_child_stderr(dump, dir);
     }
-    Ok(())
+    fold_failures(failures, failure_context)
 }
 
 /// How the run shaped its concurrency, for the run-level harm line's frame —
@@ -2192,53 +2210,28 @@ pub(crate) fn run_pool(
         .iter()
         .map(aggregate::entry_from_summary)
         .collect();
-    let agg = aggregate::build(
+    // Pool-specific inputs only: label from what OVERLAPPED (a serialized pool
+    // must keep the self-check's actionable pointer, [`pool_mode_label`]) and
+    // per-export MEASURED attribution ([`pool_export_modes`] — one
+    // `parallel_safe` export makes the RUN a pool while every heavy runs
+    // alone). Everything after is the shared tail.
+    let mode_label = pool_mode_label(really_concurrent);
+    let modes = RunModes::per_export(
+        mode_label,
+        pool_export_modes(&pool_windows).into_iter().collect(),
+    );
+    finish_run_tail(
+        &state,
         entries,
         started_at,
         finished_at,
-        Some(config_path),
-        // From what overlapped, like the harm frame above — a serialized pool
-        // must keep the self-check's actionable pointer (see
-        // [`pool_mode_label`]).
-        pool_mode_label(really_concurrent),
-    );
-    // Same shared gate as the other two tails (see [`reports_run_aggregate`]) —
-    // the pool used to spell its own `> 1` inline, which is how a rule that must
-    // agree across three runners drifts.
-    if reports_run_aggregate(&agg) {
-        aggregate::print(&agg);
-    }
-    self_check_throughput(
-        &state,
-        &agg.per_export,
-        // NOT the run-wide label: one `parallel_safe` export makes the RUN a
-        // pool while every heavy after the safe work drains runs alone, so the
-        // attribution is per-export and MEASURED — see [`pool_export_modes`].
-        &RunModes::per_export(
-            &agg.parallel_mode,
-            pool_export_modes(&pool_windows).into_iter().collect(),
-        ),
-    );
-    if reports_run_aggregate(&agg) {
-        aggregate::persist(&state, &agg, None);
-    }
-    if !failures.is_empty() {
-        let primary_idx = representative_failure_idx(&failures).unwrap();
-        let primary = failures.remove(primary_idx);
-        if failures.is_empty() {
-            return Err(primary);
-        }
-        let others = failures
-            .iter()
-            .map(|e| format!("{e:#}"))
-            .collect::<Vec<_>>()
-            .join("; ");
-        return Err(primary.context(format!(
-            "{} export(s) failed in the pool; representative error follows (also: {others})",
-            failures.len() + 1
-        )));
-    }
-    Ok(())
+        config_path,
+        mode_label,
+        &modes,
+        None,
+        failures,
+        " in the pool",
+    )
 }
 
 /// Group exports by `wave:` in ascending order; an export with no `wave:` runs
@@ -3750,10 +3743,16 @@ mod run_tail_tests {
             );
             sites += 1;
         }
+        // Down from 5: the waves/pool tails now route through ONE
+        // `finish_run_tail` (arch-roast 2026-08-21), so the gate's call sites
+        // are that seam's two (print + persist) plus `tail_plan`'s one. Fewer
+        // sites is the point — the invariant this test protects (ask about the
+        // BUILT aggregate, never a re-derived count) now holds by construction
+        // for every tail the seam serves.
         assert!(
-            sites >= 5,
-            "expected the gate at both of `run_waves`' sites, both of \
-             `run_pool`'s and inside `tail_plan` — found {sites}"
+            sites >= 3,
+            "expected the gate at `finish_run_tail`'s two sites plus \
+             `tail_plan` — found {sites}"
         );
         // …and no tail may OVERWRITE the subject on its way to the gate, which
         // is the one way back to a re-derived count that still type-checks
@@ -4098,11 +4097,20 @@ mod run_tail_tests {
                     );
                     continue;
                 }
-                // The seam's own definition is not a call.
+                // The seam's own definition is not a call. Since the shared
+                // waves/pool tail landed (arch-roast 2026-08-21), routing
+                // through `finish_run_tail(` IS routing through the seam — it
+                // owns the aggregate + self-check + persist sequence, and its
+                // own body is graded by this same loop (it builds an aggregate
+                // and must call the check directly).
                 let calls = body
                     .match_indices(seam)
                     .filter(|(i, _)| !body[..*i].ends_with("fn "))
-                    .count();
+                    .count()
+                    + body
+                        .match_indices("finish_run_tail(")
+                        .filter(|(i, _)| !body[..*i].ends_with("fn "))
+                        .count();
                 assert!(
                     calls >= builds.max(1),
                     "{rel}::{name} ends a run (it drives an export to completion \

--- a/src/pipeline/run.rs
+++ b/src/pipeline/run.rs
@@ -3126,10 +3126,66 @@ mod pool_harm_tests {
 #[cfg(test)]
 mod run_tail_tests {
     use super::{
-        RunModes, owns_throughput_self_check, pool_safe_heavy_split, reports_run_aggregate,
-        self_check_throughput_as, snapshot_then_stamp, tail_plan,
+        RunModes, fold_failures, owns_throughput_self_check, pool_safe_heavy_split,
+        reports_run_aggregate, self_check_throughput_as, snapshot_then_stamp, tail_plan,
     };
     use crate::config::ExportConfig;
+
+    /// `fold_failures` is the shared representative-failure fold the three
+    /// orchestrator tails route through (arch-roast 2026-08-21). Its whole-body
+    /// stub `Ok(())` survived the in-diff mutation gate — a run that FAILED
+    /// would then exit 0 — because every caller is a live-only tail. It is
+    /// pure, so it is graded here directly.
+    ///
+    /// Three cases, and the typed-marker downcast is the load-bearing one:
+    /// `error::classify_exit` reads the marker THROUGH anyhow's context chain,
+    /// so a multi-failure fold must keep the representative error underneath
+    /// its summary context or a data-integrity batch would exit 1 instead of 3.
+    #[test]
+    fn fold_failures_returns_ok_only_when_empty_and_keeps_the_typed_marker() {
+        use crate::error::DataIntegrityError;
+
+        // No failures → Ok. (The stub mutant makes EVERY case look like this.)
+        assert!(fold_failures(Vec::new(), " in the pool").is_ok());
+
+        // One failure → returned verbatim, marker intact.
+        let one = fold_failures(
+            vec![DataIntegrityError::new("rows differ").into()],
+            " across waves",
+        )
+        .expect_err("a failure must not fold to Ok");
+        assert_eq!(
+            crate::error::classify_exit(&one),
+            3,
+            "a single data-integrity failure must still exit 3"
+        );
+
+        // Several → the SCARIEST class is representative and its marker must
+        // survive the added context; the others are named in the message.
+        let many = fold_failures(
+            vec![
+                anyhow::anyhow!("plain boom"),
+                DataIntegrityError::new("rows differ").into(),
+            ],
+            " in the pool",
+        )
+        .expect_err("failures must not fold to Ok");
+        assert_eq!(
+            crate::error::classify_exit(&many),
+            3,
+            "the data-integrity marker must survive under the summary context, \
+             or a mixed batch exits on the wrong reason"
+        );
+        let msg = format!("{many:#}");
+        assert!(
+            msg.contains("2 export(s) failed in the pool"),
+            "the fold must count every failure and carry the caller's context; got: {msg}"
+        );
+        assert!(
+            msg.contains("plain boom"),
+            "the non-representative failures must still be listed; got: {msg}"
+        );
+    }
 
     /// Captures WARN records, because the run-over-run self-check has no other
     /// observable: it reads the state DB and LOGS. Installed once per test

--- a/tests/offline/runner_frame_gate.rs
+++ b/tests/offline/runner_frame_gate.rs
@@ -368,8 +368,16 @@ fn assert_both_job_entry_points_do(needles: &[(&str, &str)], harm: &str) {
             "{entry}: the slice ran past the function into the test module — the \
              assertions below would be satisfied by the tests' own calls"
         );
+        // Comment-stripped, so a doc-comment MENTION of the script cannot
+        // satisfy the contract (godsplit bughunt 2026-08-21, MED): only a real
+        // call in code counts.
+        let code: String = body
+            .lines()
+            .map(|l| l.split("//").next().unwrap_or(""))
+            .collect::<Vec<_>>()
+            .join("\n");
         let routes_through_script =
-            entry != script_entry && body.contains("execute_resolved_plan(");
+            entry != script_entry && code.contains("execute_resolved_plan(");
         for (what, needle) in needles {
             if !body.contains(needle) && !routes_through_script {
                 offenders.push(format!("{entry} never {what} ({needle})"));

--- a/tests/offline/runner_frame_gate.rs
+++ b/tests/offline/runner_frame_gate.rs
@@ -346,9 +346,16 @@ fn assert_both_job_entry_points_do(needles: &[(&str, &str)], harm: &str) {
     let text = std::fs::read_to_string(&job_rs).expect("read src/pipeline/job.rs");
 
     let mut offenders = Vec::new();
+    // Since the post-plan script was unified (arch-roast 2026-08-21), an entry
+    // point satisfies the contract EITHER by carrying the needles itself OR by
+    // routing through `execute_resolved_plan(` — the one script that owns them.
+    // The script's own body is then graded for every needle directly, so the
+    // contract cannot be satisfied by a route to a hollowed-out script.
+    let script_entry = "fn execute_resolved_plan(";
     for entry in [
         "pub(super) fn run_export_job(",
         "pub(crate) fn run_export_job_with_chunk_source(",
+        script_entry,
     ] {
         let start = text
             .find(entry)
@@ -361,8 +368,10 @@ fn assert_both_job_entry_points_do(needles: &[(&str, &str)], harm: &str) {
             "{entry}: the slice ran past the function into the test module — the \
              assertions below would be satisfied by the tests' own calls"
         );
+        let routes_through_script =
+            entry != script_entry && body.contains("execute_resolved_plan(");
         for (what, needle) in needles {
-            if !body.contains(needle) {
+            if !body.contains(needle) && !routes_through_script {
                 offenders.push(format!("{entry} never {what} ({needle})"));
             }
         }


### PR DESCRIPTION
Recreates #257, which GitHub auto-closed when its base branch (`feat/finalize-export-seam`) was deleted on the merge of #256. Same commits, rebased onto main; no content change.

## What

First slice of the arch-roast god-module split, adversarially challenge-confirmed before implementation:

1. **job.rs twin tails → one script.** `run_export_job` and `run_export_job_with_chunk_source` were the same ~250-line ordered script written twice (this session paid the two-sites tax twice wiring the ADR-0028 seam + its records fix). Now ONE `execute_resolved_plan(plan, state, TailPolicy)`; the nine real divergences are data. Net −96 lines.
2. **run.rs waves/pool tails → one `finish_run_tail`** + the representative-failure fold (3 copies) → one `fold_failures`. Runner-specific residue stays at call sites as data (mode label, RunModes attribution, stderr artifact, context word). The two machine-channel tails (`run()`'s branches) are the tracked next slice.
3. **Convention cops updated and RE-ARMED, not weakened.** The refactor tripped three of them (they are alive); the post-refactor bughunt then found the updates themselves had softened two — both re-armed: `runner_frame_gate` accepts routing through the unified script in **comment-stripped** text and grades the script's own body for every needle; the aggregate-gate census (5→3 sites) now **pins** that waves/pool route through `finish_run_tail`; routed seam credit is **non-fungible** (a tail building its own aggregate must self-check it directly).

## Verification

- Multi-agent bughunt over the refactor diff (4 lenses incl. transplant-fidelity line-diff and the `RunModes`-before/after-build subtlety → adversarial verify, 11 agents): **7 confirmed, 0 refuted — zero transplant or policy defects**; every real finding was guard-weakening in the cop updates, fixed above. Remaining: one intended log-wording delta (apply metrics-warn gains "(run outcome not stored)"), documented.
- Green post-rebase: 2517 lib · 265 offline; earlier on the pre-rebase tip also 51 live (waves, pool incl. split/resume, plan/apply round-trips, governor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)