### PR TITLE
refactor: arch-roast wave 2 — state row.rs seam, manifest census, preflight ProbeFacts

### DIFF
--- a/src/load/reconcile.rs
+++ b/src/load/reconcile.rs
@@ -24,6 +24,7 @@
 //! the warehouse* is the paid last mile.
 
 use crate::destination::gcs::GcsStore;
+use crate::manifest::census::{ManifestCensus, dedupe_by_run_id, ensure_single_generation};
 use crate::manifest::{MANIFEST_FILENAME, ManifestStatus, RunManifest};
 use crate::pipeline::validate_manifest::MANIFEST_MAX_BYTES;
 use anyhow::{Context, Result, bail};
@@ -100,28 +101,6 @@ pub fn fetch_manifests_keyed(
         })
         .collect::<Result<Vec<_>>>()
         .map(dedupe_by_run_id)
-}
-
-/// One manifest per RUN: the canonical `manifest.json` is a last-writer-wins
-/// POINTER to the latest run, so when its run_id is also present as an immutable
-/// `manifest-<run_id>.json` copy, keep the copy and drop the pointer (the
-/// double-count guard). A run_id present ONLY under the canonical name — a
-/// legacy run predating the run-unique copies — survives, so an upgraded prefix
-/// still counts it (#173).
-fn dedupe_by_run_id(keyed: Vec<(String, RunManifest)>) -> Vec<(String, RunManifest)> {
-    let copy_run_ids: std::collections::HashSet<&str> = keyed
-        .iter()
-        .filter(|(k, _)| is_run_unique_manifest(k.rsplit('/').next().unwrap_or("")))
-        .map(|(_, m)| m.run_id.as_str())
-        .collect();
-    keyed
-        .iter()
-        .filter(|(k, m)| {
-            is_run_unique_manifest(k.rsplit('/').next().unwrap_or(""))
-                || !copy_run_ids.contains(m.run_id.as_str())
-        })
-        .cloned()
-        .collect()
 }
 
 /// Full `gs://` URIs of the parquet to load for `new` (the not-yet-loaded run
