### PR TITLE
test(harness): five slices of harness hardening — cops that cannot go blind, a gate whose red means something

### DIFF
--- a/.github/scripts/harness_metrics.py
+++ b/.github/scripts/harness_metrics.py
@@ -1,0 +1,607 @@
+#!/usr/bin/env python3
+"""What does the test harness know about ITSELF? One JSON per CI run, so a human can read a TREND.
+
+The harness has grown gates about the product, gates about the gates, a mutation
+prioritiser and a non-vacuity rule — and no metabase about any of it. Nobody can
+answer "are more of our convention-cop guards proving their subject exists than
+last month?" or "is the live-only class of mutants growing?" without reading
+forty files. Five multi-agent bughunts over the 2026-08 refactors found ZERO
+defects in the refactored code and SEVEN in the GUARDS those refactors touched;
+three of the seven were blindness (a gate satisfiable by a doc COMMENT, a gate
+whose subjects moved away while it kept passing over nothing). Those are exactly
+the defects a trend line makes visible early — the numbers move the wrong way
+long before a human notices the guard is dead.
+
+So: emit the counts, publish them as a workflow artifact, print one line into the
+job log. This is a THERMOMETER, not a gate. Nothing here fails a build, nothing
+is a required check, and no threshold is enforced — a metric that blocks a merge
+turns into a number people manage instead of a number people read.
+
+THE ONE RULE OF THE SHAPING, and the reason it is worth a test: an UNKNOWN count
+is `null`, never `0`, and every rate over an unknown is `null` too. A run whose
+mutation job never happened must not publish "0 missed" — on a trend chart that
+is an unbroken green streak meaning "we measured nothing", which is the same
+fail-open reading `mutants_classify.py` refuses when a coverage report is
+unreadable. Unknown is a value here, and it is spelled `null` / `?`.
+
+Usage:
+  harness_metrics.py census [--root <dir>] [--out <f>|-]
+        Scan the tree and count what the harness holds: convention-cop guards
+        (a `#[test]` file that grades a checked-in subject BY NAME), how many of
+        them route that subject through `tests/offline/nonvacuity.rs` (so a
+        moved subject fails loudly instead of grading the empty set), tests that
+        declare themselves documentation rather than verification
+        (`..._documents_...`), files that declare a blind spot in prose, and the
+        DECLARED `#[test]` counts of the offline suite and the lib.
+
+  harness_metrics.py shape --in <raw.json> [--out <f>|-]
+        The PURE half: counts in, published document + summary line out. No
+        filesystem scan, no environment, no subprocess — this is what
+        `tests/offline/harness_metrics_guard.rs` drives from a fixture.
+
+  harness_metrics.py emit [--root <dir>] [--out <f>] [key=value ...]
+        census + the run's identity from the environment + whatever the
+        workflow knows about this run's mutants, shaped and written. Prints the
+        one-line human summary. `key` must be one this script declares (see
+        MUTANT_COUNTS / MUTANT_LABELS): a workflow typo is an error, not a
+        silently dropped metric.
+
+  harness_metrics.py --self-test
+        Grade the pure shaping and the census over fixtures.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+SCHEMA = "rivet-harness-metrics/v1"
+
+# The mutation gate's numbers, in the vocabulary ci.yml and mutants_classify.py
+# already publish. `in_scope` is the whole in-diff corpus before
+# .cargo/mutants.toml, `graded` what survives it, and the offline/live split is
+# the classifier's P1/P2 — the class that CAN be killed offline and the class
+# that provably cannot.
+MUTANT_COUNTS = (
+    "in_scope",
+    "excluded",
+    "graded",
+    "offline_reachable",
+    "live_only",
+    "caught",
+    "missed",
+    "unviable",
+    "timeout",
+)
+MUTANT_LABELS = ("state", "reach", "report_only_audit")
+
+GUARD_COUNTS = (
+    "guard_files",
+    "convention_cops",
+    "subject_proven_non_empty",
+    "subject_unproven",
+    "documents_only_tests",
+    "files_declaring_blind_spots",
+)
+TEST_COUNTS = ("offline_declared", "lib_declared")
+RUN_LABELS = ("repo", "run_id", "sha", "event", "ref")
+
+
+class ShapeError(ValueError):
+    """The input is not a shape this script recognises.
+
+    Raised rather than defaulted, for the reason the module docstring gives: a
+    metrics document assembled out of a misunderstanding is worse than none,
+    because it looks like data.
+    """
+
+
+# --------------------------------------------------------------------------
+# the pure half
+# --------------------------------------------------------------------------
+
+
+def as_count(value: object, field: str, warnings: list[str]) -> int | None:
+    """A count, or None for "not measured" — and never 0 for the second.
+
+    `""` (an unset GitHub Actions output), `?`, `n/a` and a missing key all mean
+    the same thing: this run did not measure it. Junk is also unknown, but says
+    so in `warnings` — a workflow that starts feeding this garbage should be
+    visible in the artifact rather than silently flat-lining at null.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ShapeError(f"`{field}` is a bool ({value!r}); counts are integers or unknown")
+    if isinstance(value, int):
+        if value < 0:
+            raise ShapeError(f"`{field}` is negative ({value}); a count cannot be")
+        return value
+    text = str(value).strip()
+    if text in ("", "?", "n/a", "unknown"):
+        return None
+    if not re.fullmatch(r"\d+", text):
+        warnings.append(
+            f"`{field}` is not a count ({text!r}) — recorded as unknown rather than guessed"
+        )
+        return None
+    return int(text)
+
+
+def as_label(value: object, field: str) -> str | None:
+    """A label, or None when the step that would have set it never ran."""
+    if value is None:
+        return None
+    if not isinstance(value, (str, int)):
+        raise ShapeError(f"`{field}` is {type(value).__name__}; labels are strings")
+    text = str(value).strip()
+    return text or None
+
+
+def rate(num: int | None, den: int | None) -> float | None:
+    """A ratio, or None when either side is unknown OR the denominator is zero.
+
+    Zero denominators are the ordinary case here (a docs-only PR grades no
+    mutants), not an exceptional one — and "0 of 0 missed" rendered as 0.0 is a
+    perfect score nobody earned.
+    """
+    if num is None or den is None or den == 0:
+        return None
+    return round(num / den, 4)
+
+
+def _block(raw: object, name: str, allowed: tuple[str, ...]) -> dict:
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise ShapeError(f"`{name}` must be an object, got {type(raw).__name__}")
+    unknown = sorted(set(raw) - set(allowed))
+    if unknown:
+        raise ShapeError(
+            f"`{name}` carries key(s) {unknown} this script does not publish. A metric the "
+            f"emitter drops silently is a metric nobody notices is gone — declare it here or "
+            f"fix the caller. Known: {sorted(allowed)}"
+        )
+    return raw
+
+
+def shape(raw: dict) -> dict:
+    """Counts in, the published document out. Pure: no I/O, no clock, no env.
+
+    Every field of the artifact is derived here, including the human summary, so
+    the JSON and the line printed into the job log cannot drift apart.
+    """
+    if not isinstance(raw, dict):
+        raise ShapeError(f"the raw input must be an object, got {type(raw).__name__}")
+    warnings: list[str] = []
+
+    run_raw = _block(raw.get("run"), "run", RUN_LABELS)
+    mut_raw = _block(raw.get("mutants"), "mutants", MUTANT_COUNTS + MUTANT_LABELS)
+    guards_raw = _block(raw.get("guards"), "guards", GUARD_COUNTS)
+    tests_raw = _block(raw.get("tests"), "tests", TEST_COUNTS)
+
+    run = {k: as_label(run_raw.get(k), f"run.{k}") for k in RUN_LABELS}
+    mutants: dict[str, object] = {k: as_label(mut_raw.get(k), f"mutants.{k}") for k in MUTANT_LABELS}
+    mutants.update(
+        {k: as_count(mut_raw.get(k), f"mutants.{k}", warnings) for k in MUTANT_COUNTS}
+    )
+    guards = {k: as_count(guards_raw.get(k), f"guards.{k}", warnings) for k in GUARD_COUNTS}
+    tests = {k: as_count(tests_raw.get(k), f"tests.{k}", warnings) for k in TEST_COUNTS}
+
+    # Arithmetic the numbers claim about each other, checked — and REPORTED, not
+    # repaired. A silently corrected total is a lie with a clean audit trail;
+    # the point of the artifact is to show when the pipeline feeding it broke.
+    scope, excluded, graded = mutants["in_scope"], mutants["excluded"], mutants["graded"]
+    if None not in (scope, excluded, graded) and scope - excluded != graded:
+        warnings.append(
+            f"mutants: in_scope {scope} - excluded {excluded} != graded {graded} — the two "
+            f"jobs feeding these disagree about this diff"
+        )
+    p1, p2 = mutants["offline_reachable"], mutants["live_only"]
+    if None not in (p1, p2, graded) and p1 + p2 != graded:
+        warnings.append(
+            f"mutants: offline_reachable {p1} + live_only {p2} != graded {graded} — the "
+            f"prioritiser and the corpus count describe different sets"
+        )
+    verdicts = [mutants[k] for k in ("caught", "missed", "unviable", "timeout")]
+    pool = p1 if p1 is not None else graded
+    if None not in verdicts and pool is not None and sum(verdicts) > pool:  # type: ignore[arg-type]
+        warnings.append(
+            f"mutants: {sum(verdicts)} verdicts recorded over a class of {pool} — more mutants "
+            f"were run than were classified"
+        )
+    cops, proven, unproven = (
+        guards["convention_cops"],
+        guards["subject_proven_non_empty"],
+        guards["subject_unproven"],
+    )
+    if None not in (cops, proven, unproven) and proven + unproven != cops:
+        warnings.append(
+            f"guards: subject_proven_non_empty {proven} + subject_unproven {unproven} != "
+            f"convention_cops {cops} — the census is double-counting or losing a guard"
+        )
+
+    doc = {
+        "schema": SCHEMA,
+        "run": run,
+        "mutants": mutants,
+        "guards": guards,
+        "tests": tests,
+        "derived": {
+            # Of the mutants that reached a VERDICT, not of the corpus: an
+            # over-budget diff runs none, and 0/0 is null (see `rate`).
+            "missed_rate": rate(
+                mutants["missed"],
+                None
+                if mutants["missed"] is None or mutants["caught"] is None
+                else mutants["missed"] + mutants["caught"],
+            ),
+            "live_only_rate": rate(mutants["live_only"], graded),
+            "subject_proven_rate": rate(proven, cops),
+        },
+        "warnings": warnings,
+    }
+    doc["summary"] = summary_line(doc)
+    return doc
+
+
+def _n(value: object) -> str:
+    """A count for human eyes: unknown is `?`, and stays visibly unknown."""
+    return "?" if value is None else str(value)
+
+
+def summary_line(doc: dict) -> str:
+    """The one line that goes into the job log.
+
+    Derived from the DOCUMENT, so the log and the artifact cannot disagree —
+    the same reason `rivet validate` re-reads what it wrote instead of trusting
+    the summary in memory.
+    """
+    m, g, t = doc["mutants"], doc["guards"], doc["tests"]
+    labels = ", ".join(
+        f"{k.replace('_', '-')}={m[k]}" for k in MUTANT_LABELS if m.get(k) is not None
+    )
+    return (
+        f"harness-metrics: mutants {_n(m['in_scope'])} in scope -> {_n(m['graded'])} graded "
+        f"({_n(m['offline_reachable'])} offline-reachable / {_n(m['live_only'])} live-only), "
+        f"{_n(m['caught'])} caught / {_n(m['missed'])} missed"
+        f"{f' [{labels}]' if labels else ''} | guards {_n(g['subject_proven_non_empty'])} of "
+        f"{_n(g['convention_cops'])} convention cops prove a non-empty subject, "
+        f"{_n(g['documents_only_tests'])} documents-only tests, "
+        f"{_n(g['files_declaring_blind_spots'])} files declare a blind spot | tests "
+        f"{_n(t['offline_declared'])} offline + {_n(t['lib_declared'])} lib (declared)"
+    )
+
+
+# --------------------------------------------------------------------------
+# the census (I/O)
+# --------------------------------------------------------------------------
+
+# A guard "grades a checked-in subject BY NAME" when it names a repo path in
+# CODE — the fragile class this whole exercise is about, since the subject can
+# move out from under it and every "no offenders" assertion below stays green.
+_SUBJECT_PATH = re.compile(
+    r'"(?:\./)?(?:src|docs|tests|dev|examples|benches|\.github|\.cargo|\.githooks)/[^"]*"'
+    r'|"(?:Cargo\.toml|Cargo\.lock|Makefile|CLAUDE\.md|README\.md)"'
+)
+# Slice 1's shared rule. A guard that routes its subject through it FAILS on a
+# missing subject instead of grading the empty set — which is precisely the
+# property this census exists to trend.
+_NONVACUITY = re.compile(r"nonvacuity::(?:subject_text|require_enumerated|require_needle)")
+_TEST_ATTR = re.compile(r"#\[(?:tokio::)?test\]")
+# CLAUDE.md: "A name must not promise what the body cannot check" — a test that
+# documents rather than verifies is named `..._documents_...` and says so.
+_DOCUMENTS_ONLY = re.compile(r"\bfn\s+\w*_documents_\w*\s*\(")
+# CLAUDE.md: "A test you cannot make RED should say so where a reader will see
+# it." These are the phrasings the repo actually uses for that declaration.
+_BLIND_SPOT = re.compile(r"CANNOT SEE|cannot be made RED|cannot go RED|CANNOT be made RED")
+
+
+def _uncommented(text: str) -> str:
+    """The file with `//` line comments removed.
+
+    Load-bearing, and for a reason already paid for: `runner_frame_gate` was
+    satisfiable by a doc COMMENT mentioning the call it demanded. A census that
+    counts a guard as grading `docs/foo.yaml` because its module doc says so
+    would make the same mistake one level up.
+    """
+    return "\n".join(l for l in text.splitlines() if not l.lstrip().startswith("//"))
+
+
+def _rs_files(root: Path, rel: str) -> list[Path]:
+    return sorted(p for p in (root / rel).rglob("*.rs") if p.is_file())
+
+
+def census(root: str | Path = ".") -> dict:
+    """Count what the harness holds. Non-vacuous by construction — see the end."""
+    root = Path(root)
+    guards, cops, proven = 0, 0, 0
+    for path in _rs_files(root, "tests/offline"):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        code = _uncommented(text)
+        if not _TEST_ATTR.search(code):
+            continue  # a shared helper module (nonvacuity.rs), not a guard
+        guards += 1
+        if _SUBJECT_PATH.search(code):
+            cops += 1
+            if _NONVACUITY.search(code):
+                proven += 1
+
+    documents_only, blind = 0, 0
+    for path in _rs_files(root, "tests") + _rs_files(root, "src"):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        documents_only += len(_DOCUMENTS_ONLY.findall(_uncommented(text)))
+        if _BLIND_SPOT.search(text):  # prose: read WITH the comments
+            blind += 1
+
+    def declared(paths: list[Path]) -> int:
+        return sum(
+            len(_TEST_ATTR.findall(p.read_text(encoding="utf-8", errors="replace"))) for p in paths
+        )
+
+    if guards == 0:
+        raise ShapeError(
+            f"no `#[test]` file under {root}/tests/offline — this census would publish a "
+            f"harness with no guards in it, which is a bug in the scan, not a fact about the "
+            f"repo. Re-point it at wherever the offline suite moved to."
+        )
+    return {
+        "guards": {
+            "guard_files": guards,
+            "convention_cops": cops,
+            "subject_proven_non_empty": proven,
+            "subject_unproven": cops - proven,
+            "documents_only_tests": documents_only,
+            "files_declaring_blind_spots": blind,
+        },
+        # DECLARED, not executed: this job runs no cargo (it is meant to cost
+        # seconds), so it counts `#[test]` attributes rather than a runner's
+        # tally. The two differ by whatever is `cfg`-gated out of a given build
+        # — a trend, not an oracle, and named `*_declared` so nobody reads it as
+        # "the suite ran this many".
+        "tests": {
+            "offline_declared": declared(_rs_files(root, "tests/offline")),
+            "lib_declared": declared(_rs_files(root, "src")),
+        },
+    }
+
+
+# --------------------------------------------------------------------------
+# self-test
+# --------------------------------------------------------------------------
+
+_FIXTURE = {
+    "run": {"repo": "acme/rivet", "run_id": "42", "sha": "deadbeef", "event": "pull_request"},
+    "mutants": {
+        "state": "in-budget",
+        "reach": "measured",
+        "report_only_audit": "oracle-holds",
+        "in_scope": 42,
+        "excluded": 8,
+        "graded": 34,
+        "offline_reachable": 27,
+        "live_only": 7,
+        "caught": 25,
+        "missed": 2,
+        "unviable": 0,
+        "timeout": 0,
+    },
+    "guards": {
+        "guard_files": 40,
+        "convention_cops": 19,
+        "subject_proven_non_empty": 13,
+        "subject_unproven": 6,
+        "documents_only_tests": 6,
+        "files_declaring_blind_spots": 3,
+    },
+    "tests": {"offline_declared": 285, "lib_declared": 2674},
+}
+
+
+def self_test() -> int:
+    """Grade the pure shaping over fixtures, and the census over a fake tree.
+
+    RED-provable one mutant at a time:
+      * `as_count` returning 0 instead of None for an unset value — the whole
+        fail-open reading this script exists to refuse;
+      * `rate` dividing by a zero denominator (or returning 0.0 for it);
+      * dropping any consistency warning — the artifact stops showing that the
+        jobs feeding it disagree;
+      * `_block` accepting an unknown key — a metric silently dropped;
+      * `_uncommented` returning the text unchanged — a guard counted as a
+        convention cop because its DOC mentions a path;
+      * `census`'s `guards == 0` guard — an empty scan publishes an empty
+        harness instead of failing.
+    """
+    doc = shape(_FIXTURE)
+    assert doc["schema"] == SCHEMA, doc["schema"]
+    assert doc["warnings"] == [], doc["warnings"]
+    assert doc["mutants"]["missed"] == 2, doc["mutants"]
+    assert doc["derived"] == {
+        "missed_rate": round(2 / 27, 4),
+        "live_only_rate": round(7 / 34, 4),
+        "subject_proven_rate": round(13 / 19, 4),
+    }, doc["derived"]
+    assert "25 caught / 2 missed" in doc["summary"], doc["summary"]
+    assert "13 of 19 convention cops" in doc["summary"], doc["summary"]
+
+    # UNKNOWN IS NOT ZERO. A run whose mutation job never happened publishes
+    # nulls and `?`s; a trend chart must show a hole, not a clean sheet.
+    blank = {
+        "mutants": {k: "" for k in MUTANT_COUNTS + MUTANT_LABELS},
+        "guards": _FIXTURE["guards"],
+        "tests": _FIXTURE["tests"],
+    }
+    doc = shape(blank)
+    assert all(doc["mutants"][k] is None for k in MUTANT_COUNTS + MUTANT_LABELS), doc["mutants"]
+    assert doc["derived"]["missed_rate"] is None, doc["derived"]
+    assert doc["derived"]["live_only_rate"] is None, doc["derived"]
+    assert "? caught / ? missed" in doc["summary"], doc["summary"]
+    assert "[" not in doc["summary"], doc["summary"]  # no empty label bracket
+    assert doc["run"] == dict.fromkeys(RUN_LABELS), doc["run"]
+
+    # A zero denominator is the ordinary docs-only case, not a division error,
+    # and not a perfect score either.
+    zero = {
+        "mutants": {"in_scope": 0, "excluded": 0, "graded": 0, "caught": 0, "missed": 0},
+        "guards": {**_FIXTURE["guards"], "convention_cops": 0},
+        "tests": _FIXTURE["tests"],
+    }
+    doc = shape(zero)
+    assert doc["derived"] == {
+        "missed_rate": None,
+        "live_only_rate": None,
+        "subject_proven_rate": None,
+    }, doc["derived"]
+
+    # Numbers that contradict each other are REPORTED, never repaired.
+    doc = shape({**_FIXTURE, "mutants": {**_FIXTURE["mutants"], "graded": 30}})
+    assert len(doc["warnings"]) == 2, doc["warnings"]
+    assert "!= graded 30" in doc["warnings"][0], doc["warnings"]
+    doc = shape({**_FIXTURE, "guards": {**_FIXTURE["guards"], "subject_unproven": 5}})
+    assert any("double-counting" in w for w in doc["warnings"]), doc["warnings"]
+    doc = shape({**_FIXTURE, "mutants": {**_FIXTURE["mutants"], "caught": 99}})
+    assert any("were run than were classified" in w for w in doc["warnings"]), doc["warnings"]
+    doc = shape({**_FIXTURE, "mutants": {**_FIXTURE["mutants"], "missed": "banana"}})
+    assert doc["mutants"]["missed"] is None and any("not a count" in w for w in doc["warnings"]), (
+        doc["warnings"]
+    )
+
+    # Shapes this script must REFUSE rather than average over.
+    for broken in (
+        [],
+        {"mutants": {"missed_mutants": 1}},
+        {"guards": {"convention_cops": -1}},
+        {"mutants": {"caught": True}},
+        {"tests": []},
+    ):
+        try:
+            shape(broken)  # type: ignore[arg-type]
+        except ShapeError:
+            pass
+        else:
+            raise AssertionError(f"shape accepted that should not be: {broken}")
+
+    # The census, over a tree built for it: one guard proving its subject, one
+    # naming a path only in a COMMENT (not a cop), one helper with no `#[test]`.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "tests/offline").mkdir(parents=True)
+        (root / "src").mkdir(parents=True)
+        (root / "tests/offline/proven.rs").write_text(
+            '#[test]\nfn a() { let _ = super::nonvacuity::subject_text("docs/x.yaml"); }\n'
+        )
+        (root / "tests/offline/bare.rs").write_text(
+            '#[test]\nfn b() { std::fs::read_to_string("src/lib.rs").unwrap(); }\n'
+            "#[test]\nfn c_documents_the_wire() {}\n"
+        )
+        (root / "tests/offline/commentary.rs").write_text(
+            '//! Grades "docs/x.yaml" — in prose only.\n'
+            "//! WHAT THIS CANNOT SEE: the runner.\n"
+            "#[test]\nfn d() {}\n"
+        )
+        (root / "tests/offline/helper.rs").write_text("pub fn h() {}\n")
+        (root / "src/lib.rs").write_text("#[cfg(test)]\nmod t { #[test] fn e() {} }\n")
+        got = census(root)
+    assert got["guards"] == {
+        "guard_files": 3,
+        "convention_cops": 2,
+        "subject_proven_non_empty": 1,
+        "subject_unproven": 1,
+        "documents_only_tests": 1,
+        "files_declaring_blind_spots": 1,
+    }, got["guards"]
+    assert got["tests"] == {"offline_declared": 4, "lib_declared": 1}, got["tests"]
+    assert shape(got)["warnings"] == [], shape(got)["warnings"]
+
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            census(tmp)
+    except ShapeError:
+        pass
+    else:
+        raise AssertionError("an empty tree must not census as a harness with no guards")
+
+    print(
+        "self-test ok: shaping (full / unknown-is-null / zero-denominator / four consistency "
+        "warnings / five refused shapes) and the census (comment-stripped cops, proven "
+        "subjects, documents-only, blind spots, declared counts, empty-tree refusal)"
+    )
+    return 0
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def _arg(argv: list[str], flag: str, default: str | None = None) -> str | None:
+    return argv[argv.index(flag) + 1] if flag in argv else default
+
+
+def _emit(path: str | None, doc: dict) -> None:
+    text = json.dumps(doc, indent=2, sort_keys=False) + "\n"
+    if path in (None, "-"):
+        sys.stdout.write(text)
+    else:
+        Path(str(path)).write_text(text)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) == 2 and argv[1] == "--self-test":
+        return self_test()
+
+    cmd = argv[1] if len(argv) > 1 else ""
+    try:
+        if cmd == "census":
+            _emit(_arg(argv, "--out", "-"), census(_arg(argv, "--root", ".") or "."))
+            return 0
+
+        if cmd == "shape":
+            src = _arg(argv, "--in")
+            if not src:
+                print(__doc__, file=sys.stderr)
+                return 2
+            doc = shape(json.loads(Path(src).read_text()))
+            _emit(_arg(argv, "--out", "-"), doc)
+            print(doc["summary"])
+            return 0
+
+        if cmd == "emit":
+            raw = census(_arg(argv, "--root", ".") or ".")
+            raw["run"] = {
+                "repo": os.environ.get("GITHUB_REPOSITORY"),
+                "run_id": os.environ.get("GITHUB_RUN_ID"),
+                "sha": os.environ.get("GITHUB_SHA"),
+                "event": os.environ.get("GITHUB_EVENT_NAME"),
+                "ref": os.environ.get("GITHUB_REF_NAME"),
+            }
+            mutants: dict[str, str] = {}
+            for pair in argv[2:]:
+                if pair.startswith("--"):
+                    continue
+                if pair in (_arg(argv, "--root"), _arg(argv, "--out")):
+                    continue
+                key, _, value = pair.partition("=")
+                mutants[key] = value
+            raw["mutants"] = mutants
+            doc = shape(raw)
+            _emit(_arg(argv, "--out", "harness-metrics.json"), doc)
+            print(doc["summary"])
+            return 0
+    except (OSError, json.JSONDecodeError, ShapeError) as e:
+        # Loud and non-zero, but this job is non-blocking by construction: the
+        # thermometer breaking must be visible without holding a merge.
+        print(f"::error::harness metrics: {e}", file=sys.stderr)
+        return 1
+
+    print(__doc__, file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/scripts/mutants_classify.py
+++ b/.github/scripts/mutants_classify.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env python3
+"""Split a PR's mutants into the ones the offline suite CAN kill and the rest.
+
+The mutation PR gate used to spend one budget on one undifferentiated pile, and
+went quiet exactly where the risk was highest: past `MUTANTS_DIFF_BUDGET` it
+graded NOTHING (`over-budget-ungraded`), and inside the budget every MISSED
+mutant read the same whether it was an assertion gap or a body no offline test
+can reach. Measured on the 2026-08-21 refactor branch: 42 mutants in scope, 30
+minutes, 16 MISSED — of which exactly ONE was a real gap (a pure function whose
+whole-body stub would have let a FAILED run exit 0). The other 15 were live-only
+paths (a runner that opens a real source, a probe that takes a live connection)
+that `cargo mutants -- --lib --bins` cannot kill at all. Fifteen unkillable
+misses is how the one real finding gets ignored.
+
+So this script PRIORITISES instead of budgeting, on a MEASURED signal rather
+than a claim:
+
+  P1  the mutant's line sits inside a function the offline test suite EXECUTES
+      (llvm-cov counted it). A test ran this code and did not notice the
+      mutation — an assertion gap in the diff, which is what the gate is for.
+      P1 is graded first and its verdict BLOCKS.
+
+  P2  the mutant's line sits inside a function llvm-cov measured at ZERO
+      executions under `--lib --bins`. No offline assertion can kill it (the
+      "--lib on a live-only path" reading of the scope-honesty rule in
+      CLAUDE.md: read a survivor as "no UNIT test executes this", not "N gaps").
+      P2 is REPORTED, with the `.cargo/mutants.toml` vocabulary to triage it —
+      an `exclude_re` entry carrying a live-oracle proof, or a unit oracle that
+      moves the function into P1.
+
+Everything else is P1. A function absent from the coverage export, a file the
+export does not mention, an unparseable or shape-changed report, no report at
+all: all fail CLOSED, to today's behaviour (grade it, and a miss is red). The
+weakening this split could have introduced — "it wasn't covered, so it does not
+count" — is available only for a function coverage OBSERVED at zero, and only
+because no offline test could have killed it whatever the gate did.
+
+Note the granularity: FUNCTION, not line. A never-executed BRANCH inside an
+executed function stays P1, because a test can reach it — "you added a path and
+tested none of it" is the gate's core finding and must keep failing. Function
+extents also match the vocabulary `.cargo/mutants.toml` already triages in
+(`"replace run_pool -> Result"`), so a P2 report is one paste from a reviewable
+exclusion.
+
+Usage:
+  mutants_classify.py reach <llvm-cov.json> <extents.tsv>
+        Convert `cargo llvm-cov --lib --bins --json` into the compact
+        `file<TAB>start_line<TAB>end_line<TAB>count` extents the partition
+        reads. Exits 1 (loudly) on any shape it does not recognise — an
+        unrecognised report must not arrive as "nothing is covered", which
+        would move the whole diff into P2.
+
+  mutants_classify.py partition <mutant-list> [--extents <tsv>]
+                      --p1 <f> --p2 <f> --drop-p1 <f> --drop-p2 <f>
+        <mutant-list> is `cargo mutants --in-diff pr.diff --list`. Writes the
+        two classes, plus the `--exclude-re` regexes that remove each class
+        from a cargo-mutants run. Without `--extents`, everything is P1.
+
+  mutants_classify.py verify <expected-p1> <actual-list>
+        Set equality between the P1 class and what cargo-mutants ACTUALLY
+        listed once the P2 exclusions were applied. The regexes are generated,
+        so their reach is checked rather than assumed — an over-broad exclusion
+        silently un-grading P1 mutants is the exact defect
+        `mutants_exclusions.py` exists to catch in the hand-written list.
+
+  mutants_classify.py --states     the state vocabulary, one per line
+  mutants_classify.py --self-test
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+# ONE mutant-name parser for the whole gate. `mutants_exclusions.py` already
+# owns it (a mutant is `<path>:<line>:<col>: <description>`), and a second copy
+# here would be a twin that drifts — the class this repo keeps paying for.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from mutants_exclusions import _plain as strip_ansi  # noqa: E402
+
+# The vocabulary this script's callers publish. `.github/workflows/ci.yml` must
+# handle every one of them; `tests/offline/mutation_gate_priority_guard.rs`
+# DERIVES the list from here rather than re-typing it, so a new state cannot be
+# added without the workflow learning it.
+REACH_STATES = ["measured", "unmeasured", "unverified"]
+P2_AUDIT_STATES = ["oracle-holds", "oracle-lied", "skipped-over-budget"]
+
+_EXPORT_TYPE = "llvm.coverage.json.export"
+
+
+class ShapeError(Exception):
+    """The coverage report is not the shape this script knows how to read.
+
+    Raised, never swallowed: an unreadable report has to reach the operator as
+    "the prioritisation did not run" (whereupon everything is graded, as
+    before), not as an empty coverage set — which would read as "no function is
+    executed" and move the entire diff into the report-only class.
+    """
+
+
+def function_extents(cov: dict, root: str = "") -> list[tuple[str, int, int, int]]:
+    """`(file, start_line, end_line, exec_count)` per function in an llvm-cov export.
+
+    Verified against a real `cargo llvm-cov --lib --bins --json` (format
+    `llvm.coverage.json.export` 3.0.1, cargo-llvm-cov 0.9.0) rather than
+    assumed: `data[0].functions[]` carries `count` (executions of that
+    instantiation), `filenames` and `regions`, each region
+    `[start_line, start_col, end_line, end_col, count, file_id, ...]`. Names are
+    v0-MANGLED in this export (`_RNvMCs..3Gov7observe`), which is why the lookup
+    is by LINE EXTENT and not by name: nothing here has to demangle, and the
+    `Type::method` / generic / closure naming that trips the exclusion patterns
+    cannot trip this.
+
+    Generic functions appear once per instantiation and closures nest inside
+    their parent's extent; the caller takes the MAX count over every extent
+    containing a line, so both fail toward P1 (graded).
+    """
+    if cov.get("type") != _EXPORT_TYPE:
+        raise ShapeError(f"expected type {_EXPORT_TYPE!r}, got {cov.get('type')!r}")
+    data = cov.get("data")
+    if not isinstance(data, list) or not data:
+        raise ShapeError("`data` is missing or empty")
+    funcs = data[0].get("functions")
+    if not isinstance(funcs, list):
+        raise ShapeError("`data[0].functions` is missing — was --summary-only passed?")
+
+    out: list[tuple[str, int, int, int]] = []
+    for fn in funcs:
+        try:
+            count = int(fn["count"])
+            names = list(fn["filenames"])
+            regions = list(fn["regions"])
+        except (KeyError, TypeError, ValueError) as e:
+            raise ShapeError(f"function record without count/filenames/regions: {e}") from None
+        # A function's regions may span several files (macro expansions), so the
+        # extent is taken per file_id rather than collapsed onto filenames[0].
+        per_file: dict[str, tuple[int, int]] = {}
+        for r in regions:
+            if not isinstance(r, list) or len(r) < 6:
+                raise ShapeError(f"region tuple too short: {r!r}")
+            start, end, file_id = int(r[0]), int(r[2]), int(r[5])
+            if file_id >= len(names):
+                raise ShapeError(f"region file_id {file_id} outside filenames {names!r}")
+            f = names[file_id]
+            lo, hi = per_file.get(f, (start, end))
+            per_file[f] = (min(lo, start), max(hi, end))
+        for f, (lo, hi) in per_file.items():
+            out.append((_relative(f, root), lo, hi, count))
+    if not out:
+        raise ShapeError("the export contains no function records at all")
+    return out
+
+
+def _relative(path: str, root: str) -> str:
+    """Coverage paths are absolute; mutant names are repo-relative."""
+    if root and path.startswith(root.rstrip("/") + "/"):
+        return path[len(root.rstrip("/")) + 1 :]
+    return path
+
+
+def load_extents(lines: list[str]) -> dict[str, list[tuple[int, int, int]]]:
+    """The extents TSV back into `{file: [(start, end, count), …]}`."""
+    by_file: dict[str, list[tuple[int, int, int]]] = {}
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        f, lo, hi, count = line.split("\t")
+        by_file.setdefault(f, []).append((int(lo), int(hi), int(count)))
+    return by_file
+
+
+def site_line(name: str) -> tuple[str, int] | None:
+    """`(file, line)` of a mutant, or None when the name is not that shape."""
+    parts = strip_ansi(name).split(":", 3)
+    if len(parts) < 3:
+        return None
+    try:
+        return parts[0], int(parts[1])
+    except ValueError:
+        return None
+
+
+def partition(
+    mutants: list[str], extents: dict[str, list[tuple[int, int, int]]] | None
+) -> tuple[list[str], list[str]]:
+    """(P1, P2) — graded-and-blocking, and reported-only.
+
+    A mutant is P2 only on POSITIVE evidence: a function extent in the same file
+    contains its line, and every such extent was measured at zero executions.
+    No extents at all (`extents is None`), no extent for the file, no extent
+    containing the line, an unparseable name — all P1. Every one of those is a
+    case where the gate does not KNOW, and not knowing must not buy a mutant its
+    way out of being graded.
+    """
+    if extents is None:
+        return list(mutants), []
+    p1: list[str] = []
+    p2: list[str] = []
+    for name in mutants:
+        site = site_line(name)
+        if site is None:
+            p1.append(name)
+            continue
+        f, line = site
+        containing = [c for (lo, hi, c) in extents.get(f, []) if lo <= line <= hi]
+        if containing and max(containing) == 0:
+            p2.append(name)
+        else:
+            p1.append(name)
+    return p1, p2
+
+
+def exclusion_regexes(mutants: list[str]) -> list[str]:
+    """`--exclude-re` patterns that remove EXACTLY these mutants and no others.
+
+    cargo-mutants matches `--exclude-re` against the full name — verified on
+    cargo-mutants 27.1.0: `^src/tuning/adaptive.rs:34:5: replace … with 0$`
+    removes that one mutant and leaves its line-mates. So each pattern is the
+    anchored, regex-ESCAPED whole name: a mutant description carries `->`, `*`,
+    `+`, `(`, `[` and `.`, and an unescaped one is the over-broad exclusion this
+    gate's other half (`mutants_exclusions.py`) exists to catch. The reach of
+    the generated set is not trusted either — `verify` re-lists the corpus with
+    them applied and demands the remainder is exactly P1.
+    """
+    return ["^" + re.escape(strip_ansi(n).strip()) + "$" for n in mutants]
+
+
+def verify(expected: list[str], actual: list[str]) -> list[str]:
+    """Errors when the post-exclusion listing is not exactly the expected class."""
+    want = {strip_ansi(n).strip() for n in expected if n.strip()}
+    got = {strip_ansi(n).strip() for n in actual if n.strip()}
+    errors = []
+    if want - got:
+        sample = "\n  ".join(sorted(want - got)[:5])
+        errors.append(
+            f"::error::the generated exclusions removed {len(want - got)} mutant(s) that "
+            "belong to the GRADED class — an over-broad pattern is un-grading code the gate "
+            f"is supposed to block on:\n  {sample}"
+        )
+    if got - want:
+        sample = "\n  ".join(sorted(got - want)[:5])
+        errors.append(
+            f"::error::{len(got - want)} mutant(s) survived the exclusions that were meant to "
+            "be deprioritised — the restriction did not take, so the run below would not be "
+            f"the class it reports:\n  {sample}"
+        )
+    return errors
+
+
+# --------------------------------------------------------------------------
+# Self-test. Every case below is RED-provable against ONE mutant in this file;
+# the mutant is named in the assertion's comment.
+# --------------------------------------------------------------------------
+
+# The shape a real `cargo llvm-cov --lib --bins --json` emits, reduced to the
+# four records that matter: a called free function, a called method, an
+# UNCALLED method, and a function in another file. Copied from a live probe run
+# (cargo-llvm-cov 0.9.0, export 3.0.1), not invented — an invented fixture would
+# make this an oracle of itself.
+_COV = {
+    "type": _EXPORT_TYPE,
+    "version": "3.0.1",
+    "data": [
+        {
+            "functions": [
+                {
+                    "name": "_RNvCs_8covprobe12plain_called",
+                    "count": 7,
+                    "filenames": ["/repo/src/lib.rs"],
+                    "regions": [[7, 41, 7, 55, 7, 0, 0, 0]],
+                },
+                {
+                    "name": "_RNvMCs_8covprobeNtB2_3Gov7observe",
+                    "count": 3,
+                    "filenames": ["/repo/src/lib.rs"],
+                    "regions": [[10, 5, 14, 6, 3, 0, 0, 0]],
+                },
+                {
+                    # A CLOSURE inside `observe`: llvm-cov emits it as its own
+                    # record, nested in its parent's extent and counted
+                    # separately. It makes the "max over every containing
+                    # extent" rule observable — with `min` the executed parent
+                    # would be judged by its unexecuted closure and every mutant
+                    # between lines 11 and 13 would fall out of the graded class.
+                    "name": "_RNvXNvMCs_8covprobeNtB2_3Gov7observe0Bb_",
+                    "count": 0,
+                    "filenames": ["/repo/src/lib.rs"],
+                    "regions": [[11, 9, 13, 10, 0, 0, 0, 0]],
+                },
+                {
+                    "name": "_RNvMCs_8covprobeNtB2_3Gov12never_called",
+                    "count": 0,
+                    "filenames": ["/repo/src/lib.rs"],
+                    "regions": [[20, 5, 26, 6, 0, 0, 0, 0]],
+                },
+                {
+                    "name": "_RNvNtCs_8covprobe5inner13in_other_file",
+                    "count": 1,
+                    "filenames": ["/repo/src/inner.rs"],
+                    "regions": [[1, 1, 3, 2, 1, 0, 0, 0]],
+                },
+            ]
+        }
+    ],
+}
+
+
+def self_test() -> int:
+    """Grade the classifier over the shapes it must judge.
+
+    RED-provable one mutant at a time:
+      * `partition`'s `extents is None` arm returning `([], mutants)` — the
+        no-coverage case stops being graded;
+      * `containing and max(containing) == 0` widened to `not containing or
+        max(...) == 0` — an UNMEASURED site buys its way into the report-only
+        class, which is the whole weakening this split must not have;
+      * `max(containing)` -> `min(containing)` — a closure inside an executed
+        function drops out of the graded class;
+      * dropping `re.escape` in `exclusion_regexes` — the pattern for a
+        `with vec![]` stub stops being a valid regex at all (unterminated
+        character set), which is what an unescaped generated pattern does to a
+        corpus full of `->`, `*`, `+`, `(` and `[`;
+      * `function_extents` returning `[]` instead of raising on a shape it does
+        not know — an unreadable report reads as "nothing is covered".
+    """
+    extents_rows = function_extents(_COV, root="/repo")
+    ext = load_extents([f"{f}\t{lo}\t{hi}\t{c}" for (f, lo, hi, c) in extents_rows])
+    assert ext["src/lib.rs"] == [(7, 7, 7), (10, 14, 3), (11, 13, 0), (20, 26, 0)], ext
+    assert ext["src/inner.rs"] == [(1, 3, 1)], ext
+
+    mutants = [
+        # inside an EXECUTED function -> graded
+        "src/lib.rs:7:41: replace plain_called -> usize with 0",
+        # a never-taken BRANCH inside an executed function is still graded: a
+        # test can reach it, and "you added a path and tested none of it" is the
+        # finding this gate exists for. This line also sits inside an UNEXECUTED
+        # closure record nested in the executed parent, so it is the case that
+        # distinguishes max-over-containing-extents from min.
+        "src/lib.rs:12:9: replace < with <= in Gov::observe",
+        # inside a function measured at ZERO executions -> report-only
+        "src/lib.rs:21:9: replace Gov::never_called -> usize with 0",
+        # a file the export never mentions -> graded (the gate does not know)
+        "src/pipeline/run.rs:99:1: replace run_pool -> Result<()> with Ok(())",
+        # a line no extent covers -> graded, same reason
+        "src/lib.rs:999:1: replace parsed_but_uncovered -> usize with 0",
+        # an unparseable name -> graded
+        "not a mutant name at all",
+    ]
+    p1, p2 = partition(mutants, ext)
+    assert p2 == ["src/lib.rs:21:9: replace Gov::never_called -> usize with 0"], p2
+    assert len(p1) == 5, p1
+    assert "src/lib.rs:12:9: replace < with <= in Gov::observe" in p1, p1
+    assert "src/pipeline/run.rs:99:1: replace run_pool -> Result<()> with Ok(())" in p1, p1
+
+    # No coverage at all: everything is graded, exactly as before this script.
+    p1, p2 = partition(mutants, None)
+    assert (p1, p2) == (mutants, []), (p1, p2)
+
+    # Generated exclusions are exact: each removes its own mutant and nothing
+    # else, over a corpus whose names differ only in the trailing literal.
+    # `vec![]` is in the corpus deliberately: cargo-mutants writes that literal
+    # for every `-> Vec<_>` stub (`replace introspect_all -> Result<Vec<TableInfo>>`
+    # and friends live in .cargo/mutants.toml today), and UNESCAPED it is an
+    # unterminated character set — an invalid regex, not a wrong one. Without
+    # `re.escape` this loop raises instead of asserting, which is the point:
+    # generated patterns are matched against names full of `->`, `*`, `+`, `(`
+    # and `[`.
+    corpus = [
+        "src/lib.rs:7:41: replace plain_called -> usize with 0",
+        "src/lib.rs:7:41: replace plain_called -> usize with 1",
+        "src/lib.rs:21:9: replace Gov::never_called -> usize with 0",
+        "src/init/mod.rs:31:1: replace introspect_all -> Result<Vec<T>> with Ok(vec![])",
+    ]
+    for pat, target in zip(exclusion_regexes(corpus), corpus, strict=True):
+        hits = [n for n in corpus if re.search(pat, n)]
+        assert hits == [target], (pat, hits)
+
+    # …and the verification catches both directions of a restriction that did
+    # not take. (An exclusion may only ever REMOVE, so `got - want` is the
+    # "nothing was excluded" case and `want - got` the over-broad one.)
+    assert not verify(corpus, corpus)
+    errs = verify(corpus, corpus[:1])
+    assert errs and "belong to the GRADED class" in errs[0], errs
+    errs = verify(corpus[:1], corpus)
+    assert errs and "survived the exclusions" in errs[0], errs
+
+    # A report shape this script does not know is an ERROR, never an empty
+    # coverage set — the difference between "the prioritisation did not run"
+    # and "no function in this crate is executed".
+    for broken in (
+        {"type": "something.else", "data": [{"functions": []}]},
+        {"type": _EXPORT_TYPE, "data": []},
+        {"type": _EXPORT_TYPE, "data": [{}]},
+        {"type": _EXPORT_TYPE, "data": [{"functions": [{"count": 1}]}]},
+        {
+            "type": _EXPORT_TYPE,
+            "data": [
+                {"functions": [{"count": 1, "filenames": ["/repo/a.rs"], "regions": [[1, 2]]}]}
+            ],
+        },
+        {
+            "type": _EXPORT_TYPE,
+            "data": [
+                {
+                    "functions": [
+                        {"count": 1, "filenames": ["/repo/a.rs"], "regions": [[1, 1, 2, 1, 1, 9]]}
+                    ]
+                }
+            ],
+        },
+        {"type": _EXPORT_TYPE, "data": [{"functions": []}]},
+    ):
+        try:
+            function_extents(broken, root="/repo")
+        except ShapeError:
+            pass
+        else:
+            raise AssertionError(f"shape accepted that should not be: {broken}")
+
+    print(
+        "self-test ok: executed / zero-coverage / unmeasured-file / uncovered-line / "
+        "unparseable classification, the no-coverage fallback, exact exclusions, "
+        "both verify directions, and six rejected report shapes"
+    )
+    return 0
+
+
+def _write(path: str | None, lines: list[str]) -> None:
+    if path:
+        Path(path).write_text("".join(f"{line}\n" for line in lines))
+
+
+def _arg(argv: list[str], flag: str) -> str | None:
+    return argv[argv.index(flag) + 1] if flag in argv else None
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) == 2 and argv[1] == "--self-test":
+        return self_test()
+    if len(argv) == 2 and argv[1] == "--states":
+        for state in REACH_STATES + P2_AUDIT_STATES:
+            print(state)
+        return 0
+
+    if len(argv) >= 2 and argv[1] == "reach":
+        if len(argv) != 4:
+            print(__doc__, file=sys.stderr)
+            return 2
+        try:
+            cov = json.loads(Path(argv[2]).read_text())
+            rows = function_extents(cov, root=str(Path.cwd()))
+        except (OSError, json.JSONDecodeError, ShapeError) as e:
+            print(
+                f"::error::cannot read the coverage export {argv[2]}: {e}. The mutation gate "
+                "will fall back to grading EVERY in-diff mutant (its behaviour before "
+                "prioritisation) rather than treat an unreadable report as 'nothing is "
+                "covered', which would move the whole diff into the report-only class.",
+                file=sys.stderr,
+            )
+            return 1
+        Path(argv[3]).write_text("".join(f"{f}\t{lo}\t{hi}\t{c}\n" for (f, lo, hi, c) in rows))
+        covered = sum(1 for *_, c in rows if c > 0)
+        print(f"{len(rows)} function extents, {covered} executed by the offline suite")
+        return 0
+
+    if len(argv) >= 2 and argv[1] == "partition":
+        if len(argv) < 3:
+            print(__doc__, file=sys.stderr)
+            return 2
+        mutants = [
+            strip_ansi(line).strip()
+            for line in Path(argv[2]).read_text().splitlines()
+            if strip_ansi(line).strip()
+        ]
+        extents_path = _arg(argv, "--extents")
+        extents = None
+        if extents_path:
+            extents = load_extents(Path(extents_path).read_text().splitlines())
+        p1, p2 = partition(mutants, extents)
+        _write(_arg(argv, "--p1"), p1)
+        _write(_arg(argv, "--p2"), p2)
+        _write(_arg(argv, "--drop-p1"), exclusion_regexes(p1))
+        _write(_arg(argv, "--drop-p2"), exclusion_regexes(p2))
+        reach = "measured" if extents is not None else "unmeasured"
+        print(f"reach={reach} p1={len(p1)} p2={len(p2)}")
+        for name in p2:
+            print(f"  report-only (offline coverage 0): {name}")
+        return 0
+
+    if len(argv) == 4 and argv[1] == "verify":
+        expected = Path(argv[2]).read_text().splitlines()
+        actual = Path(argv[3]).read_text().splitlines()
+        errors = verify(expected, actual)
+        for line in errors:
+            print(line)
+        return 1 if errors else 0
+
+    print(__doc__, file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,13 @@ jobs:
       p1: ${{ steps.mutate.outputs.p1 }}
       p2: ${{ steps.mutate.outputs.p2 }}
       p2_audit: ${{ steps.mutate.outputs.p2_audit }}
+      # The run's tally, for the non-blocking `harness-metrics` job only. These
+      # are the ONLY outputs here nothing asserts on: a thermometer, published
+      # beside the evidence rather than instead of it.
+      caught: ${{ steps.mutate.outputs.caught }}
+      missed: ${{ steps.mutate.outputs.missed }}
+      timeout: ${{ steps.mutate.outputs.timeout }}
+      unviable: ${{ steps.mutate.outputs.unviable }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -514,6 +521,18 @@ jobs:
           rc=0
           cargo mutants --in-diff pr.diff ${DROP_P2[@]+"${DROP_P2[@]}"} -j 2 -- --lib --bins || rc=$?
           verdict "$rc"
+          # The run's own tally, published for the harness-metrics THERMOMETER
+          # (see the `harness-metrics` job). Nothing gates on these; they exist
+          # so a human can read a trend instead of re-deriving it from forty
+          # log lines. Absent files stay ABSENT — an unset output is `null` in
+          # the artifact, never 0, because "the run never happened" and "nothing
+          # was missed" must not look alike on a chart.
+          for class in caught missed timeout unviable; do
+            f="mutants.out/$class.txt"
+            if [ -f "$f" ]; then
+              say "$class" "$(grep -c . "$f" || true)"
+            fi
+          done
           # THE REPORT-ONLY CLASS IS ITSELF AUDITED, whenever the budget stretches
           # to it. "These mutants cannot be killed offline" is a claim, and the
           # one thing that can falsify it is running them: if the offline suite
@@ -590,6 +609,10 @@ jobs:
       expected_state: ${{ steps.coverage.outputs.expected_state || steps.scope.outputs.expected_state }}
       graded: ${{ steps.graded.outputs.graded }}
       untiered: ${{ steps.coverage.outputs.untiered }}
+      # Thermometer only (the `harness-metrics` job): the in-diff corpus before
+      # .cargo/mutants.toml, and how much of it the exclusions removed.
+      in_scope: ${{ steps.graded.outputs.in_scope }}
+      excluded: ${{ steps.graded.outputs.excluded }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -684,6 +707,12 @@ jobs:
           all=$(grep -c . diff-all.txt || true)
           graded=$(grep -c . diff-graded.txt || true)
           echo "graded=$graded" >> "$GITHUB_OUTPUT"
+          # The corpus BEFORE .cargo/mutants.toml, and what it removed — the
+          # only place in this workflow that knows either. Published for the
+          # non-blocking `harness-metrics` job so "how much of each diff does
+          # the exclusion list eat?" is a trend line rather than an argument.
+          echo "in_scope=$all" >> "$GITHUB_OUTPUT"
+          echo "excluded=$((all - graded))" >> "$GITHUB_OUTPUT"
           if [ "$all" -eq 0 ]; then
             echo "::notice::this diff changes no mutable source line — zero mutants is correct here."
             exit 0
@@ -933,6 +962,69 @@ jobs:
           fi
           echo "ok: audit and run agree on '$STATE'; the run's verdict is '${RESULT:-n/a}' over ${P1:-$COUNT} graded / ${P2:-0} reported mutants (reach='${REACH:-n/a}', report-only audit '${P2_AUDIT:-n/a}')."
 
+  # A THERMOMETER for the harness itself — the one job here that grades nothing.
+  #
+  # Every gate above measures the product, or a gate that measures the product.
+  # Nothing measured the HARNESS: how many convention-cop guards there are, how
+  # many of them prove their subject exists (tests/offline/nonvacuity.rs), how
+  # much of each diff the exclusion list eats, how the offline-reachable and
+  # live-only mutant classes are moving, how many tests declare themselves
+  # documentation rather than verification. Those numbers are knowable and
+  # nobody was writing them down, so a guard could rot for months with every
+  # signal a reader has still reading green (three did — see nonvacuity.rs).
+  #
+  # It is deliberately NOT a gate, and the shape of the job says so: no
+  # threshold, no `needs:` from anything, `continue-on-error` on top of an
+  # `if: always()`, and no toolchain — checkout plus python3, seconds. A metric
+  # with teeth becomes a number people MANAGE (pad the cop count, name a test
+  # `_documents_` to duck a red); a metric a human reads once a month is a
+  # trend. `tests/offline/harness_metrics_guard.rs` asserts that it stays that
+  # way, and grades the emitter's pure shaping from a fixture of counts.
+  harness-metrics:
+    name: Harness self-metrics (trend, not a gate)
+    runs-on: ubuntu-latest
+    needs: [mutants-in-diff, mutants-gate-sanity]
+    # `always()`: the interesting runs are exactly the ones where a job above
+    # ended badly, and a thermometer that only reports on healthy runs draws a
+    # flat line through every incident.
+    if: always()
+    continue-on-error: true
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      # Unset inputs are passed through as EMPTY, and the emitter records an
+      # empty count as `null` — never 0. A docs-only PR, a skipped mutation job
+      # or a timed-out one must leave a HOLE in the trend, because "0 missed"
+      # and "nothing ran" are opposite readings of the same chart.
+      - name: Emit this run's harness metrics
+        id: emit
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/harness_metrics.py emit --out harness-metrics.json \
+            state='${{ needs.mutants-in-diff.outputs.state }}' \
+            reach='${{ needs.mutants-in-diff.outputs.reach }}' \
+            report_only_audit='${{ needs.mutants-in-diff.outputs.p2_audit }}' \
+            in_scope='${{ needs.mutants-gate-sanity.outputs.in_scope }}' \
+            excluded='${{ needs.mutants-gate-sanity.outputs.excluded }}' \
+            graded='${{ needs.mutants-gate-sanity.outputs.graded }}' \
+            offline_reachable='${{ needs.mutants-in-diff.outputs.p1 }}' \
+            live_only='${{ needs.mutants-in-diff.outputs.p2 }}' \
+            caught='${{ needs.mutants-in-diff.outputs.caught }}' \
+            missed='${{ needs.mutants-in-diff.outputs.missed }}' \
+            unviable='${{ needs.mutants-in-diff.outputs.unviable }}' \
+            timeout='${{ needs.mutants-in-diff.outputs.timeout }}' \
+            | tee summary.txt
+          # …and into the run's UI, where a human actually passes by. The line
+          # is read back off the artifact's own `summary` field by the emitter,
+          # so the log and the JSON cannot drift.
+          echo "::notice::$(cat summary.txt)"
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: harness-metrics
+          path: harness-metrics.json
+          if-no-files-found: warn
+
   # The gate's own scripts, graded. Seconds, no toolchain. Each `selftest` is a
   # unit check of the parser or coercion the gate depends on; `check` grades the
   # nightly rotation itself (a tier naming a moved file, an arm that tiers no
@@ -965,6 +1057,14 @@ jobs:
       # wasn't covered, so it doesn't count".
       - name: The mutant prioritiser fails closed
         run: python3 .github/scripts/mutants_classify.py --self-test
+      # The harness thermometer's SHAPING, over fixtures of counts: an unknown
+      # count must publish as null and never 0, a rate over an unknown or a zero
+      # denominator must be null, contradictory inputs must be reported rather
+      # than repaired, and the census must refuse to describe an empty tree as a
+      # harness with no guards. No gate rides on the numbers; the numbers still
+      # have to be true.
+      - name: The harness metrics say `unknown`, not `zero`
+        run: python3 .github/scripts/harness_metrics.py --self-test
       # `--self-test` returns before any stage, container or binary is touched —
       # it grades the argv/env coercion only, so this invocation needs no
       # RIVET_PREV_RELEASE_BIN and is not a gate run (cf. the Makefile-scoped

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  # How many in-diff mutants the 90-minute `mutants-in-diff` budget can grade
+  # How many in-diff mutants the `mutants-in-diff` budget can grade
   # (~80s each at -j2 on a 2-core runner). ONE definition, read by both the job
   # that spends the budget and the blocking `mutants-gate-sanity` job that
   # audits what the budget skipped — two copies of this number are two gates
@@ -185,14 +185,29 @@ jobs:
   # own diff = your new code has an assertion gap — fail here, in minutes,
   # instead of surfacing in the nightly tier runs. Equivalent mutants are
   # excluded via .cargo/mutants.toml (with reasons).
+  #
+  # Since 2026-08-21 the mutants are PRIORITISED before they are budgeted: the
+  # ones in code the offline suite is measured to EXECUTE are graded first and
+  # block, the ones in functions measured at ZERO offline executions are
+  # reported. Two things that used to be one signal, because they are two
+  # findings — "a test ran this and did not notice" is your assertion gap;
+  # "nothing offline runs this at all" is a triage question for
+  # .cargo/mutants.toml. See the reach step below for the measurement and the
+  # partition comment for what the split may and may not excuse.
   mutants-in-diff:
     name: Mutants (changed lines)
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     # First live run: 52 mutants took 42m on the 2-core runner (cold baseline
     # build 270s + ~80s/mutant) — 45m was one flaky rebuild away from a
-    # spurious timeout on a large PR.
-    timeout-minutes: 90
+    # spurious timeout on a large PR. Raised 90 -> 120 when the offline-REACH
+    # measurement was added below: it takes an instrumented build plus one
+    # `--lib --bins` run (capped at 25m of its own), and the grading capacity
+    # $MUTANTS_DIFF_BUDGET describes has to survive that. It usually PAYS for
+    # itself — every live-only mutant it deprioritises is ~90s not spent — but
+    # a diff that is fully offline-reachable pays the measurement for nothing,
+    # so the ceiling absorbs it rather than the budget.
+    timeout-minutes: 120
     # Advisory, not blocking: a foundational-module PR (e.g. the ~3k-line
     # `src/load` layer = ~400 in-diff mutants) can't finish inside the per-diff
     # budget — killing mutants doesn't help, the run is just too large. The
@@ -216,6 +231,20 @@ jobs:
       sub: ${{ steps.mutate.outputs.sub }}
       count: ${{ steps.mutate.outputs.count }}
       outcome: ${{ steps.report.outputs.outcome }}
+      # The PRIORITISATION's evidence, published for the same reason as the
+      # rest: this job cannot fail, so what it decided has to be readable from
+      # outside. `reach` is whether the offline-coverage measurement produced a
+      # usable answer (measured / unmeasured / unverified); `p1` is how many
+      # in-diff mutants sit in code the offline suite EXECUTES (graded, and
+      # blocking); `p2` how many sit in functions measured at zero executions
+      # (reported); `p2_audit` what happened when the report-only class was
+      # itself graded — `oracle-lied` means the offline suite CAUGHT one of
+      # them, i.e. the classification was wrong and the report-only class is
+      # not safe.
+      reach: ${{ steps.mutate.outputs.reach }}
+      p1: ${{ steps.mutate.outputs.p1 }}
+      p2: ${{ steps.mutate.outputs.p2 }}
+      p2_audit: ${{ steps.mutate.outputs.p2_audit }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -271,6 +300,46 @@ jobs:
       - name: Install cargo-mutants
         if: steps.scope.outputs.code == 'true'
         run: cargo install cargo-mutants --locked
+      # WHAT CAN THE OFFLINE SUITE EVEN REACH? Measured once, so the run below
+      # can spend its budget on mutants it is able to kill.
+      #
+      # The gate used to grade one undifferentiated pile and went quiet exactly
+      # where the risk is highest: past the budget it graded NOTHING, and inside
+      # it every MISSED mutant read alike. Measured on the 2026-08-21 refactor
+      # branch: 42 mutants, 30 minutes, 16 missed — of which ONE was a real gap
+      # (a pure function whose whole-body stub would have let a FAILED run exit
+      # 0) and 15 were live-only bodies `cargo mutants -- --lib --bins` cannot
+      # kill at all. Fifteen unkillable misses is how the one real finding gets
+      # ignored, and it is the same "--lib on a live-only path" scope-honesty
+      # reading CLAUDE.md already insists on: read a survivor as "no UNIT test
+      # executes this", not as N gaps.
+      #
+      # `--lib --bins` here is not a detail: it must be the SAME test scope the
+      # mutation run uses (`cargo mutants … -- --lib --bins`), or the coverage
+      # would describe a different suite from the one doing the killing.
+      #
+      # continue-on-error + a step timeout, deliberately: this measurement is a
+      # REFINEMENT, never a precondition. If cargo-llvm-cov fails to install,
+      # the build breaks, or the run outlasts its 25 minutes, `fn-extents.tsv`
+      # is absent, the classifier is told nothing, and every in-diff mutant is
+      # graded strictly — this gate's behaviour before prioritisation existed.
+      # The one thing that must never happen is an unreadable report arriving as
+      # "no function is covered", which would move a whole diff into the
+      # report-only class; `mutants_classify.py reach` fails loudly on any shape
+      # it does not recognise rather than emit an empty answer.
+      - name: Measure what the offline suite reaches
+        id: reach
+        if: steps.scope.outputs.code == 'true'
+        continue-on-error: true
+        timeout-minutes: 25
+        env:
+          CARGO_PROFILE_DEV_DEBUG: "0"
+        run: |
+          set -euo pipefail
+          rustup component add llvm-tools-preview
+          cargo install cargo-llvm-cov --locked
+          cargo llvm-cov --lib --bins --json --output-path cov.json
+          python3 .github/scripts/mutants_classify.py reach cov.json fn-extents.tsv
       - name: Mutate the PR diff
         id: mutate
         if: steps.scope.outputs.code == 'true'
@@ -320,7 +389,7 @@ jobs:
           }
           git diff "origin/$BASE_REF"...HEAD > pr.diff
           # BUDGET GUARD. Every mutant is its own incremental build — ~80s on a
-          # 2-core runner at -j2, so the 90-minute ceiling grades roughly 120
+          # 2-core runner at -j2, so the job's ceiling grades roughly 120
           # ($MUTANTS_DIFF_BUDGET). A five-round branch like #230 yields 416
           # (158 run.rs, 104 pool.rs, 44 adaptive.rs, ...) ≈ 4.6 h: the job dies
           # at the ceiling having graded a fraction of the diff and reported
@@ -346,7 +415,63 @@ jobs:
           list_into diff-list.txt
           COUNT=$(grep -c . diff-list.txt || true)
           say count "$COUNT"
-          if [ "$COUNT" -gt "$MUTANTS_DIFF_BUDGET" ]; then
+          # PRIORITISE, then budget — they are not the same decision, and doing
+          # only the second is what made this gate useless on the diffs that
+          # need it most. Every in-diff mutant is put in one of two classes on
+          # MEASURED evidence (see the reach step above):
+          #
+          #   P1  its line is inside a function llvm-cov saw EXECUTE under
+          #       `--lib --bins`. A test ran this code and did not notice the
+          #       mutation: an assertion gap in this diff. Graded first, and its
+          #       verdict is what this job reports.
+          #   P2  its line is inside a function measured at ZERO executions. No
+          #       offline assertion can kill it, so failing on it teaches people
+          #       to pad diffs or stop touching live-only files. Reported, in
+          #       the vocabulary .cargo/mutants.toml already triages in.
+          #
+          # Everything the classifier does not KNOW — no measurement, a file the
+          # report never mentions, a line no extent covers, an unparseable name
+          # — is P1. The split may only ever excuse a function OBSERVED at zero,
+          # and the granularity is the FUNCTION: a never-taken branch inside an
+          # executed function stays P1, because a test can reach it and "you
+          # added a path and tested none of it" is this gate's core finding.
+          CLASSIFY=.github/scripts/mutants_classify.py
+          if [ -s fn-extents.tsv ]; then
+            REACH=measured
+            python3 "$CLASSIFY" partition diff-list.txt --extents fn-extents.tsv \
+              --p1 p1.txt --p2 p2.txt --drop-p1 drop-p1.txt --drop-p2 drop-p2.txt
+          else
+            REACH=unmeasured
+            python3 "$CLASSIFY" partition diff-list.txt \
+              --p1 p1.txt --p2 p2.txt --drop-p1 drop-p1.txt --drop-p2 drop-p2.txt
+            echo "::warning::the offline-reach measurement produced nothing (see the step above), so no mutant was deprioritised: the whole diff is graded and any miss is red — this gate's behaviour before prioritisation. Fail-closed, but the budget is being spent on mutants that may be unkillable offline."
+          fi
+          P2=$(grep -c . p2.txt || true)
+          DROP_P2=()
+          if [ "$REACH" = "measured" ] && [ "$P2" -gt 0 ]; then
+            while IFS= read -r pat; do DROP_P2+=(--exclude-re "$pat"); done < drop-p2.txt
+            # The restriction is VERIFIED, not claimed. These regexes are
+            # GENERATED, and an over-broad exclusion silently un-grading P1
+            # mutants is precisely the defect `mutants_exclusions.py` polices in
+            # the hand-written list (`in check` also ate `check_null_ratios` &
+            # co). So the corpus is re-listed with them applied and the
+            # remainder must be EXACTLY P1 — if it is not, they are discarded
+            # and the whole diff is graded. A wrong restriction must not be the
+            # thing that decides what gets graded.
+            list_into p1-check.txt "${DROP_P2[@]}"
+            if ! python3 "$CLASSIFY" verify p1.txt p1-check.txt; then
+              REACH=unverified
+              DROP_P2=()
+              P2=0
+              echo "::warning::the generated P2 exclusions did not remove exactly the report-only class (errors above), so they are DISCARDED and every in-diff mutant is graded."
+            fi
+          fi
+          [ "$REACH" = "measured" ] || P2=0
+          P1=$((COUNT - P2))
+          say reach "$REACH"
+          say p1 "$P1"
+          say p2 "$P2"
+          if [ "$P1" -gt "$MUTANTS_DIFF_BUDGET" ]; then
             # ONE over-budget state now, where there used to be five.
             #
             # All five partitioned the diff into files the nightly tier rotation
@@ -360,9 +485,15 @@ jobs:
             # With nothing to defer to, grading an arbitrary SUBSET would be the
             # worse option: a partial pass reads as coverage. So an over-budget
             # diff is simply not graded, and says so.
+            #
+            # The test is on P1, not on the whole diff, and that is the point of
+            # the prioritisation: the offline-reachable subset is not an
+            # arbitrary slice — it is every mutant this run could have killed,
+            # so grading it is coverage of exactly the class the gate speaks
+            # about. Only when even THAT does not fit is the diff ungraded.
             say state over-budget-ungraded
             say result n/a
-            echo "::notice::this diff yields $COUNT mutants, past the $MUTANTS_DIFF_BUDGET this job's 90-minute budget can grade (~90s each in CI, dominated by the rebuild). It is NOT graded — there is no nightly rotation to defer to, and grading a slice would look like coverage without being it. Split the PR into changes that fit, or accept that mutation testing has nothing to say about this one."
+            echo "::notice::this diff yields $COUNT mutants, $P1 of them in code the offline suite executes — past the $MUTANTS_DIFF_BUDGET this job's budget can grade (~90s each in CI, dominated by the rebuild). It is NOT graded — there is no nightly rotation to defer to, and grading a slice would look like coverage without being it. Split the PR into changes that fit, or accept that mutation testing has nothing to say about this one."
             exit 0
           fi
           # "Did this gate grade anything at all?" is NOT asked here: this job is
@@ -381,8 +512,37 @@ jobs:
           # measure against every offline test target, then triage what's left.
           say state in-budget
           rc=0
-          cargo mutants --in-diff pr.diff -j 2 -- --lib --bins || rc=$?
+          cargo mutants --in-diff pr.diff ${DROP_P2[@]+"${DROP_P2[@]}"} -j 2 -- --lib --bins || rc=$?
           verdict "$rc"
+          # THE REPORT-ONLY CLASS IS ITSELF AUDITED, whenever the budget stretches
+          # to it. "These mutants cannot be killed offline" is a claim, and the
+          # one thing that can falsify it is running them: if the offline suite
+          # CATCHES one, the coverage-based classification was wrong and the
+          # report-only class is unsound — `Mutants (coverage verdict)` fails on
+          # `oracle-lied`. This is what keeps the split from becoming the excuse
+          # ("it wasn't covered, so it doesn't count") that a report-only class
+          # otherwise grows into: whenever the whole diff would have fitted the
+          # budget anyway, the gate spends exactly what it used to spend and
+          # checks its own oracle with it. Past the budget the audit is skipped
+          # and SAID to be skipped — that is the trade the prioritisation buys,
+          # and it is named rather than implied.
+          if [ "$P2" -gt 0 ]; then
+            if [ $((P1 + P2)) -le "$MUTANTS_DIFF_BUDGET" ]; then
+              DROP_P1=()
+              while IFS= read -r pat; do DROP_P1+=(--exclude-re "$pat"); done < drop-p1.txt
+              cargo mutants --in-diff pr.diff ${DROP_P1[@]+"${DROP_P1[@]}"} -j 2 \
+                -o p2-audit -- --lib --bins || true
+              if [ -s p2-audit/mutants.out/caught.txt ]; then
+                say p2_audit oracle-lied
+                echo "::error::the offline suite CAUGHT $(grep -c . p2-audit/mutants.out/caught.txt) mutant(s) this run had classified as unkillable offline. The coverage measurement and the test run disagree, so the report-only class is not safe and nothing may be deprioritised on it:"
+                sed -n '1,10p' p2-audit/mutants.out/caught.txt >&2
+              else
+                say p2_audit oracle-holds
+              fi
+            else
+              say p2_audit skipped-over-budget
+            fi
+          fi
           exit "$rc"
       # The job's own conclusion is unreadable (continue-on-error), so the last
       # thing it does is write down what happened — including the cases where
@@ -607,6 +767,17 @@ jobs:
             echo "::error::the previous step recorded no in-diff mutant count — it did not complete, so there is nothing to audit."
             exit 1
           fi
+          # This audit deliberately does NOT measure offline reach: it is the
+          # `--list`-only job, seconds long, and an instrumented build here
+          # would make the auditor as expensive as the thing it audits (and give
+          # it its own way to break). So it computes `expected_state` from the
+          # WHOLE diff, and the run job — which does have the measurement — may
+          # legally report `in-budget` where this says `over-budget-ungraded`:
+          # the offline-reachable subset fitted even though the diff did not.
+          # That is the ONE permitted disagreement, and `Mutants (coverage
+          # verdict)` accepts it only against the run's published evidence
+          # (reach=measured, p1 <= budget < count, p2 > 0). Every other
+          # mismatch stays an error.
           if [ "$graded" -le "$MUTANTS_DIFF_BUDGET" ]; then
             state in-budget
             echo "ok: $graded in-diff mutants is within the $MUTANTS_DIFF_BUDGET budget, so the whole diff is in the per-diff gate's SCOPE. Whether that run reached a verdict is asserted by 'Mutants (coverage verdict)', which reads the run's own recorded outcome."
@@ -659,6 +830,10 @@ jobs:
           UNTIERED: ${{ needs.mutants-in-diff.outputs.untiered }}
           SUB: ${{ needs.mutants-in-diff.outputs.sub }}
           COUNT: ${{ needs.mutants-in-diff.outputs.count }}
+          REACH: ${{ needs.mutants-in-diff.outputs.reach }}
+          P1: ${{ needs.mutants-in-diff.outputs.p1 }}
+          P2: ${{ needs.mutants-in-diff.outputs.p2 }}
+          P2_AUDIT: ${{ needs.mutants-in-diff.outputs.p2_audit }}
         run: |
           set -euo pipefail
           if [ "$SCRIPTS_RESULT" != "success" ]; then
@@ -678,10 +853,43 @@ jobs:
             exit 0
           fi
           if [ -z "$STATE" ]; then
-            echo "::error::'Mutants (changed lines)' recorded NO state (step outcome: ${OUTCOME:-none}) — it never reached a verdict about this diff. Because that job is continue-on-error its own red X does not block; this one does. Read its log: the usual causes are a failed cargo-mutants install and the 90-minute timeout (if it timed out inside the budget, MUTANTS_DIFF_BUDGET is set too high)."
+            echo "::error::'Mutants (changed lines)' recorded NO state (step outcome: ${OUTCOME:-none}) — it never reached a verdict about this diff. Because that job is continue-on-error its own red X does not block; this one does. Read its log: the usual causes are a failed cargo-mutants install and the two-hour timeout (if it timed out inside the budget, MUTANTS_DIFF_BUDGET is set too high)."
             exit 1
           fi
-          if [ "$STATE" != "$EXPECTED" ]; then
+          # THE PRIORITISATION'S OWN INVARIANTS. The run job cannot fail (it is
+          # continue-on-error), so the claims it makes about which mutants it
+          # graded are checked here, against the numbers it published.
+          #
+          # `oracle-lied` is the load-bearing one: the offline suite CAUGHT a
+          # mutant the coverage measurement said it never executes. Whichever of
+          # the two is wrong, the report-only class is unsound while they
+          # disagree — so nothing may be deprioritised on it, and this is a hard
+          # failure rather than a note.
+          if [ "$P2_AUDIT" = "oracle-lied" ]; then
+            echo "::error::'Mutants (changed lines)' deprioritised mutants as unkillable offline and then CAUGHT some of them offline. The coverage measurement and the test run contradict each other, so the report-only class cannot be trusted to hold anything. Read that job's log (the caught names are printed there): either the reach measurement is measuring the wrong test scope, or the classifier is putting reachable code in the report-only class."
+            exit 1
+          fi
+          if [ -n "$P1" ] && [ -n "$COUNT" ] && [ "$P1" -gt "$COUNT" ]; then
+            echo "::error::the run reports $P1 offline-reachable mutants out of $COUNT in scope — a subset cannot be larger than the set it is taken from, so the two numbers do not come from one measurement of this diff."
+            exit 1
+          fi
+          # The ONE legal disagreement between the audit and the run: the audit
+          # is `--list`-only and has no coverage measurement, so it judges the
+          # WHOLE diff against the budget, while the run judges the
+          # offline-reachable subset. `over-budget-ungraded` (audit) vs
+          # `in-budget` (run) therefore means "prioritisation rescued a diff
+          # that would otherwise have been graded by nothing" — accepted only
+          # against the evidence that makes it true, never on the state name.
+          RESCUE=no
+          if [ "$EXPECTED" = "over-budget-ungraded" ] && [ "$STATE" = "in-budget" ]; then
+            if [ "$REACH" != "measured" ] || [ "${P2:-0}" -le 0 ] || [ "${P1:-0}" -gt "$MUTANTS_DIFF_BUDGET" ]; then
+              echo "::error::the run graded a diff the audit measured as over-budget, without the evidence that makes that legal (reach='$REACH', p1='$P1', p2='$P2', budget=$MUTANTS_DIFF_BUDGET). A gate may narrow what it grades only on a measurement it can show."
+              exit 1
+            fi
+            RESCUE=yes
+            echo "::notice::prioritisation rescued this diff: $P1 of $COUNT in-diff mutants are in code the offline suite executes and were graded; the other $P2 are in functions measured at ZERO offline executions. Before this split the whole diff would have been graded by nothing."
+          fi
+          if [ "$RESCUE" = "no" ] && [ "$STATE" != "$EXPECTED" ]; then
             echo "::error::the two mutation gates disagree about this diff: the audit computed '$EXPECTED', the run reported '$STATE'. One of them mis-measured, and one of them is the source of the coverage claim — neither may be believed until they agree."
             exit 1
           fi
@@ -692,11 +900,16 @@ jobs:
           case "$STATE" in
             in-budget)
               if [ -z "$RESULT" ]; then
-                echo "::error::'Mutants (changed lines)' had this diff in scope (state '$STATE', step outcome ${OUTCOME:-none}) and recorded NO verdict — the run was killed mid-flight, which on this job means the 90-minute timeout. An in-scope diff that nothing finished grading is the vacuous gate with a longer runtime. If it timed out while under the count guard, MUTANTS_DIFF_BUDGET ($MUTANTS_DIFF_BUDGET) is set too high for this runner."
+                echo "::error::'Mutants (changed lines)' had this diff in scope (state '$STATE', step outcome ${OUTCOME:-none}) and recorded NO verdict — the run was killed mid-flight, which on this job means the two-hour timeout. An in-scope diff that nothing finished grading is the vacuous gate with a longer runtime. If it timed out while under the count guard, MUTANTS_DIFF_BUDGET ($MUTANTS_DIFF_BUDGET) is set too high for this runner."
                 exit 1
               fi
               ;;
           esac
+          # What the gate did NOT say, said. A report-only class is only honest
+          # while its size and its unaudited-ness are visible.
+          if [ "$REACH" = "unmeasured" ] || [ "$REACH" = "unverified" ]; then
+            echo "::warning::the offline-reach measurement did not produce a usable answer (reach='$REACH'), so nothing was prioritised and every in-diff mutant was graded strictly — this gate's behaviour before the split. Not a failure; a large diff simply goes ungraded on budget where prioritisation would have rescued it."
+          fi
           # The over-budget case is REPORTED, and reported as what it is. Before
           # 2026-08-17 it was four states that partitioned the diff against the
           # nightly tier rotation and deferred part of it there; the rotation
@@ -708,14 +921,17 @@ jobs:
           # mutant. But it is said OUT LOUD, because the thing this whole job
           # exists to prevent is a diff nobody graded arriving as a green check.
           if [ "$STATE" = "over-budget-ungraded" ]; then
-            echo "::warning::mutation testing says NOTHING about this diff — it yields more mutants than the per-diff budget can grade, and there is no rotation to defer to. Not a failure; split the PR if you want the coverage."
+            echo "::warning::mutation testing says NOTHING about this diff — even the ${P1:-$COUNT} mutants in code the offline suite EXECUTES are more than the per-diff budget can grade, and there is no rotation to defer to. Not a failure; split the PR if you want the coverage."
             echo "ok: audit and run agree on '$STATE' — ungraded, and recorded as ungraded."
             exit 0
           fi
           if [ "$RESULT" = "missed" ]; then
-            echo "::warning::'Mutants (changed lines)' reports MISSED mutants in this diff ($COUNT in scope). That job is advisory by design (a foundational-module PR cannot finish its run), so this does not block — but a missed mutant in your own diff is an assertion gap in your own code. Read its log."
+            echo "::warning::'Mutants (changed lines)' reports MISSED mutants in this diff (${P1:-$COUNT} graded of $COUNT in scope). Every one of them is in code the offline suite EXECUTES when reach='$REACH' is 'measured' — a test ran that line and did not notice the change, which is an assertion gap in your own code, not a live-only path. Read its log."
           fi
-          echo "ok: audit and run agree on '$STATE'; the run's verdict is '${RESULT:-n/a}'."
+          if [ "${P2:-0}" -gt 0 ] && [ "$P2_AUDIT" = "skipped-over-budget" ]; then
+            echo "::warning::$P2 in-diff mutants sit in functions the offline suite never executes; the budget did not stretch to running them, so nothing in this run contradicts that classification. Triage them in .cargo/mutants.toml with the live oracle that DOES kill them (proven by hand, per the entries already there), or give them a unit oracle and they move into the graded class."
+          fi
+          echo "ok: audit and run agree on '$STATE'; the run's verdict is '${RESULT:-n/a}' over ${P1:-$COUNT} graded / ${P2:-0} reported mutants (reach='${REACH:-n/a}', report-only audit '${P2_AUDIT:-n/a}')."
 
   # The gate's own scripts, graded. Seconds, no toolchain. Each `selftest` is a
   # unit check of the parser or coercion the gate depends on; `check` grades the
@@ -739,6 +955,16 @@ jobs:
       # is gone.
       - name: The exclusion checker's own site/function keying
         run: python3 .github/scripts/mutants_exclusions.py --self-test
+      # The PRIORITISER's classification, graded over a coverage export copied
+      # from a real `cargo llvm-cov --lib --bins --json` run: an executed
+      # function, an untaken branch inside one, a function measured at zero, a
+      # file the report never mentions, an uncovered line, an unparseable name —
+      # and six report shapes it must REFUSE rather than read as "nothing is
+      # covered". Everything it does not know must land in the graded class;
+      # that fallback is the only thing standing between this split and "it
+      # wasn't covered, so it doesn't count".
+      - name: The mutant prioritiser fails closed
+        run: python3 .github/scripts/mutants_classify.py --self-test
       # `--self-test` returns before any stage, container or binary is touched —
       # it grades the argv/env coercion only, so this invocation needs no
       # RIVET_PREV_RELEASE_BIN and is not a gate run (cf. the Makefile-scoped

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -605,6 +605,29 @@ one, and PROVE which by mutating and running the live suite: `total_rows += `
 file as a lib-suite survivor — is caught by three. What the live suite did NOT
 catch was worth the search: see the failed-chunk guard below.
 
+The corollary that keeps that exclusion HONEST: **a body the offline gate cannot
+reach may not DECIDE.** Excluding a live-only function wholesale
+(`replace run_pool -> Result`) is a truthful claim about the BODY and a silent
+one about the branches inside it — every `&&`, `!` or `x > y` written there is a
+mutant excluded with nothing asked in return. Measured: five decisions were
+pulled out of `execute_resolved_plan` (`src/pipeline/job.rs`) BY HAND this
+session — `should_reconcile`, `plan_rejection_error`,
+`resume_success_gate_applies`, `rerun_warning_applies`,
+`dispatches_to_cdc_runner` — each only because the in-diff gate pointed at that
+one operator and someone argued it out; `fold_failures` (`src/pipeline/run.rs`)
+came out of the same pass and was a REAL gap, with no unit oracle at all. Six
+extractions, six ad-hoc arguments, and nothing stopping the seventh from being
+written inline tomorrow. So the rule, not the litigation: **a live-only body is
+GLUE — sequencing, I/O, error context — and calls a NAMED PURE PREDICATE for
+anything it decides**; the predicate is offline-testable and its mutants are
+graded, the glue stays excluded for the reason its exclusion gives. The tell that
+this went wrong is an operator-shaped entry in `.cargo/mutants.toml` (`delete !
+in run_pool`, `replace == with != in check$`): that is a decision that should
+have been a function. Enforced by `tests/offline/live_only_purity_gate.rs`, which
+DERIVES the live-only set from the config's whole-function exclusions (never a
+typed-in list) and holds each body at a shrink-only ceiling — lower a row the
+moment you extract, and it fails downward too so the win stays banked.
+
 Scope honesty: mutation testing measures assertion SENSITIVITY on code that
 exists. It cannot see a missing behaviour (the manifest-clobber fix itself was
 invisible to it — an independent-oracle harness caught that), nor a test and

--- a/docs/mutation-plan.md
+++ b/docs/mutation-plan.md
@@ -125,6 +125,31 @@ boolean coercion in `build_array` (`*v != 0` -> `*v == 0`) DOES fail the live
 subset (`live_init::init_mysql_schema_wide_discovers_seeded_table`). For that
 class the claim holds — as a measurement now, not an assurance.
 
+## The harness's own thermometer (2026-08-21)
+
+Every loop above measures the PRODUCT. Nothing measured the harness, so a guard
+could rot for months with every signal a reader has still reading green — three
+did (see `tests/offline/nonvacuity.rs`). The `harness-metrics` job in ci.yml now
+emits one JSON per run (`.github/scripts/harness_metrics.py`, uploaded as the
+`harness-metrics` artifact, one-line summary in the job log):
+
+- **mutants** — in scope, excluded by `.cargo/mutants.toml`, graded, and the
+  classifier's offline-reachable / live-only split, plus caught / missed.
+- **guards** — convention-cop guards (a `#[test]` file grading a checked-in
+  subject by NAME), how many prove that subject is non-empty, how many tests
+  are named `..._documents_...` (documentation, not verification), how many
+  files declare a blind spot in prose.
+- **tests** — DECLARED `#[test]` counts for the offline suite and the lib (the
+  job runs no cargo; it counts attributes, so the number differs from a
+  runner's tally by whatever is `cfg`-gated out).
+
+It is a THERMOMETER: no threshold, no `needs:` from any job, `continue-on-error`
+on top of `if: always()`. A metric with teeth becomes a number people manage
+(pad the cop count; rename a test `_documents_` to duck a red). An unknown count
+is published as `null`, never `0` — "the mutation job never ran" and "nothing
+was missed" must not draw the same line. `tests/offline/harness_metrics_guard.rs`
+grades the shaping from a fixture of counts and keeps the job non-blocking.
+
 ## Triage verdicts
 
 - **add-test** — write the unit test that kills it (e.g. the pilot's

--- a/docs/mutation-plan.md
+++ b/docs/mutation-plan.md
@@ -31,8 +31,30 @@ Narrow live filters for Tier 3 (mutate X → run only its guards):
 ## Three enforcement loops
 
 1. **PR gate — `cargo mutants --in-diff` (minutes).** Mutates only the lines
-   the PR changed, `--lib` cycle. A NEW missed mutant in your own diff fails
-   the check. Cheapest and fairest: everyone pays only for their own code.
+   the PR changed, `--lib --bins` cycle. A NEW missed mutant in your own diff
+   fails the check. Cheapest and fairest: everyone pays only for their own code.
+
+   Since 2026-08-21 the in-diff mutants are **prioritised before they are
+   budgeted** (`.github/scripts/mutants_classify.py`, wired into the
+   `mutants-in-diff` job). `cargo llvm-cov --lib --bins` measures which
+   functions the offline suite actually EXECUTES, and each mutant lands in one
+   of two classes:
+
+   - **graded** — its line is inside an executed function. A test ran that code
+     and did not notice the change: an assertion gap, and the gate's red.
+   - **reported** — its line is inside a function measured at ZERO executions.
+     No offline assertion can kill it; it is a triage question
+     (`.cargo/mutants.toml` with a live-oracle proof, or a unit oracle that
+     moves the function into the graded class).
+
+   This is what makes the gate useful on a big diff: the budget guard now tests
+   the GRADED subset, so a foundational PR that used to be graded by nothing
+   gets its offline-reachable mutants graded. Two properties keep the split
+   from becoming an excuse — everything the measurement does not KNOW (no
+   report, an unmentioned file, an unparseable name) stays in the graded class,
+   and whenever the budget stretches to it the reported class is RUN as an
+   audit: if the offline suite catches one of them, the classification was
+   wrong and `Mutants (coverage verdict)` fails.
 2. **Nightly (devbox self-hosted runner).** Full `--lib` runs over Tier 0-2 in
    rotation (~500-1000 mutants/night). Result diffed against the committed
    baseline (`docs/mutants-baseline.txt`): any missed mutant NOT in the

--- a/docs/runner-coverage-matrix.yaml
+++ b/docs/runner-coverage-matrix.yaml
@@ -88,6 +88,30 @@
 # Building this ledger then surfaced a bigger one — value-checksum Form B was absent on
 # ALL three large-table runners.
 #
+# COLUMNS ARE DERIVED, 2026-08-21. Every paragraph above argues about the column
+# set — the ~8 loops, the collapse to 5, the 2026-08-16 split — and until now the
+# `engines:` line below was a hand-written list tied to NOTHING: the generative
+# column guard (tests/offline/chunking_matrix_guard.rs #5) only knows enum-keyed
+# ledgers (SourceType / ExportTarget / DestinationType), and a runner is not an
+# enum variant, so this ledger was the one matrix whose columns nobody derived.
+# `runner_matrix_columns_are_derived_from_the_commit_loops` closes that: a
+# top-level fn under src/pipeline that drains through `commit::record_part` IS a
+# commit loop (ADR-0028's own definition of the seam every runner must call), the
+# derivation finds exactly the EIGHT the header above names, and COMMIT_LOOP_COLUMN
+# maps each to its column here. It fails in both directions — a ninth loop with no
+# column (RED-proven: a new record_part-draining fn; 271 other offline tests stayed
+# green), and a column whose loop is gone (RED-proven: the mongo_parallel runner
+# deleted; the ledger went on grading its column, cells and ratchet and all).
+#
+# The ADR-0028 half is graded structurally rather than by more cells: the rows
+# below whose `na:` rests on "it runs ONCE at the finalize_export seam"
+# (schema_drift_gate, shape_drift_warn, value_checksum_form_b — the guard reads
+# that set from THIS file's `what:` prose, it is not hand-listed there) are honest
+# only while the seam has exactly one caller.
+# `the_export_tail_seam_has_one_caller_and_no_runner_re_applies_it` asserts that,
+# and names those rows when it fails — so a runner re-applying the tail is a
+# diff-time failure instead of three `na` cells quietly becoming false.
+
 # Columns are the five RUNNER families. A cell is EXACTLY one of:
 #   test: <fn>  — the feature is applied on this runner AND a test proves it.
 #   na:   <why> — the feature genuinely does not apply to this runner (by design),

--- a/tests/offline/attestation_matrix_guard.rs
+++ b/tests/offline/attestation_matrix_guard.rs
@@ -29,12 +29,25 @@ const MATRIX: &str = "docs/attestation-matrix.yaml";
 const UNVERIFIED_RATCHET: usize = 0;
 
 fn claims() -> Vec<Value> {
-    let s = fs::read_to_string(MATRIX).unwrap_or_else(|e| panic!("read {MATRIX}: {e}"));
+    let s = super::nonvacuity::subject_text(MATRIX);
     let doc: Value = serde_yaml_ng::from_str(&s).unwrap_or_else(|e| panic!("parse {MATRIX}: {e}"));
-    doc.get("claims")
+    let out: Vec<Value> = doc
+        .get("claims")
         .and_then(|c| c.as_sequence())
         .unwrap_or_else(|| panic!("{MATRIX} must have a `claims:` sequence"))
-        .clone()
+        .clone();
+    // A PRESENT but empty (or truncated) `claims:` is the dangerous shape: all
+    // five guards below iterate it, so zero rows means five green tests over a
+    // ledger asserting nothing — and this is the ledger whose rows read as
+    // GUARANTEES. 16 claims today.
+    super::nonvacuity::require_enumerated(
+        out.len(),
+        10,
+        &format!("`claims:` rows in {MATRIX}"),
+        "Restore the rows or re-point this reader; an attestation ledger that parses to \
+         nothing still renders as `independence: independent` to every reader of the file.",
+    );
+    out
 }
 
 fn field(c: &Value, k: &str) -> Option<String> {

--- a/tests/offline/cdc_axis_matrix_guard.rs
+++ b/tests/offline/cdc_axis_matrix_guard.rs
@@ -39,12 +39,34 @@ fn matrix() -> Value {
     serde_yaml_ng::from_str(&s).unwrap_or_else(|e| panic!("parse {MATRIX}: {e}"))
 }
 
+/// One section of the ledger, floor-checked.
+///
+/// A missing section already panics; a PRESENT but empty one did not, and that
+/// is the direction that passes: `every_cdc_config_field_has_a_row` compares
+/// declared ids against parsed source, and with zero declared ids the
+/// `difference` in the stale direction is empty while the missing direction is
+/// answered by whatever the source scan found. The floors are today's counts
+/// (9 / 6 / 11) minus room for ordinary edits.
 fn rows(section: &str) -> Vec<Value> {
-    matrix()
+    let out: Vec<Value> = matrix()
         .get(section)
         .and_then(|v| v.as_sequence())
         .unwrap_or_else(|| panic!("{MATRIX} must have a `{section}:` sequence"))
-        .clone()
+        .clone();
+    let floor = match section {
+        "config_fields" => 5,
+        "crash_hooks" => 4,
+        "shape_axes" => 6,
+        _ => 0,
+    };
+    super::nonvacuity::require_enumerated(
+        out.len(),
+        floor,
+        &format!("`{section}:` rows in {MATRIX}"),
+        "Restore the rows or re-point this reader — an empty axis section reads as full \
+         coverage of an axis nothing is graded on.",
+    );
+    out
 }
 
 fn all_rows() -> Vec<Value> {

--- a/tests/offline/chunking_matrix_guard.rs
+++ b/tests/offline/chunking_matrix_guard.rs
@@ -37,8 +37,19 @@
 //!    an INDEPENDENT oracle (a DuckDB/source-vs-dest re-read, outside rivet's decode
 //!    family) lowers the ceiling. So the shared-decode self-oracle debt is visible
 //!    and monotonically shrinks toward 0.
+//! 8. GENERATIVE runner-column completeness — #5 on the one axis that is not an
+//!    enum. `docs/runner-coverage-matrix.yaml` is keyed on RUNNERS, so #5 matched
+//!    none of its predicates and its column line was hand-written and tied to
+//!    nothing. The required set is derived from the product instead: a top-level
+//!    fn that drains through `commit::record_part` IS a commit loop (ADR-0028's
+//!    own definition of the seam every runner must call), and the derived set is
+//!    compared to the declared columns in BOTH directions — a new runner with no
+//!    column, and a column whose runner is gone. Its sibling grades the other half
+//!    of ADR-0028: the export TAIL has exactly one caller, which is what lets
+//!    several rows of that ledger be runner-agnostic `na` instead of a cell per
+//!    runner.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
@@ -242,8 +253,11 @@ struct Matrix {
 #[derive(Deserialize)]
 struct Scenario {
     id: String,
-    #[serde(default, rename = "what")]
-    _what: Option<String>,
+    /// The row's prose. Read by guard #8, which derives the rows whose `na`
+    /// cells REST on the ADR-0028 seam from the ledger itself rather than from
+    /// a hand-kept list here.
+    #[serde(default)]
+    what: Option<String>,
     #[serde(flatten)]
     cells: HashMap<String, Cell>,
 }
@@ -958,4 +972,369 @@ fn every_docs_yaml_parses_as_yaml() {
         checked >= 20,
         "parsed only {checked} YAML file(s) under docs/ — the walk found nothing to grade"
     );
+}
+
+// ── Guard #8: the runner axis, derived ────────────────────────────────────────
+//
+// The two generative guards above key on an ENUM, which is why neither of them
+// sees `docs/runner-coverage-matrix.yaml`: its columns are RUNNERS, and a runner
+// is not an enum variant — it is a commit loop the dispatcher fans out to. That
+// ledger's own header admits the consequence ("the columns collapse to FIVE
+// runner FAMILIES … the code actually has ~EIGHT distinct commit loops"), and
+// the collapse has already cost twice: a `test` cell proven only on
+// keyset_SEQUENTIAL while keyset_PARALLEL lacked the drift gate, and a governor
+// cell whose two runners had disjoint evidence until the 2026-08-16 column split.
+// Both were caught by a human reading the grid, because the column list was a
+// hand-written line of YAML tied to nothing.
+
+/// The ONE call that makes a function an export RUNNER.
+///
+/// ADR-0028 chose `commit::record_part` as the seam precisely because it is "the
+/// single drain point every runner — including parallel workers — must call to
+/// write". That makes it the honest structural definition of the runner set: a
+/// function that commits parts is a commit loop whether or not anyone remembered
+/// to give it a column.
+const COMMIT_DRAIN: &str = "commit::record_part(";
+
+/// Every COMMIT LOOP the product has → the runner-coverage COLUMN it collapses
+/// into. This table is the collapse the ledger's header describes, written where
+/// a guard can read it instead of in prose — and it is graded in BOTH directions
+/// by [`runner_matrix_columns_are_derived_from_the_commit_loops`]:
+///
+/// * a loop the derivation finds and this table does not name is a NEW runner
+///   with no column (the parallel-keyset shape: a second commit loop under an
+///   existing column, invisible to every cell in it);
+/// * a name here the derivation no longer finds is a MAPPING that outlived its
+///   runner, and a column claimed only by such names is a column for a runner
+///   that no longer exists.
+///
+/// So the hand-written part is the COLLAPSE (which loop belongs to which
+/// family), never the SET — the set comes from the code every time.
+const COMMIT_LOOP_COLUMN: &[(&str, &str)] = &[
+    ("run_single_export", "single"),
+    ("run_chunked_sequential", "chunked"),
+    ("run_chunked_parallel", "chunked"),
+    ("run_chunked_sequential_checkpoint", "chunked_checkpoint"),
+    ("run_chunked_parallel_checkpoint", "chunked_checkpoint"),
+    ("run_keyset", "keyset"),
+    ("run_keyset_parallel", "keyset"),
+    ("run_mongo_parallel", "mongo_parallel"),
+];
+
+const RUNNER_MATRIX: &str = "docs/runner-coverage-matrix.yaml";
+
+/// The seam ADR-0028 funnels the export TAIL through, and the one function
+/// allowed to call it. An allowlist rather than a count, so the exception a
+/// future dispatcher needs is written down WITH its reason (the shape
+/// `runner_frame_gate` already uses for the destination door).
+const TAIL_SEAM: &str = "finalize_export(";
+const TAIL_SEAM_CALLERS: &[(&str, &str)] = &[(
+    "execute_resolved_plan",
+    "THE dispatcher — ADR-0028 applies the tail here, once, between the runner returning \
+     and finalize_manifest",
+)];
+
+/// Every top-level fn under `src/pipeline` whose body calls `needle`, mapped to
+/// the first call site (`rel:line`) so a failure can name its witness.
+///
+/// Three things this deliberately does NOT count, each of them a way a text
+/// guard goes blind in the safe-looking direction:
+///
+/// * a COMMENT naming the call — `runner_frame_gate` was satisfiable by a doc
+///   mention of the very call it demanded. Honesty about strength: no comment in
+///   the tree forges either token TODAY, so stripping changes no verdict now. The
+///   nearest is `parallel_checkpoint.rs:430`, which writes
+///   `commit::record_part(state=None)` in prose inside a fn that is already a
+///   commit loop by its real drain at :578 — a rename away from mattering. Three
+///   runner files (single, keyset ×3, mongo_parallel) DO name
+///   `finalize::finalize_export` in their tail comments; they escape only because
+///   they write it without the trailing `(`. Verified by
+///   removing the strip and re-running: still green — which is why this bullet
+///   says "defence against the class", not "load-bearing today".
+/// * a `#[cfg(test)]` block — a unit test that calls the seam is not a runner.
+///   This one IS load-bearing: `finalize.rs`'s own unit tests call the seam
+///   twice, and counting them would make the seam look re-applied.
+/// * the DECLARATION line: `fn finalize_export(` is not a call to itself.
+fn top_level_callers_of(needle: &str) -> BTreeMap<String, String> {
+    let root = repo_root().join("src/pipeline");
+    let mut out = BTreeMap::new();
+    let mut stack = vec![root];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).expect("read src/pipeline") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                continue;
+            }
+            // `sink/tests.rs` is a `#[cfg(test)] mod tests;` body in its own
+            // file, so the in-file cfg(test) skip below cannot see it: a unit
+            // test there would otherwise register as a runner.
+            if path.file_stem().and_then(|e| e.to_str()) == Some("tests") {
+                continue;
+            }
+            let rel = path
+                .strip_prefix(repo_root())
+                .expect("under repo root")
+                .to_string_lossy()
+                .replace('\\', "/");
+            let text = std::fs::read_to_string(&path).expect("read source");
+            scan_top_level_callers(&text, &rel, needle, &mut out);
+        }
+    }
+    out
+}
+
+/// [`top_level_callers_of`] for one file. Brace depth decides what "top level"
+/// means, so a nested fn or a worker closure is attributed to the fn that owns
+/// it — which is what a "commit loop" is: the loop, not the closure inside it.
+fn scan_top_level_callers(text: &str, rel: &str, needle: &str, out: &mut BTreeMap<String, String>) {
+    let mut depth: i64 = 0;
+    let mut current: Option<String> = None;
+    // `Some(d)` while inside a `#[cfg(test)]` item whose body opened at depth d.
+    let mut skip_below: Option<i64> = None;
+    let mut pending_cfg_test = false;
+    for (i, line) in text.lines().enumerate() {
+        let code = line.split("//").next().unwrap_or("");
+        let before = depth;
+        let top_level = before == 0 && !line.starts_with([' ', '\t']);
+        if skip_below.is_none() {
+            if top_level && code.trim_start().starts_with("#[cfg(test)]") {
+                pending_cfg_test = true;
+            } else if top_level && let Some(name) = top_level_fn_name(code) {
+                current = Some(name);
+            } else if code.contains(needle)
+                && let Some(owner) = &current
+            {
+                out.entry(owner.clone())
+                    .or_insert_with(|| format!("{rel}:{}", i + 1));
+            }
+        }
+        depth += code.matches('{').count() as i64 - code.matches('}').count() as i64;
+        depth = depth.max(0);
+        if pending_cfg_test {
+            if depth > before {
+                // The cfg(test) item's body just opened — skip until it closes.
+                skip_below = Some(before);
+                pending_cfg_test = false;
+                current = None;
+            } else if code.trim_end().ends_with(';') {
+                // `#[cfg(test)] mod tests;` — the file is walked on its own, and
+                // nothing to skip here.
+                pending_cfg_test = false;
+            }
+        }
+        if let Some(d) = skip_below
+            && depth <= d
+        {
+            skip_below = None;
+        }
+    }
+}
+
+/// `pub(crate) async fn foo(` → `Some("foo")`, for a line at column 0.
+fn top_level_fn_name(code: &str) -> Option<String> {
+    let mut rest = code.trim_start();
+    if let Some(after) = rest.strip_prefix("pub") {
+        rest = match after.strip_prefix('(') {
+            Some(vis) => vis.split_once(')')?.1.trim_start(),
+            None => after.trim_start(),
+        };
+    }
+    for kw in ["const ", "async ", "unsafe ", "extern "] {
+        if let Some(r) = rest.strip_prefix(kw) {
+            rest = r.trim_start();
+        }
+    }
+    let name: String = rest
+        .strip_prefix("fn ")?
+        .chars()
+        .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+        .collect();
+    (!name.is_empty()).then_some(name)
+}
+
+/// GENERATIVE runner-column completeness — guard #5's third axis, for the one
+/// ledger whose columns are neither engines nor targets nor destinations.
+///
+/// The required column set is derived from the PRODUCT: every top-level fn that
+/// drains through `commit::record_part` is a commit loop, and every commit loop
+/// belongs to exactly one column. Both directions fail:
+///
+/// * a commit loop with no mapping/column — the new-runner hole. `keyset` held
+///   two loops under one column for a whole release and the drift gate was
+///   absent on one of them; a THIRD loop appearing under some column is the same
+///   defect, and nothing in the tree asked about it before this.
+/// * a mapping (and so a column) whose loop is gone — the ledger keeps grading a
+///   runner that no longer exists, cells and ratchet and all.
+///
+/// Scope honesty: this grades the COLUMN SET, not the cells. Whether a `test:`
+/// cell is proven on both loops of a collapsed column is still prose (the
+/// 2026-08-04 per-variant audit); what changes is that the collapse itself is now
+/// written where a guard reads it, so growing an eighth loop into a ninth is a
+/// CI failure rather than a header paragraph nobody re-reads.
+#[test]
+fn runner_matrix_columns_are_derived_from_the_commit_loops() {
+    // NON-VACUITY: the whole derivation keys on one token. Rename the drain and
+    // a scan for it finds no runners, maps nothing, and passes — the direction
+    // text guards always fail in.
+    super::nonvacuity::require_needle(
+        &super::nonvacuity::subject_text("src/pipeline/single.rs"),
+        "src/pipeline/single.rs",
+        COMMIT_DRAIN,
+        1,
+        "If the commit drain moved off `commit::record_part`, re-point COMMIT_DRAIN at the \
+         new seam — the runner set is DERIVED from it, so a stale token derives nothing.",
+    );
+    let loops = top_level_callers_of(COMMIT_DRAIN);
+    super::nonvacuity::require_enumerated(
+        loops.len(),
+        6,
+        "commit loops (top-level fns that call the drain) found under src/pipeline",
+        "The runners moved, or the scan lost its subject — 8 loops live under src/pipeline \
+         today (single, chunked ×2, checkpoint ×2, keyset ×2, mongo_parallel).",
+    );
+
+    let matrix = load_matrix(RUNNER_MATRIX);
+    let columns: HashSet<&str> = matrix.engines.iter().map(String::as_str).collect();
+    let mapped: HashMap<&str, &str> = COMMIT_LOOP_COLUMN.iter().copied().collect();
+
+    // Direction 1 — a NEW runner, and no column for it.
+    for (name, site) in &loops {
+        let column = mapped.get(name.as_str()).unwrap_or_else(|| {
+            panic!(
+                "`{name}` ({site}) commits parts through {COMMIT_DRAIN} — it is an export \
+                 COMMIT LOOP — and no column of {RUNNER_MATRIX} claims it. Every per-export \
+                 feature (a gate, an integrity record, a stamp, a warning) is now something \
+                 this runner can miss while every count and sum stays green. Map it in \
+                 COMMIT_LOOP_COLUMN: to an existing column if it is a variant of that family \
+                 (say so in the ledger's header, as keyset_sequential/parallel are), or to a \
+                 NEW column, which needs a test/na/gap cell in every scenario."
+            )
+        });
+        assert!(
+            columns.contains(column),
+            "`{name}` ({site}) maps to column '{column}', which {RUNNER_MATRIX} does not \
+             declare. Add it to `engines:` (and a cell per scenario) — a runner with no \
+             column is graded by nothing."
+        );
+    }
+
+    // Direction 2 — a column for a runner that no longer exists. Checked per
+    // MAPPING, not per column, so a family losing ONE of its two loops (the
+    // collapse the header warns about) is caught too, not just an empty column.
+    for (name, column) in COMMIT_LOOP_COLUMN {
+        assert!(
+            loops.contains_key(*name),
+            "COMMIT_LOOP_COLUMN maps `{name}` → column '{column}' of {RUNNER_MATRIX}, and no \
+             top-level fn under src/pipeline calls {COMMIT_DRAIN} under that name any more. \
+             Either the loop was renamed (re-point the mapping) or it is gone — in which case \
+             drop it here, and if it was the column's last loop, drop the column and its cells \
+             rather than leaving the ledger to grade a runner the product does not have. \
+             Found: {:?}",
+            loops.keys().collect::<Vec<_>>()
+        );
+    }
+    let claimed: HashSet<&str> = COMMIT_LOOP_COLUMN.iter().map(|(_, c)| *c).collect();
+    for column in &matrix.engines {
+        assert!(
+            claimed.contains(column.as_str()),
+            "{RUNNER_MATRIX} declares column '{column}' and no commit loop maps to it. A \
+             column nothing runs is cells nobody can falsify — delete it, or map the loop it \
+             stands for in COMMIT_LOOP_COLUMN."
+        );
+    }
+}
+
+/// The ADR-0028 tail is applied at ONE seam — which is what lets several rows of
+/// the runner ledger be runner-AGNOSTIC instead of a cell per runner.
+///
+/// Before ADR-0028 the drift gate, the Form-B harvest and the shape-drift warn
+/// were re-assembled by hand in seven commit loops, and the ledger graded each
+/// one because each could forget. They now run once, from the CommitLedger the
+/// runners feed, in `finalize_export` — so those rows say `na: shared seam` and
+/// the honest guard for them is not more cells, it is this: that the seam has
+/// exactly one caller and no runner re-applies it.
+///
+/// That claim was prose in three `what:` fields and nothing checked it. If a
+/// runner starts calling the seam itself, those rows quietly become lies (a
+/// per-runner application graded by an `na` cell that says there isn't one) —
+/// the runner-bypass class returning through the door the ADR closed. This turns
+/// that into a diff-time failure naming the rows that would be affected.
+///
+/// The comment-blindness matters here more than anywhere: every runner's tail
+/// comment NAMES `finalize::finalize_export` while calling nothing, so a scan
+/// that counted comments would report the seam applied in five runners today.
+#[test]
+fn the_export_tail_seam_has_one_caller_and_no_runner_re_applies_it() {
+    super::nonvacuity::require_needle(
+        &super::nonvacuity::subject_text("src/pipeline/finalize.rs"),
+        "src/pipeline/finalize.rs",
+        &format!("fn {TAIL_SEAM}"),
+        1,
+        "The ADR-0028 tail seam was renamed or moved — re-point TAIL_SEAM at it. Grading a \
+         seam that no longer exists by that name passes over nothing.",
+    );
+
+    // The ledger rows whose `na:` cells REST on the seam being singular, read
+    // from the ledger itself rather than hand-listed here — so a row that starts
+    // (or stops) depending on the seam is named by the message without anyone
+    // remembering to update this test.
+    let matrix = load_matrix(RUNNER_MATRIX);
+    let seam_rows: Vec<&str> = matrix
+        .scenarios
+        .iter()
+        .filter(|s| {
+            s.what
+                .as_deref()
+                .is_some_and(|w| w.contains("finalize_export"))
+        })
+        .map(|s| s.id.as_str())
+        .collect();
+    super::nonvacuity::require_enumerated(
+        seam_rows.len(),
+        2,
+        "scenarios of the runner ledger that cite the finalize_export seam",
+        "Those rows are `na` BECAUSE the tail is applied once; if they no longer say so, \
+         either the ADR was reversed (then they need per-runner cells again) or the prose \
+         drifted away from the mechanism it depends on.",
+    );
+
+    let callers = top_level_callers_of(TAIL_SEAM);
+    let allowed: HashMap<&str, &str> = TAIL_SEAM_CALLERS.iter().copied().collect();
+    for (dispatcher, _) in TAIL_SEAM_CALLERS {
+        assert!(
+            callers.contains_key(*dispatcher),
+            "`{dispatcher}` no longer calls {TAIL_SEAM} — the export tail is applied nowhere \
+             (or somewhere this guard cannot see). Found callers: {:?}",
+            callers.keys().collect::<Vec<_>>()
+        );
+    }
+
+    let loops: HashSet<&str> = COMMIT_LOOP_COLUMN.iter().map(|(f, _)| *f).collect();
+    for (caller, site) in &callers {
+        if allowed.contains_key(caller.as_str()) {
+            continue;
+        }
+        let runner = if loops.contains(caller.as_str()) {
+            format!(
+                " `{caller}` is a COMMIT LOOP: this is the runner-bypass class returning — \
+                 the tail re-applied per runner, which is what ADR-0028 removed and what \
+                 rows [{}] now describe as shared-seam `na` cells.",
+                seam_rows.join(", ")
+            )
+        } else {
+            String::new()
+        };
+        panic!(
+            "{TAIL_SEAM} is called from `{caller}` ({site}), which is not an approved seam \
+             caller.{runner} If a second dispatcher genuinely needs the tail, add it to \
+             TAIL_SEAM_CALLERS with its reason; if a runner needs a feature the seam does not \
+             give it, that feature is per-runner again and rows [{}] of {RUNNER_MATRIX} need \
+             real cells instead of `na: shared seam`.",
+            seam_rows.join(", ")
+        );
+    }
 }

--- a/tests/offline/cli_flag_coverage_guard.rs
+++ b/tests/offline/cli_flag_coverage_guard.rs
@@ -36,7 +36,7 @@ const EXEMPT: &[(&str, &str)] = &[
 /// Every long flag `src/cli/args.rs` declares: `long = "name"` when named,
 /// else the kebab-cased field under a bare `long`.
 fn declared_long_flags() -> BTreeSet<String> {
-    let src = std::fs::read_to_string("src/cli/args.rs").expect("read src/cli/args.rs");
+    let src = super::nonvacuity::subject_text("src/cli/args.rs");
     let mut flags = BTreeSet::new();
     for (start, _) in src.match_indices("#[arg(") {
         let Some(close) = src[start..].find(")]") else {
@@ -85,7 +85,8 @@ fn referenced_in_tests(haystack: &str, flag: &str) -> bool {
 
 fn test_tree_text() -> String {
     let mut out = String::new();
-    let mut stack = vec![std::path::PathBuf::from("tests")];
+    let mut files = 0usize;
+    let mut stack = vec![super::nonvacuity::repo_root().join("tests")];
     while let Some(dir) = stack.pop() {
         if dir.ends_with(".live-tmp") {
             continue;
@@ -95,10 +96,22 @@ fn test_tree_text() -> String {
             if p.is_dir() {
                 stack.push(p);
             } else if p.extension().is_some_and(|x| x == "rs") {
+                files += 1;
                 out.push_str(&std::fs::read_to_string(&p).unwrap_or_default());
             }
         }
     }
+    // This haystack decides which flags count as covered. A truncated walk
+    // fails LOUD in the coverage direction (every flag reads unreferenced), so
+    // the vacuity risk is the other way round only for the STALE-exemption half
+    // — but a walk that lost the tree should say so as a missing subject rather
+    // than through a hundred false "untested flag" lines. 150+ files today.
+    super::nonvacuity::require_enumerated(
+        files,
+        60,
+        "`.rs` files walked under tests/",
+        "The test tree moved; this sweep is deciding flag coverage from a fraction of it.",
+    );
     out
 }
 

--- a/tests/offline/harness_metrics_guard.rs
+++ b/tests/offline/harness_metrics_guard.rs
@@ -1,0 +1,484 @@
+//! The harness's own THERMOMETER — the numbers must be true even though nothing
+//! rides on them.
+//!
+//! `.github/scripts/harness_metrics.py` publishes one JSON per CI run: how many
+//! convention-cop guards this repo holds, how many of them prove their subject
+//! is non-empty (`nonvacuity.rs`), how much of each diff `.cargo/mutants.toml`
+//! removes, how the offline-reachable and live-only mutant classes are moving,
+//! how many tests declare themselves documentation rather than verification.
+//! Nobody was writing any of that down, which is how three guards rotted for
+//! months with every signal a reader has still reading green.
+//!
+//! It is not a gate and this file must keep it from becoming one: a metric with
+//! teeth is a number people MANAGE (pad the cop count; rename a test
+//! `..._documents_...` to duck a red), a metric a human reads is a trend.
+//!
+//! What is graded here, and why it is worth grading at all:
+//!
+//! 1. **Unknown is `null`, never `0`.** A run whose mutation job was skipped,
+//!    timed out or never started must leave a HOLE in the trend. Published as
+//!    `0 missed` it is an unbroken green streak meaning "we measured nothing" —
+//!    the same fail-open reading `mutants_classify.py` refuses when a coverage
+//!    report is unreadable, one layer further out where nothing fails loudly.
+//! 2. **The census is not vacuous.** It is a text scan over `tests/offline/`,
+//!    i.e. exactly the fragile class `nonvacuity.rs` exists for; a scan that
+//!    stops matching publishes a harness with no guards in it and the chart
+//!    just... declines.
+//! 3. **The workflow still emits it, and still does not gate on it.**
+//!
+//! Scope honesty, said plainly: this file cannot run GitHub Actions. It reads
+//! the workflow's steps and runs the emitter over fixtures; it cannot prove the
+//! artifact upload succeeds on a runner. That failure mode is handled by
+//! construction rather than by assertion — the job is `continue-on-error` on
+//! top of `if: always()`, so a broken thermometer costs a missing artifact and
+//! nothing else.
+//!
+//! One deviation from the "no subprocess" instinct, stated because it is a real
+//! one: the emitter is PYTHON (it must run in a checkout-plus-python3 job with
+//! no toolchain — a Rust emitter would make the cheapest job in the file build
+//! the whole test tree), so the shaping tests below drive it through `python3`
+//! the way `mutation_gate_priority_guard` drives the classifier. What they do
+//! NOT do is shell out to `cargo`, `cargo-mutants` or `gh`: every count they
+//! grade is a FIXTURE this file wrote.
+
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const CI: &str = ".github/workflows/ci.yml";
+const EMITTER: &str = ".github/scripts/harness_metrics.py";
+const JOB: &str = "harness-metrics";
+
+fn root() -> &'static str {
+    env!("CARGO_MANIFEST_DIR")
+}
+
+fn emitter(args: &[&str]) -> std::process::Output {
+    Command::new("python3")
+        .arg(EMITTER)
+        .args(args)
+        .current_dir(root())
+        .output()
+        .unwrap_or_else(|e| {
+            panic!(
+                "run `python3 {EMITTER} {}`: {e} — python3 is a prerequisite of every gate \
+                 script in this repo, not a reason to skip",
+                args.join(" ")
+            )
+        })
+}
+
+/// A scratch directory for the count fixtures this file shapes.
+///
+/// Hand-rolled rather than `tempfile`, and named by pid+nanos, for the same two
+/// reasons `mutation_gate_priority_guard` gives: this suite links once for ~40
+/// modules, and parallel runs of the same module must not collide.
+fn scratch(tag: &str) -> std::path::PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!(
+        "rivet-harnessmetrics-{tag}-{}-{nanos}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).expect("create scratch dir");
+    dir
+}
+
+/// Shape one fixture of counts through the emitter's PURE half.
+///
+/// `shape` reads a JSON of counts and writes the published document: no tree
+/// scan, no environment, no clock. So what comes back is a function of the
+/// numbers this test wrote and nothing else — the fixture cannot be answered by
+/// the state of the repo, which is what makes the expectations below
+/// hand-writable.
+fn shaped(tag: &str, raw: &str) -> serde_json::Value {
+    let dir = scratch(tag);
+    let input = dir.join("raw.json");
+    let output = dir.join("metrics.json");
+    std::fs::write(&input, raw).expect("write the fixture of counts");
+    let out = emitter(&[
+        "shape",
+        "--in",
+        input.to_str().unwrap(),
+        "--out",
+        output.to_str().unwrap(),
+    ]);
+    assert!(
+        out.status.success(),
+        "`{EMITTER} shape` failed on a fixture it must accept:\n{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let written = std::fs::read_to_string(&output).expect("the shaped document");
+    // The document is read from the FILE the emitter wrote (what CI uploads),
+    // and the summary from its stdout (what CI prints) — the two artifacts the
+    // job actually produces, checked against each other below.
+    let doc: serde_json::Value = serde_json::from_str(&written)
+        .unwrap_or_else(|e| panic!("`{EMITTER} shape` did not write JSON ({e}):\n{written}"));
+    assert_eq!(
+        doc["summary"].as_str(),
+        Some(String::from_utf8_lossy(&out.stdout).trim()),
+        "the line printed into the job log is not the `summary` field of the artifact — the \
+         two must be one string, or the log and the trend disagree"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+    doc
+}
+
+/// The published document is exactly the one a human can predict from the
+/// counts that went in.
+///
+/// The oracle is HAND-WRITTEN, not recomputed from the emitter's own arithmetic
+/// (CLAUDE.md's self-oracle rule: a test that derives `expected` from the code
+/// it guards cannot catch the bug). 2/(2+25) and 13/19 are typed out below
+/// because a reader has to be able to check them by eye.
+///
+/// RED-proven by renaming `subject_proven_rate` in `harness_metrics.py`'s
+/// `derived` block: this test fails on the missing key while the emitter's own
+/// self-test — which asserts `derived` as a whole — fails too.
+#[test]
+fn shaping_a_fixture_of_counts_matches_a_hand_written_document() {
+    let doc = shaped(
+        "full",
+        r#"{
+          "run": {"repo": "acme/rivet", "run_id": "42", "sha": "deadbeef", "event": "pull_request"},
+          "mutants": {"state": "in-budget", "reach": "measured", "report_only_audit": "oracle-holds",
+                      "in_scope": 42, "excluded": 8, "graded": 34,
+                      "offline_reachable": 27, "live_only": 7,
+                      "caught": 25, "missed": 2, "unviable": 0, "timeout": 0},
+          "guards": {"guard_files": 40, "convention_cops": 19, "subject_proven_non_empty": 13,
+                     "subject_unproven": 6, "documents_only_tests": 6,
+                     "files_declaring_blind_spots": 3},
+          "tests": {"offline_declared": 285, "lib_declared": 2674}
+        }"#,
+    );
+
+    assert_eq!(doc["schema"], "rivet-harness-metrics/v1");
+    assert_eq!(doc["mutants"]["missed"], 2);
+    assert_eq!(doc["mutants"]["live_only"], 7);
+    assert_eq!(doc["guards"]["subject_unproven"], 6);
+    assert_eq!(doc["tests"]["lib_declared"], 2674);
+    // 2 missed of the 27 that reached a verdict; 7 live-only of 34 graded;
+    // 13 of 19 cops proving their subject. Rounded to four places by the
+    // emitter — the values a chart plots.
+    assert_eq!(doc["derived"]["missed_rate"], 0.0741);
+    assert_eq!(doc["derived"]["live_only_rate"], 0.2059);
+    assert_eq!(doc["derived"]["subject_proven_rate"], 0.6842);
+    assert_eq!(
+        doc["warnings"].as_array().map(Vec::len),
+        Some(0),
+        "a self-consistent fixture must produce no warnings; got {:?}",
+        doc["warnings"]
+    );
+    // The one line a human reads in the job log is DERIVED from the document,
+    // so the log and the artifact cannot drift apart.
+    let summary = doc["summary"].as_str().expect("summary is a string");
+    for fragment in [
+        "25 caught / 2 missed",
+        "13 of 19 convention cops",
+        "285 offline + 2674 lib",
+    ] {
+        assert!(
+            summary.contains(fragment),
+            "the human summary lost `{fragment}`: {summary}"
+        );
+    }
+}
+
+/// An UNMEASURED count publishes as `null`, and every rate over it as `null`.
+///
+/// This is the defect the emitter exists to avoid, and it is a fail-OPEN one:
+/// a docs-only PR, a skipped mutation job or one killed by its two-hour ceiling
+/// all hand this emitter empty strings. Recorded as `0`, they draw a run with
+/// zero missed mutants — a perfect score for a run that measured nothing, and
+/// on a trend chart the healthiest-looking line in the file. The hole has to
+/// stay a hole, in the JSON (`null`) and in the log (`?`).
+///
+/// RED-proven by making `as_count` return `0` instead of `None` for an unset
+/// value in `harness_metrics.py`: this test fails on `mutants.missed` being 0,
+/// and the emitter's self-test fails with it.
+#[test]
+fn an_unmeasured_count_publishes_null_never_zero() {
+    let doc = shaped(
+        "unknown",
+        r#"{
+          "mutants": {"state": "", "reach": "", "report_only_audit": "",
+                      "in_scope": "", "excluded": "", "graded": "",
+                      "offline_reachable": "", "live_only": "",
+                      "caught": "", "missed": "", "unviable": "", "timeout": ""},
+          "guards": {"guard_files": 40, "convention_cops": 0, "subject_proven_non_empty": 0,
+                     "subject_unproven": 0, "documents_only_tests": 6,
+                     "files_declaring_blind_spots": 3},
+          "tests": {"offline_declared": 285, "lib_declared": 2674}
+        }"#,
+    );
+
+    for field in [
+        "in_scope",
+        "excluded",
+        "graded",
+        "offline_reachable",
+        "live_only",
+        "caught",
+        "missed",
+        "unviable",
+        "timeout",
+        "state",
+        "reach",
+        "report_only_audit",
+    ] {
+        assert!(
+            doc["mutants"][field].is_null(),
+            "`mutants.{field}` came back as {} for a run that measured nothing. Zero is a \
+             MEASUREMENT; the trend must show a hole, not a clean sheet.",
+            doc["mutants"][field]
+        );
+    }
+    for field in ["missed_rate", "live_only_rate", "subject_proven_rate"] {
+        assert!(
+            doc["derived"][field].is_null(),
+            "`derived.{field}` is {} — a rate over an unknown (or over a zero denominator, as \
+             `convention_cops: 0` is here) is not a score, and 0.0 reads as a perfect one",
+            doc["derived"][field]
+        );
+    }
+    let summary = doc["summary"].as_str().expect("summary is a string");
+    assert!(
+        summary.contains("? caught / ? missed") && !summary.contains("0 caught"),
+        "the log line must show the hole too: {summary}"
+    );
+}
+
+/// The emitter's own unit checks — RUN here, so they have a call site outside
+/// CI and fail before the push.
+///
+/// They grade the shaping over fixtures (full document, unknown-is-null, zero
+/// denominator, four consistency warnings, five refused input shapes) and the
+/// census over a fake tree — including the file that names a repo path only in
+/// a COMMENT and must therefore NOT count as a convention cop. That last case
+/// is the `runner_frame_gate` defect (a gate satisfiable by a doc comment) one
+/// level up, in the thing that counts the gates.
+///
+/// RED-proven twice against `harness_metrics.py`: making `_uncommented` return
+/// its input unchanged (the comment-only file is counted as a cop: 3 != 2), and
+/// replacing `census`'s `guards == 0` refusal with a plain return (an empty
+/// tree censuses as a harness holding no guards).
+#[test]
+fn the_emitter_passes_its_own_self_test() {
+    let out = emitter(&["--self-test"]);
+    assert!(
+        out.status.success(),
+        "{EMITTER} fails its own self-test:\n{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+/// The census describes THIS repo, and does not describe a truncated scan of
+/// it.
+///
+/// Floors, not equalities: the numbers are a trend and every ordinary PR moves
+/// them. What the floors catch is the scan that stopped matching — which lands
+/// near zero, not one short — and `guard_files` is pinned against an
+/// INDEPENDENT count taken here, so a census that counts the wrong set of files
+/// disagrees with a reader of the same directory.
+///
+/// RED-proven by dropping the `#[test]` filter from `census` in
+/// `harness_metrics.py` (every `.rs` under tests/offline becomes a guard file:
+/// 40 counted vs 39 independently counted, and `nonvacuity.rs` — a helper with
+/// no test in it — is what the disagreement names).
+#[test]
+fn the_census_counts_the_guards_this_repo_actually_holds() {
+    let out = emitter(&["census"]);
+    assert!(
+        out.status.success(),
+        "`{EMITTER} census` failed on this repo:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let doc: serde_json::Value = serde_json::from_slice(&out.stdout).expect("census JSON");
+    let n = |block: &str, field: &str| -> u64 {
+        doc[block][field]
+            .as_u64()
+            .unwrap_or_else(|| panic!("census has no `{block}.{field}`: {doc}"))
+    };
+
+    // An independent count of the same subject: every `.rs` under tests/offline
+    // that carries a `#[test]`. Taken here rather than read from the census, so
+    // the two can disagree — which is the whole point of an oracle.
+    let dir = std::path::Path::new(root()).join("tests/offline");
+    let mut with_tests = 0;
+    for entry in std::fs::read_dir(&dir).expect("read tests/offline") {
+        let path = entry.expect("dir entry").path();
+        if path.extension().is_some_and(|e| e == "rs")
+            && std::fs::read_to_string(&path)
+                .expect("read a guard")
+                .contains("#[test]")
+        {
+            with_tests += 1;
+        }
+    }
+    super::nonvacuity::require_enumerated(
+        with_tests,
+        25,
+        "`#[test]`-bearing files in tests/offline",
+        "This test's own oracle read almost nothing — fix the read before believing the \
+         comparison below.",
+    );
+    assert_eq!(
+        n("guards", "guard_files"),
+        with_tests as u64,
+        "the census counts a different set of guard files than a reader of tests/offline \
+         does. It is meant to count the files that hold `#[test]`s — a helper module \
+         (nonvacuity.rs) is not a guard, and a guard the scan cannot see is a guard missing \
+         from every number below."
+    );
+
+    // Floors far below today's counts (39 guard files / 19 cops / 13 proven /
+    // 285 offline / 2674 lib on 2026-08-21): a scan that lost its subject lands
+    // at zero, and these fire there rather than on a normal diff.
+    for (block, field, floor) in [
+        ("guards", "convention_cops", 8usize),
+        ("guards", "subject_proven_non_empty", 5),
+        ("tests", "offline_declared", 120),
+        ("tests", "lib_declared", 800),
+    ] {
+        super::nonvacuity::require_enumerated(
+            n(block, field) as usize,
+            floor,
+            &format!("`{block}.{field}` counted by {EMITTER}"),
+            "The census scan lost its subject — re-point it at wherever the harness moved to; \
+             a metric that silently reports a harness with nothing in it is worse than none.",
+        );
+    }
+    assert!(
+        n("guards", "subject_proven_non_empty") <= n("guards", "convention_cops")
+            && n("guards", "convention_cops") <= n("guards", "guard_files"),
+        "the census contradicts itself: {} proven <= {} cops <= {} guard files does not hold",
+        n("guards", "subject_proven_non_empty"),
+        n("guards", "convention_cops"),
+        n("guards", "guard_files"),
+    );
+    assert!(
+        n("guards", "convention_cops") < n("guards", "guard_files"),
+        "EVERY guard file counted as a convention cop — this repo has offline tests that read \
+         no checked-in subject at all (config_fuzz, retry_integration, …), so a census that \
+         finds a repo path in all of them is matching comments or matching everything"
+    );
+}
+
+/// The workflow EMITS the metrics — and still does not gate on them.
+///
+/// Two halves of one property, and both have bitten this repo in other clothes.
+/// A script nobody calls is the dead-code-behind-a-green-cell shape
+/// (`blessed_path.verify_blessed_path`, registered `test` for four engines with
+/// no caller in the tree). A metric that acquires teeth is worse than useless:
+/// people optimise the number instead of the harness — a cop count is trivially
+/// padded, and `..._documents_...` becomes a way to duck a red rather than an
+/// honest label.
+///
+/// The needles are matched against the job's `run:` shell with comments
+/// stripped, because a gate satisfiable by a doc COMMENT is not hypothetical
+/// here (`runner_frame_gate` was, and passed while grading nothing).
+///
+/// RED-proven three times: deleting the `harness_metrics.py emit` step;
+/// dropping `continue-on-error: true` from the job; and adding
+/// `harness-metrics` to `mutants-verdict`'s `needs:` (the thermometer becomes a
+/// dependency of a blocking job, i.e. a gate).
+#[test]
+fn the_workflow_emits_the_metrics_and_never_gates_on_them() {
+    let text = super::nonvacuity::subject_text(CI);
+    let doc: serde_yaml_ng::Value =
+        serde_yaml_ng::from_str(&text).unwrap_or_else(|e| panic!("parse {CI}: {e}"));
+    let jobs = doc["jobs"].as_mapping().expect("ci.yml has jobs");
+    let job = jobs
+        .get(serde_yaml_ng::Value::from(JOB))
+        .unwrap_or_else(|| {
+            panic!(
+                "{CI} has no `{JOB}` job — the harness metrics are emitted by nobody, and \
+                 every assertion below would grade an absent subject. If the job was renamed, \
+                 re-point this guard at it."
+            )
+        });
+
+    let steps = job["steps"].as_sequence().expect("the job has steps");
+    let shell: String = steps
+        .iter()
+        .filter_map(|s| s.get("run").and_then(|r| r.as_str()))
+        .flat_map(|s| s.lines())
+        .filter(|l| !l.trim_start().starts_with('#'))
+        .collect::<Vec<_>>()
+        .join("\n");
+    super::nonvacuity::require_enumerated(
+        shell.lines().count(),
+        3,
+        &format!("non-comment shell lines in ci.yml's `{JOB}` job"),
+        "The job parsed but its scripts did not — this guard is reading the workflow wrong, \
+         and every needle below would miss against an empty haystack.",
+    );
+    for (needle, why) in [
+        (
+            "harness_metrics.py emit",
+            "the emitter itself; without it the job publishes nothing and the trend flat-lines \
+             at whatever was last uploaded",
+        ),
+        (
+            "::notice::",
+            "the one-line human summary in the job log — an artifact nobody opens is a metric \
+             nobody reads",
+        ),
+    ] {
+        super::nonvacuity::require_needle(
+            &shell,
+            &format!("ci.yml's `{JOB}` shell"),
+            needle,
+            1,
+            &format!("The metrics job must run `{needle}` — it is {why}."),
+        );
+    }
+    let uploads = steps.iter().any(|s| {
+        s.get("uses")
+            .and_then(|u| u.as_str())
+            .is_some_and(|u| u.contains("upload-artifact"))
+    });
+    assert!(
+        uploads,
+        "ci.yml's `{JOB}` job does not upload its JSON — a metrics file that lives and dies \
+         inside one runner is not a trend anybody can read across runs"
+    );
+    // Its shaping is graded where it is cheap to grade: the gate-scripts job.
+    super::nonvacuity::require_needle(
+        &text,
+        CI,
+        "harness_metrics.py --self-test",
+        1,
+        "The emitter's own unit checks must run in CI too, not only in this suite.",
+    );
+
+    // …and the half that keeps it a thermometer.
+    assert_eq!(
+        job.get("continue-on-error").and_then(|v| v.as_bool()),
+        Some(true),
+        "ci.yml's `{JOB}` job is not `continue-on-error: true` — a broken thermometer must \
+         never hold a merge. The numbers here are a trend, and the moment they can fail a PR \
+         people start managing the number instead of the harness."
+    );
+    let depends_on_metrics: Vec<String> = jobs
+        .iter()
+        .filter(|(name, _)| name.as_str() != Some(JOB))
+        .filter(|(_, spec)| match spec.get("needs") {
+            Some(serde_yaml_ng::Value::String(one)) => one == JOB,
+            Some(serde_yaml_ng::Value::Sequence(many)) => {
+                many.iter().any(|n| n.as_str() == Some(JOB))
+            }
+            _ => false,
+        })
+        .map(|(name, _)| name.as_str().unwrap_or("?").to_string())
+        .collect();
+    assert!(
+        depends_on_metrics.is_empty(),
+        "{depends_on_metrics:?} depend(s) on `{JOB}`, which makes the thermometer a \
+         PRECONDITION of another job. Nothing may block on these numbers: publish them, read \
+         them, and gate on the guards themselves."
+    );
+}

--- a/tests/offline/live_only_purity_gate.rs
+++ b/tests/offline/live_only_purity_gate.rs
@@ -1,0 +1,867 @@
+//! LIVE-ONLY PURITY: a body no offline test can reach may not DECIDE.
+//!
+//! `.cargo/mutants.toml` excludes a handful of functions WHOLESALE — `replace
+//! run_pool -> Result`, `replace check -> Result<bool> with Ok`, … — under the
+//! documented "`--lib` on a live-only path" class: they open a real source, a
+//! real destination or a real process, so `cargo mutants --in-diff` (which has
+//! no stand) reports every mutant in them MISSED whatever the assertions say.
+//! That exclusion is honest about the BODY. It is not honest about the
+//! DECISIONS inside the body: an `&&`, a `!`, a `x > y` in an `if` is a branch
+//! whose mutant is now excluded too, and no unit test is asked for it.
+//!
+//! Measured this session, and the reason this gate exists: five decisions were
+//! pulled out of `execute_resolved_plan` (`src/pipeline/job.rs`) BY HAND —
+//! `should_reconcile`, `plan_rejection_error`, `resume_success_gate_applies`,
+//! `rerun_warning_applies`, `dispatches_to_cdc_runner` — each time only because
+//! the mutation gate pointed at that exact operator and someone had to argue it
+//! out one at a time. `fold_failures` (`src/pipeline/run.rs`) came out of the
+//! same pass and was a REAL gap, not a triage: the fold had no unit oracle at
+//! all. Six extractions, six ad-hoc arguments, and nothing to stop the seventh
+//! from being written inline tomorrow.
+//!
+//! So state the rule instead of re-litigating it: **a live-only body is glue —
+//! sequencing, I/O, error context — and calls NAMED PREDICATES for anything it
+//! decides.** The predicate is pure, offline-testable, and its mutants are
+//! graded; the glue around it stays excluded for the reason the exclusion says.
+//!
+//! # What counts as a decision
+//!
+//! `&&`, `||` and negation `!` anywhere in the body, and a comparison
+//! (`== != <= >= < >`) inside an `if`/`while` CONDITION. Those are exactly the
+//! shapes cargo-mutants rewrites (`replace && with ||`, `delete !`, `replace >
+//! with >=`), so the count is a count of excluded mutants.
+//!
+//! Scope honesty, stated rather than implied:
+//!
+//! * a comparison in a `let`, a `match` arm or a closure body is NOT counted —
+//!   the rule as written covers `if`/`while`, and widening it later is a
+//!   tightening, never a loosening. Do not read a zero here as "no comparison
+//!   in this function";
+//! * `match` and `if let` are not counted either. They dispatch on a shape, and
+//!   cargo-mutants' `delete match arm` mutants on the live-only dispatchers are
+//!   already triaged individually in `mutants.toml` with a live oracle each;
+//! * this is a SOURCE lint. It grades the text of a body, not its behaviour. It
+//!   cannot tell a decision that matters from one that does not — which is the
+//!   point: the ratchet says "argue this one out", and the argument's home is a
+//!   named predicate with a unit test, not a comment.
+//!
+//! # The ratchet
+//!
+//! [`BASELINE`] holds today's offenders at today's counts, the same shrink-only
+//! shape as `rig_adoption_guard`'s bespoke-site ledger. A site that is not
+//! listed must be CLEAN; a listed site may not grow; a listed site that has been
+//! cleaned up must have its ceiling LOWERED in the same diff, so every
+//! extraction is banked and cannot be spent later as silent slack.
+
+use std::collections::BTreeMap;
+
+/// Decisions counted in one live-only body, per shape.
+///
+/// Kept as separate counters rather than a total so a failure names WHICH
+/// mutant class grew — the fix for an `&&` (a named predicate) is not the fix
+/// for a `>` in a loop bound.
+#[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
+struct Decisions {
+    /// `&&`, anywhere in the body.
+    and: usize,
+    /// `||` used as an operator — a zero-argument closure (`move || …`,
+    /// `unwrap_or_else(|| …)`) is not a decision and is not counted.
+    or: usize,
+    /// Negation `!x`. A macro bang (`assert!`, `format!`) and the `!=`
+    /// operator are not negations and are not counted here.
+    not: usize,
+    /// A comparison inside an `if`/`while` condition.
+    cmp: usize,
+}
+
+impl Decisions {
+    fn total(self) -> usize {
+        self.and + self.or + self.not + self.cmp
+    }
+    fn exceeds(self, cap: Decisions) -> bool {
+        self.and > cap.and || self.or > cap.or || self.not > cap.not || self.cmp > cap.cmp
+    }
+    fn under(self, cap: Decisions) -> bool {
+        self.and < cap.and || self.or < cap.or || self.not < cap.not || self.cmp < cap.cmp
+    }
+}
+
+/// `(site, and, or, not, cmp)` — the decisions each live-only body still makes
+/// inline. Site is `<path>::<fn>`; regenerate a row from this gate's own
+/// failure message, which prints the actual counts.
+///
+/// Shrink freely — LOWER a number the moment you extract a predicate. Growing
+/// one, or adding a row, means a new decision is now excluded from the mutation
+/// corpus with nothing asked in return: the reviewed alternative is a named
+/// pure function next door plus its unit test, which is what the six
+/// extractions this ledger was born from ended up as.
+const BASELINE: &[(&str, usize, usize, usize, usize)] = &[
+    // ── the export RUNNERS ───────────────────────────────────────────────
+    // The three big-table runners each own their execution loop, and each loop
+    // is dense with pagination/plan arithmetic. These are the ceilings most
+    // worth spending: the runner-bypass class in CLAUDE.md is precisely a
+    // per-runner decision that no offline test grades.
+    ("src/pipeline/keyset.rs::run_keyset", 5, 1, 3, 2),
+    ("src/pipeline/keyset.rs::run_keyset_parallel", 8, 0, 4, 4),
+    (
+        "src/pipeline/mongo_parallel.rs::run_mongo_parallel",
+        1,
+        0,
+        1,
+        1,
+    ),
+    ("src/pipeline/single.rs::run_with_reconnect", 0, 0, 0, 1),
+    // run_pool is the bounded work-stealing executor. Its two headline
+    // decisions (next_eligible, advise_split) are ALREADY extracted and
+    // unit-tested — mutants.toml says so — and what remains is the HeavyGuard
+    // reset and the giant-lookup glue. Those remaining operators are why
+    // `delete ! in run_pool` and `replace == with != in run_pool` had to be
+    // triaged as separate entries: this ledger is the list of such entries
+    // waiting to be written.
+    ("src/pipeline/run.rs::run_pool", 7, 1, 6, 2),
+    (
+        "src/pipeline/parallel_children.rs::run_exports_as_child_processes",
+        0,
+        0,
+        5,
+        3,
+    ),
+    // ── the orchestration scripts ────────────────────────────────────────
+    // execute_resolved_plan is where the six hand-extractions came FROM, so its
+    // row is the direct measure of how much of that pass is left.
+    ("src/pipeline/job.rs::execute_resolved_plan", 2, 0, 0, 1),
+    ("src/pipeline/plan_cmd.rs::run_plan_command", 1, 0, 3, 1),
+    // ── source/introspection glue ────────────────────────────────────────
+    ("src/init/mod.rs::introspect_all", 2, 0, 3, 1),
+    ("src/init/mysql.rs::density_probe", 1, 0, 1, 2),
+    ("src/init/postgres.rs::density_probe", 0, 0, 1, 0),
+    ("src/source/postgres/mod.rs::pg_run_export", 2, 0, 2, 4),
+    // ── preflight ────────────────────────────────────────────────────────
+    // `check` diagnoses every export against a live source. The `==` in its
+    // overlay export-match loop is already a named mutants.toml entry
+    // (`replace == with != in check$`, anchored) — same story as run_pool.
+    ("src/preflight/mod.rs::check", 6, 0, 7, 2),
+];
+
+// ── reading the live-only set out of the mutation config ─────────────────
+
+/// The whole-function exclusions, as `(fn name, return-type prefix)`.
+///
+/// DERIVED from `.cargo/mutants.toml`, never typed in: the enumerated dimension
+/// here is "which functions the gate excludes wholesale", and a hand-written
+/// copy of it grades only what its author already knew (CLAUDE.md, "derive the
+/// enumerated dimension"). A new live-only exclusion therefore enters this
+/// gate's subject the moment it is added to the config — which is exactly the
+/// moment someone is deciding whether the body it hides is glue or logic.
+///
+/// The link is load-bearing in BOTH directions, and RED-proven so: drifting the
+/// `check` entry's discriminator to `-> Result<Verdict>` (a stand-in for the
+/// function being renamed or its signature changing) makes it resolve to no
+/// body, and the per-name non-vacuity assertion in [`graded_sites`] fails
+/// naming the dead exclusion — rather than grading zero bodies and calling the
+/// tree pure. Honest scope: the same class via an actual `fn` rename cannot be
+/// exercised the same way, because the tree then does not compile and no test
+/// runs at all — a louder failure, but not this one's.
+///
+/// A whole-function stub mutant is named `replace <fn> -> <ret> with <value>`
+/// (or `replace <fn> with <value>` when there is no return type), so an entry
+/// of that SHAPE is a live-only claim about the whole body. Operator entries
+/// (`replace == with != in check$`, `delete ! in run_pool`) are equivalence or
+/// per-operator triage, not a body claim, and are skipped — they are, in fact,
+/// the symptom this gate exists to make unnecessary.
+fn live_only_functions() -> Vec<(String, Option<String>)> {
+    let mut out = Vec::new();
+    for pat in super::mutation_gate_config::exclude_patterns() {
+        let Some(rest) = pat.strip_prefix("replace ") else {
+            continue;
+        };
+        let name: String = rest
+            .chars()
+            .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+            .collect();
+        if name.is_empty() {
+            continue;
+        }
+        let tail = &rest[name.len()..];
+        // `replace <fn> -> <ret> with <val>` / `replace <fn> with <val>`. The
+        // `-> ` and `with ` spellings are cargo-mutants', not ours.
+        let ret = if let Some(after) = tail.strip_prefix(" -> ") {
+            let ret = after.split(" with ").next().unwrap_or(after).trim();
+            // The entry is a REGEX, so its literal text carries backslash
+            // escapes (`Result<\(\)>`); compare against source text unescaped.
+            let ret: String = {
+                let mut s = String::new();
+                let mut chars = ret.chars();
+                while let Some(c) = chars.next() {
+                    if c == '\\' {
+                        if let Some(n) = chars.next() {
+                            s.push(n);
+                        }
+                    } else {
+                        s.push(c);
+                    }
+                }
+                s
+            };
+            if ret.is_empty() { None } else { Some(ret) }
+        } else if tail.starts_with(" with ") || tail == " with" || tail.starts_with(" ->") {
+            // `replace density_probe with …` (no return type) and
+            // `replace pg_run_export ->` (truncated before it) are both
+            // name-only claims: no discriminator, so grade every site of that
+            // name.
+            None
+        } else {
+            continue; // not a whole-function stub entry
+        };
+        out.push((name, ret));
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+// ── reading Rust source without being fooled by it ───────────────────────
+
+/// Blank out comments, string literals and char literals, preserving offsets.
+///
+/// A lint that reads raw source grades its own doc comments: `runner_frame_gate`
+/// shipped satisfiable by a doc-COMMENT mention of the call it demanded, and the
+/// fix was exactly this. Offsets are preserved (each removed byte becomes a
+/// space) so a brace scan over the result still lands on the real braces.
+fn blank_noncode(src: &str) -> String {
+    let b: Vec<char> = src.chars().collect();
+    let mut out = String::with_capacity(b.len());
+    let mut i = 0usize;
+    let keep = |out: &mut String, c: char| out.push(if c == '\n' { '\n' } else { ' ' });
+    while i < b.len() {
+        // line comment
+        if b[i] == '/' && b.get(i + 1) == Some(&'/') {
+            while i < b.len() && b[i] != '\n' {
+                keep(&mut out, b[i]);
+                i += 1;
+            }
+            continue;
+        }
+        // block comment (nesting, as rustc allows)
+        if b[i] == '/' && b.get(i + 1) == Some(&'*') {
+            let mut depth = 0usize;
+            while i < b.len() {
+                if b[i] == '/' && b.get(i + 1) == Some(&'*') {
+                    depth += 1;
+                    keep(&mut out, b[i]);
+                    keep(&mut out, b[i + 1]);
+                    i += 2;
+                    continue;
+                }
+                if b[i] == '*' && b.get(i + 1) == Some(&'/') {
+                    depth -= 1;
+                    keep(&mut out, b[i]);
+                    keep(&mut out, b[i + 1]);
+                    i += 2;
+                    if depth == 0 {
+                        break;
+                    }
+                    continue;
+                }
+                keep(&mut out, b[i]);
+                i += 1;
+            }
+            continue;
+        }
+        // raw string: r"…" / r#"…"# / br##"…"##
+        if (b[i] == 'r' || b[i] == 'b')
+            && let Some(start) = raw_string_start(&b, i)
+        {
+            let hashes = start.1;
+            let mut j = start.0;
+            for c in &b[i..j] {
+                keep(&mut out, *c);
+            }
+            'raw: while j < b.len() {
+                if b[j] == '"' && b[j + 1..].iter().take(hashes).all(|c| *c == '#') {
+                    for c in &b[j..(j + 1 + hashes).min(b.len())] {
+                        keep(&mut out, *c);
+                    }
+                    j += 1 + hashes;
+                    break 'raw;
+                }
+                keep(&mut out, b[j]);
+                j += 1;
+            }
+            i = j;
+            continue;
+        }
+        // ordinary string
+        if b[i] == '"' {
+            keep(&mut out, b[i]);
+            i += 1;
+            while i < b.len() && b[i] != '"' {
+                if b[i] == '\\' {
+                    keep(&mut out, b[i]);
+                    i += 1;
+                    if i >= b.len() {
+                        break;
+                    }
+                }
+                keep(&mut out, b[i]);
+                i += 1;
+            }
+            if i < b.len() {
+                keep(&mut out, b[i]);
+                i += 1;
+            }
+            continue;
+        }
+        // char literal vs LIFETIME: `'a` is a lifetime, `'x'` and `'\n'` are not
+        if b[i] == '\'' && (b.get(i + 1) == Some(&'\\') || b.get(i + 2) == Some(&'\'')) {
+            keep(&mut out, b[i]);
+            i += 1;
+            while i < b.len() && b[i] != '\'' {
+                if b[i] == '\\' {
+                    keep(&mut out, b[i]);
+                    i += 1;
+                    if i >= b.len() {
+                        break;
+                    }
+                }
+                keep(&mut out, b[i]);
+                i += 1;
+            }
+            if i < b.len() {
+                keep(&mut out, b[i]);
+                i += 1;
+            }
+            continue;
+        }
+        out.push(b[i]);
+        i += 1;
+    }
+    out
+}
+
+/// If a raw-string literal opens at `i`, return `(index of the opening quote,
+/// hash count)`.
+fn raw_string_start(b: &[char], i: usize) -> Option<(usize, usize)> {
+    let mut j = i;
+    if b[j] == 'b' {
+        j += 1;
+    }
+    if b.get(j) != Some(&'r') {
+        return None;
+    }
+    // `r` must start a token, not end an identifier (`char`, `for`).
+    if i > 0 && (b[i - 1].is_ascii_alphanumeric() || b[i - 1] == '_') {
+        return None;
+    }
+    j += 1;
+    let mut hashes = 0usize;
+    while b.get(j) == Some(&'#') {
+        hashes += 1;
+        j += 1;
+    }
+    if b.get(j) == Some(&'"') {
+        Some((j + 1, hashes))
+    } else {
+        None
+    }
+}
+
+/// Every `fn <name>` in `code` (already blanked), as `(return type, body)`.
+///
+/// The body is the brace-matched text INCLUDING its braces; the return type is
+/// the text between a depth-0 `->` and the opening brace, empty when the
+/// function returns unit.
+fn fn_sites(code: &str, name: &str) -> Vec<(String, String)> {
+    let b: Vec<char> = code.chars().collect();
+    let needle: Vec<char> = format!("fn {name}").chars().collect();
+    let mut out = Vec::new();
+    let mut i = 0usize;
+    while i + needle.len() < b.len() {
+        if b[i..].starts_with(&needle[..])
+            && (i == 0 || !(b[i - 1].is_ascii_alphanumeric() || b[i - 1] == '_'))
+        {
+            let mut j = i + needle.len();
+            while b.get(j) == Some(&' ') {
+                j += 1;
+            }
+            // The next token settles it: `fn foo(` / `fn foo<T>(` is our
+            // function; `fn foo_bar(` was excluded by the word boundary above.
+            if b.get(j) == Some(&'(') || b.get(j) == Some(&'<') {
+                let mut depth = 0i32;
+                let mut ret_at: Option<usize> = None;
+                let mut k = j;
+                while k < b.len() {
+                    match b[k] {
+                        '(' | '[' => depth += 1,
+                        ')' | ']' => depth -= 1,
+                        '<' => depth += 1,
+                        '>' => depth -= 1,
+                        ';' if depth <= 0 => break, // a trait signature, no body
+                        '{' if depth <= 0 => {
+                            let body_end = match_brace(&b, k);
+                            let ret = ret_at
+                                .map(|r| b[r..k].iter().collect::<String>().trim().to_string())
+                                .unwrap_or_default();
+                            if let Some(end) = body_end {
+                                out.push((ret, b[k..=end].iter().collect::<String>()));
+                            }
+                            break;
+                        }
+                        _ => {}
+                    }
+                    if b[k] == '-' && b.get(k + 1) == Some(&'>') {
+                        if depth == 0 && ret_at.is_none() {
+                            ret_at = Some(k + 2);
+                        }
+                        k += 2; // `->`'s `>` is not an angle close
+                        continue;
+                    }
+                    k += 1;
+                }
+            }
+        }
+        i += 1;
+    }
+    out
+}
+
+fn match_brace(b: &[char], open: usize) -> Option<usize> {
+    let mut depth = 0i32;
+    for (k, c) in b.iter().enumerate().skip(open) {
+        match c {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(k);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Count the decision shapes in a blanked body.
+fn decisions(body: &str) -> Decisions {
+    let b: Vec<char> = body.chars().collect();
+    let mut d = Decisions::default();
+    let identish = |c: char| c.is_ascii_alphanumeric() || c == '_';
+    let mut i = 0usize;
+    while i < b.len() {
+        if b[i] == '&' && b.get(i + 1) == Some(&'&') {
+            d.and += 1;
+            i += 2;
+            continue;
+        }
+        if b[i] == '|' && b.get(i + 1) == Some(&'|') {
+            // `||` is a ZERO-ARG CLOSURE far more often than an or in this
+            // code (`move || {}`, `unwrap_or_else(|| …)`), and cargo-mutants
+            // does not mutate a closure's pipes. Decide by what precedes it:
+            // a value (ident, `)`, `]`, `?`) means `or`; anything else, or the
+            // `move`/`return` keyword, means closure.
+            let mut k = i;
+            while k > 0 && b[k - 1].is_whitespace() {
+                k -= 1;
+            }
+            let prev = if k == 0 { ' ' } else { b[k - 1] };
+            let mut word = String::new();
+            if identish(prev) {
+                let mut w = k;
+                while w > 0 && identish(b[w - 1]) {
+                    w -= 1;
+                }
+                word = b[w..k].iter().collect();
+            }
+            let closure_keyword = matches!(word.as_str(), "move" | "return" | "else" | "in");
+            if (identish(prev) || matches!(prev, ')' | ']' | '?')) && !closure_keyword {
+                d.or += 1;
+            }
+            i += 2;
+            continue;
+        }
+        if b[i] == '!' {
+            let prev = if i == 0 { ' ' } else { b[i - 1] };
+            if identish(prev) || prev == ':' {
+                // a macro bang: `assert!`, `vec!`, `write!`
+            } else if b.get(i + 1) == Some(&'=') {
+                i += 2; // `!=` — a comparison, counted only in an if/while
+                continue;
+            } else {
+                d.not += 1;
+            }
+            i += 1;
+            continue;
+        }
+        i += 1;
+    }
+    d.cmp = comparisons_in_conditions(&b);
+    d
+}
+
+/// Comparisons inside `if`/`while` conditions.
+///
+/// The condition runs from the keyword to the `{` that opens its block at paren
+/// depth 0 — which is also where an `if let` pattern lives, and a pattern holds
+/// no comparison, so it contributes nothing.
+fn comparisons_in_conditions(b: &[char]) -> usize {
+    let identish = |c: char| c.is_ascii_alphanumeric() || c == '_';
+    let mut n = 0usize;
+    let mut i = 0usize;
+    while i < b.len() {
+        let kw = ["if", "while"].iter().find(|k| {
+            let k: Vec<char> = k.chars().collect();
+            b[i..].starts_with(&k[..])
+                && (i == 0 || !identish(b[i - 1]))
+                && b.get(i + k.len()).is_some_and(|c| !identish(*c))
+        });
+        let Some(kw) = kw else {
+            i += 1;
+            continue;
+        };
+        let mut j = i + kw.len();
+        let mut depth = 0i32;
+        while j < b.len() {
+            match b[j] {
+                '(' | '[' => depth += 1,
+                ')' | ']' => depth -= 1,
+                '{' if depth <= 0 => break,
+                _ => {}
+            }
+            j += 1;
+        }
+        let cond = &b[i + kw.len()..j.min(b.len())];
+        let mut k = 0usize;
+        while k < cond.len() {
+            let two = (cond[k], cond.get(k + 1).copied().unwrap_or(' '));
+            if matches!(two, ('=', '=') | ('!', '=') | ('<', '=') | ('>', '=')) {
+                n += 1;
+                k += 2;
+                continue;
+            }
+            // A bare `<`/`>` only when spaced on both sides: unspaced, it is a
+            // generic or a turbofish (`Vec<u8>`, `as::<T>`).
+            if matches!(cond[k], '<' | '>')
+                && k > 0
+                && cond[k - 1] == ' '
+                && cond.get(k + 1) == Some(&' ')
+            {
+                n += 1;
+            }
+            k += 1;
+        }
+        i = j.max(i + 1);
+    }
+    n
+}
+
+// ── the graded set ───────────────────────────────────────────────────────
+
+/// Every `<path>::<fn>` site a whole-function exclusion covers, with its
+/// decision counts.
+fn graded_sites() -> BTreeMap<String, Decisions> {
+    let root = super::nonvacuity::repo_root().join("src");
+    let mut files: Vec<std::path::PathBuf> = Vec::new();
+    let mut stack = vec![root.clone()];
+    while let Some(dir) = stack.pop() {
+        for e in std::fs::read_dir(&dir).expect("read src/").flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                stack.push(p);
+            } else if p.extension().is_some_and(|x| x == "rs") {
+                files.push(p);
+            }
+        }
+    }
+    files.sort();
+    // The walk is itself a subject: `src/` reorganising under a gate that
+    // reads it is how `destructive_delete_gate` went blind while passing.
+    super::nonvacuity::require_enumerated(
+        files.len(),
+        60,
+        "`.rs` files walked under src/",
+        "The crate's sources moved — re-point this gate, or it will grade zero live-only \
+         bodies and call every one of them pure.",
+    );
+    let blanked: Vec<(String, String)> = files
+        .iter()
+        .map(|p| {
+            let rel = p
+                .strip_prefix(super::nonvacuity::repo_root())
+                .expect("under repo root")
+                .to_string_lossy()
+                .replace('\\', "/");
+            let text = super::nonvacuity::subject_text(&rel);
+            (rel, blank_noncode(&text))
+        })
+        .collect();
+
+    let mut sites: BTreeMap<String, Decisions> = BTreeMap::new();
+    for (name, ret) in live_only_functions() {
+        let mut hits = 0usize;
+        for (rel, code) in &blanked {
+            for (actual_ret, body) in fn_sites(code, &name) {
+                // Same-named siblings are real (`check` also names a struct
+                // helper in preflight/cdc_health.rs, `density_probe` exists per
+                // engine). The exclusion regex carries the return type when it
+                // needs to disambiguate, so honour it; with no return type in
+                // the entry, grade EVERY site of that name — a gate that grades
+                // one function too many is a nuisance, one that grades none is
+                // the defect.
+                if let Some(want) = &ret
+                    && !actual_ret.starts_with(want.as_str())
+                {
+                    continue;
+                }
+                hits += 1;
+                sites.insert(format!("{rel}::{name}"), decisions(&body));
+            }
+        }
+        // NON-VACUITY, per name: an exclusion whose function was renamed,
+        // inlined or whose return type drifted resolves to NO body, and a
+        // gate over no bodies finds no offenders. `.cargo/mutants.toml` is
+        // the claim; `src/` is the subject — they must still meet.
+        assert!(
+            hits > 0,
+            "NON-VACUITY: the live-only exclusion for `{name}`{} resolves to no function in \
+             src/. Either the function moved/was renamed (re-point the exclusion AND this \
+             gate's baseline row), or the exclusion is DEAD — a dead exclusion triages \
+             nothing while claiming to.",
+            ret.as_deref()
+                .map(|r| format!(" (-> {r})"))
+                .unwrap_or_default()
+        );
+    }
+    sites
+}
+
+// ── the guards ───────────────────────────────────────────────────────────
+
+/// A live-only body decides nothing the offline gate has not been shown.
+///
+/// RED-proven twice, mutant applied to the PRODUCT and reverted:
+///
+/// * `let _mutant = true && false;` into the clean body of
+///   `refuse_compressed_binlog` — fails with
+///   `src/source/mysql/cdc.rs::refuse_compressed_binlog: and=1 … — NOT in the
+///   ratchet at all`;
+/// * `let _mutant = if 1 > 0 {…}` into the LISTED body of
+///   `run_with_reconnect` — fails with `cmp=2 > ceiling … cmp=1`.
+///
+/// Also RED against a mutant in the GATE: stubbing [`blank_noncode`] to
+/// `src.to_string()` (the `runner_frame_gate` defect — a lint that grades its
+/// own doc comments) fails this test and the scanner's own test together.
+#[test]
+fn live_only_bodies_decide_only_through_named_predicates() {
+    let baseline: BTreeMap<&str, Decisions> = BASELINE
+        .iter()
+        .map(|(s, and, or, not, cmp)| {
+            (
+                *s,
+                Decisions {
+                    and: *and,
+                    or: *or,
+                    not: *not,
+                    cmp: *cmp,
+                },
+            )
+        })
+        .collect();
+    let sites = graded_sites();
+
+    // 16 sites today. The floor catches a config or a walk that stopped
+    // resolving them — at which point every assertion below passes over the
+    // empty set, which is how a source lint reports green while grading
+    // nothing.
+    super::nonvacuity::require_enumerated(
+        sites.len(),
+        10,
+        "live-only function sites resolved from .cargo/mutants.toml",
+        "The whole-function exclusions changed shape — re-read `live_only_functions`.",
+    );
+    // ONE clean site, not today's three: this floor asks only whether the
+    // scanner can still say "pure" at all — a scanner that counts syntax as
+    // decisions reports zero clean bodies and every ceiling in the ratchet
+    // becomes noise. Set higher, it PREEMPTS the offender verdict below and
+    // reports a vacuity failure for what is really a new decision (measured
+    // while RED-proving this gate: an `&&` added to `refuse_compressed_binlog`
+    // failed here, naming the scanner, instead of naming the offender). The
+    // real guard against a noisy scanner is
+    // `the_decision_scanner_counts_operators_not_syntax`, which grades it
+    // against hand-written bodies.
+    super::nonvacuity::require_enumerated(
+        sites.values().filter(|d| d.total() == 0).count(),
+        1,
+        "live-only bodies that are already CLEAN",
+        "No live-only body reads as pure — check the decision scanner before the repo.",
+    );
+
+    let mut grew: Vec<String> = Vec::new();
+    for (site, d) in &sites {
+        match baseline.get(site.as_str()) {
+            Some(cap) if d.exceeds(*cap) => grew.push(format!(
+                "{site}: and={} or={} not={} cmp={} > ceiling and={} or={} not={} cmp={}",
+                d.and, d.or, d.not, d.cmp, cap.and, cap.or, cap.not, cap.cmp
+            )),
+            None if d.total() > 0 => grew.push(format!(
+                "{site}: and={} or={} not={} cmp={} — NOT in the ratchet at all",
+                d.and, d.or, d.not, d.cmp
+            )),
+            _ => {}
+        }
+    }
+    assert!(
+        grew.is_empty(),
+        "a live-only body grew a DECISION the mutation gate cannot reach.\n\
+         `.cargo/mutants.toml` excludes these bodies wholesale because no offline test \
+         can execute them — so every branch written inline here is a mutant excluded \
+         with nothing asked in return, and the next in-diff run will point at it and \
+         someone will argue it out one at a time (six such extractions this session).\n\
+         Do it once instead: move the decision into a NAMED pure predicate beside the \
+         function (`should_reconcile`, `resume_success_gate_applies`, `fold_failures` are \
+         the templates), unit-test it, and leave the glue calling it. If the branch \
+         genuinely cannot be extracted, raise this site's ceiling in a reviewed diff \
+         that says why.\n{}",
+        grew.join("\n")
+    );
+}
+
+/// The ratchet records its wins, or it is a growth allowance.
+///
+/// Slack in a shrink-only ledger is exactly as wide as every past extraction —
+/// a body cleaned last month silently buys back its old operator count. Same
+/// rule and same failure shape as `rig_adoption_guard`'s downward test.
+///
+/// RED-proven with the extraction this ledger exists to bank: deleting the `!`
+/// in `src/init/postgres.rs::density_probe` (the shape of moving a negation
+/// into `probe_trustworthy`'s caller) without lowering the row fails with
+/// `actual … not=0 < ceiling … not=1 — lower it`. It also fired for real
+/// while this gate was being written: four rows carried a `move ||` closure
+/// counted as an `or`, and the downward test refused them.
+#[test]
+fn the_purity_ratchet_matches_reality_downward_too() {
+    let sites = graded_sites();
+    let mut slack: Vec<String> = Vec::new();
+    for (site, and, or, not, cmp) in BASELINE {
+        let cap = Decisions {
+            and: *and,
+            or: *or,
+            not: *not,
+            cmp: *cmp,
+        };
+        match sites.get(*site) {
+            None => slack.push(format!(
+                "{site}: listed but no longer a live-only site — drop the row (and check \
+                 whether its `.cargo/mutants.toml` exclusion is dead too)"
+            )),
+            Some(d) if d.under(cap) => slack.push(format!(
+                "{site}: actual and={} or={} not={} cmp={} < ceiling and={} or={} not={} \
+                 cmp={} — lower it",
+                d.and, d.or, d.not, d.cmp, cap.and, cap.or, cap.not, cap.cmp
+            )),
+            Some(_) => {}
+        }
+    }
+    assert!(
+        slack.is_empty(),
+        "the live-only purity ratchet has slack; tighten it so each extraction stays \
+         banked:\n{}",
+        slack.join("\n")
+    );
+}
+
+/// The scanner must count what cargo-mutants would mutate — and nothing else.
+///
+/// An INDEPENDENT oracle, not a re-read of src/: every expectation below is a
+/// hand-written number over a hand-written body. The false positives it pins
+/// are the ones this scanner actually had while being written (a `move ||`
+/// closure read as an `or`, `assert!` read as a negation, `Vec<u8>` in an `if`
+/// read as a comparison) — each of which would have banked a phantom operator
+/// into the ratchet and made a real one invisible under it.
+#[test]
+fn the_decision_scanner_counts_operators_not_syntax() {
+    let count = |src: &str| decisions(&blank_noncode(src));
+
+    assert_eq!(
+        count("{ if a && !b { x(); } }"),
+        Decisions {
+            and: 1,
+            or: 0,
+            not: 1,
+            cmp: 0
+        }
+    );
+    // Closures are not decisions; macro bangs are not negations; a comparison
+    // outside a condition is out of this rule's stated scope.
+    assert_eq!(
+        count(
+            "{ std::thread::spawn(move || { assert!(ok); }); \
+             let f = || 1; v.unwrap_or_else(|| 0); let q = a == b; }"
+        ),
+        Decisions::default()
+    );
+    // …but a real `||` between two values is.
+    assert_eq!(count("{ if a() || b { } }").or, 1);
+    assert_eq!(count("{ if flags[i] || done { } }").or, 1);
+    // Generics and turbofish inside a condition are not comparisons; spaced
+    // relational operators are.
+    assert_eq!(count("{ if v.parse::<u64>().is_ok() { } }").cmp, 0);
+    assert_eq!(count("{ if n > 0 { } while i <= len { } }").cmp, 2);
+    assert_eq!(count("{ if a != b { } }").cmp, 1);
+    // `!=` is a comparison, never a negation — double-counting it would make
+    // every ceiling in the ratchet a lie in the same direction.
+    assert_eq!(count("{ if a != b { } }").not, 0);
+    // Comments and strings are TEXT. A doc comment naming `&&` is how
+    // `runner_frame_gate` was satisfiable by prose.
+    assert_eq!(
+        count("{ /* a && b */ let s = \"x || y\"; let r = r#\"!z\"#; }"),
+        Decisions::default()
+    );
+    // A lifetime is not a char literal — mis-lexing `'a` swallows the rest of
+    // the body as a string and reports a pure function.
+    assert_eq!(count("{ let x: &'static str = \"\"; if !p { } }").not, 1);
+}
+
+/// The graded set is read out of the config, not typed in.
+///
+/// Pins the SHAPES `live_only_functions` must recognise against hand-written
+/// input, and asserts the two kinds of entry stay separated: a whole-function
+/// stub is a claim about a BODY (graded here), an operator entry is a triage of
+/// one mutant (not graded here — and the thing this gate exists to stop needing).
+#[test]
+fn only_whole_function_exclusions_are_read_as_live_only_claims() {
+    let real = live_only_functions();
+    let names: Vec<&str> = real.iter().map(|(n, _)| n.as_str()).collect();
+    for expect in ["run_pool", "check", "density_probe", "pg_run_export"] {
+        assert!(
+            names.contains(&expect),
+            "`{expect}` is excluded wholesale in .cargo/mutants.toml but this gate did not \
+             read it as a live-only claim: {names:?}"
+        );
+    }
+    // Operator/equivalence entries name a function too — and must NOT be read
+    // as a body claim, or the gate would demand purity of `hash_value` and
+    // `overlay_measured_rows`, which are unit-tested and mutation-graded.
+    for not_a_body in [
+        "overlay_measured_rows",
+        "hash_value",
+        "compute_part_checksums",
+    ] {
+        assert!(
+            !names.contains(&not_a_body),
+            "`{not_a_body}` is an OPERATOR triage, not a whole-function live-only claim, \
+             but this gate graded it: {names:?}"
+        );
+    }
+    // The return type is what tells same-named siblings apart; losing it makes
+    // `check` mean every `fn check` in the tree.
+    let check_ret = real
+        .iter()
+        .find(|(n, _)| n == "check")
+        .and_then(|(_, r)| r.clone());
+    assert_eq!(
+        check_ret.as_deref(),
+        Some("Result<bool>"),
+        "the `check` exclusion's return-type discriminator was not decoded"
+    );
+}

--- a/tests/offline/mssql_column_data_fixture_guard.rs
+++ b/tests/offline/mssql_column_data_fixture_guard.rs
@@ -24,7 +24,6 @@
 //! cannot see a wrong answer.
 
 use std::collections::BTreeSet;
-use std::path::PathBuf;
 
 const SRC: &str = "src/source/mssql/cdc.rs";
 
@@ -68,8 +67,7 @@ const ROW_BOUND: &[(&str, &str)] = &[
 ];
 
 fn source() -> String {
-    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(SRC);
-    std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()))
+    super::nonvacuity::subject_text(SRC)
 }
 
 fn variants(text: &str) -> BTreeSet<String> {
@@ -101,6 +99,17 @@ fn branched_on(src: &str) -> BTreeSet<String> {
         let end = rest.find("\n}\n").unwrap_or(rest.len());
         out.extend(variants(&rest[..end]));
     }
+    // The BRANCHED-ON side is the requirement the fixture is graded against,
+    // and it is sliced by `find("\n}\n")` off each `fn` header — a formatting
+    // change that moves the first top-level `}` earlier truncates it, and a
+    // truncated requirement is satisfied by whatever the fixture happens to
+    // feed. 17 variants today.
+    super::nonvacuity::require_enumerated(
+        out.len(),
+        10,
+        &format!("ColumnData variants parsed out of the two mappers in {SRC}"),
+        "Fix the slice (the mappers are still there) rather than the floor.",
+    );
     out
 }
 

--- a/tests/offline/mutation_gate_config.rs
+++ b/tests/offline/mutation_gate_config.rs
@@ -161,7 +161,7 @@ fn toml_string_array(text: &str, key: &str) -> Option<Vec<String>> {
     Some(out)
 }
 
-fn exclude_patterns() -> Vec<String> {
+pub fn exclude_patterns() -> Vec<String> {
     let out = toml_string_array(&config_text(), "exclude_re")
         .expect("`exclude_re` not found in .cargo/mutants.toml — did the config's shape change?");
     assert!(

--- a/tests/offline/mutation_gate_priority_guard.rs
+++ b/tests/offline/mutation_gate_priority_guard.rs
@@ -1,0 +1,366 @@
+//! The mutation gate PRIORITISES its mutants — this guards the half that can
+//! quietly stop meaning anything.
+//!
+//! `.github/workflows/ci.yml`'s `mutants-in-diff` job used to grade one
+//! undifferentiated pile against one budget, and went quiet exactly where the
+//! risk is highest: past `MUTANTS_DIFF_BUDGET` it graded NOTHING, and inside it
+//! every MISSED mutant read alike. Measured on the 2026-08-21 refactor branch:
+//! 42 mutants in scope, 30 minutes, 16 missed — ONE a real assertion gap (a
+//! pure function whose whole-body stub would have let a FAILED run exit 0), 15
+//! live-only bodies `cargo mutants -- --lib --bins` cannot kill at all.
+//!
+//! `.github/scripts/mutants_classify.py` splits them on a MEASURED signal (the
+//! offline suite's own llvm-cov function coverage): mutants in executed code
+//! are graded and block, mutants in functions measured at ZERO executions are
+//! reported. The split is only honest while two properties hold, and both are
+//! invisible to the workflow itself:
+//!
+//! 1. **Everything unknown is GRADED.** No measurement, an unmentioned file, a
+//!    line no extent covers, an unparseable name — all stay in the blocking
+//!    class. The moment "we did not measure it" starts meaning "it does not
+//!    count", this stops being prioritisation and becomes an excuse. The first
+//!    two tests here run the real classifier and assert exactly that.
+//! 2. **The workflow still CALLS it, and handles every verdict it can produce.**
+//!    A classifier nobody invokes is the dead-code-behind-a-green-cell shape
+//!    CLAUDE.md names (`verify_blessed_path` was registered `test` for four
+//!    engines with no call site anywhere); a state the workflow does not handle
+//!    is a verdict that arrives as an empty string and is treated as "fine".
+//!
+//! WHAT THESE GUARDS CANNOT SEE, said plainly: none of them runs GitHub
+//! Actions. They read the workflow's steps and run the classifier; they cannot
+//! prove that `cargo llvm-cov` produces a usable report on the CI runner. That
+//! failure mode is handled by construction instead of by assertion — the reach
+//! step is `continue-on-error` with its own timeout, and an absent report means
+//! every mutant is graded, i.e. the gate's behaviour before this existed.
+//!
+//! The classifier's own classification logic is graded by its `--self-test`,
+//! which the first test RUNS (the `Gate scripts (self-tests)` CI job runs it
+//! too; this makes it fail locally, before the push).
+
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const CI: &str = ".github/workflows/ci.yml";
+const CLASSIFY: &str = ".github/scripts/mutants_classify.py";
+
+fn root() -> &'static str {
+    env!("CARGO_MANIFEST_DIR")
+}
+
+fn classify(args: &[&str]) -> std::process::Output {
+    Command::new("python3")
+        .arg(CLASSIFY)
+        .args(args)
+        .current_dir(root())
+        .output()
+        .unwrap_or_else(|e| {
+            panic!(
+                "run `python3 {CLASSIFY} {}`: {e} — python3 is a prerequisite of every gate \
+                 script in this repo, not a reason to skip",
+                args.join(" ")
+            )
+        })
+}
+
+/// A scratch directory for the fixture lists the classifier reads and writes.
+///
+/// Hand-rolled rather than `tempfile`: this suite links once for ~40 modules
+/// and a dependency added for two files is a dependency the whole binary pays
+/// for. Named by pid+nanos so parallel runs of this module cannot collide.
+fn scratch(tag: &str) -> std::path::PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!(
+        "rivet-mutprio-{tag}-{}-{nanos}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).expect("create scratch dir");
+    dir
+}
+
+/// The `run:` scripts of one CI job, joined, with SHELL COMMENTS stripped.
+///
+/// Two strippings, and both are load-bearing. The YAML parser drops `#`
+/// comments between steps; this drops the ones INSIDE a `run: |` block, where
+/// the reasoning for each guard lives and quotes the very commands the guard
+/// below looks for. A gate satisfiable by a doc comment is not hypothetical
+/// here — `runner_frame_gate` was, and passed while grading nothing.
+fn job_shell(job: &str, floor: usize) -> String {
+    let text = super::nonvacuity::subject_text(CI);
+    let doc: serde_yaml_ng::Value =
+        serde_yaml_ng::from_str(&text).unwrap_or_else(|e| panic!("parse {CI}: {e}"));
+    let steps = doc["jobs"][job]["steps"].as_sequence().unwrap_or_else(|| {
+        panic!(
+            "{CI}: job `{job}` has no steps — this guard grades that job's shell, and with \
+                the job renamed it would grade nothing. Re-point it at the new name."
+        )
+    });
+    let shell: String = steps
+        .iter()
+        .filter_map(|s| s.get("run").and_then(|r| r.as_str()))
+        .flat_map(|s| s.lines())
+        .filter(|l| !l.trim_start().starts_with('#'))
+        .collect::<Vec<_>>()
+        .join("\n");
+    super::nonvacuity::require_enumerated(
+        shell.lines().count(),
+        floor,
+        &format!("non-comment shell lines in ci.yml's `{job}` job"),
+        "The job's steps parsed but its scripts did not — this guard is reading the workflow \
+         wrong, and every needle below would miss against an empty haystack.",
+    );
+    shell
+}
+
+/// The classifier's own unit checks — executed, so they have a call site here
+/// and not only in CI.
+///
+/// It grades the shapes the partition must judge (executed function, untaken
+/// branch inside one, function measured at zero, unmentioned file, uncovered
+/// line, unparseable name), the no-coverage fallback, the exactness of the
+/// generated `--exclude-re` patterns, both directions of the post-exclusion
+/// verification, and six coverage-report shapes it must REFUSE rather than read
+/// as "nothing is covered". Each case is RED-provable against one named mutant
+/// in the script; the mutants are listed in its `self_test` docstring.
+#[test]
+fn the_mutant_prioritiser_passes_its_own_self_test() {
+    let out = classify(&["--self-test"]);
+    assert!(
+        out.status.success(),
+        "{CLASSIFY} fails its own self-test:\n{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+/// WITHOUT a coverage measurement, every mutant is graded.
+///
+/// This is the property that keeps the split from becoming "it wasn't covered,
+/// so it doesn't count": the report-only class may be entered only on positive
+/// evidence (a function llvm-cov OBSERVED at zero executions), and every other
+/// answer — including "the measurement did not run at all" — falls back to the
+/// gate's pre-prioritisation behaviour, where a missed mutant is red.
+///
+/// Driven through the real script over a fixture list, so it grades the
+/// classifier a CI runner would invoke rather than a re-implementation of its
+/// rule in this test.
+///
+/// RED-proven by inverting `partition`'s no-extents arm in
+/// `mutants_classify.py` (`return list(mutants), []` -> `return [], list(mutants)`):
+/// this test fails with p2=3 while the script's own self-test fails too.
+#[test]
+fn an_unmeasured_offline_reach_grades_every_mutant() {
+    let dir = scratch("unmeasured");
+    let list = dir.join("diff-list.txt");
+    std::fs::write(
+        &list,
+        "src/pipeline/run.rs:99:1: replace run_pool -> Result<()> with Ok(())\n\
+         src/manifest.rs:10:5: replace * with + in compute_part_checksums\n\
+         src/plan/waves.rs:109:38: replace && with || in pack\n",
+    )
+    .expect("write fixture list");
+    let p1 = dir.join("p1.txt");
+    let p2 = dir.join("p2.txt");
+    let out = classify(&[
+        "partition",
+        list.to_str().unwrap(),
+        "--p1",
+        p1.to_str().unwrap(),
+        "--p2",
+        p2.to_str().unwrap(),
+    ]);
+    assert!(out.status.success(), "partition failed: {out:?}");
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    assert!(
+        stdout.contains("reach=unmeasured") && stdout.contains("p1=3") && stdout.contains("p2=0"),
+        "with no coverage measurement the classifier must put EVERY mutant in the graded \
+         class and say so; it reported: {stdout}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&p1).expect("p1").lines().count(),
+        3,
+        "the graded class lost a mutant the gate is supposed to block on"
+    );
+    assert!(
+        std::fs::read_to_string(&p2).expect("p2").trim().is_empty(),
+        "a mutant was deprioritised with NO measurement behind it — the report-only class may \
+         only be entered on an observed zero coverage count"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// WITH a measurement, only an observed ZERO buys the report-only class.
+///
+/// The three mutants below are the three answers the classifier can reach on a
+/// real report, and only one of them is "not graded": a function measured at
+/// zero executions. A never-taken BRANCH inside an executed function stays
+/// graded (a test can reach it — "you added a path and tested none of it" is
+/// the finding this gate exists for), and so does a file the coverage report
+/// never mentions.
+///
+/// RED-proven twice in `mutants_classify.py`: widening the P2 test to
+/// `not containing or max(containing) == 0` moves the unmentioned file into the
+/// report-only class (p2=2 here), and `max(containing)` -> `min(containing)`
+/// moves the covered branch there.
+#[test]
+fn only_a_function_measured_at_zero_leaves_the_graded_class() {
+    let dir = scratch("measured");
+    let list = dir.join("diff-list.txt");
+    std::fs::write(
+        &list,
+        "src/a.rs:12:9: replace < with <= in executed_fn\n\
+         src/a.rs:41:5: replace never_run -> usize with 0\n\
+         src/b.rs:7:1: replace unmentioned -> usize with 0\n",
+    )
+    .expect("write fixture list");
+    let extents = dir.join("fn-extents.tsv");
+    // `file<TAB>start<TAB>end<TAB>exec_count`, as `mutants_classify.py reach`
+    // writes it from a real `cargo llvm-cov --lib --bins --json` export.
+    // The second row is a CLOSURE record nested inside the executed function
+    // (llvm-cov emits one per closure, counted separately) — it is what makes
+    // "max over every containing extent" observable here rather than assumed.
+    std::fs::write(
+        &extents,
+        "src/a.rs\t10\t20\t7\nsrc/a.rs\t11\t14\t0\nsrc/a.rs\t40\t50\t0\n",
+    )
+    .expect("write extents");
+    let p1 = dir.join("p1.txt");
+    let p2 = dir.join("p2.txt");
+    let out = classify(&[
+        "partition",
+        list.to_str().unwrap(),
+        "--extents",
+        extents.to_str().unwrap(),
+        "--p1",
+        p1.to_str().unwrap(),
+        "--p2",
+        p2.to_str().unwrap(),
+    ]);
+    assert!(out.status.success(), "partition failed: {out:?}");
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    assert!(
+        stdout.contains("reach=measured") && stdout.contains("p1=2") && stdout.contains("p2=1"),
+        "expected exactly the zero-coverage function to be deprioritised; got: {stdout}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&p2).expect("p2").trim(),
+        "src/a.rs:41:5: replace never_run -> usize with 0",
+        "the report-only class is not the set of functions measured at zero executions"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The classifier is CALLED by the gate — in the job that grades, and in the
+/// job that self-tests it.
+///
+/// Registration is a claim about behaviour; only a call site is evidence
+/// (CLAUDE.md, after `blessed_path.verify_blessed_path` sat behind four green
+/// matrix cells with no caller in the tree). The needles are matched against
+/// the job's `run:` shell with comments stripped, so the long comment blocks
+/// above each command — which name these very invocations — cannot satisfy it.
+///
+/// RED-proven three times, each with the rest of this file staying green:
+/// replacing the MEASURED partition branch with `true` (the workflow still
+/// calls the classifier and still grades one undifferentiated pile — caught on
+/// `--extents fn-extents.tsv`); turning the post-exclusion `verify` into
+/// `if false`; and deleting the `--self-test` step from `gate-scripts`.
+#[test]
+fn the_mutation_gate_actually_invokes_the_prioritiser() {
+    let mutate = job_shell("mutants-in-diff", 40);
+    for (needle, why) in [
+        (
+            "mutants_classify.py reach",
+            "the offline-reach measurement — without it nothing is measured and the gate \
+             cannot tell an assertion gap from a live-only body",
+        ),
+        (
+            "partition diff-list.txt",
+            "the classification of THIS diff's mutants",
+        ),
+        (
+            // The MEASURED branch specifically. `partition` is invoked twice —
+            // once with the coverage extents and once without — and only the
+            // first one prioritises anything; losing it leaves a workflow that
+            // still calls the classifier and still grades one undifferentiated
+            // pile, which is the defect wearing the fix's clothes.
+            "--extents fn-extents.tsv",
+            "the classification's only MEASURED input; without it the partition \
+             is the no-coverage fallback and nothing is ever prioritised",
+        ),
+        (
+            "verify p1.txt p1-check.txt",
+            "the check that the generated exclusions removed exactly the report-only class; \
+             without it an over-broad pattern silently un-grades blocking mutants",
+        ),
+    ] {
+        super::nonvacuity::require_needle(
+            &mutate,
+            "ci.yml's `mutants-in-diff` shell",
+            needle,
+            1,
+            &format!(
+                "The mutation gate must invoke `{needle}` — it is {why}. If the command moved, \
+                 re-point this guard at it; a prioritiser nobody calls leaves the workflow \
+                 grading the old undifferentiated pile while this file reports green."
+            ),
+        );
+    }
+    super::nonvacuity::require_needle(
+        // Three one-line `run:` steps, hence the floor of 2: the point of a
+        // floor is to catch a job whose scripts stopped PARSING (which lands at
+        // zero), not to count them — set at 3 it fires on the deleted step
+        // before the needle does, and reports "this guard is reading the
+        // workflow wrong" about a workflow the guard read correctly.
+        &job_shell("gate-scripts", 2),
+        "ci.yml's `gate-scripts` shell",
+        "mutants_classify.py --self-test",
+        1,
+        "The classifier's own unit checks must run in CI, not only in this suite.",
+    );
+}
+
+/// Every verdict the classifier can publish is HANDLED by the workflow.
+///
+/// The vocabulary is DERIVED from the script (`--states`), never re-typed here:
+/// a hand-written list grades only the states its author already knew, which is
+/// the defect (CLAUDE.md, "derive the enumerated dimension, never type it in").
+/// A state the workflow neither sets nor reads arrives at the blocking verdict
+/// job as an empty string, and an empty string is exactly what that job treats
+/// as "nothing to worry about".
+///
+/// RED-proven by adding a state (`"degraded"`) to `REACH_STATES` in
+/// `mutants_classify.py` and leaving ci.yml alone.
+#[test]
+fn every_state_the_prioritiser_can_publish_is_handled_by_the_workflow() {
+    let out = classify(&["--states"]);
+    assert!(out.status.success(), "--states failed: {out:?}");
+    let states: Vec<String> = String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    super::nonvacuity::require_enumerated(
+        states.len(),
+        4,
+        "states published by mutants_classify.py --states",
+        "The vocabulary is read from the script; an empty read would make this guard grade \
+         nothing at all.",
+    );
+
+    // Both jobs: the run job SETS these, the verdict job READS them.
+    let shell = format!(
+        "{}\n{}",
+        job_shell("mutants-in-diff", 40),
+        job_shell("mutants-verdict", 20)
+    );
+    let unhandled: Vec<&String> = states.iter().filter(|s| !shell.contains(*s)).collect();
+    assert!(
+        unhandled.is_empty(),
+        "these classifier states appear nowhere in the mutation gate's shell: {unhandled:?}. \
+         A state the workflow neither publishes nor reads reaches `Mutants (coverage verdict)` \
+         as an empty value, which that job reads as 'no concern' — the fail-open shape this \
+         whole gate keeps paying for. Teach ci.yml the state, or delete it from the script."
+    );
+}

--- a/tests/offline/mysql_wire_type_fixture_guard.rs
+++ b/tests/offline/mysql_wire_type_fixture_guard.rs
@@ -30,7 +30,6 @@
 //! blind spots and neither replaces the other.
 
 use std::collections::BTreeSet;
-use std::path::PathBuf;
 
 const SRC: &str = "src/source/mysql/arrow_convert.rs";
 
@@ -47,8 +46,7 @@ const UNREACHABLE: &[(&str, &str)] = &[(
 )];
 
 fn source() -> String {
-    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(SRC);
-    std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()))
+    super::nonvacuity::subject_text(SRC)
 }
 
 /// Every `MYSQL_TYPE_*` token inside `fn <name>`, up to the next top-level `}`.
@@ -99,6 +97,18 @@ fn required() -> BTreeSet<String> {
     let src = source();
     let mut r = types_named_by_fn(&src, "mysql_native_type_name");
     r.extend(types_named_by_fn(&src, "mysql_type_to_rivet"));
+    // The REQUIRED side is where this guard can go blind: both functions are
+    // sliced by `find("\n}\n")` off their `fn` header, so a formatting change
+    // that moves the first top-level `}` earlier truncates the branch list —
+    // and a truncated requirement is trivially satisfied by whatever the
+    // fixture happens to cover. 29 types today.
+    super::nonvacuity::require_enumerated(
+        r.len(),
+        20,
+        &format!("MYSQL_TYPE_* branches parsed out of the two mappers in {SRC}"),
+        "Fix the slice (the mappers are still there) rather than the floor — this set IS the \
+         requirement the fixture is graded against.",
+    );
     r
 }
 

--- a/tests/offline/nonvacuity.rs
+++ b/tests/offline/nonvacuity.rs
@@ -1,0 +1,100 @@
+//! One rule, one place: a guard must FAIL when its SUBJECT is missing.
+//!
+//! Every gate in this directory that resolves its subject by NAME — a path, a
+//! needle, a YAML key — has two ways to go wrong, and only one of them is
+//! visible. It can find the subject and disagree with it (loud: an ordinary
+//! failure naming the drift), or it can fail to FIND the subject and grade the
+//! empty set instead — at which point every assertion below is vacuously true
+//! and the guard reports green while checking nothing.
+//!
+//! The second is not hypothetical here. `destructive_delete_gate` keyed on an
+//! expression shape, the construction moved into a helper, and the gate went on
+//! passing over ZERO delete sites; it survives only because it asserts "parsed
+//! only {} fn bodies from dispatch.rs — this guard is reading it wrong" before
+//! grading anything. `runner_frame_gate` was satisfiable by a doc-COMMENT
+//! mention of the call it demanded. An inline census in `src/pipeline/run.rs`
+//! stopped pinning what it claimed to. Five multi-agent bughunts over the
+//! 2026-08 refactors found ZERO defects in the refactored code and SEVEN in the
+//! guards those refactors had to touch — text-matching guards are fragile in
+//! exactly this direction, and always in the safe-looking one.
+//!
+//! So the rule is written ONCE, here, rather than re-typed per guard in
+//! whatever wording its author reached for (this repo already had it phrased
+//! three different ways in three files). Read the subject through
+//! [`subject_text`]; state the floor the code justifies through
+//! [`require_enumerated`] / [`require_needle`]. A guard whose subject moves then
+//! fails ON THE MISSING SUBJECT, naming what it can no longer find, instead of
+//! on some downstream assertion that still happens to hold over nothing.
+//!
+//! Scope honesty: this makes a guard's BLINDNESS loud. It does not make the
+//! guard right — a floor that is met by a subject the guard misreads is still a
+//! guard misreading its subject. The floors below are therefore stated with the
+//! count the repo holds today, so a truncating parser (which lands somewhere
+//! near zero, not one short) is what they catch.
+
+use std::path::PathBuf;
+
+/// The repo root — `CARGO_MANIFEST_DIR` of this test crate.
+///
+/// Guards in this directory are written to run from the root, and most read
+/// bare relative paths. Resolving through here instead makes the read
+/// independent of the runner's cwd, which is one fewer way for a subject to go
+/// "missing" for a reason that is not drift.
+pub fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Read a repo-relative subject file, failing loudly and by NAME when it is
+/// gone or empty.
+///
+/// The `unwrap_or_default()` this replaces is the whole defect in one call: a
+/// moved file becomes an empty string, an empty string matches no needle, and a
+/// "no offenders" assertion passes.
+pub fn subject_text(rel: &str) -> String {
+    let path = repo_root().join(rel);
+    let text = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "NON-VACUITY: subject `{rel}` cannot be read ({e}). This guard grades that file; \
+             with the file gone it would grade nothing at all. Re-point the guard at wherever \
+             the subject moved to — do not delete the assertion."
+        )
+    });
+    assert!(
+        !text.trim().is_empty(),
+        "NON-VACUITY: subject `{rel}` is empty — every needle below would miss, and every \
+         `no offenders` assertion would pass over an empty haystack."
+    );
+    text
+}
+
+/// The set a guard is about to grade must clear a floor its own subject
+/// justifies.
+///
+/// `what` names the set in the subject's terms ("`scenarios:` rows of
+/// docs/perf-matrix.yaml"), `hint` says what to do — re-point the parser, not
+/// lower the floor. Floors are set far below today's count on purpose: they
+/// catch a parser that lost the SECTION (landing at or near zero), not one row
+/// added or removed in a normal diff.
+pub fn require_enumerated(found: usize, floor: usize, what: &str, hint: &str) {
+    assert!(
+        found >= floor,
+        "NON-VACUITY: only {found} {what} (floor {floor}) — this guard is about to grade a \
+         truncated or empty set, which passes every assertion below while checking nothing. \
+         {hint}"
+    );
+}
+
+/// The needle a source lint keys on must still OCCUR in the text it reads.
+///
+/// A lint over `foo(` says nothing once `foo` is renamed: there are no
+/// occurrences, so there are no offenders, so it is green. This asserts the
+/// subject of the lint exists before its verdict is believed.
+pub fn require_needle(text: &str, subject: &str, needle: &str, floor: usize, hint: &str) {
+    let found = text.matches(needle).count();
+    assert!(
+        found >= floor,
+        "NON-VACUITY: `{subject}` contains {found} occurrence(s) of `{needle}` (floor {floor}) \
+         — the thing this guard lints for is not there, so its verdict is about an empty \
+         search, not about the code. {hint}"
+    );
+}

--- a/tests/offline/perf_matrix_guard.rs
+++ b/tests/offline/perf_matrix_guard.rs
@@ -34,11 +34,28 @@ fn scalar(v: &Value) -> String {
     }
 }
 
+/// The `scenarios:` rows, floor-checked.
+///
+/// The `unwrap_or_default()` below is why the floor is here and not left to the
+/// callers: a renamed or re-nested key yields the EMPTY vector, and all three
+/// tests in this file then pass over it — the column-completeness loop grades no
+/// rows, `measured_cells_are_non_empty` grades no cells, and the gap count is
+/// zero, which is exactly the ratchet. Every signal green, nothing measured.
 fn scenarios(v: &Value) -> Vec<&Value> {
-    v.get("scenarios")
+    let out: Vec<&Value> = v
+        .get("scenarios")
         .and_then(|s| s.as_sequence())
         .map(|s| s.iter().collect())
-        .unwrap_or_default()
+        .unwrap_or_default();
+    // 7 rows today; the floor catches a lost SECTION, not an edited row.
+    super::nonvacuity::require_enumerated(
+        out.len(),
+        4,
+        &format!("`scenarios:` rows in {PERF_MATRIX}"),
+        "Re-point this parser at wherever the perf scenarios now live — a perf ledger that \
+         parses to nothing reports a full house of measured baselines it never read.",
+    );
+    out
 }
 
 /// A perf cell is `{measured: ...}` | `{gap: ...}` | `{na: ...}`.

--- a/tests/offline/release_gate_matrix_guard.rs
+++ b/tests/offline/release_gate_matrix_guard.rs
@@ -62,7 +62,7 @@ const ENGINES: [&str; 4] = ["postgres", "mysql", "mssql", "mongo"];
 const GAP_RATCHET: usize = 10;
 
 fn load(path: &str) -> Value {
-    let s = fs::read_to_string(path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    let s = super::nonvacuity::subject_text(path);
     serde_yaml_ng::from_str(&s).unwrap_or_else(|e| panic!("parse {path}: {e}"))
 }
 
@@ -75,11 +75,38 @@ fn scalar(v: &Value) -> String {
     }
 }
 
+/// A top-level sequence of the ledger, floor-checked per section.
+///
+/// The `unwrap_or_default()` is the vacuity: a renamed or re-nested key hands
+/// back the EMPTY vector, and then `every_gate_function_has_a_ledger_row_and_
+/// vice_versa` finds no ids to demand functions for, the column-completeness
+/// loop grades no scenarios, and the gap count is zero — under the ratchet. The
+/// release-gate ledger reports a clean sweep having read nothing.
+///
+/// Floors are the counts the ledger holds today (9 scenarios / 22 preflights /
+/// 7 infra) minus room for ordinary edits: they catch a lost SECTION, not a
+/// deleted row, and a section that legitimately shrinks past its floor is a
+/// deliberate diff on this line.
 fn seq<'a>(v: &'a Value, key: &str) -> Vec<&'a Value> {
-    v.get(key)
+    let out: Vec<&Value> = v
+        .get(key)
         .and_then(|s| s.as_sequence())
         .map(|s| s.iter().collect())
-        .unwrap_or_default()
+        .unwrap_or_default();
+    let floor = match key {
+        "scenarios" => 5,
+        "preflights" => 12,
+        "infra" => 4,
+        _ => 0,
+    };
+    super::nonvacuity::require_enumerated(
+        out.len(),
+        floor,
+        &format!("`{key}:` rows in {GATE_MATRIX}"),
+        "Re-point this reader at the section's new name/nesting — the guards below cannot \
+         tell an empty ledger from a fully covered one.",
+    );
+    out
 }
 
 /// A cell is `test` (bare string) | `{na: ...}` | `{gap: ...}`.

--- a/tests/offline/rig_adoption_guard.rs
+++ b/tests/offline/rig_adoption_guard.rs
@@ -37,7 +37,11 @@ const BASELINE: &[(&str, usize)] = &[
 ];
 
 fn bespoke_sites(path: &std::path::Path) -> usize {
-    let text = std::fs::read_to_string(path).unwrap_or_default();
+    // NOT `unwrap_or_default()`: an unreadable file scored ZERO bespoke sites,
+    // which is under every ceiling — the ratchet would have read a vanished or
+    // permission-denied file as a fully migrated one.
+    let text = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("NON-VACUITY: read {}: {e}", path.display()));
     // Raw invocations, the shared config-writer, AND hand-rolled yaml source
     // headers: the run_rivet* helper family spawns RIVET_BIN without either of
     // the first two tokens, so a file could hand-build a config via fs::write
@@ -57,7 +61,8 @@ fn bespoke_runner_sites_never_grow_per_file() {
     let baseline: BTreeMap<&str, usize> = BASELINE.iter().copied().collect();
     let mut over: Vec<String> = Vec::new();
     let mut unknown: Vec<String> = Vec::new();
-    for e in std::fs::read_dir("tests/live")
+    let mut scanned = 0usize;
+    for e in std::fs::read_dir(super::nonvacuity::repo_root().join("tests/live"))
         .expect("read tests/live")
         .flatten()
     {
@@ -65,6 +70,7 @@ fn bespoke_runner_sites_never_grow_per_file() {
         if p.extension().is_none_or(|x| x != "rs") {
             continue;
         }
+        scanned += 1;
         let name = p.file_name().unwrap().to_string_lossy().to_string();
         let n = bespoke_sites(&p);
         match baseline.get(name.as_str()) {
@@ -73,6 +79,16 @@ fn bespoke_runner_sites_never_grow_per_file() {
             _ => {}
         }
     }
+    // The live tree IS this ratchet's subject: a scan that finds no live files
+    // reports "nothing grew" for the same reason it reports nothing at all. 98
+    // files today, so the floor catches a moved directory, not a deleted test.
+    super::nonvacuity::require_enumerated(
+        scanned,
+        40,
+        "`.rs` files scanned under tests/live",
+        "The live suite moved — point this ratchet at its new home, or it will bank every \
+         future bespoke site as a migration.",
+    );
     assert!(
         over.is_empty() && unknown.is_empty(),
         "bespoke rivet-runner sites grew past the ratchet: over {over:?}; new files with \
@@ -90,7 +106,7 @@ fn the_baseline_matches_reality_downward_too() {
     let baseline: BTreeMap<&str, usize> = BASELINE.iter().copied().collect();
     let mut slack: Vec<String> = Vec::new();
     for (name, &cap) in &baseline {
-        let p = std::path::Path::new("tests/live").join(name);
+        let p = super::nonvacuity::repo_root().join("tests/live").join(name);
         if !p.exists() {
             slack.push(format!("{name}: listed but deleted — drop the entry"));
             continue;

--- a/tests/offline/runner_frame_gate.rs
+++ b/tests/offline/runner_frame_gate.rs
@@ -47,7 +47,23 @@ fn batch_writers_obtain_destinations_only_through_the_frame() {
         ),
     ];
 
+    // NON-VACUITY, before any verdict: this lint's whole subject is the token
+    // `create_destination(`, and a lint over a token that no longer exists finds
+    // no offenders and reports green. `frame.rs` is the door, so the door's own
+    // call is the proof the token is still the one to lint for — rename it and
+    // this fails HERE, naming the missing subject, instead of passing over a
+    // tree that no longer contains it.
+    super::nonvacuity::require_needle(
+        &super::nonvacuity::subject_text("src/pipeline/frame.rs"),
+        "src/pipeline/frame.rs",
+        "create_destination(",
+        1,
+        "If destination creation was renamed or moved off the frame, re-point this gate at \
+         the new call — the runner-bypass class it guards did not go away with the name.",
+    );
+
     let mut offenders = Vec::new();
+    let mut scanned = 0usize;
     let mut stack = vec![root.clone()];
     while let Some(dir) = stack.pop() {
         for entry in std::fs::read_dir(&dir).expect("read src/pipeline") {
@@ -68,6 +84,7 @@ fn batch_writers_obtain_destinations_only_through_the_frame() {
                 continue;
             }
             let text = std::fs::read_to_string(&path).expect("read source");
+            scanned += 1;
             for (ln, line) in text.lines().enumerate() {
                 // Only CALLS count; a comment naming the function does not.
                 let code = line.split("//").next().unwrap_or("");
@@ -77,6 +94,15 @@ fn batch_writers_obtain_destinations_only_through_the_frame() {
             }
         }
     }
+    // The walk itself is a subject: `src/pipeline` split into submodules once
+    // already, and a gate that walks a directory which has moved out from under
+    // it reports "no offenders" over zero files. 40+ modules today.
+    super::nonvacuity::require_enumerated(
+        scanned,
+        20,
+        "non-allowlisted `.rs` files scanned under src/pipeline",
+        "The runners moved out of src/pipeline — walk wherever they live now.",
+    );
     assert!(
         offenders.is_empty(),
         "a batch writer bypassed RunnerFrame::open — the cross-shape guard does not\n\

--- a/tests/offline/scenario_artifact_matrix_guard.rs
+++ b/tests/offline/scenario_artifact_matrix_guard.rs
@@ -18,15 +18,9 @@
 //! (an unknown class, an unknown engine, an unexplained restriction).
 
 use std::collections::BTreeSet;
-use std::path::PathBuf;
-
-fn repo_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-}
 
 fn matrix_text() -> String {
-    let p = repo_root().join("docs/scenario-artifact-matrix.yaml");
-    std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()))
+    super::nonvacuity::subject_text("docs/scenario-artifact-matrix.yaml")
 }
 
 /// Values under a top-level `engines: [a, b]` inline list.
@@ -109,6 +103,17 @@ fn scenarios(text: &str) -> Vec<(String, BTreeSet<String>, BTreeSet<String>, boo
     if let Some(s) = cur.take() {
         out.push(s);
     }
+    // The `scenarios:` HEADING missing panics above; a heading whose rows this
+    // hand-rolled line parser no longer recognises (a re-indent, a different
+    // list style) yields zero rows — and all four guards below iterate rows, so
+    // zero rows is four green tests over a ledger asserting nothing. 14 today.
+    super::nonvacuity::require_enumerated(
+        out.len(),
+        8,
+        "scenario rows parsed from docs/scenario-artifact-matrix.yaml",
+        "The rows are still there and this parser stopped seeing them — fix the parser \
+         rather than the floor.",
+    );
     out
 }
 

--- a/tests/offline_suite.rs
+++ b/tests/offline_suite.rs
@@ -69,6 +69,8 @@ mod run_summary_contract;
 
 #[path = "offline/cli_flag_coverage_guard.rs"]
 mod cli_flag_coverage_guard;
+#[path = "offline/live_only_purity_gate.rs"]
+mod live_only_purity_gate;
 #[path = "offline/live_service_ports_guard.rs"]
 mod live_service_ports_guard;
 #[path = "offline/rig_adoption_guard.rs"]

--- a/tests/offline_suite.rs
+++ b/tests/offline_suite.rs
@@ -42,6 +42,8 @@ mod format_fuzz;
 mod mssql_column_data_fixture_guard;
 #[path = "offline/mutation_gate_config.rs"]
 mod mutation_gate_config;
+#[path = "offline/mutation_gate_priority_guard.rs"]
+mod mutation_gate_priority_guard;
 #[path = "offline/mysql_wire_type_fixture_guard.rs"]
 mod mysql_wire_type_fixture_guard;
 // Not a test module: the shared non-vacuity rule the grep-shaped guards call so

--- a/tests/offline_suite.rs
+++ b/tests/offline_suite.rs
@@ -44,6 +44,10 @@ mod mssql_column_data_fixture_guard;
 mod mutation_gate_config;
 #[path = "offline/mysql_wire_type_fixture_guard.rs"]
 mod mysql_wire_type_fixture_guard;
+// Not a test module: the shared non-vacuity rule the grep-shaped guards call so
+// a moved subject fails LOUDLY instead of grading the empty set.
+#[path = "offline/nonvacuity.rs"]
+mod nonvacuity;
 #[path = "offline/perf_matrix_guard.rs"]
 mod perf_matrix_guard;
 #[path = "offline/planner_fuzz.rs"]

--- a/tests/offline_suite.rs
+++ b/tests/offline_suite.rs
@@ -38,6 +38,8 @@ mod examples_parse;
 mod extension_seam;
 #[path = "offline/format_fuzz.rs"]
 mod format_fuzz;
+#[path = "offline/harness_metrics_guard.rs"]
+mod harness_metrics_guard;
 #[path = "offline/mssql_column_data_fixture_guard.rs"]
 mod mssql_column_data_fixture_guard;
 #[path = "offline/mutation_gate_config.rs"]


### PR DESCRIPTION
Derived from the 2026-08-21 evidence: **five multi-agent bughunts over refactors found zero defects in the refactors and seven in the GUARDS the refactors had to touch.** Text-matching guards are fragile; behaviour/telltale guards are not. Each slice attacks one measured failure.

## The five slices

1. **`fee2a21` — a grep-shaped guard must FAIL when its subject is missing.** New shared `tests/offline/nonvacuity.rs` (`subject_text` / `require_enumerated` / `require_needle`) wired into **10 guards**. Closes the class that bit `destructive_delete_gate` this session: its subjects moved to another file and it kept passing while grading nothing. `unwrap_or_default()` on a moved file — an empty haystack that satisfies every downstream assertion — is now impossible.

2. **`246350e` — the mutation gate grades what the offline suite REACHES first.** New `.github/scripts/mutants_classify.py` partitions in-diff mutants by llvm-cov reachability: P1 (offline-reachable → a real assertion gap, fails) vs P2 (live-only body → reported, does not drown the signal). Budget applies to the graded subset. Measured motivation: 42 mutants / 30 min / 16 missed, of which exactly **one** was a real gap — a pure fn whose stub would have made a FAILED run exit 0.

3. **`2498517` — matrix columns derived from the commit loops.** The runner-coverage guard now finds commit loops by their drain through `commit::record_part` (ADR-0028's own definition) and finds exactly the **eight** the ledger header names, failing in both directions on drift. Plus an ADR-0028 sibling: the export-tail seam has one caller and no runner re-applies it.

4. **`24dee61` — a live-only body may not DECIDE.** New `live_only_purity_gate.rs`: functions excluded as live-only in `.cargo/mutants.toml` may not carry their own branching (and/or/not/cmp ceilings, shrink-only ratchet). This session extracted five such decisions by hand — one at a time, each because the mutation gate pointed at it. Now the mutants stop existing instead of being excluded. Rule documented in CLAUDE.md beside the scope-honesty note.

5. **`aa91bf4` — a thermometer for the harness itself.** `harness_metrics.py` emits one JSON per CI run (mutants in-scope/graded/P1/P2/excluded, cop census with proven-subject counts, suite sizes, guards that declare themselves unprovable) + a one-line `::notice::`. Non-blocking, additive: a trend a human can read before an incident.

## Verification

Every slice is RED-proven in its own commit. Verified independently by me on the branch: **2512 lib · 281 offline** (16 new guards), both CI scripts pass their `--self-test` (classification/verify directions, shaping/census refusals).

## Known follow-up (evidence attached)

A **third mutant class** the slices do not yet cover: a *verbatim MOVE*. PR #258 relocated ~800 lines with zero logic change and the gate reported **43 missed, 42 of them in the moved file**, burning 85 of 90 budget minutes. Relocated byte-identical lines are not new authorship; git already computes rename/similarity. Should be reported explicitly (never silently dropped) so the gate never looks like it graded more than it did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)