@@ -239,9 +218,11 @@ pub fn gc_orphans(
     // Success parts → keep. Failed/Interrupted parts → terminal (their run is
     // done, so deletable regardless of `active`). A part in NEITHER set has no
     // manifest at all — the ambiguous case `active` gates.
+    let census = ManifestCensus::new(keyed);
     let mut keep: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut terminal: std::collections::HashSet<String> = std::collections::HashSet::new();
-    for (key, m) in keyed {
+    for run in census.runs() {
+        let (key, m) = (run.key, run.manifest);
         match m.status {
             ManifestStatus::Success => keep.extend(resolve_parts(key, m)),
             // A `running` manifest is a LIVE run's marker (schema-less, no parts).
@@ -260,7 +241,7 @@ pub fn gc_orphans(
                 // referencing parts that are gone (post-0.24.3 review HIGH). Spare exactly those
                 // (KEEP); everything else stays terminal debris, deletable even while an
                 // UNRELATED export's run is active (no over-defer of genuine crash leftovers).
-                if superseded_by_active_running(m, keyed) {
+                if census.adopted_by_active_running(run) {
                     keep.extend(resolve_parts(key, m));
                 } else {
                     terminal.extend(resolve_parts(key, m));
@@ -295,10 +276,10 @@ pub fn gc_orphans(
     // run's marker would accumulate forever. A NON-superseded running manifest is
     // the ACTIVE signal and MUST survive — deletion here is gated on SUPERSESSION,
     // never on `active`.
-    for (key, m) in keyed {
-        if m.status == ManifestStatus::Running && is_superseded(m, keyed) {
-            removed_bytes += store.stat_size(key).unwrap_or(0);
-            store.remove(key)?;
+    for run in census.runs() {
+        if run.manifest.status == ManifestStatus::Running && census.superseded(run) {
+            removed_bytes += store.stat_size(run.key).unwrap_or(0);
+            store.remove(run.key)?;
             removed += 1;
         }
     }
@@ -308,207 +289,44 @@ pub fn gc_orphans(
 /// Is a LIVE run's `running` MARKER manifest present under the prefix — the
 /// bucket-side projection of the run-status ledger, for a cross-boundary load
 /// (Airflow / a foreign-host `rivet load`) that cannot read the extract's state
-/// DB? True iff some `running` manifest is NOT superseded by a NEWER manifest
-/// (any status) of the SAME export — the same clock-free supersession the ledger
-/// uses (a newer `started_at` means the old running run crashed and its successor
-/// already re-ran). `gc_orphans`'s `active` is `ledger_active OR this`, so the two
-/// signals are belt-and-suspenders: the ledger is precise co-located, the marker
-/// covers cross-host.
+/// DB? `gc_orphans`'s `active` is `ledger_active OR this`, so the two signals are
+/// belt-and-suspenders: the ledger is precise co-located, the marker covers
+/// cross-host. The supersession rule it reads is the census's
+/// ([`ManifestCensus::active_running`]) — the same one gc's marker sweep deletes
+/// by, so the two can never disagree about which marker is live.
 pub fn has_active_running_manifest(keyed: &[(String, RunManifest)]) -> bool {
-    keyed
-        .iter()
-        .any(|(_, m)| m.status == ManifestStatus::Running && !is_superseded(m, keyed))
-}
-
-/// True if `m` (a Failed/Interrupted manifest) is superseded by a LIVE run of the SAME
-/// export — a non-superseded `Running` marker with a newer `started_at`. That live run is a
-/// chunk-checkpoint resume which ADOPTS the crashed run's run_id and REUSES its committed
-/// parts, so those parts are being adopted, NOT dead debris — gc must SPARE them until the
-/// resume finalizes. Same clock-free family/supersession seam as [`is_superseded`]. When no
-/// same-export run is live, the parts stay terminal (deleted even while an unrelated run is
-/// active), so genuine crash debris is never over-deferred.
-fn superseded_by_active_running(m: &RunManifest, keyed: &[(String, RunManifest)]) -> bool {
-    keyed.iter().any(|(_, o)| {
-        o.status == ManifestStatus::Running
-            && crate::manifest::identity_family(o, keyed)
-                == crate::manifest::identity_family(m, keyed)
-            && o.started_at > m.started_at
-            && !is_superseded(o, keyed)
-    })
-}
-
-/// A `running` manifest is SUPERSEDED when a NEWER run of the SAME export exists
-/// (a higher `started_at`) — it crashed and its successor already re-ran, so it
-/// no longer protects anything. The ONE clock-free staleness predicate, shared by
-/// [`has_active_running_manifest`] (spare the non-superseded) and `gc_orphans`'s
-/// marker-GC sweep (delete the superseded). The ledger enforces the same rule in
-/// SQL — that copy cannot share this Rust.
-fn is_superseded(m: &RunManifest, keyed: &[(String, RunManifest)]) -> bool {
-    // FAMILY, not name: a CDC run's `running` marker carries the EXPORT name
-    // while the drain's terminal manifest carries the TABLE string, so with
-    // `name:` ≠ `table:` a name-only compare never matched — a crashed marker
-    // stayed "active" forever and gc over-deferred cleanup permanently. Same
-    // recorded-identity seam as `ensure_single_export`.
-    //
-    // BUT a `--pool --split` fans ONE family into N units (`{family}#0..#N-1`) that run
-    // CONCURRENTLY under that shared family. A later-STARTED sibling that finishes first must
-    // NOT make an earlier, still-live sibling look superseded — that would let a cross-host
-    // gc_orphans (whose only liveness signal is `has_active_running_manifest`) delete the live
-    // sibling's in-flight parts (post-0.24.3 convergence HIGH). A crash SUCCESSOR of a unit
-    // shares its export_NAME (`orders#0` re-run), so it still supersedes correctly; only a
-    // DIFFERENT sibling (`orders#1` vs `orders#0`) is excluded.
-    keyed.iter().any(|(_, o)| {
-        crate::manifest::identity_family(o, keyed) == crate::manifest::identity_family(m, keyed)
-            && o.started_at > m.started_at
-            && !are_split_siblings(o, m)
-    })
-}
-
-/// True if `a` and `b` are DIFFERENT split units of the same family (`{family}#i` vs
-/// `{family}#j`, i≠j) — concurrent siblings, not a crash + successor. Keyed off the export
-/// NAME pattern because a split unit's running marker carries `split_window: None` (it is
-/// overwritten by the terminal), so the name is the only sibling discriminator on a marker.
-fn are_split_siblings(a: &RunManifest, b: &RunManifest) -> bool {
-    fn unit_index(m: &RunManifest) -> Option<&str> {
-        // "orders#0" with family "orders" → Some("0"); a non-split name → None.
-        if m.export_family.is_empty() {
-            return None;
-        }
-        m.export_name
-            .strip_prefix(m.export_family.as_str())
-            .and_then(|s| s.strip_prefix('#'))
-            .filter(|s| !s.is_empty() && s.chars().all(|c| c.is_ascii_digit()))
-    }
-    a.export_family == b.export_family
-        && a.export_name != b.export_name
-        && unit_index(a).is_some()
-        && unit_index(b).is_some()
+    ManifestCensus::new(keyed).active_running()
 }
 
 /// Full/chunked loads care only about the LATEST snapshot: from `keyed` (all run
-/// manifests under the prefix) pick the newest by `finished_at`. Full loads
-/// OVERWRITE, so exactly ONE snapshot may be loaded (loading every accumulated
-/// run would duplicate rows). Deliberately **not** ledger-gated: full
+/// manifests under the prefix) pick the newest run of each split unit
+/// ([`ManifestCensus::latest_generation`], which owns the grouping rule). Full
+/// loads OVERWRITE, so exactly ONE generation may be loaded (loading every
+/// accumulated run would duplicate rows). Deliberately **not** ledger-gated: full
 /// re-materializes the latest snapshot on *every* load, so a re-load self-heals a
 /// drifted target and stays resilient to hidden in-place source updates. An empty
 /// input (no staged run — e.g. the staging was cleaned) yields an empty
 /// selection, so the caller no-ops WITHOUT truncating the target.
-///
-/// Ordering parses `finished_at` as an instant — a lexical byte compare mis-picks
-/// on mixed RFC3339 precision (`…00.5Z` sorts before `…00Z`) — and falls back to
-/// lexical only if a timestamp fails to parse, so a malformed manifest can't panic.
 pub fn latest_full(keyed: Vec<(String, RunManifest)>) -> Vec<(String, RunManifest)> {
-    // Group by export_name, then take the LATEST manifest per group. A `--pool --split`
-    // snapshot is N units `{family}#0..#N-1`, each its OWN run_id/manifest that finishes at
-    // a slightly different instant; the old `max_by` over the WHOLE set picked exactly ONE
-    // manifest — silently dropping the other N-1 units on a Full (replace) load. Grouping by
-    // export_name loads each unit's latest run. A non-split full export keeps ONE export_name
-    // across repeated runs → a single group → the single latest snapshot, unchanged replace
-    // semantics. BTreeMap so the selection order is deterministic (by unit name).
-    let mut latest: std::collections::BTreeMap<String, (String, RunManifest)> =
-        std::collections::BTreeMap::new();
-    for (key, m) in keyed {
-        let newer = match latest.get(&m.export_name) {
-            None => true,
-            Some((_, prev)) => finished_after(&m.finished_at, &prev.finished_at),
-        };
-        if newer {
-            latest.insert(m.export_name.clone(), (key, m));
-        }
-    }
-    latest.into_values().collect()
+    let picked: Vec<usize> = ManifestCensus::new(&keyed)
+        .latest_generation()
+        .iter()
+        .map(|r| r.index)
+        .collect();
+    take_in_order(keyed, &picked)
 }
 
-/// True if `a`'s finished-at instant is strictly after `b`'s (RFC3339; falls back to a
-/// lexical compare only if either fails to parse — the same ordering `latest_full` used
-/// before it grouped by unit).
-fn finished_after(a: &str, b: &str) -> bool {
-    match (
-        chrono::DateTime::parse_from_rfc3339(a).ok(),
-        chrono::DateTime::parse_from_rfc3339(b).ok(),
-    ) {
-        (Some(x), Some(y)) => x > y,
-        _ => a > b,
-    }
-}
-
-/// A Full selection must be ONE coherent split generation (or a single plain snapshot). A
-/// `--pool --split` prefix accumulates a manifest copy per unit per run (different run_ids →
-/// different part names → nothing overwrites), and there is no generation id, so if a later run
-/// split into a DIFFERENT unit count — or the export toggled unsplit↔split — [`latest_full`]'s
-/// group-by-unit selection would mix TWO generations: their windows overlap and a Full (replace)
-/// load would DUPLICATE rows (the count gate can't catch it — `expected_rows` inflates with the
-/// parts). Every coherent split generation has EXACTLY one bottom unit (`lo == None`) and one
-/// top (`hi == None`) and no plain/split mix; violate that and we cannot tell which parts form
-/// the current snapshot, so REFUSE loudly rather than silently duplicate. (Proper fix: stamp a
-/// split-generation id on the units — tracked follow-up.)
-fn ensure_single_split_generation(selected: &[(String, RunManifest)]) -> Result<()> {
-    let split: Vec<&RunManifest> = selected
+/// Move the entries at `picked` out of `keyed`, in `picked`'s order — the census
+/// selects by INDEX into the caller's slice, so materialising it costs no clone.
+fn take_in_order(
+    keyed: Vec<(String, RunManifest)>,
+    picked: &[usize],
+) -> Vec<(String, RunManifest)> {
+    let mut slots: Vec<Option<(String, RunManifest)>> = keyed.into_iter().map(Some).collect();
+    picked
         .iter()
-        .map(|(_, m)| m)
-        .filter(|m| m.split_window.is_some())
-        .collect();
-    if split.is_empty() {
-        return Ok(()); // a plain single-snapshot selection is always coherent
-    }
-    let plain = selected.len() - split.len();
-    let bottoms = split
-        .iter()
-        .filter(|m| m.split_window.as_ref().unwrap().lo.is_none())
-        .count();
-    let tops = split
-        .iter()
-        .filter(|m| m.split_window.as_ref().unwrap().hi.is_none())
-        .count();
-    if plain > 0 || bottoms > 1 || tops > 1 {
-        anyhow::bail!(
-            "Full load over a --pool --split prefix selected parts from MORE THAN ONE split \
-             generation ({} split units incl. {bottoms} bottom + {tops} top window(s){}); \
-             loading their union would DUPLICATE rows. The prefix holds a prior split run's \
-             leftover parts (a later run split into a different unit count, or the export \
-             toggled split↔unsplit). Load into a FRESH destination prefix (or clear the stale \
-             generation) and re-run.",
-            split.len(),
-            if plain > 0 {
-                format!(", plus {plain} non-split snapshot(s)")
-            } else {
-                String::new()
-            }
-        );
-    }
-    // bottoms==1, tops==1, plain==0 is NECESSARY but NOT sufficient. When two generations
-    // split into the SAME unit COUNT but at DIFFERENT boundaries and an INTERIOR unit is
-    // substituted from the older generation (its newer sibling crashed, so latest_full falls
-    // back to the stale Success), the selection still has exactly one bottom + one top — yet
-    // the windows no longer tile: a GAP loses rows and an OVERLAP duplicates them, and the
-    // count gate can't see it (expected_rows inflates with the parts). Post-0.24.3 review HIGH.
-    //
-    // A coherent split tiles the key space: every INTERIOR boundary appears once as some
-    // unit's `hi` and once as the NEXT unit's `lo`. So the multiset of non-None `lo` bounds
-    // must equal the multiset of non-None `hi` bounds. Compare them sorted — order-free, no
-    // numeric parse of opaque key text (a gap leaves a `hi` with no matching `lo`; an overlap
-    // leaves a `lo` with no matching `hi`).
-    let mut los: Vec<&String> = split
-        .iter()
-        .filter_map(|m| m.split_window.as_ref().unwrap().lo.as_ref())
-        .collect();
-    let mut his: Vec<&String> = split
-        .iter()
-        .filter_map(|m| m.split_window.as_ref().unwrap().hi.as_ref())
-        .collect();
-    los.sort();
-    his.sort();
-    if los != his {
-        anyhow::bail!(
-            "Full load over a --pool --split prefix selected an INCOHERENT set of split windows \
-             — the interior boundaries do not tile the key space, so a later run re-sampled to \
-             different boundaries and an older unit was substituted for a crashed one. Their \
-             union LOSES the gap rows and DUPLICATES the overlap rows (the count gate can't see \
-             it). Interior lower bounds {los:?} != upper bounds {his:?}. Load into a FRESH \
-             destination prefix (or clear the stale generation) and re-run."
-        );
-    }
-    Ok(())
+        .filter_map(|&i| slots.get_mut(i).and_then(Option::take))
+        .collect()
 }
 
 /// Which run manifests to load for `mode`, given the ledger's already-`loaded`
@@ -551,7 +369,10 @@ pub fn select_runs(
     match mode {
         crate::load::plan::LoadMode::Full => {
             let sel = latest_full(keyed);
-            ensure_single_split_generation(&sel)?;
+            // ...and that selection must be ONE coherent split generation — the
+            // other half of the census's split classification, so the grouping
+            // above and the coherence check here read the SAME unit identity.
+            ensure_single_generation(&ManifestCensus::new(&sel).runs().iter().collect::<Vec<_>>())?;
             Ok(sel)
         }
         _ => Ok(keyed
@@ -1612,7 +1433,7 @@ mod tests {
         // Post-0.24.3 convergence HIGH: `--pool --split` fans `orders` into siblings that run
         // CONCURRENTLY under the shared family "orders". orders#2 started LAST (T2) but its window
         // is smallest so it finishes FIRST (Success); orders#0/#1 are still Running with in-flight
-        // parts. is_superseded keyed on (family, started_at) alone would mark #0/#1 superseded by
+        // parts. Supersession keyed on (family, started_at) alone would mark #0/#1 superseded by
         // #2 → has_active_running_manifest=false → a cross-host gc_orphans deletes #0/#1's live
         // parts. The sibling exclusion must keep the two live markers ACTIVE. RED against the
         // pre-fix predicate (which returned false here).
@@ -1639,8 +1460,10 @@ mod tests {
         // A crash SUCCESSOR (same export_name, newer start) MUST still supersede the crashed marker.
         let crashed = unit("orders#0", ManifestStatus::Running, "2026-01-01T00:00:00Z");
         let successor = unit("orders#0", ManifestStatus::Running, "2026-01-02T00:00:00Z");
+        let rerun = [crashed, successor];
+        let census = ManifestCensus::new(&rerun);
         assert!(
-            is_superseded(&crashed.1, &[crashed.clone(), successor]),
+            census.superseded(&census.runs()[0]),
             "a re-run of the SAME unit (orders#0) must still supersede its crashed marker"
         );
     }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -30,6 +30,14 @@
 
 use serde::{Deserialize, Serialize};
 
+/// The relational algebra ABOVE these types: which runs live under one prefix
+/// and how they relate (dedupe, family membership, split-unit identity,
+/// supersession, generation coherence, claimed parts). It lives beside the
+/// naming/family helpers below — the writer's home is the truth's home — so the
+/// two verifiers over one artifact set (`--validate`, `rivet load`) answer from
+/// ONE classification instead of two dialects that must agree by review.
+pub mod census;
+
 /// Current manifest schema version.  See ADR-0012 §Manifest schema.
 pub const MANIFEST_VERSION: u32 = 1;
 

--- a/src/manifest/census.rs
+++ b/src/manifest/census.rs
@@ -1,0 +1,742 @@
+//! **Layer: Trust contract**
+//!
+//! ONE census over the manifests under a destination prefix: given the
+//! `(key, manifest)` pairs a reader listed, it answers *which runs live here and
+//! how do they relate* — run enumeration + run-id dedupe, family membership,
+//! split-unit identity, supersession/liveness, generation coherence, and the
+//! per-family claimed-part set.
+//!
+//! Two verifiers ask those questions over the SAME artifact set — `--validate`
+//! (`pipeline::validate_manifest`, "is every declared part present and is
+//! anything here unaccounted for") and `rivet load`
+//! (`load::reconcile`, "which runs may I load, and what may I delete"). They used
+//! to each define the relations for themselves, in two dialects: validate keyed a
+//! split unit off `split_window`, reconcile off the `{family}#i` export-NAME
+//! pattern; each dialect was blind exactly where the other could see, and every
+//! split bug of the 0.24.x pool/split hardening had to be diagnosed against both.
+//! The relations live here now; the two verifiers keep only their distinct
+//! question, and the I/O that feeds them stays where it is (validate reads the
+//! sidecars through a `Destination`, reconcile through the GCS store).
+//!
+//! Pure and borrow-only: a census is a view over the caller's slice — no I/O, no
+//! clones, so both callers can build one per pass without paying for it.
+
+use super::{
+    ManifestStatus, PartStatus, RunManifest, identity_family, is_run_unique_manifest_name,
+};
+use anyhow::Result;
+
+/// One run in the census: the manifest, the key it was read from, and the two
+/// derived identities every relation below is phrased in — its FAMILY and, when
+/// it is a `--pool --split` unit, its unit index.
+#[derive(Debug)]
+pub struct CensusRun<'a> {
+    /// Position in the slice the census was built from. Lets a caller that owns
+    /// that slice materialise a selection without cloning the manifests.
+    pub index: usize,
+    /// Storage key the manifest was read from (the canonical `manifest.json`
+    /// pointer or an immutable `manifest-<run_id>.json` copy).
+    pub key: &'a str,
+    pub manifest: &'a RunManifest,
+    family: &'a str,
+    unit: Option<&'a str>,
+}
+
+impl<'a> CensusRun<'a> {
+    /// The family this run belongs to — [`identity_family`] resolved ONCE, over
+    /// the whole census, so a legacy (family-less) manifest joins the recorded
+    /// family of a manifest sharing its `export_name` instead of standing alone.
+    pub fn family(&self) -> &'a str {
+        self.family
+    }
+
+    /// The `{family}#i` unit index when the export NAME carries one.
+    pub fn unit_index(&self) -> Option<&'a str> {
+        self.unit
+    }
+
+    /// Is this run a `--pool --split` UNIT of its family?
+    ///
+    /// The two signals are reconciled here, once, because each is blind where the
+    /// other sees:
+    /// - `split_window` is the precise mark a UNIT's terminal manifest carries —
+    ///   but a unit's `running` MARKER carries `split_window: None` (the terminal
+    ///   overwrites it), so supersession, which must read markers, cannot use it;
+    /// - the `{family}#i` export NAME is all a marker carries — but it is a
+    ///   naming convention, so a unit whose terminal manifest lost its name shape
+    ///   would fall out of validate's presence check.
+    ///
+    /// Either signal is sufficient. This is where a stamped split-generation id
+    /// lands when it exists (the tracked follow-up
+    /// [`ensure_single_generation`] documents), replacing both.
+    pub fn is_split_unit(&self) -> bool {
+        self.unit.is_some() || self.manifest.split_window.is_some()
+    }
+}
+
+/// The relations over one prefix's manifests. Build with [`ManifestCensus::new`];
+/// every query is a pure read over the borrowed slice.
+#[derive(Debug)]
+pub struct ManifestCensus<'a> {
+    runs: Vec<CensusRun<'a>>,
+}
+
+impl<'a> ManifestCensus<'a> {
+    /// Census the `(key, manifest)` pairs a reader listed under one prefix.
+    ///
+    /// Run enumeration applies the run-id dedupe ([`dedupe_by_run_id`]) so the
+    /// canonical pointer and its immutable copy never count as two runs; family
+    /// and unit index are resolved once per run.
+    pub fn new(keyed: &'a [(String, RunManifest)]) -> Self {
+        let runs = keep_one_per_run(keyed)
+            .into_iter()
+            .enumerate()
+            .filter(|(_, keep)| *keep)
+            .map(|(index, _)| {
+                let (key, manifest) = &keyed[index];
+                let family = identity_family(manifest, keyed);
+                CensusRun {
+                    index,
+                    key: key.as_str(),
+                    manifest,
+                    family,
+                    unit: unit_index(manifest, family),
+                }
+            })
+            .collect();
+        Self { runs }
+    }
+
+    /// Every run under the prefix, in listing order.
+    pub fn runs(&self) -> &[CensusRun<'a>] {
+        &self.runs
+    }
+
+    /// A `running` manifest is SUPERSEDED when a NEWER run of the SAME family
+    /// exists (a higher `started_at`) — it crashed and its successor already
+    /// re-ran, so it no longer protects anything. The ONE clock-free staleness
+    /// predicate, shared by [`Self::active_running`] (spare the non-superseded)
+    /// and `gc_orphans`'s marker-GC sweep (delete the superseded). The ledger
+    /// enforces the same rule in SQL — that copy cannot share this Rust.
+    ///
+    /// FAMILY, not name: a CDC run's `running` marker carries the EXPORT name
+    /// while the drain's terminal manifest carries the TABLE string, so with
+    /// `name:` ≠ `table:` a name-only compare never matched — a crashed marker
+    /// stayed "active" forever and gc over-deferred cleanup permanently.
+    ///
+    /// BUT a `--pool --split` fans ONE family into N units (`{family}#0..#N-1`)
+    /// that run CONCURRENTLY under that shared family. A later-STARTED sibling
+    /// that finishes first must NOT make an earlier, still-live sibling look
+    /// superseded — that would let a cross-host `gc_orphans` (whose only liveness
+    /// signal is [`Self::active_running`]) delete the live sibling's in-flight
+    /// parts (post-0.24.3 convergence HIGH). A crash SUCCESSOR of a unit shares
+    /// its export NAME (`orders#0` re-run), so it still supersedes correctly;
+    /// only a DIFFERENT sibling (`orders#1` vs `orders#0`) is excluded.
+    pub fn superseded(&self, run: &CensusRun<'_>) -> bool {
+        self.runs.iter().any(|o| {
+            o.family == run.family()
+                && o.manifest.started_at > run.manifest.started_at
+                && !split_siblings(o, run)
+        })
+    }
+
+    /// Is a LIVE run's `running` MARKER manifest present under the prefix — the
+    /// bucket-side projection of the run-status ledger, for a cross-boundary load
+    /// (Airflow / a foreign-host `rivet load`) that cannot read the extract's
+    /// state DB? True iff some `running` manifest is not [`Self::superseded`].
+    pub fn active_running(&self) -> bool {
+        self.runs
+            .iter()
+            .any(|r| r.manifest.status == ManifestStatus::Running && !self.superseded(r))
+    }
+
+    /// True if `run` (a Failed/Interrupted manifest) is superseded by a LIVE run
+    /// of the SAME family — a non-superseded `Running` marker with a newer
+    /// `started_at`. That live run is a chunk-checkpoint resume which ADOPTS the
+    /// crashed run's run_id and REUSES its committed parts, so those parts are
+    /// being adopted, NOT dead debris — gc must SPARE them until the resume
+    /// finalizes. When no same-family run is live, the parts stay terminal
+    /// (deleted even while an unrelated run is active), so genuine crash debris is
+    /// never over-deferred.
+    pub fn adopted_by_active_running(&self, run: &CensusRun<'_>) -> bool {
+        self.runs.iter().any(|o| {
+            o.manifest.status == ManifestStatus::Running
+                && o.family == run.family()
+                && o.manifest.started_at > run.manifest.started_at
+                && !self.superseded(o)
+        })
+    }
+
+    /// The LATEST run per split unit — the snapshot generation a Full (replace)
+    /// load materialises.
+    ///
+    /// Grouped by export NAME, then the newest per group by `finished_at`. A
+    /// `--pool --split` snapshot is N units `{family}#0..#N-1`, each its OWN
+    /// run_id/manifest finishing at a slightly different instant; a `max_by` over
+    /// the WHOLE set picks exactly ONE — silently dropping the other N-1 units on
+    /// a Full load. A non-split export keeps ONE export_name across repeated runs
+    /// → a single group → the single latest snapshot, unchanged replace semantics.
+    /// Ordered by unit name (BTreeMap) so the selection is deterministic.
+    ///
+    /// Coherence of the selection is a separate question — see
+    /// [`ensure_single_generation`].
+    pub fn latest_generation(&self) -> Vec<&CensusRun<'a>> {
+        let mut latest: std::collections::BTreeMap<&str, &CensusRun<'a>> =
+            std::collections::BTreeMap::new();
+        for run in &self.runs {
+            let name = run.manifest.export_name.as_str();
+            let newer = match latest.get(name) {
+                None => true,
+                Some(prev) => finished_after(&run.manifest.finished_at, &prev.manifest.finished_at),
+            };
+            if newer {
+                latest.insert(name, run);
+            }
+        }
+        latest.into_values().collect()
+    }
+
+    /// The `--pool --split` UNITS of `family` (see [`CensusRun::is_split_unit`]).
+    ///
+    /// A plain export's family is its own name, so its HISTORICAL repeated-run
+    /// copies share the family too — but they are SUPERSEDED snapshots, not
+    /// co-current units, and a presence check over them would false-fail on a
+    /// legitimately cleaned old part. An empty family cannot disambiguate
+    /// anything, so it selects nothing.
+    pub fn split_units(&self, family: &str) -> Vec<&CensusRun<'a>> {
+        if family.is_empty() {
+            return Vec::new();
+        }
+        self.runs
+            .iter()
+            .filter(|r| r.family == family && r.is_split_unit())
+            .collect()
+    }
+
+    /// The set of destination keys CLAIMED by the runs of `family` — every
+    /// `Committed` part they declare, resolved against `manifest_dir`.
+    ///
+    /// Covers BOTH split units AND a plain export's superseded historical / CDC-
+    /// soak copies, so neither reads as untracked surplus (noise that also MASKS
+    /// a real orphan). A FOREIGN family's parts are never claimed, so
+    /// cross-contamination under a mistakenly-shared prefix still surfaces. An
+    /// empty family claims nothing — a legacy prefix is single-run, and folding by
+    /// empty family could hide cross-contamination.
+    pub fn claimed_parts(
+        &self,
+        family: &str,
+        manifest_dir: &str,
+    ) -> std::collections::BTreeSet<String> {
+        let mut out = std::collections::BTreeSet::new();
+        if family.is_empty() {
+            return out;
+        }
+        for run in self.runs.iter().filter(|r| r.family == family) {
+            for p in &run.manifest.parts {
+                if p.status == PartStatus::Committed {
+                    out.insert(super::join_key(manifest_dir, &p.path));
+                }
+            }
+        }
+        out
+    }
+}
+
+/// True if `a` and `b` are DIFFERENT split units of the same family (`{family}#i`
+/// vs `{family}#j`, i≠j) — concurrent siblings, not a crash + successor.
+fn split_siblings(a: &CensusRun<'_>, b: &CensusRun<'_>) -> bool {
+    a.family() == b.family()
+        && a.manifest.export_name != b.manifest.export_name
+        && a.is_split_unit()
+        && b.is_split_unit()
+}
+
+/// `"orders#0"` under family `"orders"` → `Some("0")`; a non-split name → `None`.
+/// A family-less manifest has no prefix to strip, so it is never a unit.
+fn unit_index<'a>(m: &'a RunManifest, family: &str) -> Option<&'a str> {
+    if family.is_empty() {
+        return None;
+    }
+    m.export_name
+        .strip_prefix(family)
+        .and_then(|s| s.strip_prefix('#'))
+        .filter(|s| !s.is_empty() && s.chars().all(|c| c.is_ascii_digit()))
+}
+
+/// True if `a`'s finished-at instant is strictly after `b`'s (RFC3339; falls back
+/// to a lexical compare only if either fails to parse). Parses as an INSTANT — a
+/// lexical byte compare mis-picks on mixed RFC3339 precision (`…00.5Z` sorts
+/// before `…00Z`) — and never panics on a malformed manifest.
+fn finished_after(a: &str, b: &str) -> bool {
+    match (
+        chrono::DateTime::parse_from_rfc3339(a).ok(),
+        chrono::DateTime::parse_from_rfc3339(b).ok(),
+    ) {
+        (Some(x), Some(y)) => x > y,
+        _ => a > b,
+    }
+}
+
+/// Per-entry keep mask for the run-id dedupe — the rule [`dedupe_by_run_id`] and
+/// [`ManifestCensus::new`] share so a census and the vector it was built from
+/// enumerate the SAME runs.
+fn keep_one_per_run(keyed: &[(String, RunManifest)]) -> Vec<bool> {
+    let copy_run_ids: std::collections::HashSet<&str> = keyed
+        .iter()
+        .filter(|(k, _)| is_copy_key(k))
+        .map(|(_, m)| m.run_id.as_str())
+        .collect();
+    keyed
+        .iter()
+        .map(|(k, m)| is_copy_key(k) || !copy_run_ids.contains(m.run_id.as_str()))
+        .collect()
+}
+
+/// A listed key whose final segment is a per-run manifest COPY
+/// (`manifest-<run_id>.json`) rather than the canonical pointer.
+fn is_copy_key(key: &str) -> bool {
+    is_run_unique_manifest_name(key.rsplit('/').next().unwrap_or(""))
+}
+
+/// One manifest per RUN: the canonical `manifest.json` is a last-writer-wins
+/// POINTER to the latest run, so when its run_id is also present as an immutable
+/// `manifest-<run_id>.json` copy, keep the copy and drop the pointer (the
+/// double-count guard). A run_id present ONLY under the canonical name — a legacy
+/// run predating the run-unique copies — survives, so an upgraded prefix still
+/// counts it (#173).
+pub fn dedupe_by_run_id(keyed: Vec<(String, RunManifest)>) -> Vec<(String, RunManifest)> {
+    let keep = keep_one_per_run(&keyed);
+    keyed
+        .into_iter()
+        .zip(keep)
+        .filter_map(|(entry, keep)| keep.then_some(entry))
+        .collect()
+}
+
+/// A Full selection must be ONE coherent split generation (or a single plain
+/// snapshot). A `--pool --split` prefix accumulates a manifest copy per unit per
+/// run (different run_ids → different part names → nothing overwrites), and there
+/// is no generation id, so if a later run split into a DIFFERENT unit count — or
+/// the export toggled unsplit↔split — [`ManifestCensus::latest_generation`]'s
+/// group-by-unit selection would mix TWO generations: their windows overlap and a
+/// Full (replace) load would DUPLICATE rows (the count gate can't catch it —
+/// `expected_rows` inflates with the parts). Every coherent split generation has
+/// EXACTLY one bottom unit (`lo == None`) and one top (`hi == None`) and no
+/// plain/split mix; violate that and we cannot tell which parts form the current
+/// snapshot, so REFUSE loudly rather than silently duplicate. (Proper fix: stamp a
+/// split-generation id on the units — tracked follow-up; it lands beside
+/// [`CensusRun::is_split_unit`], the other half of this question.)
+///
+/// Keyed off `split_window` rather than [`CensusRun::is_split_unit`] because
+/// coherence needs the WINDOW itself (the boundaries must tile), not merely
+/// unit-hood: a windowless unit is a `running` MARKER, which a Full selection has
+/// already filtered out (only `Success` runs are loadable).
+pub fn ensure_single_generation(selected: &[&CensusRun<'_>]) -> Result<()> {
+    let split: Vec<&RunManifest> = selected
+        .iter()
+        .map(|r| r.manifest)
+        .filter(|m| m.split_window.is_some())
+        .collect();
+    if split.is_empty() {
+        return Ok(()); // a plain single-snapshot selection is always coherent
+    }
+    let plain = selected.len() - split.len();
+    let bottoms = split
+        .iter()
+        .filter(|m| m.split_window.as_ref().unwrap().lo.is_none())
+        .count();
+    let tops = split
+        .iter()
+        .filter(|m| m.split_window.as_ref().unwrap().hi.is_none())
+        .count();
+    if plain > 0 || bottoms > 1 || tops > 1 {
+        anyhow::bail!(
+            "Full load over a --pool --split prefix selected parts from MORE THAN ONE split \
+             generation ({} split units incl. {bottoms} bottom + {tops} top window(s){}); \
+             loading their union would DUPLICATE rows. The prefix holds a prior split run's \
+             leftover parts (a later run split into a different unit count, or the export \
+             toggled split↔unsplit). Load into a FRESH destination prefix (or clear the stale \
+             generation) and re-run.",
+            split.len(),
+            if plain > 0 {
+                format!(", plus {plain} non-split snapshot(s)")
+            } else {
+                String::new()
+            }
+        );
+    }
+    // bottoms==1, tops==1, plain==0 is NECESSARY but NOT sufficient. When two generations
+    // split into the SAME unit COUNT but at DIFFERENT boundaries and an INTERIOR unit is
+    // substituted from the older generation (its newer sibling crashed, so latest_generation
+    // falls back to the stale Success), the selection still has exactly one bottom + one top —
+    // yet the windows no longer tile: a GAP loses rows and an OVERLAP duplicates them, and the
+    // count gate can't see it (expected_rows inflates with the parts). Post-0.24.3 review HIGH.
+    //
+    // A coherent split tiles the key space: every INTERIOR boundary appears once as some
+    // unit's `hi` and once as the NEXT unit's `lo`. So the multiset of non-None `lo` bounds
+    // must equal the multiset of non-None `hi` bounds. Compare them sorted — order-free, no
+    // numeric parse of opaque key text (a gap leaves a `hi` with no matching `lo`; an overlap
+    // leaves a `lo` with no matching `hi`).
+    let mut los: Vec<&String> = split
+        .iter()
+        .filter_map(|m| m.split_window.as_ref().unwrap().lo.as_ref())
+        .collect();
+    let mut his: Vec<&String> = split
+        .iter()
+        .filter_map(|m| m.split_window.as_ref().unwrap().hi.as_ref())
+        .collect();
+    los.sort();
+    his.sort();
+    if los != his {
+        anyhow::bail!(
+            "Full load over a --pool --split prefix selected an INCOHERENT set of split windows \
+             — the interior boundaries do not tile the key space, so a later run re-sampled to \
+             different boundaries and an older unit was substituted for a crashed one. Their \
+             union LOSES the gap rows and DUPLICATES the overlap rows (the count gate can't see \
+             it). Interior lower bounds {los:?} != upper bounds {his:?}. Load into a FRESH \
+             destination prefix (or clear the stale generation) and re-run."
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::{
+        MANIFEST_VERSION, ManifestDestination, ManifestPart, ManifestSource, SplitWindow,
+    };
+
+    /// A minimal Success manifest — the census reads only identity, timing,
+    /// status, window and parts, so everything else is inert filler.
+    fn m(run: &str, export_name: &str, family: &str) -> RunManifest {
+        RunManifest {
+            manifest_version: MANIFEST_VERSION,
+            run_id: run.into(),
+            export_name: export_name.into(),
+            export_family: family.into(),
+            started_at: "2026-08-21T00:00:00Z".into(),
+            finished_at: "2026-08-21T00:01:00Z".into(),
+            status: ManifestStatus::Success,
+            source: ManifestSource {
+                engine: "postgres".into(),
+                schema: Some("public".into()),
+                table: Some("orders".into()),
+                extraction: None,
+            },
+            destination: ManifestDestination {
+                kind: "local".into(),
+                uri: "file:///tmp/out".into(),
+            },
+            format: "parquet".into(),
+            compression: "zstd".into(),
+            schema_fingerprint: "xxh3:0123456789abcdef".into(),
+            row_count: 0,
+            part_count: 0,
+            parts: Vec::new(),
+            column_checksums: None,
+            checksum_key_column: None,
+            checksum_render: None,
+            row_hash: None,
+            mode: "batch".into(),
+            split_window: None,
+        }
+    }
+
+    fn part(path: &str, status: PartStatus) -> ManifestPart {
+        ManifestPart {
+            part_id: 0,
+            path: path.into(),
+            rows: 10,
+            size_bytes: 100,
+            content_fingerprint: "xxh3:0123456789abcdef".into(),
+            content_md5: String::new(),
+            status,
+        }
+    }
+
+    fn window(lo: Option<&str>, hi: Option<&str>) -> SplitWindow {
+        SplitWindow {
+            key_column: "id".into(),
+            lo: lo.map(str::to_string),
+            hi: hi.map(str::to_string),
+        }
+    }
+
+    fn keyed(run: &str, m: RunManifest) -> (String, RunManifest) {
+        (format!("base/manifest-{run}.json"), m)
+    }
+
+    // ── run enumeration ──────────────────────────────────────────────────────
+
+    /// The canonical pointer and the copy of the SAME run are ONE run; a run
+    /// recorded only under the canonical name (a legacy prefix that later gained
+    /// copies) still counts.
+    #[test]
+    fn census_counts_one_run_per_run_id_keeping_a_legacy_canonical_only_run() {
+        let keyed = vec![
+            (
+                "base/manifest.json".to_string(),
+                m("r2", "orders", "orders"),
+            ),
+            (
+                "base/manifest-r2.json".to_string(),
+                m("r2", "orders", "orders"),
+            ),
+            (
+                "base/old/manifest.json".to_string(),
+                m("r1", "orders", "orders"),
+            ),
+        ];
+        let census = ManifestCensus::new(&keyed);
+        let keys: Vec<&str> = census.runs().iter().map(|r| r.key).collect();
+        assert_eq!(
+            keys,
+            vec!["base/manifest-r2.json", "base/old/manifest.json"],
+            "the pointer loses to its own copy; the legacy canonical-only run survives"
+        );
+        assert_eq!(
+            census.runs()[1].index,
+            2,
+            "index points back into the caller's slice so a selection needs no clone"
+        );
+    }
+
+    // ── family + split-unit identity ─────────────────────────────────────────
+
+    /// A legacy (family-less) manifest joins the recorded family of a manifest
+    /// sharing its export NAME — the upgrade story `identity_family` owns,
+    /// resolved once for every consumer of the census.
+    #[test]
+    fn a_legacy_manifest_takes_the_recorded_family_of_the_same_export_name() {
+        let keyed = vec![
+            keyed("r1", m("r1", "orders", "")),
+            keyed("r2", m("r2", "orders", "orders_cdc")),
+        ];
+        let census = ManifestCensus::new(&keyed);
+        assert_eq!(census.runs()[0].family(), "orders_cdc");
+    }
+
+    /// EITHER signal makes a split unit: the terminal manifest's `split_window`
+    /// (whose name shape a future scheme could change) OR the `{family}#i` export
+    /// name (all a `running` MARKER carries, since the terminal overwrites its
+    /// window). A plain export's repeated run is neither.
+    #[test]
+    fn split_unit_identity_reconciles_the_window_and_the_name_pattern() {
+        let mut windowed = m("r1", "daily-unit", "daily");
+        windowed.split_window = Some(window(None, Some("1000")));
+        let mut marker = m("r2", "daily#1", "daily");
+        marker.status = ManifestStatus::Running;
+        let keyed = vec![
+            keyed("r1", windowed),
+            keyed("r2", marker),
+            keyed("r3", m("r3", "daily", "daily")), // plain repeated run
+        ];
+        let census = ManifestCensus::new(&keyed);
+        let units: Vec<&str> = census
+            .split_units("daily")
+            .iter()
+            .map(|r| r.manifest.export_name.as_str())
+            .collect();
+        assert_eq!(
+            units,
+            vec!["daily-unit", "daily#1"],
+            "a windowed terminal AND a `#i`-named marker are units; a plain run is not"
+        );
+        assert!(
+            census.split_units("").is_empty(),
+            "an empty family disambiguates nothing"
+        );
+    }
+
+    // ── supersession / liveness ──────────────────────────────────────────────
+
+    /// A later-STARTED split sibling that finished first must not mask a live
+    /// sibling — concurrent units of one family, not a crash + successor.
+    #[test]
+    fn a_split_sibling_does_not_supersede_a_live_sibling_but_its_own_rerun_does() {
+        let live = {
+            let mut x = m("r0", "orders#0", "orders");
+            x.status = ManifestStatus::Running;
+            x.started_at = "2026-08-21T00:00:00Z".into();
+            x
+        };
+        let sibling = {
+            let mut x = m("r1", "orders#1", "orders");
+            x.started_at = "2026-08-21T00:00:30Z".into();
+            x
+        };
+        let keyed = vec![keyed("r0", live), keyed("r1", sibling)];
+        let census = ManifestCensus::new(&keyed);
+        assert!(!census.superseded(&census.runs()[0]));
+        assert!(census.active_running(), "the live unit is still writing");
+
+        // A crash SUCCESSOR of the SAME unit shares its export name → supersedes.
+        let mut rerun = m("r2", "orders#0", "orders");
+        rerun.started_at = "2026-08-21T00:01:00Z".into();
+        let keyed = vec![
+            keyed.into_iter().next().unwrap(),
+            ("base/manifest-r2.json".to_string(), rerun),
+        ];
+        let census = ManifestCensus::new(&keyed);
+        assert!(census.superseded(&census.runs()[0]));
+        assert!(!census.active_running());
+    }
+
+    /// A LIVE same-family run is adopting a crashed run's committed parts
+    /// (chunk-checkpoint resume reuses the run_id), so gc must spare them; with no
+    /// live run they are terminal debris.
+    #[test]
+    fn a_terminal_run_is_adopted_only_while_a_same_family_run_is_live() {
+        let mut crashed = m("r1", "orders", "orders");
+        crashed.status = ManifestStatus::Interrupted;
+        crashed.started_at = "2026-08-21T00:00:00Z".into();
+        let mut live = m("r2", "orders", "orders");
+        live.status = ManifestStatus::Running;
+        live.started_at = "2026-08-21T00:05:00Z".into();
+
+        let alone = vec![keyed("r1", crashed.clone())];
+        let census = ManifestCensus::new(&alone);
+        assert!(!census.adopted_by_active_running(&census.runs()[0]));
+
+        let resuming = vec![keyed("r1", crashed), keyed("r2", live)];
+        let census = ManifestCensus::new(&resuming);
+        assert!(census.adopted_by_active_running(&census.runs()[0]));
+    }
+
+    // ── generation selection + coherence ─────────────────────────────────────
+
+    /// The latest run PER UNIT — a split snapshot's N units all belong to the
+    /// selection, and their coherence check passes when the windows tile.
+    #[test]
+    fn latest_generation_takes_the_newest_run_of_every_unit() {
+        let unit = |run: &str, name: &str, finished: &str, lo, hi| {
+            let mut x = m(run, name, "daily");
+            x.finished_at = finished.into();
+            x.split_window = Some(window(lo, hi));
+            keyed(run, x)
+        };
+        let keyed = vec![
+            unit("r1", "daily#0", "2026-08-21T00:01:00Z", None, Some("500")),
+            unit("r2", "daily#0", "2026-08-21T00:02:00Z", None, Some("500")),
+            unit("r3", "daily#1", "2026-08-21T00:01:30Z", Some("500"), None),
+        ];
+        let census = ManifestCensus::new(&keyed);
+        let sel = census.latest_generation();
+        let runs: Vec<&str> = sel.iter().map(|r| r.manifest.run_id.as_str()).collect();
+        assert_eq!(
+            runs,
+            vec!["r2", "r3"],
+            "newest per unit, ordered by unit name"
+        );
+        ensure_single_generation(&sel).expect("the two windows tile the key space");
+    }
+
+    /// Two generations mixed in one selection — the union would DUPLICATE rows, so
+    /// the census refuses rather than let the count gate miss it.
+    #[test]
+    fn ensure_single_generation_refuses_a_mixed_and_a_non_tiling_selection() {
+        let unit = |run: &str, name: &str, lo, hi| {
+            let mut x = m(run, name, "daily");
+            x.split_window = Some(window(lo, hi));
+            keyed(run, x)
+        };
+        // Two bottoms: a 2-unit generation plus a stale 3-unit one.
+        let mixed = vec![
+            unit("r1", "daily#0", None, Some("500")),
+            unit("r2", "daily#1", Some("500"), None),
+            unit("r3", "daily#2", None, Some("300")),
+        ];
+        let census = ManifestCensus::new(&mixed);
+        let sel = census.latest_generation();
+        let err = ensure_single_generation(&sel).unwrap_err().to_string();
+        assert!(err.contains("MORE THAN ONE split generation"), "{err}");
+
+        // One bottom + one top, but the interior boundaries do not meet.
+        let holed = vec![
+            unit("r1", "daily#0", None, Some("500")),
+            unit("r2", "daily#1", Some("700"), None),
+        ];
+        let census = ManifestCensus::new(&holed);
+        let sel = census.latest_generation();
+        let err = ensure_single_generation(&sel).unwrap_err().to_string();
+        assert!(err.contains("INCOHERENT set of split windows"), "{err}");
+
+        // A plain single snapshot is always coherent.
+        let plain = vec![keyed("r1", m("r1", "orders", "orders"))];
+        let census = ManifestCensus::new(&plain);
+        ensure_single_generation(&census.latest_generation()).unwrap();
+    }
+
+    // ── claimed parts ────────────────────────────────────────────────────────
+
+    /// Every SAME-FAMILY run's committed parts are claimed (a split unit AND a
+    /// plain export's superseded historical copy), never a foreign family's, never
+    /// a quarantined part, and nothing at all under an empty family.
+    #[test]
+    fn claimed_parts_covers_the_family_only_and_committed_only() {
+        let with_part = |run: &str, name: &str, fam: &str, path: &str, status| {
+            let mut x = m(run, name, fam);
+            x.parts = vec![part(path, status)];
+            keyed(run, x)
+        };
+        let keyed = vec![
+            with_part(
+                "r1",
+                "daily#0",
+                "daily",
+                "daily#0_p.parquet",
+                PartStatus::Committed,
+            ),
+            with_part(
+                "r2",
+                "daily",
+                "daily",
+                "daily_old.parquet",
+                PartStatus::Committed,
+            ),
+            with_part(
+                "r3",
+                "daily#1",
+                "daily",
+                "daily#1_q.parquet",
+                PartStatus::Quarantined,
+            ),
+            with_part(
+                "r4",
+                "other",
+                "other",
+                "other_p.parquet",
+                PartStatus::Committed,
+            ),
+            // A manifest with NO identity at all (no family, no name) resolves to the
+            // empty family. It must never fold with anything — an empty family groups
+            // unrelated legacy runs together, which is how cross-contamination hides.
+            {
+                let (k, mut nameless) =
+                    with_part("r5", "", "", "nameless_p.parquet", PartStatus::Committed);
+                nameless.split_window = Some(window(None, None));
+                (k, nameless)
+            },
+        ];
+        let census = ManifestCensus::new(&keyed);
+        let claimed = census.claimed_parts("daily", "sub");
+        assert_eq!(
+            claimed,
+            ["sub/daily#0_p.parquet", "sub/daily_old.parquet"]
+                .into_iter()
+                .map(String::from)
+                .collect(),
+            "same-family committed parts only, resolved against the manifest dir: {claimed:?}"
+        );
+        assert!(
+            census.claimed_parts("", "sub").is_empty(),
+            "an empty family claims nothing — not even a part declared by a manifest that \
+             resolves to it"
+        );
+        assert!(
+            census.split_units("").is_empty(),
+            "…and nothing is a split UNIT of the empty family, window or not"
+        );
+    }
+}

--- a/src/pipeline/split.rs
+++ b/src/pipeline/split.rs
@@ -259,8 +259,8 @@ fn read_unit_manifests(
 /// fixed, non-{run_id} prefix) completed the same ordinal, its Success masks a CURRENT-generation
 /// unit that crashed, and the skip drops it. The silent-loss chain requires a full split export
 /// run REPEATEDLY into one accumulating prefix — an atypical pattern — AND is caught at LOAD by
-/// the tiling backstop `ensure_single_split_generation` (a mixed-generation selection whose
-/// windows do not tile is REFUSED loudly, not silently gapped/duplicated). The precise run-side
+/// the tiling backstop `manifest::census::ensure_single_generation` (a mixed-generation
+/// selection whose windows do not tile is REFUSED loudly, not silently gapped/duplicated). The precise run-side
 /// fix is generation-scoping (a generation id on `SplitWindow`, or matching the reconstructed
 /// window per ordinal before skipping) — tracked; the load guard makes the interim non-silent.
 pub(crate) fn completed_units_in_prefix(

--- a/src/pipeline/validate_manifest.rs
+++ b/src/pipeline/validate_manifest.rs
@@ -35,6 +35,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::destination::{Destination, ObjectMeta};
 use crate::error::Result;
+use crate::manifest::census::ManifestCensus;
 use crate::manifest::{
     MANIFEST_FILENAME, PartStatus, RunManifest, SUCCESS_FILENAME, is_run_unique_manifest_name,
     join_key, parse_success_marker, success_marker_body,
@@ -570,12 +571,19 @@ impl ManifestVerification {
 /// Regardless of depth, `depth_level` on the returned verdict records the
 /// level this pass ran at.
 /// Read every run-unique manifest COPY (`manifest-<run_id>.json`) named in the
-/// prefix listing. Best-effort: a copy that fails to read or parse is skipped —
-/// the untracked scan it feeds is advisory, so a bad sibling copy must never turn
-/// validate into an error (worst case a part it would have claimed stays flagged,
-/// the pre-#167 behaviour). The canonical `manifest.json` is not a copy and is
-/// excluded (it is already the primary manifest).
-fn read_sibling_manifests(dest: &dyn Destination, listing: &[ObjectMeta]) -> Vec<RunManifest> {
+/// prefix listing, keyed by the storage key it was read from (what
+/// [`ManifestCensus`] enumerates runs by). Best-effort: a copy that fails to read
+/// or parse is skipped — the untracked scan it feeds is advisory, so a bad sibling
+/// copy must never turn validate into an error (worst case a part it would have
+/// claimed stays flagged, the pre-#167 behaviour). The canonical `manifest.json`
+/// is not a copy and is excluded (it is already the primary manifest).
+///
+/// This is validate's I/O half; every question ASKED of the copies — which of them
+/// are this family's split units, which parts they claim — is the census's.
+fn read_sibling_manifests(
+    dest: &dyn Destination,
+    listing: &[ObjectMeta],
+) -> Vec<(String, RunManifest)> {
     let mut out = Vec::new();
     for meta in listing {
         let base = meta.key.rsplit('/').next().unwrap_or("");
@@ -585,65 +593,29 @@ fn read_sibling_manifests(dest: &dyn Destination, listing: &[ObjectMeta]) -> Vec
         if let Ok(bytes) = read_capped(dest, &meta.key, MANIFEST_MAX_BYTES)
             && let Ok(m) = serde_json::from_slice::<RunManifest>(&bytes)
         {
-            out.push(m);
-        }
-    }
-    out
-}
-
-/// The set of destination keys claimed by a SAME-FAMILY sibling run-unique manifest copy
-/// (#167 merge-back). A part is claimed only when a sibling of the SAME `export_family`
-/// declared it `Committed`, so a foreign export's parts under a mistakenly-shared prefix are
-/// still surfaced as untracked. Covers BOTH split units AND a plain export's superseded
-/// historical / CDC-soak copies, so neither reads as surplus. Pure — the I/O (reading the
-/// copies) is [`read_sibling_manifests`]'s job.
-fn sibling_claimed_part_keys(
-    siblings: &[RunManifest],
-    canonical_family: &str,
-    manifest_dir: &str,
-) -> std::collections::BTreeSet<String> {
-    let mut out = std::collections::BTreeSet::new();
-    if canonical_family.is_empty() {
-        // A legacy manifest with no family: never claim across copies (a legacy prefix is
-        // single-run, and folding by empty family could hide cross-contamination).
-        return out;
-    }
-    for m in siblings {
-        if m.export_family != canonical_family {
-            continue;
-        }
-        for p in &m.parts {
-            if p.status == PartStatus::Committed {
-                out.insert(join_key(manifest_dir, &p.path));
-            }
+            out.push((meta.key.clone(), m));
         }
     }
     out
 }
 
 /// A working manifest whose `parts` are the UNION of `canonical`'s parts and every
-/// SAME-FAMILY **split-unit** sibling copy's `Committed` parts, deduped by declared path. The
-/// reconcile target for a `--pool --split` prefix: presence/size/md5 then cover EVERY unit,
-/// not just the last writer whose parts the canonical `manifest.json` happens to list.
+/// `Committed` part declared by a SAME-FAMILY **split unit** under the prefix, deduped by
+/// declared path. The reconcile target for a `--pool --split` prefix: presence/size/md5 then
+/// cover EVERY unit, not just the last writer whose parts the canonical `manifest.json`
+/// happens to list (#167 merge-back).
 ///
-/// A sibling is folded ONLY when it carries a `split_window` — the precise mark of a
-/// co-current split UNIT (finding 2). A plain export's family is its own name, so its
-/// HISTORICAL repeated-run copies share the family too, but they are SUPERSEDED snapshots
-/// (no `split_window`); folding them would presence-check a legitimately cleaned old part and
-/// false-fail. The canonical's own copy is among the siblings, so seeding `seen` with the
-/// canonical's parts keeps it from being added twice. Only `parts` differ from `canonical`.
-fn merge_split_unit_parts(canonical: &RunManifest, siblings: &[RunManifest]) -> RunManifest {
+/// WHICH copies are units is [`ManifestCensus::split_units`]'s answer, not validate's — a
+/// plain export's HISTORICAL repeated-run copies share the family but are SUPERSEDED
+/// snapshots, and presence-checking a legitimately cleaned old part would false-fail. The
+/// canonical's own copy is among them, so seeding `seen` with the canonical's parts keeps it
+/// from being added twice. Only `parts` differ from `canonical`.
+fn merge_split_unit_parts(canonical: &RunManifest, census: &ManifestCensus<'_>) -> RunManifest {
     let mut merged = canonical.clone();
     let mut seen: std::collections::BTreeSet<String> =
         merged.parts.iter().map(|p| p.path.clone()).collect();
-    for m in siblings {
-        if m.export_family != canonical.export_family {
-            continue; // never fold a FOREIGN family's parts into the check
-        }
-        if m.split_window.is_none() {
-            continue; // only co-current SPLIT units — not superseded plain repeated-run copies
-        }
-        for p in &m.parts {
+    for unit in census.split_units(&canonical.export_family) {
+        for p in &unit.manifest.parts {
             if p.status == PartStatus::Committed && seen.insert(p.path.clone()) {
                 merged.parts.push(p.clone());
             }
@@ -784,7 +756,8 @@ pub fn verify_at_destination(
                 } else {
                     read_sibling_manifests(dest, &listing)
                 };
-                let target = merge_split_unit_parts(&manifest, &siblings);
+                let census = ManifestCensus::new(&siblings);
+                let target = merge_split_unit_parts(&manifest, &census);
                 let mut rec = reconcile_manifest_against_listing(&target, &listing, manifest_dir);
                 // Same-family sibling parts — the folded split units AND a plain export's
                 // SUPERSEDED historical / CDC-soak copies (no split_window, so NOT folded
@@ -792,8 +765,7 @@ pub fn verify_at_destination(
                 // must not read as untracked surplus (noise that also MASKS a real orphan). A
                 // foreign family's parts are never claimed, so cross-contamination still shows.
                 if !rec.untracked.is_empty() && !manifest.export_family.is_empty() {
-                    let claimed =
-                        sibling_claimed_part_keys(&siblings, &manifest.export_family, manifest_dir);
+                    let claimed = census.claimed_parts(&manifest.export_family, manifest_dir);
                     rec.untracked.retain(|o| !claimed.contains(&o.key));
                 }
                 Some(rec)
@@ -1053,11 +1025,18 @@ mod tests {
         }
     }
 
+    /// A sibling copy keyed the way the prefix listing hands it to the census.
+    fn sib_keyed(m: RunManifest) -> (String, RunManifest) {
+        (crate::manifest::run_unique_manifest_name(&m.export_name), m)
+    }
+
     /// merge_split_unit_parts folds every SAME-FAMILY SPLIT-UNIT sibling's committed parts
-    /// (those carrying a split_window) into the reconcile target, and EXCLUDES both a FOREIGN
-    /// family's parts and a SAME-FAMILY non-split (plain, superseded) copy's parts — so a
-    /// `--pool --split` snapshot is checked across ALL units without false-checking a plain
-    /// export's historical run or a foreign export sharing the prefix.
+    /// into the reconcile target, and EXCLUDES both a FOREIGN family's parts and a
+    /// SAME-FAMILY non-split (plain, superseded) copy's parts — so a `--pool --split`
+    /// snapshot is checked across ALL units without false-checking a plain export's
+    /// historical run or a foreign export sharing the prefix. WHICH copies are units is the
+    /// census's classification (`ManifestCensus::split_units`); this pins how validate turns
+    /// that answer into the presence-check target.
     #[test]
     fn merge_split_unit_parts_folds_split_siblings_only() {
         let unit = |name: &str, path: &str, fam: &str, split: bool| {
@@ -1066,9 +1045,9 @@ mod tests {
             m.export_name = name.into();
             m.parts[0].path = path.into();
             m.split_window = if split { Some(split_win()) } else { None };
-            m
+            sib_keyed(m)
         };
-        let canonical = unit("daily#3", "daily#3_p.parquet", "daily", true); // last split writer
+        let canonical = unit("daily#3", "daily#3_p.parquet", "daily", true).1; // last split writer
         let siblings = vec![
             unit("daily#0", "daily#0_p.parquet", "daily", true),
             unit("daily#1", "daily#1_p.parquet", "daily", true),
@@ -1076,7 +1055,7 @@ mod tests {
             unit("daily", "daily_old.parquet", "daily", false),  // SAME family, PLAIN (superseded)
             unit("other#0", "other_p.parquet", "other", true),   // FOREIGN family
         ];
-        let merged = merge_split_unit_parts(&canonical, &siblings);
+        let merged = merge_split_unit_parts(&canonical, &ManifestCensus::new(&siblings));
         let paths: std::collections::BTreeSet<&str> =
             merged.parts.iter().map(|p| p.path.as_str()).collect();
         assert_eq!(
@@ -1119,7 +1098,8 @@ mod tests {
         sib.parts[0].status = PartStatus::Quarantined;
         sib.split_window = Some(split_win());
 
-        let merged = merge_split_unit_parts(&canonical, &[sib]);
+        let siblings = vec![sib_keyed(sib)];
+        let merged = merge_split_unit_parts(&canonical, &ManifestCensus::new(&siblings));
         let paths: Vec<&str> = merged.parts.iter().map(|p| p.path.as_str()).collect();
         assert_eq!(
             paths,
@@ -1128,60 +1108,10 @@ mod tests {
         );
     }
 
-    /// sibling_claimed_part_keys claims a SAME-FAMILY sibling's committed parts (so a split
-    /// unit AND a plain export's superseded historical copy are both kept out of untracked),
-    /// but never a FOREIGN family's (cross-contamination must still surface as untracked).
-    #[test]
-    fn sibling_claimed_part_keys_claims_same_family_only() {
-        let unit = |name: &str, path: &str, fam: &str| {
-            let mut m = build_manifest(vec![part(0, 10, 100, "fp")], ManifestStatus::Success);
-            m.export_family = fam.into();
-            m.export_name = name.into();
-            m.parts[0].path = path.into();
-            m
-        };
-        let siblings = vec![
-            unit("daily#0", "daily#0_p.parquet", "daily"),
-            unit("daily", "daily_old.parquet", "daily"), // plain superseded copy, same family
-            unit("other", "other_p.parquet", "other"),
-        ];
-        let claimed = sibling_claimed_part_keys(&siblings, "daily", "");
-        assert!(
-            claimed.contains("daily#0_p.parquet") && claimed.contains("daily_old.parquet"),
-            "same-family parts (split unit AND plain historical) must be claimed: {claimed:?}"
-        );
-        assert!(
-            !claimed.contains("other_p.parquet"),
-            "a FOREIGN family's part must NOT be claimed — cross-contamination must surface"
-        );
-    }
-
-    /// A legacy canonical (empty family) claims nothing — the widening never applies where a
-    /// family cannot disambiguate.
-    #[test]
-    fn sibling_claimed_part_keys_empty_family_claims_nothing() {
-        let mut m = build_manifest(vec![part(0, 10, 100, "fp")], ManifestStatus::Success);
-        m.export_family = "daily".into();
-        m.parts[0].path = "p.parquet".into();
-        assert!(
-            sibling_claimed_part_keys(&[m], "", "").is_empty(),
-            "an empty canonical family must claim nothing"
-        );
-    }
-
-    /// A non-committed (quarantined) sibling part is NOT claimed — only durable committed
-    /// parts belong to the dataset.
-    #[test]
-    fn sibling_claimed_part_keys_skips_non_committed() {
-        let mut m = build_manifest(vec![part(0, 10, 100, "fp")], ManifestStatus::Success);
-        m.export_family = "daily".into();
-        m.parts[0].path = "q.parquet".into();
-        m.parts[0].status = PartStatus::Quarantined;
-        assert!(
-            sibling_claimed_part_keys(&[m], "daily", "").is_empty(),
-            "a quarantined part must not be claimed as a tracked dataset part"
-        );
-    }
+    // The claimed-part set validate subtracts from its untracked scan is the census's
+    // (`ManifestCensus::claimed_parts`) — same-family only, committed only, nothing under an
+    // empty family. Its unit tests live beside it, in `manifest::census`; the end-to-end
+    // section below still pins that VALIDATE subtracts it.
 
     /// End-to-end: a `--pool --split` prefix where a NON-last unit's part is missing must
     /// FAIL validation. Before the merge-back fix, verify reconciled only the canonical

--- a/src/preflight/analysis.rs
+++ b/src/preflight/analysis.rs
@@ -138,6 +138,71 @@ pub(crate) fn strategy_probes_index(export: &ExportConfig) -> bool {
     ) || export.chunk_by_key.is_some()
 }
 
+// ── The probe seam: one diagnostic skeleton, three engines' catalog SQL ──────
+//
+// ADR-0015 (source introspection is a data-shape seam, not a trait) applies
+// here verbatim: the PROBES share nothing extractable — `pg_index` vs
+// `information_schema.STATISTICS` vs `sys.indexes`, three client crates, three
+// dialects — so they stay per-engine free functions. What they share is the
+// WIRING: which column to probe, when to probe it, and how the answer becomes a
+// verdict. That policy was hand-copied into all three `diagnose_*` (down to the
+// verbatim auto-pk comment), which is the mechanism by which `chunk_by_key` was
+// missed three ways. The three targets below plus [`assemble_diagnostic`] hold
+// it ONCE, so the next strategy or check lands once.
+
+/// The base relation the catalog probes key on, for the PG/MySQL diagnostics:
+/// the configured `table:` when there is one, else the single relation parsed
+/// out of a simple `SELECT … FROM <table>`. `None` for anything that is not one
+/// base table (joins, subqueries, hand-written inline SQL) — the probes then
+/// degrade to an honest "unknown" rather than describing the wrong relation.
+/// MSSQL resolves its own base relation (`strip_select_star_from` first, then
+/// the same simple-FROM parser) because its probes key on the RENDERED query;
+/// it feeds the result into the same two targets below.
+pub(crate) fn preflight_base_table<'a>(
+    export: &'a ExportConfig,
+    base_query: &'a str,
+) -> Option<&'a str> {
+    export
+        .table
+        .as_deref()
+        .or_else(|| super::postgres::table_from_simple_query(base_query))
+}
+
+/// The table an engine runs its single-int-PK probe against — `Some` ONLY when
+/// the planner would actually auto-resolve this export's chunk column
+/// ([`should_auto_resolve_chunk_pk`]) and the base relation is known. The gate
+/// `build_plan` mirrors: without it `range_col` / the strategy label / the index
+/// probe target a different column than the run reads, and a PK-indexed table
+/// reports a false UNSAFE + `chunked(?, …)` (post-0.24.3 MED).
+pub(crate) fn auto_pk_probe_target<'a>(
+    export: &ExportConfig,
+    base_table: Option<&'a str>,
+) -> Option<&'a str> {
+    if should_auto_resolve_chunk_pk(export) {
+        base_table
+    } else {
+        None
+    }
+}
+
+/// The `(table, column)` an engine runs its leading-key index probe against —
+/// `Some` ONLY when the strategy reads on an indexed key
+/// ([`strategy_probes_index`]), the read column resolves
+/// ([`preflight_range_col_resolved`]) and the base relation is known. A `None`
+/// here means "no catalog answer", which [`assemble_diagnostic`] reads as "keep
+/// the engine's plan hint" — never as "no index".
+pub(crate) fn index_probe_target<'a>(
+    export: &'a ExportConfig,
+    auto_pk: Option<&'a str>,
+    base_table: Option<&'a str>,
+) -> Option<(&'a str, &'a str)> {
+    if !strategy_probes_index(export) {
+        return None;
+    }
+    let col = preflight_range_col_resolved(export, auto_pk)?;
+    Some((base_table?, col))
+}
+
 /// #149: measured beats declared — and the report SAYS which it stands on.
 ///
 /// After one successful run, `export_metrics.total_rows` is EXACT; the catalog
@@ -918,6 +983,128 @@ pub(crate) fn build_suggestion(
     }
 }
 
+/// What one engine's catalog/plan probes ANSWERED about an export — the data
+/// shape the three SQL diagnostics hand to [`assemble_diagnostic`].
+///
+/// Every field is an observation, never a decision: the engine says what it
+/// found (or `None` where the probe was skipped / failed / has no analogue on
+/// that engine), and the policy above turns the set into a verdict. Fill it with
+/// the shared targets — [`auto_pk_probe_target`] for `auto_pk`,
+/// [`index_probe_target`] for `catalog_index` — so a probe never runs on a
+/// column the run does not read.
+pub(crate) struct ProbeFacts {
+    /// The single-integer PK the planner would auto-resolve an unset chunked
+    /// `chunk_column` to (`build_plan`). `None` when the export does not
+    /// auto-resolve, the base relation is unknown, or the PK is composite /
+    /// non-integer / absent — exactly when the planner would not use one either.
+    pub auto_pk: Option<String>,
+    /// Scan-free row estimate (PG EXPLAIN `rows=`, MySQL EXPLAIN `rows`, MSSQL
+    /// `dm_db_partition_stats`). `None` = unknown, which the checks read as
+    /// "unknown", never as zero.
+    pub row_estimate: Option<i64>,
+    /// Average bytes per row, where the engine has a figure worth trusting.
+    /// `None` on MySQL by choice (`AVG_ROW_LENGTH` rides the same InnoDB random
+    /// dives as `TABLE_ROWS`), which skips the oversized-chunk check.
+    pub avg_row_bytes: Option<i64>,
+    /// MIN/MAX of the incremental key expression or the range column, as text.
+    pub range_min: Option<String>,
+    pub range_max: Option<String>,
+    /// Human-readable access-path description from the query plan (`Seq Scan`,
+    /// `range using PRIMARY`). `None` where the engine exposes no parseable plan
+    /// over the diagnostic's seam (MSSQL) — the printer then omits the line
+    /// rather than fabricating one.
+    pub scan_type: Option<String>,
+    /// Did the plan for the BASE query use an index? A weak hint: the base query
+    /// has no WHERE, so PG/MySQL legitimately pick a seq scan on a perfectly
+    /// indexed chunk column. `false` where there is no plan to read (MSSQL).
+    pub plan_uses_index: bool,
+    /// Is the read column the leading key of an index on the base table, per the
+    /// CATALOG? `Some(true)`/`Some(false)` from a clean probe, `None` when the
+    /// probe was not run ([`index_probe_target`] said no) or failed.
+    pub catalog_index: Option<bool>,
+    /// The server's configured connection cap, for the parallelism check.
+    pub db_max_connections: Option<u32>,
+}
+
+/// Turn one engine's [`ProbeFacts`] into the export's [`ExportDiagnostic`] —
+/// the policy half of every `diagnose_*`, written once.
+///
+/// Owns the decisions the three engines used to each hand-copy: the
+/// catalog-overrides-the-plan-hint rule, the auto-resolved strategy label, and
+/// the verdict / profile / parallelism / warnings / suggestion assembly. The
+/// engines keep only their dialect-specific SQL, so a new check (or a new
+/// strategy) is wired HERE and every engine gets it — the diagnostic-bypass fix
+/// stated once instead of three times.
+pub(crate) fn assemble_diagnostic(
+    export: &ExportConfig,
+    facts: ProbeFacts,
+) -> super::ExportDiagnostic {
+    let ProbeFacts {
+        auto_pk,
+        row_estimate,
+        avg_row_bytes,
+        range_min,
+        range_max,
+        scan_type,
+        plan_uses_index,
+        catalog_index,
+        db_max_connections,
+    } = facts;
+
+    // The plan hint describes the BASE query (no WHERE), where a seq scan is
+    // often the right plan even on a perfectly indexed chunk column. The run
+    // does not issue that query — it issues `WHERE range_col >= $lo AND < $hi`
+    // (or `> $last`), which uses the btree. So a catalog YES outranks the plan
+    // hint; a catalog NO or an unavailable/skipped probe leaves the hint
+    // standing, since the catalog answer is about the range column only.
+    let uses_index = match catalog_index {
+        Some(true) => true,
+        Some(false) | None => plan_uses_index,
+    };
+
+    let strategy = derive_strategy_resolved(export, auto_pk.as_deref());
+    let verdict = compute_verdict(
+        row_estimate,
+        uses_index,
+        export.cursor_column.is_some(),
+        avg_row_bytes,
+        export.parallel,
+    );
+    let recommended_profile = recommend_profile(row_estimate, uses_index, export);
+    let recommended_parallel = recommend_parallelism(export, row_estimate, uses_index);
+    let warnings = collect_warnings(
+        export,
+        row_estimate,
+        avg_row_bytes,
+        range_min.as_deref(),
+        range_max.as_deref(),
+        db_max_connections,
+    );
+    let suggestion = build_suggestion(&verdict, row_estimate, uses_index, export);
+
+    super::ExportDiagnostic {
+        row_source: None,
+        export_name: export.name.clone(),
+        strategy,
+        mode: diagnose_mode_str(export),
+        cursor_column: export.cursor_column.clone(),
+        row_estimate,
+        avg_row_bytes,
+        cursor_min: range_min.clone(),
+        cursor_max: range_max.clone(),
+        scan_type,
+        uses_index,
+        verdict,
+        recommended_profile,
+        recommended_parallel,
+        warnings,
+        suggestion,
+        chunk_min: range_min,
+        chunk_max: range_max,
+        db_max_connections,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1282,6 +1469,169 @@ mod tests {
             !strategy_probes_index(&cfg("mode: full\n")),
             "a plain full scan reads no indexed key — must NOT probe"
         );
+    }
+
+    // ── the shared skeleton: probe targets + assemble_diagnostic ─────────────
+    // The wiring the three engines used to hand-copy. Fabricating ProbeFacts is
+    // legitimate here because the POLICY is the subject; per-engine probe
+    // correctness (does this catalog SQL answer truthfully?) stays with the live
+    // suites, where a real catalog is the oracle.
+
+    fn facts() -> ProbeFacts {
+        ProbeFacts {
+            auto_pk: None,
+            row_estimate: Some(1_000),
+            avg_row_bytes: None,
+            range_min: None,
+            range_max: None,
+            scan_type: None,
+            plan_uses_index: false,
+            catalog_index: None,
+            db_max_connections: None,
+        }
+    }
+
+    #[test]
+    fn index_probe_target_names_the_column_every_read_strategy_reads_on() {
+        let t = Some("orders");
+        assert_eq!(
+            index_probe_target(&cfg("mode: chunked\nchunk_column: id\n"), None, t),
+            Some(("orders", "id"))
+        );
+        assert_eq!(
+            index_probe_target(&cfg("mode: chunked\nchunk_by_key: uuid\n"), None, t),
+            Some(("orders", "uuid")),
+            "keyset probes its seek key, not the absent chunk_column"
+        );
+        assert_eq!(
+            index_probe_target(
+                &cfg("mode: time_window\ntime_column: ts\ndays_window: 7\n"),
+                None,
+                t
+            ),
+            Some(("orders", "ts"))
+        );
+        assert_eq!(
+            index_probe_target(&cfg("mode: chunked\n"), Some("id"), t),
+            Some(("orders", "id")),
+            "an auto-resolved chunk PK is the column the run ranges on — probe THAT"
+        );
+        assert_eq!(
+            index_probe_target(&cfg("mode: full\n"), None, t),
+            None,
+            "a plain full scan reads no indexed key — no probe to run"
+        );
+        assert_eq!(
+            index_probe_target(&cfg("mode: chunked\nchunk_column: id\n"), None, None),
+            None,
+            "an unresolvable base relation must not be guessed at"
+        );
+    }
+
+    #[test]
+    fn auto_pk_probe_target_fires_only_where_the_planner_auto_resolves() {
+        assert_eq!(
+            auto_pk_probe_target(&cfg("mode: chunked\n"), Some("orders")),
+            Some("orders")
+        );
+        assert_eq!(
+            auto_pk_probe_target(&cfg("mode: chunked\nchunk_column: id\n"), Some("orders")),
+            None,
+            "an explicit chunk_column is what the planner ranges on — no PK probe"
+        );
+        assert_eq!(
+            auto_pk_probe_target(&cfg("mode: full\n"), Some("orders")),
+            None
+        );
+        assert_eq!(auto_pk_probe_target(&cfg("mode: chunked\n"), None), None);
+    }
+
+    #[test]
+    fn assemble_diagnostic_lets_a_catalog_yes_outrank_the_base_plan_hint() {
+        let e = cfg("mode: chunked\nchunk_column: id\n");
+        // The false-DEGRADED case the override exists for: EXPLAIN of the
+        // no-WHERE base query says Seq Scan, the catalog says the chunk column
+        // leads a btree, and the run issues the BETWEEN that uses it.
+        let d = assemble_diagnostic(
+            &e,
+            ProbeFacts {
+                plan_uses_index: false,
+                catalog_index: Some(true),
+                ..facts()
+            },
+        );
+        assert!(d.uses_index, "a catalog YES must beat the base-query plan");
+
+        // A clean catalog NO is about the range column only, so the plan hint
+        // (which described the whole query) still stands.
+        let d = assemble_diagnostic(
+            &e,
+            ProbeFacts {
+                plan_uses_index: true,
+                catalog_index: Some(false),
+                ..facts()
+            },
+        );
+        assert!(d.uses_index);
+
+        // No catalog answer (probe skipped or failed) => the plan hint, verbatim.
+        for hint in [true, false] {
+            let d = assemble_diagnostic(
+                &e,
+                ProbeFacts {
+                    plan_uses_index: hint,
+                    catalog_index: None,
+                    ..facts()
+                },
+            );
+            assert_eq!(d.uses_index, hint, "no catalog answer keeps the plan hint");
+        }
+    }
+
+    #[test]
+    fn assemble_diagnostic_labels_the_auto_resolved_pk_not_a_question_mark() {
+        let d = assemble_diagnostic(
+            &cfg("mode: chunked\nchunk_size: 50000\n"),
+            ProbeFacts {
+                auto_pk: Some("id".to_string()),
+                ..facts()
+            },
+        );
+        assert_eq!(d.strategy, "chunked(id, size=50000)");
+        assert!(
+            !d.strategy.contains('?'),
+            "the `?` placeholder is the diagnostic-bypass tell"
+        );
+    }
+
+    /// The skeleton is only de-triplicated while every engine ROUTES through it.
+    /// A second `ExportDiagnostic { … }` literal in an engine file is the old
+    /// wiring growing back — and with it the next check that lands in one engine
+    /// and silently skips the other two (the diagnostic-bypass class). Mongo is
+    /// deliberately NOT in this list: it runs no catalog probe and no policy
+    /// (full-scan only, mode-advice suppressed), so it keeps its own literal.
+    #[test]
+    fn every_sql_engine_diagnostic_routes_through_the_assembler() {
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/preflight");
+        for engine in ["postgres.rs", "mysql.rs", "mssql.rs"] {
+            let src = std::fs::read_to_string(dir.join(engine)).expect("read engine diagnostic");
+            // Comment-stripped, so a mention in prose cannot satisfy the gate.
+            let code = src
+                .lines()
+                .filter(|l| !l.trim_start().starts_with("//"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            assert!(
+                code.contains("assemble_diagnostic("),
+                "{engine} must build its diagnostic through the shared assembler"
+            );
+            assert!(
+                !code.contains("ExportDiagnostic {"),
+                "{engine} constructs an ExportDiagnostic itself — the assembly \
+                 policy (index override, strategy label, warnings) is shared and \
+                 must not be re-stated per engine"
+            );
+        }
     }
 
     // ── keyset (chunk_by_key) must be labelled keyset, never `chunked(?, …)` ──

--- a/src/preflight/mssql.rs
+++ b/src/preflight/mssql.rs
@@ -70,8 +70,6 @@ fn fetch_max_connections_mssql(conn: &mut MssqlSource) -> Option<u32> {
 }
 
 fn diagnose_mssql(conn: &mut MssqlSource, export: &ExportConfig) -> Result<ExportDiagnostic> {
-    let mode_str = diagnose_mode_str(export);
-
     let base_query = resolve_preflight_base_query(export);
     let base_query = base_query.as_str();
 
@@ -89,22 +87,20 @@ fn diagnose_mssql(conn: &mut MssqlSource, export: &ExportConfig) -> Result<Expor
     // `SELECT * FROM <table>` — both resolve to a single relation here. Anything
     // the parser can't reduce to one base table (joins, subqueries, hand-written
     // inline SQL) yields `None`, and the row-estimate / index probes degrade to
-    // an honest "unknown" rather than guessing the wrong relation.
+    // an honest "unknown" rather than guessing the wrong relation. Resolved from
+    // the RENDERED query (not `preflight_base_table`'s configured-`table:` first
+    // order) because the MSSQL catalog probes key on the emitted relation.
     let base_table =
         strip_select_star_from(base_query).or_else(|| table_from_simple_query(base_query));
 
-    // build_plan auto-resolves an UNSET chunked chunk_column to the single-integer PK; resolve it
-    // here too so range_col / the strategy label / the index probe target the SAME column, else
-    // the export reports a false UNSAFE + chunked(?,…) on a PK-indexed table (post-0.24.3 MED).
-    let auto_pk: Option<String> = if should_auto_resolve_chunk_pk(export) {
-        base_table.and_then(|t| single_int_pk_mssql(conn, t))
-    } else {
-        None
-    };
+    // build_plan auto-resolves an UNSET chunked chunk_column to the single-integer PK, and
+    // `auto_pk_probe_target` is that gate — so range_col / the strategy label / the index
+    // probe target the SAME column, not a `?` placeholder on a PK-indexed table.
+    let auto_pk: Option<String> =
+        auto_pk_probe_target(export, base_table).and_then(|t| single_int_pk_mssql(conn, t));
 
     // chunk_column (range) OR chunk_by_key (keyset) OR cursor_column (incremental) OR the
-    // auto-resolved PK above — the run's real read column. Without any of these range_col is
-    // None, so the index probe below never runs and the verdict falls to a false "no index".
+    // auto-resolved PK above — the run's real read column.
     let range_col = preflight_range_col_resolved(export, auto_pk.as_deref());
 
     // Row estimate from `sys.dm_db_partition_stats` — the same fast,
@@ -135,32 +131,15 @@ fn diagnose_mssql(conn: &mut MssqlSource, export: &ExportConfig) -> Result<Expor
     };
 
     // Honest index signal: no query plan is parsed (SQL Server has no portable
-    // `EXPLAIN` over the scalar seam), so `scan_type` stays `None`. For
-    // chunked/incremental modes the catalog *can* answer the question that
-    // actually matters for the run (`WHERE range_col > $last` / `BETWEEN`): is
-    // the range column the single leading key of some index? That fact alone
-    // drives the verdict, the same way the PG/MySQL catalog probe overrides
-    // their EXPLAIN hint.
-    let scan_type = None;
-    let uses_index = if strategy_probes_index(export)
-        && let Some(col) = range_col
-        && let Some(table) = base_table
-    {
-        column_has_index_mssql(conn, table, col).unwrap_or(false)
-    } else {
-        false
-    };
+    // `EXPLAIN` over the scalar seam), so `scan_type` stays `None` and the plan
+    // hint is a hard `false`. For chunked/incremental modes the catalog *can*
+    // answer the question that actually matters for the run
+    // (`WHERE range_col > $last` / `BETWEEN`): is the range column the single
+    // leading key of some index? With no plan hint to fall back on, that fact
+    // alone drives `uses_index` through the shared override policy.
+    let catalog_index = index_probe_target(export, auto_pk.as_deref(), base_table)
+        .and_then(|(table, col)| column_has_index_mssql(conn, table, col));
 
-    let strategy = derive_strategy_resolved(export, auto_pk.as_deref());
-    let verdict = compute_verdict(
-        row_estimate,
-        uses_index,
-        export.cursor_column.is_some(),
-        avg_row_bytes,
-        export.parallel,
-    );
-    let recommended_profile = recommend_profile(row_estimate, uses_index, export);
-    let recommended_parallel = recommend_parallelism(export, row_estimate, uses_index);
     // SQL Server's `@@MAX_CONNECTIONS` IS the portable analogue of PG
     // max_connections / MySQL @@max_connections (the configured `user
     // connections` cap; default 32767 ≈ unlimited, so the warning is inert on a
@@ -168,37 +147,21 @@ fn diagnose_mssql(conn: &mut MssqlSource, export: &ExportConfig) -> Result<Expor
     // same query_scalar seam so the connection-limit check has parity with the
     // other engines.
     let db_max_connections = fetch_max_connections_mssql(conn);
-    let warnings = collect_warnings(
-        export,
-        row_estimate,
-        avg_row_bytes,
-        range_min.as_deref(),
-        range_max.as_deref(),
-        db_max_connections,
-    );
-    let suggestion = build_suggestion(&verdict, row_estimate, uses_index, export);
 
-    Ok(ExportDiagnostic {
-        row_source: None,
-        export_name: export.name.clone(),
-        strategy,
-        mode: mode_str,
-        cursor_column: export.cursor_column.clone(),
-        row_estimate,
-        avg_row_bytes,
-        cursor_min: range_min.clone(),
-        cursor_max: range_max.clone(),
-        scan_type,
-        uses_index,
-        verdict,
-        recommended_profile,
-        recommended_parallel,
-        warnings,
-        suggestion,
-        chunk_min: range_min.clone(),
-        chunk_max: range_max.clone(),
-        db_max_connections,
-    })
+    Ok(assemble_diagnostic(
+        export,
+        ProbeFacts {
+            auto_pk,
+            row_estimate,
+            avg_row_bytes,
+            range_min,
+            range_max,
+            scan_type: None,
+            plan_uses_index: false,
+            catalog_index,
+            db_max_connections,
+        },
+    ))
 }
 
 /// Row estimate from `sys.dm_db_partition_stats` for `[schema.]table`. Mirrors

--- a/src/preflight/mysql.rs
+++ b/src/preflight/mysql.rs
@@ -73,26 +73,16 @@ fn diagnose_mysql(
 ) -> Result<ExportDiagnostic> {
     use mysql::prelude::Queryable;
 
-    let mode_str = diagnose_mode_str(export);
-
     let base_query = resolve_preflight_base_query(export);
     let base_query = base_query.as_str();
-    // build_plan auto-resolves an UNSET chunked chunk_column to the single-integer PK; resolve
-    // it here too so range_col / the strategy label / the index probe target the SAME column,
-    // else the export reports a false UNSAFE + chunked(?,…) on a PK-indexed table (post-0.24.3 MED).
-    let auto_pk: Option<String> = if should_auto_resolve_chunk_pk(export) {
-        export
-            .table
-            .as_deref()
-            .or_else(|| super::postgres::table_from_simple_query(base_query))
-            .and_then(|t| single_int_pk_mysql(conn, t))
-    } else {
-        None
-    };
+    let base_table = preflight_base_table(export, base_query);
+    // build_plan auto-resolves an UNSET chunked chunk_column to the single-integer PK, and
+    // `auto_pk_probe_target` is that gate — so range_col / the strategy label / the index
+    // probe target the SAME column, not a `?` placeholder on a PK-indexed table.
+    let auto_pk: Option<String> =
+        auto_pk_probe_target(export, base_table).and_then(|t| single_int_pk_mysql(conn, t));
     // The column the run actually reads on: chunk_column for range chunking, chunk_by_key for
-    // keyset (seek), cursor_column for incremental, or the auto-resolved PK above — a keyset
-    // table has neither chunk_column nor cursor_column, so without any of these range_col is
-    // None and every downstream probe silently degrades to a false unindexed full-scan verdict.
+    // keyset (seek), cursor_column for incremental, or the auto-resolved PK above.
     let range_col = preflight_range_col_resolved(export, auto_pk.as_deref());
     let effective_query = if let Some(order) = incremental_key_expr(export, SourceType::Mysql) {
         format!(
@@ -180,74 +170,34 @@ fn diagnose_mysql(
         }
     };
 
-    // Same logic as the PG side: EXPLAIN of the base query reports `ALL`
-    // (full table scan) for a no-WHERE read, even on tables where the
-    // chunk_column is a perfect PK with a btree. The chunk runner actually
-    // issues `WHERE chunk_col >= $lo AND chunk_col < $hi`, which would use
-    // the index. Override `uses_index` from the catalog when the column is
-    // the leading key of some index on the table.
-    let uses_index = if strategy_probes_index(export)
-        && let Some(col) = range_col
-        && let Some(table) = export
-            .table
-            .as_deref()
-            .or_else(|| super::postgres::table_from_simple_query(base_query))
-    {
-        match column_has_index_mysql(conn, table, col) {
-            Some(true) => true,
-            Some(false) => plan_uses_index,
-            None => plan_uses_index,
-        }
-    } else {
-        plan_uses_index
-    };
+    // Same logic as the PG side: EXPLAIN of the base query reports `ALL` (full
+    // table scan) for a no-WHERE read, even on tables where the chunk_column is
+    // a perfect PK with a btree. The chunk runner actually issues
+    // `WHERE chunk_col >= $lo AND chunk_col < $hi`, which would use the index —
+    // so answer from the catalog and let `assemble_diagnostic` apply the shared
+    // override policy.
+    let catalog_index = index_probe_target(export, auto_pk.as_deref(), base_table)
+        .and_then(|(table, col)| column_has_index_mysql(conn, table, col));
 
-    let strategy = derive_strategy_resolved(export, auto_pk.as_deref());
-    let verdict = compute_verdict(
-        row_estimate,
-        uses_index,
-        export.cursor_column.is_some(),
-        None, // MySQL exposes no reliable avg_row_bytes pre-run → can't predict RSS
-        export.parallel,
-    );
-    let recommended_profile = recommend_profile(row_estimate, uses_index, export);
-    let recommended_parallel = recommend_parallelism(export, row_estimate, uses_index);
-    // MySQL has no trustworthy scan-free row-width estimate (information_schema
-    // AVG_ROW_LENGTH shares the same InnoDB random-dive statistics as TABLE_ROWS,
-    // which #1 already declined to trust), so the oversized-chunk check is skipped
-    // here by passing `None` — same stance as the row-estimate density diagnostic.
-    let avg_row_bytes: Option<i64> = None;
-    let warnings = collect_warnings(
+    Ok(assemble_diagnostic(
         export,
-        row_estimate,
-        avg_row_bytes,
-        range_min.as_deref(),
-        range_max.as_deref(),
-        db_max_connections,
-    );
-    let suggestion = build_suggestion(&verdict, row_estimate, uses_index, export);
-
-    Ok(ExportDiagnostic {
-        row_source: None,
-        export_name: export.name.clone(),
-        strategy,
-        mode: mode_str,
-        cursor_column: export.cursor_column.clone(),
-        row_estimate,
-        avg_row_bytes,
-        cursor_min: range_min.clone(),
-        cursor_max: range_max.clone(),
-        scan_type,
-        uses_index,
-        verdict,
-        recommended_profile,
-        recommended_parallel,
-        warnings,
-        suggestion,
-        chunk_min: range_min.clone(),
-        chunk_max: range_max.clone(),
-        db_max_connections,
-    })
+        ProbeFacts {
+            auto_pk,
+            row_estimate,
+            // MySQL has no trustworthy scan-free row-width estimate
+            // (information_schema AVG_ROW_LENGTH shares the same InnoDB random-dive
+            // statistics as TABLE_ROWS, which #1 already declined to trust), so the
+            // oversized-chunk check and the RSS prediction are skipped here by
+            // passing `None` — same stance as the row-estimate density diagnostic.
+            avg_row_bytes: None,
+            range_min,
+            range_max,
+            scan_type,
+            plan_uses_index,
+            catalog_index,
+            db_max_connections,
+        },
+    ))
 }
 
 fn mysql_row_get_string(row: &mysql::Row, col: &str) -> Option<String> {

--- a/src/preflight/postgres.rs
+++ b/src/preflight/postgres.rs
@@ -48,28 +48,19 @@ fn diagnose_pg(
     export: &ExportConfig,
     db_max_connections: Option<u32>,
 ) -> Result<ExportDiagnostic> {
-    let mode_str = diagnose_mode_str(export);
-
     let base_query = resolve_preflight_base_query(export);
     let base_query = base_query.as_str();
+    let base_table = preflight_base_table(export, base_query);
 
     // The planner auto-resolves an UNSET chunked chunk_column to the single-integer PK
-    // (build_plan). Resolve it here too so range_col / the strategy label / the index probe
-    // target that SAME column — else every such export reports a false UNSAFE + `chunked(?,…)`
-    // + "create an index on chunk_column" on an already-PK-indexed table (post-0.24.3 MED).
-    let auto_pk: Option<String> = if should_auto_resolve_chunk_pk(export) {
-        export
-            .table
-            .as_deref()
-            .or_else(|| table_from_simple_query(base_query))
-            .and_then(|t| single_int_pk_pg(client, t))
-    } else {
-        None
-    };
+    // (build_plan), and `auto_pk_probe_target` is that gate — so range_col / the strategy
+    // label / the index probe target the SAME column the run ranges on, instead of reporting
+    // a false UNSAFE + `chunked(?,…)` on an already-PK-indexed table.
+    let auto_pk: Option<String> =
+        auto_pk_probe_target(export, base_table).and_then(|t| single_int_pk_pg(client, t));
 
     // chunk_column (range) OR chunk_by_key (keyset) OR cursor_column (incremental) OR the
-    // auto-resolved PK above — the column the run actually reads on. Omitting any of these
-    // leaves range_col = None, which the index override below reads as "no index" → false UNSAFE.
+    // auto-resolved PK above — the column the run actually reads on.
     let range_col = preflight_range_col_resolved(export, auto_pk.as_deref());
 
     let effective_query = if let Some(order) = incremental_key_expr(export, SourceType::Postgres) {
@@ -121,73 +112,29 @@ fn diagnose_pg(
     let (scan_type, plan_uses_index) = analyze_plan_pg(client, &effective_query);
 
     // The EXPLAIN above runs against the *base* query (the whole table,
-    // typically). PostgreSQL picks `Seq Scan` for a full-table read even
-    // when there's a perfect btree on the chunk column — the index path is
-    // genuinely slower for a full read. But the chunked/incremental run
-    // does NOT issue the base query; it issues `WHERE chunk_col >= $lo
-    // AND chunk_col < $hi`, which *will* use the btree.
-    //
-    // So for those modes, ask the catalog directly: is there a btree index
-    // whose leading column is the range column? If yes, treat it as
-    // indexed regardless of what EXPLAIN said for the base query. This
-    // collapses the most common false-DEGRADED case (chunked on a PK).
-    let uses_index = if strategy_probes_index(export)
-        && let Some(col) = range_col
-        && let Some(table) = export
-            .table
-            .as_deref()
-            .or_else(|| table_from_simple_query(base_query))
-    {
-        match column_has_btree_pg(client, table, col) {
-            Some(true) => true,
-            Some(false) => plan_uses_index,
-            None => plan_uses_index,
-        }
-    } else {
-        plan_uses_index
-    };
+    // typically). PostgreSQL picks `Seq Scan` for a full-table read even when
+    // there's a perfect btree on the chunk column — the index path is genuinely
+    // slower for a full read. But the chunked/incremental run does NOT issue the
+    // base query; it issues `WHERE chunk_col >= $lo AND chunk_col < $hi`, which
+    // *will* use the btree. So answer the question from the catalog and let
+    // `assemble_diagnostic` apply the shared override policy.
+    let catalog_index = index_probe_target(export, auto_pk.as_deref(), base_table)
+        .and_then(|(table, col)| column_has_btree_pg(client, table, col));
 
-    let strategy = derive_strategy_resolved(export, auto_pk.as_deref());
-    let verdict = compute_verdict(
-        row_estimate,
-        uses_index,
-        export.cursor_column.is_some(),
-        avg_row_bytes,
-        export.parallel,
-    );
-    let recommended_profile = recommend_profile(row_estimate, uses_index, export);
-    let recommended_parallel = recommend_parallelism(export, row_estimate, uses_index);
-    let warnings = collect_warnings(
+    Ok(assemble_diagnostic(
         export,
-        row_estimate,
-        avg_row_bytes,
-        range_min.as_deref(),
-        range_max.as_deref(),
-        db_max_connections,
-    );
-    let suggestion = build_suggestion(&verdict, row_estimate, uses_index, export);
-
-    Ok(ExportDiagnostic {
-        row_source: None,
-        export_name: export.name.clone(),
-        strategy,
-        mode: mode_str,
-        cursor_column: export.cursor_column.clone(),
-        row_estimate,
-        avg_row_bytes,
-        cursor_min: range_min.clone(),
-        cursor_max: range_max.clone(),
-        scan_type,
-        uses_index,
-        verdict,
-        recommended_profile,
-        recommended_parallel,
-        warnings,
-        suggestion,
-        chunk_min: range_min.clone(),
-        chunk_max: range_max.clone(),
-        db_max_connections,
-    })
+        ProbeFacts {
+            auto_pk,
+            row_estimate,
+            avg_row_bytes,
+            range_min,
+            range_max,
+            scan_type,
+            plan_uses_index,
+            catalog_index,
+            db_max_connections,
+        },
+    ))
 }
 
 /// Returns `(row_estimate, avg_row_bytes)` parsed from one EXPLAIN — the top

--- a/src/state/checkpoint.rs
+++ b/src/state/checkpoint.rs
@@ -2,7 +2,7 @@ use rusqlite::TransactionBehavior;
 
 use crate::error::Result;
 
-use super::{StateConn, StateRef, StateStore, open_connection, pg_sql};
+use super::{StateConn, StateRef, StateStore, open_connection};
 
 /// One row from `chunk_task` for display / debugging.
 #[derive(Debug, Clone)]
@@ -30,20 +30,11 @@ impl StateStore {
     /// Distinct `export_name` values that currently have at least one
     /// `chunk_run` row with `status = 'in_progress'` (interrupted run — resume or reset).
     pub fn list_export_names_with_in_progress_chunk_runs(&self) -> Result<Vec<String>> {
-        let sql = "SELECT DISTINCT export_name FROM chunk_run WHERE status = 'in_progress' ORDER BY export_name ASC";
-        match &self.conn {
-            StateConn::Sqlite(c) => {
-                let mut stmt = c.prepare(sql)?;
-                let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
-                rows.collect::<std::result::Result<Vec<_>, _>>()
-                    .map_err(Into::into)
-            }
-            StateConn::Postgres(client) => {
-                let mut c = client.borrow_mut();
-                let rows = c.query(&pg_sql(sql), &[])?;
-                Ok(rows.iter().map(|row| row.get(0)).collect())
-            }
-        }
+        self.query(
+            "SELECT DISTINCT export_name FROM chunk_run WHERE status = 'in_progress' ORDER BY export_name ASC",
+            &[],
+            |r| r.text(0),
+        )
     }
 
     /// Whether this export has a resumable checkpoint — an in-progress chunk run
@@ -64,24 +55,13 @@ impl StateStore {
         &self,
         export_name: &str,
     ) -> Result<Option<(String, String)>> {
-        let sql = "SELECT run_id, plan_hash FROM chunk_run
+        self.query_opt(
+            "SELECT run_id, plan_hash FROM chunk_run
              WHERE export_name = ?1 AND status = 'in_progress'
-             ORDER BY created_at DESC LIMIT 1";
-        match &self.conn {
-            StateConn::Sqlite(c) => {
-                let mut stmt = c.prepare(sql)?;
-                let mut rows =
-                    stmt.query_map([export_name], |row| Ok((row.get(0)?, row.get(1)?)))?;
-                Ok(rows.next().transpose()?)
-            }
-            StateConn::Postgres(client) => {
-                // Single borrow for the duration of this call; safe because all Postgres
-                // operations in StateStore are sequential (no re-entrant borrows).
-                let mut c = client.borrow_mut();
-                let rows = c.query(&pg_sql(sql), &[&export_name])?;
-                Ok(rows.first().map(|row| (row.get(0), row.get(1))))
-            }
-        }
+             ORDER BY created_at DESC LIMIT 1",
+            &[export_name.into()],
+            |r| (r.text(0), r.text(1)),
+        )
     }
 
     pub fn create_chunk_run(
@@ -92,38 +72,23 @@ impl StateStore {
         max_chunk_attempts: u32,
     ) -> Result<()> {
         let now = chrono::Utc::now().to_rfc3339();
-        let sql = "INSERT INTO chunk_run (run_id, export_name, plan_hash, status, max_chunk_attempts, created_at, updated_at)
-             VALUES (?1, ?2, ?3, 'in_progress', ?4, ?5, ?5)";
-        match &self.conn {
-            StateConn::Sqlite(c) => {
-                c.execute(
-                    sql,
-                    rusqlite::params![
-                        run_id,
-                        export_name,
-                        plan_hash,
-                        max_chunk_attempts as i64,
-                        now
-                    ],
-                )?;
-            }
-            StateConn::Postgres(client) => {
-                let mut c = client.borrow_mut();
-                c.execute(
-                    &pg_sql(sql),
-                    &[
-                        &run_id,
-                        &export_name,
-                        &plan_hash,
-                        &(max_chunk_attempts as i64),
-                        &now,
-                    ],
-                )?;
-            }
-        }
+        self.execute(
+            "INSERT INTO chunk_run (run_id, export_name, plan_hash, status, max_chunk_attempts, created_at, updated_at)
+             VALUES (?1, ?2, ?3, 'in_progress', ?4, ?5, ?5)",
+            &[
+                run_id.into(),
+                export_name.into(),
+                plan_hash.into(),
+                (max_chunk_attempts as i64).into(),
+                now.into(),
+            ],
+        )?;
         Ok(())
     }
 
+    /// Divergent-by-design (row.rs exemption): a transactional batch insert on
+    /// each backend's native transaction + prepared-statement API — not dialect
+    /// ceremony, so it stays an explicit two-arm match.
     pub fn insert_chunk_tasks(&self, run_id: &str, ranges: &[(i64, i64)]) -> Result<()> {
         if ranges.is_empty() {
             return Ok(());
@@ -178,19 +143,11 @@ impl StateStore {
     /// Mark tasks left `running` after a crash as `pending` so they can be retried.
     pub fn reset_stale_running_chunk_tasks(&self, run_id: &str) -> Result<usize> {
         let now = chrono::Utc::now().to_rfc3339();
-        let sql = "UPDATE chunk_task SET status = 'pending', updated_at = ?1
-             WHERE run_id = ?2 AND status = 'running'";
-        match &self.conn {
-            StateConn::Sqlite(c) => {
-                let n = c.execute(sql, rusqlite::params![now, run_id])?;
-                Ok(n)
-            }
-            StateConn::Postgres(client) => {
-                let mut c = client.borrow_mut();
-                let n = c.execute(&pg_sql(sql), &[&now, &run_id])?;
-                Ok(n as usize)
-            }
-        }
+        self.execute(
+            "UPDATE chunk_task SET status = 'pending', updated_at = ?1
+             WHERE run_id = ?2 AND status = 'running'",
+            &[now.into(), run_id.into()],
+        )
     }
 
     /// Un-pin chunks a prior run gave up on so an explicit `--resume` retries them.
@@ -211,19 +168,11 @@ impl StateStore {
     /// Returns the number of chunks un-pinned.
     pub fn reset_failed_chunk_tasks_for_resume(&self, run_id: &str) -> Result<usize> {
         let now = chrono::Utc::now().to_rfc3339();
-        let sql = "UPDATE chunk_task SET status = 'pending', attempts = 0, updated_at = ?1
-             WHERE run_id = ?2 AND status = 'failed'";
-        match &self.conn {
-            StateConn::Sqlite(c) => {
-                let n = c.execute(sql, rusqlite::params![now, run_id])?;
-                Ok(n)
-            }
-            StateConn::Postgres(client) => {
-                let mut c = client.borrow_mut();
-                let n = c.execute(&pg_sql(sql), &[&now, &run_id])?;
-                Ok(n as usize)
-            }
-        }
+        self.execute(
+            "UPDATE chunk_task SET status = 'pending', attempts = 0, updated_at = ?1
+             WHERE run_id = ?2 AND status = 'failed'",
+            &[now.into(), run_id.into()],
+        )
     }
 
     /// Atomically claim the next pending or retryable failed chunk.
@@ -263,6 +212,11 @@ impl StateStore {
 
     /// Claim next chunk using a fresh connection identified by `state_ref`.
     /// Used by parallel workers that cannot share a single connection.
+    ///
+    /// Divergent-by-design (row.rs exemption): fresh per-worker connections via
+    /// `StateRef` and genuinely different SQL per backend (Postgres `FOR UPDATE
+    /// SKIP LOCKED` vs SQLite rowid + IMMEDIATE tx) — do not re-migrate this
+    /// onto the ceremony seam.
     pub fn claim_next_chunk_task_at_ref(
         state_ref: &StateRef,
         run_id: &str,
@@ -314,24 +268,18 @@ impl StateStore {
         file_name: Option<&str>,
     ) -> Result<()> {
         let now = chrono::Utc::now().to_rfc3339();
-        let sql = "UPDATE chunk_task
+        self.execute(
+            "UPDATE chunk_task
              SET status = 'completed', rows_written = ?1, file_name = ?2, last_error = NULL, updated_at = ?3
-             WHERE run_id = ?4 AND chunk_index = ?5";
-        match &self.conn {
-            StateConn::Sqlite(c) => {
-                c.execute(
-                    sql,
-                    rusqlite::params![rows_written, file_name, now, run_id, chunk_index],
-                )?;
-            }
-            StateConn::Postgres(client) => {
-                let mut c = client.borrow_mut();
-                c.execute(
-                    &pg_sql(sql),
-                    &[&rows_written, &file_name, &now, &run_id, &chunk_index],
-                )?;
-            }
-        }
+             WHERE run_id = ?4 AND chunk_index = ?5",
+            &[
+                rows_written.into(),
+                file_name.into(),
+                now.into(),
+                run_id.into(),
+                chunk_index.into(),
+            ],
+        )?;
         Ok(())
     }
 
@@ -366,61 +314,40 @@ impl StateStore {
                     attempts = (SELECT max_chunk_attempts FROM chunk_run WHERE run_id = ?3)
              WHERE run_id = ?3 AND chunk_index = ?4"
         };
-        match &self.conn {
-            StateConn::Sqlite(c) => {
-                c.execute(sql, rusqlite::params![err, now, run_id, chunk_index])?;
-            }
-            StateConn::Postgres(client) => {
-                let mut c = client.borrow_mut();
-                c.execute(&pg_sql(sql), &[&err, &now, &run_id, &chunk_index])?;
-            }
-        }
+        self.execute(
+            sql,
+            &[err.into(), now.into(), run_id.into(), chunk_index.into()],
+        )?;
         Ok(())
     }
 
     pub fn count_chunk_tasks_total(&self, run_id: &str) -> Result<usize> {
-        let sql = "SELECT COUNT(*) FROM chunk_task WHERE run_id = ?1";
-        match &self.conn {
-            StateConn::Sqlite(c) => {
-                let n: i64 = c.query_row(sql, [run_id], |row| row.get(0))?;
-                Ok(n as usize)
-            }
-            StateConn::Postgres(client) => {
-                let mut c = client.borrow_mut();
-                let row = c.query_one(&pg_sql(sql), &[&run_id])?;
-                let n: i64 = row.get(0);
-                Ok(n as usize)
-            }
-        }
+        let n = self
+            .query_opt(
+                "SELECT COUNT(*) FROM chunk_task WHERE run_id = ?1",
+                &[run_id.into()],
+                |r| r.i64(0),
+            )?
+            .unwrap_or(0);
+        Ok(n as usize)
     }
 
     pub fn count_chunk_tasks_not_completed(&self, run_id: &str) -> Result<i64> {
-        let sql = "SELECT COUNT(*) FROM chunk_task WHERE run_id = ?1 AND status != 'completed'";
-        match &self.conn {
-            StateConn::Sqlite(c) => {
-                let n: i64 = c.query_row(sql, [run_id], |row| row.get(0))?;
-                Ok(n)
-            }
-            StateConn::Postgres(client) => {
-                let mut c = client.borrow_mut();
-                let row = c.query_one(&pg_sql(sql), &[&run_id])?;
-                Ok(row.get(0))
-            }
-        }
+        Ok(self
+            .query_opt(
+                "SELECT COUNT(*) FROM chunk_task WHERE run_id = ?1 AND status != 'completed'",
+                &[run_id.into()],
+                |r| r.i64(0),
+            )?
+            .unwrap_or(0))
     }
 
     pub fn finalize_chunk_run_completed(&self, run_id: &str) -> Result<()> {
         let now = chrono::Utc::now().to_rfc3339();
-        let sql = "UPDATE chunk_run SET status = 'completed', updated_at = ?1 WHERE run_id = ?2";
-        match &self.conn {
-            StateConn::Sqlite(c) => {
-                c.execute(sql, rusqlite::params![now, run_id])?;
-            }
-            StateConn::Postgres(client) => {
-                let mut c = client.borrow_mut();
-                c.execute(&pg_sql(sql), &[&now, &run_id])?;
-            }
-        }
+        self.execute(
+            "UPDATE chunk_run SET status = 'completed', updated_at = ?1 WHERE run_id = ?2",
+            &[now.into(), run_id.into()],
+        )?;
         Ok(())
     }
 
@@ -451,7 +378,8 @@ impl StateStore {
         reason: &str,
     ) -> Result<usize> {
         let now = chrono::Utc::now().to_rfc3339();
-        let sql = "UPDATE chunk_task
+        self.execute(
+            "UPDATE chunk_task
              SET status = 'pending',
                  attempts = 0,
                  file_name = NULL,
@@ -460,56 +388,28 @@ impl StateStore {
                  updated_at = ?2
              WHERE run_id = ?3
                AND chunk_index = ?4
-               AND status = 'completed'";
-        match &self.conn {
-            StateConn::Sqlite(c) => {
-                let n = c.execute(sql, rusqlite::params![reason, now, run_id, chunk_index])?;
-                Ok(n)
-            }
-            StateConn::Postgres(client) => {
-                let mut c = client.borrow_mut();
-                let n = c.execute(&pg_sql(sql), &[&reason, &now, &run_id, &chunk_index])?;
-                Ok(n as usize)
-            }
-        }
+               AND status = 'completed'",
+            &[reason.into(), now.into(), run_id.into(), chunk_index.into()],
+        )
     }
 
     /// Remove all chunk runs and tasks for an export (abandon resume).
     pub fn reset_chunk_checkpoint(&self, export_name: &str) -> Result<usize> {
-        match &self.conn {
-            StateConn::Sqlite(c) => {
-                let run_ids: Vec<String> = {
-                    let mut stmt =
-                        c.prepare("SELECT run_id FROM chunk_run WHERE export_name = ?1")?;
-                    let rows = stmt.query_map([export_name], |row| row.get(0))?;
-                    rows.collect::<std::result::Result<Vec<_>, _>>()?
-                };
-                for rid in &run_ids {
-                    let _ = c.execute("DELETE FROM chunk_task WHERE run_id = ?1", [rid]);
-                }
-                let deleted = c.execute(
-                    "DELETE FROM chunk_run WHERE export_name = ?1",
-                    [export_name],
-                )?;
-                Ok(deleted)
-            }
-            StateConn::Postgres(client) => {
-                let mut c = client.borrow_mut();
-                let rows = c.query(
-                    "SELECT run_id FROM chunk_run WHERE export_name = $1",
-                    &[&export_name],
-                )?;
-                let run_ids: Vec<String> = rows.iter().map(|r| r.get(0)).collect();
-                for rid in &run_ids {
-                    let _ = c.execute("DELETE FROM chunk_task WHERE run_id = $1", &[rid]);
-                }
-                let deleted = c.execute(
-                    "DELETE FROM chunk_run WHERE export_name = $1",
-                    &[&export_name],
-                )?;
-                Ok(deleted as usize)
-            }
+        let run_ids = self.query(
+            "SELECT run_id FROM chunk_run WHERE export_name = ?1",
+            &[export_name.into()],
+            |r| r.text(0),
+        )?;
+        for rid in &run_ids {
+            let _ = self.execute(
+                "DELETE FROM chunk_task WHERE run_id = ?1",
+                &[rid.as_str().into()],
+            );
         }
+        self.execute(
+            "DELETE FROM chunk_run WHERE export_name = ?1",
+            &[export_name.into()],
+        )
     }
 
     /// Latest chunk_run row for an export (any status), for `rivet state chunks`.
@@ -517,65 +417,30 @@ impl StateStore {
         &self,
         export_name: &str,
     ) -> Result<Option<(String, String, String, String)>> {
-        let sql = "SELECT run_id, plan_hash, status, updated_at FROM chunk_run
-             WHERE export_name = ?1 ORDER BY updated_at DESC LIMIT 1";
-        match &self.conn {
-            StateConn::Sqlite(c) => {
-                let mut stmt = c.prepare(sql)?;
-                let mut rows = stmt.query_map([export_name], |row| {
-                    Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
-                })?;
-                Ok(rows.next().transpose()?)
-            }
-            StateConn::Postgres(client) => {
-                let mut c = client.borrow_mut();
-                let rows = c.query(&pg_sql(sql), &[&export_name])?;
-                Ok(rows
-                    .first()
-                    .map(|row| (row.get(0), row.get(1), row.get(2), row.get(3))))
-            }
-        }
+        self.query_opt(
+            "SELECT run_id, plan_hash, status, updated_at FROM chunk_run
+             WHERE export_name = ?1 ORDER BY updated_at DESC LIMIT 1",
+            &[export_name.into()],
+            |r| (r.text(0), r.text(1), r.text(2), r.text(3)),
+        )
     }
 
     pub fn list_chunk_tasks_for_run(&self, run_id: &str) -> Result<Vec<ChunkTaskInfo>> {
-        let sql = "SELECT chunk_index, start_key, end_key, status, attempts, last_error, rows_written, file_name
-             FROM chunk_task WHERE run_id = ?1 ORDER BY chunk_index ASC";
-        match &self.conn {
-            StateConn::Sqlite(c) => {
-                let mut stmt = c.prepare(sql)?;
-                let rows = stmt.query_map([run_id], |row| {
-                    Ok(ChunkTaskInfo {
-                        chunk_index: row.get(0)?,
-                        start_key: row.get(1)?,
-                        end_key: row.get(2)?,
-                        status: row.get(3)?,
-                        attempts: row.get(4)?,
-                        last_error: row.get(5)?,
-                        rows_written: row.get(6)?,
-                        file_name: row.get(7)?,
-                    })
-                })?;
-                rows.collect::<std::result::Result<Vec<_>, _>>()
-                    .map_err(Into::into)
-            }
-            StateConn::Postgres(client) => {
-                let mut c = client.borrow_mut();
-                let rows = c.query(&pg_sql(sql), &[&run_id])?;
-                Ok(rows
-                    .iter()
-                    .map(|row| ChunkTaskInfo {
-                        chunk_index: row.get(0),
-                        start_key: row.get(1),
-                        end_key: row.get(2),
-                        status: row.get(3),
-                        attempts: row.get(4),
-                        last_error: row.get(5),
-                        rows_written: row.get(6),
-                        file_name: row.get(7),
-                    })
-                    .collect())
-            }
-        }
+        self.query(
+            "SELECT chunk_index, start_key, end_key, status, attempts, last_error, rows_written, file_name
+             FROM chunk_task WHERE run_id = ?1 ORDER BY chunk_index ASC",
+            &[run_id.into()],
+            |r| ChunkTaskInfo {
+                chunk_index: r.i64(0),
+                start_key: r.text(1),
+                end_key: r.text(2),
+                status: r.text(3),
+                attempts: r.i64(4),
+                last_error: r.opt_text(5),
+                rows_written: r.opt_i64(6),
+                file_name: r.opt_text(7),
+            },
+        )
     }
 }
 
@@ -864,64 +729,34 @@ impl StateStore {
     pub fn record_strategy_snapshot(&self, s: &StrategySnapshot) -> Result<()> {
         let now = chrono::Utc::now().to_rfc3339();
         let ver = env!("CARGO_PKG_VERSION");
-        let sql = "INSERT INTO strategy_snapshot (
+        self.execute(
+            "INSERT INTO strategy_snapshot (
                  export_name, source_schema, source_table, row_estimate, total_bytes,
                  avg_row_bytes, chosen_mode, strategy_kind, key_column, chunk_size,
                  rivet_version, captured_at,
                  catalog_rows, density, estimate_method, probe_k, probe_w
              ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
-                 ?13, ?14, ?15, ?16, ?17)";
-        match &self.conn {
-            StateConn::Sqlite(c) => {
-                c.execute(
-                    sql,
-                    rusqlite::params![
-                        s.export_name,
-                        s.source_schema,
-                        s.source_table,
-                        s.row_estimate,
-                        s.total_bytes,
-                        s.avg_row_bytes,
-                        s.chosen_mode,
-                        s.strategy_kind,
-                        s.key_column,
-                        s.chunk_size,
-                        ver,
-                        now,
-                        s.catalog_rows,
-                        s.density,
-                        s.estimate_method,
-                        s.probe_k,
-                        s.probe_w,
-                    ],
-                )?;
-            }
-            StateConn::Postgres(client) => {
-                let mut c = client.borrow_mut();
-                c.execute(
-                    &pg_sql(sql),
-                    &[
-                        &s.export_name,
-                        &s.source_schema,
-                        &s.source_table,
-                        &s.row_estimate,
-                        &s.total_bytes,
-                        &s.avg_row_bytes,
-                        &s.chosen_mode,
-                        &s.strategy_kind,
-                        &s.key_column,
-                        &s.chunk_size,
-                        &ver,
-                        &now,
-                        &s.catalog_rows,
-                        &s.density,
-                        &s.estimate_method,
-                        &s.probe_k,
-                        &s.probe_w,
-                    ],
-                )?;
-            }
-        }
+                 ?13, ?14, ?15, ?16, ?17)",
+            &[
+                s.export_name.as_str().into(),
+                s.source_schema.as_deref().into(),
+                s.source_table.as_str().into(),
+                s.row_estimate.into(),
+                s.total_bytes.into(),
+                s.avg_row_bytes.into(),
+                s.chosen_mode.as_str().into(),
+                s.strategy_kind.as_deref().into(),
+                s.key_column.as_deref().into(),
+                s.chunk_size.into(),
+                ver.into(),
+                now.into(),
+                s.catalog_rows.into(),
+                s.density.into(),
+                s.estimate_method.as_deref().into(),
+                s.probe_k.into(),
+                s.probe_w.into(),
+            ],
+        )?;
         Ok(())
     }
 }

--- a/src/state/metrics.rs
+++ b/src/state/metrics.rs
@@ -1,6 +1,8 @@
 use crate::error::Result;
 
-use super::{StateConn, StateStore, pg_sql};
+#[cfg(test)]
+use super::StateConn;
+use super::StateStore;
 
 /// One row from `export_metrics`.
 #[derive(Debug)]
@@ -102,15 +104,10 @@ impl StateStore {
     /// Drop a run's in-flight `running` aggregate. Only ever called by
     /// [`record_metric_full`], immediately before the terminal row replaces it.
     fn clear_running_metric(&self, run_id: &str) -> Result<()> {
-        let sql = "DELETE FROM export_metrics WHERE run_id = ?1 AND status = 'running'";
-        match &self.conn {
-            StateConn::Sqlite(c) => {
-                c.execute(sql, rusqlite::params![run_id])?;
-            }
-            StateConn::Postgres(client) => {
-                client.borrow_mut().execute(&pg_sql(sql), &[&run_id])?;
-            }
-        }
+        self.execute(
+            "DELETE FROM export_metrics WHERE run_id = ?1 AND status = 'running'",
+            &[run_id.into()],
+        )?;
         Ok(())
     }
 
@@ -159,20 +156,17 @@ impl StateStore {
         // idempotent against the v21 partial unique index, and the UPDATE that
         // follows recomputes the whole projection from `file_log`, so the final
         // row is correct no matter which worker won or in what order they ran.
-        match &self.conn {
-            StateConn::Sqlite(c) => {
-                c.execute(
-                    ins,
-                    rusqlite::params![export_name, run_id, now, mode, format],
-                )?;
-                c.execute(upd, rusqlite::params![run_id, now])?;
-            }
-            StateConn::Postgres(client) => {
-                let mut c = client.borrow_mut();
-                c.execute(&pg_sql(ins), &[&export_name, &run_id, &now, &mode, &format])?;
-                c.execute(&pg_sql(upd), &[&run_id, &now])?;
-            }
-        }
+        self.execute(
+            ins,
+            &[
+                export_name.into(),
+                run_id.into(),
+                now.as_str().into(),
+                mode.into(),
+                format.into(),
+            ],
+        )?;
+        self.execute(upd, &[run_id.into(), now.into()])?;
         Ok(())
     }
 
@@ -199,101 +193,50 @@ impl StateStore {
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16,
              ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31,
              ?32, ?33, ?34, ?35, ?36, ?37, ?38, ?39)";
-        match &self.conn {
-            StateConn::Sqlite(c) => {
-                c.execute(
-                    sql,
-                    rusqlite::params![
-                        m.export_name,
-                        m.run_id,
-                        now,
-                        m.duration_ms,
-                        m.total_rows,
-                        m.peak_rss_mb,
-                        m.status,
-                        m.error_message,
-                        m.tuning_profile,
-                        m.format,
-                        m.mode,
-                        m.files_produced,
-                        m.bytes_written,
-                        m.retries,
-                        m.validated,
-                        m.schema_changed,
-                        m.files_committed,
-                        m.reconciled,
-                        m.source_count,
-                        m.quality_passed,
-                        m.pg_temp_bytes_delta,
-                        m.batch_size,
-                        m.batch_size_memory_mb,
-                        m.skip_reason,
-                        m.schema_fingerprint,
-                        m.chunk_size,
-                        m.parallel,
-                        m.source_type,
-                        m.destination_type,
-                        m.rivet_version,
-                        m.longest_chunk_ms,
-                        m.chunk_key,
-                        m.error_class,
-                        m.cursor_min,
-                        m.cursor_max,
-                        m.key_descriptor_json,
-                        m.offending_value,
-                        m.server_context_json,
-                        m.bytes_read
-                    ],
-                )?;
-            }
-            StateConn::Postgres(client) => {
-                let mut c = client.borrow_mut();
-                c.execute(
-                    &pg_sql(sql),
-                    &[
-                        &m.export_name,
-                        &m.run_id,
-                        &now,
-                        &m.duration_ms,
-                        &m.total_rows,
-                        &m.peak_rss_mb,
-                        &m.status,
-                        &m.error_message,
-                        &m.tuning_profile,
-                        &m.format,
-                        &m.mode,
-                        &m.files_produced,
-                        &m.bytes_written,
-                        &m.retries,
-                        &m.validated,
-                        &m.schema_changed,
-                        &m.files_committed,
-                        &m.reconciled,
-                        &m.source_count,
-                        &m.quality_passed,
-                        &m.pg_temp_bytes_delta,
-                        &m.batch_size,
-                        &m.batch_size_memory_mb,
-                        &m.skip_reason,
-                        &m.schema_fingerprint,
-                        &m.chunk_size,
-                        &m.parallel,
-                        &m.source_type,
-                        &m.destination_type,
-                        &m.rivet_version,
-                        &m.longest_chunk_ms,
-                        &m.chunk_key,
-                        &m.error_class,
-                        &m.cursor_min,
-                        &m.cursor_max,
-                        &m.key_descriptor_json,
-                        &m.offending_value,
-                        &m.server_context_json,
-                        &m.bytes_read,
-                    ],
-                )?;
-            }
-        }
+        self.execute(
+            sql,
+            &[
+                m.export_name.as_str().into(),
+                m.run_id.as_str().into(),
+                now.into(),
+                m.duration_ms.into(),
+                m.total_rows.into(),
+                m.peak_rss_mb.into(),
+                m.status.as_str().into(),
+                m.error_message.as_deref().into(),
+                m.tuning_profile.as_deref().into(),
+                m.format.as_deref().into(),
+                m.mode.as_deref().into(),
+                m.files_produced.into(),
+                m.bytes_written.into(),
+                m.retries.into(),
+                m.validated.into(),
+                m.schema_changed.into(),
+                m.files_committed.into(),
+                m.reconciled.into(),
+                m.source_count.into(),
+                m.quality_passed.into(),
+                m.pg_temp_bytes_delta.into(),
+                m.batch_size.into(),
+                m.batch_size_memory_mb.into(),
+                m.skip_reason.as_deref().into(),
+                m.schema_fingerprint.as_deref().into(),
+                m.chunk_size.into(),
+                m.parallel.into(),
+                m.source_type.as_deref().into(),
+                m.destination_type.as_deref().into(),
+                m.rivet_version.as_deref().into(),
+                m.longest_chunk_ms.into(),
+                m.chunk_key.as_deref().into(),
+                m.error_class.as_deref().into(),
+                m.cursor_min.as_deref().into(),
+                m.cursor_max.as_deref().into(),
+                m.key_descriptor_json.as_deref().into(),
+                m.offending_value.as_deref().into(),
+                m.server_context_json.as_deref().into(),
+                m.bytes_read.into(),
+            ],
+        )?;
         Ok(())
     }
 
@@ -331,6 +274,9 @@ impl StateStore {
 
     /// Test-only read of the `export_harm` rows for a run, `(metric, delta)`
     /// sorted by metric — lets tests trace the harm signal through the table.
+    ///
+    /// Divergent-by-design (row.rs exemption): a sqlite-only test probe (the
+    /// non-sqlite arm deliberately returns empty), so it keeps its raw match.
     #[cfg(test)]
     pub(crate) fn harm_rows_for_test(&self, run_id: &str) -> Vec<(String, i64)> {
         match &self.conn {
@@ -354,6 +300,9 @@ impl StateStore {
     /// Test-only raw scalar read of a v9 metric column the typed `get_metrics`
     /// path intentionally doesn't surface — lets tests pin that the wide INSERT
     /// mapped each field to the right column (catches a positional param swap).
+    ///
+    /// Divergent-by-design (row.rs exemption): a sqlite-only test probe with a
+    /// `format!`-interpolated column name, so it keeps its raw match.
     #[cfg(test)]
     pub(crate) fn metric_scalar_i64(&self, run_id: &str, column: &str) -> Option<i64> {
         match &self.conn {

--- a/src/state/row.rs
+++ b/src/state/row.rs
@@ -31,6 +31,8 @@ pub(super) enum StateParam {
     Text(String),
     OptText(Option<String>),
     Bool(bool),
+    OptBool(Option<bool>),
+    OptF64(Option<f64>),
 }
 
 impl From<i64> for StateParam {
@@ -68,6 +70,16 @@ impl From<bool> for StateParam {
         StateParam::Bool(v)
     }
 }
+impl From<Option<bool>> for StateParam {
+    fn from(v: Option<bool>) -> Self {
+        StateParam::OptBool(v)
+    }
+}
+impl From<Option<f64>> for StateParam {
+    fn from(v: Option<f64>) -> Self {
+        StateParam::OptF64(v)
+    }
+}
 
 impl rusqlite::types::ToSql for StateParam {
     fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
@@ -77,6 +89,8 @@ impl rusqlite::types::ToSql for StateParam {
             StateParam::Text(v) => v.to_sql(),
             StateParam::OptText(v) => v.to_sql(),
             StateParam::Bool(v) => v.to_sql(),
+            StateParam::OptBool(v) => v.to_sql(),
+            StateParam::OptF64(v) => v.to_sql(),
         }
     }
 }
@@ -93,6 +107,8 @@ fn pg_params(params: &[StateParam]) -> Vec<&(dyn postgres::types::ToSql + Sync)>
                 StateParam::Text(v) => v,
                 StateParam::OptText(v) => v,
                 StateParam::Bool(v) => v,
+                StateParam::OptBool(v) => v,
+                StateParam::OptF64(v) => v,
             }
         })
         .collect()


### PR DESCRIPTION
Recreates #260, which GitHub auto-closed when its base branch (`refactor/load-eviction`) was deleted on the merge of #258. Same three commits, rebased onto main; no content change.

Final slice of the arch-roast work. Three independent Strong candidates, each implemented from its challenge-confirmed spec.

## What

1. **state: finish the row.rs seam migration.** ~15 hand-written `match Sqlite/Postgres` ceremony sites in `checkpoint.rs` + `metrics.rs` rewritten onto the existing `StateStore::query/query_opt/execute` + `StateRow` seam — the migration `row.rs`'s own doc declared ("66 sites across 14 files") but never finished. **−200 lines**; genuinely backend-divergent sites kept, each with a one-line exemption reason.
2. **manifest: one `ManifestCensus`.** New `src/manifest/census.rs` — a pure census over a prefix's `(key, RunManifest)` pairs — replaces two independent definitions of "what runs live under this prefix". Both consumers rewired: `load/reconcile.rs` **−220**, `pipeline/validate_manifest.rs` **−140**. The "one oracle across backends, or two that disagree about the bug" rule applied to the two verifiers.
3. **preflight: one `ProbeFacts` assembler.** `diagnose_pg` / `diagnose_mysql` / `diagnose_mssql` hand-copied the same skeleton (gate → extraction → probe → assemble → analyze). Now: per-engine probes stay free functions (deliberately NOT a trait — ADR-0015 rejects `trait Introspector`), the skeleton lives once. Product-only delta **−46 lines**; this is the diagnostic-bypass class fix — the strategy enumeration happens in one place.

## Verification

- **Two independent multi-agent bughunts over this diff: 7 findings, 0 confirmed, 7 refuted.** The second hunt's lenses (backend parity sqlite↔pg, oracle drift — "unification must not adopt the weaker definition", diagnostic fidelity, cross-agent interference) returned empty on 3 of 4 — the convergence signal.
- Green post-rebase on main: **2545 lib · 281 offline**, clippy `-D warnings` clean. Live suites were run per-candidate by each implementer (checkpoint/metrics/state-backend; validate/reconcile/load; preflight/check/plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)