### PR TITLE
refactor(load/bigquery): talk to BigQuery over REST, drop the `bq` CLI transport

### DIFF
--- a/src/destination/gcs_auth.rs
+++ b/src/destination/gcs_auth.rs
@@ -1,3 +1,19 @@
+//! Google ADC (`authorized_user`) credentials — rivet's ONE Google auth path.
+//!
+//! `reqsign`'s token loader has no `authorized_user` arm, so anything talking to
+//! a Google API natively needs this module or it authenticates in CI and fails
+//! on a developer laptop. Two consumers, one credential:
+//!
+//! - [`AdcUserTokenLoader`] — async, plugged into opendal's
+//!   `customized_token_loader` for the GCS destination.
+//! - [`BlockingAdcTokenSource`] — blocking, for the synchronous BigQuery REST
+//!   loader (`src/load/bq_rest.rs`).
+//!
+//! Both read the file through [`load_adc_credentials`], send the body
+//! [`AdcCredentials::refresh_grant_body`] builds, parse the reply with
+//! [`parse_token_response`], and age it with [`token_still_fresh`]. Only the
+//! `reqwest` flavour differs.
+
 use std::fmt;
 use std::future::Future;
 use std::path::PathBuf;
@@ -34,6 +50,68 @@ struct AdcFile {
     client_id: Option<String>,
     client_secret: Option<String>,
     refresh_token: Option<String>,
+    /// The project billed for API quota when the caller is a USER credential.
+    /// `gcloud auth application-default login` writes it; JSON APIs that meter
+    /// per-project (BigQuery) reject a user token without it.
+    quota_project_id: Option<String>,
+}
+
+/// ADC `authorized_user` credentials — the ONE credential shape rivet mints
+/// Google access tokens from, shared by both consumers in this file: the async
+/// opendal/GCS signer ([`AdcUserTokenLoader`]) and the blocking BigQuery REST
+/// client ([`BlockingAdcTokenSource`]).
+///
+/// The grant body and the response parse live here, once, so the two transports
+/// differ only in which `reqwest` flavour dispatches the request.
+pub(crate) struct AdcCredentials {
+    pub(crate) client_id: String,
+    // SecOps: long-lived secrets; heap zeroed on drop, never logged.
+    pub(crate) client_secret: Zeroizing<String>,
+    pub(crate) refresh_token: Zeroizing<String>,
+    pub(crate) quota_project: Option<String>,
+}
+
+impl fmt::Debug for AdcCredentials {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // SecOps: `Debug` is reachable from `Result::unwrap_err` and from any
+        // consumer that derives it — render only the PUBLIC fields.
+        f.debug_struct("AdcCredentials")
+            .field("client_id", &self.client_id)
+            .field("quota_project", &self.quota_project)
+            .finish_non_exhaustive()
+    }
+}
+
+impl AdcCredentials {
+    /// Credentials from literal values — the seam tests build a loader through
+    /// without an ADC file on disk.
+    #[cfg(test)]
+    pub(crate) fn for_test(client_id: &str, client_secret: &str, refresh_token: &str) -> Self {
+        Self {
+            client_id: client_id.to_string(),
+            client_secret: Zeroizing::new(client_secret.to_string()),
+            refresh_token: Zeroizing::new(refresh_token.to_string()),
+            quota_project: None,
+        }
+    }
+
+    /// The `refresh_token` grant body, form-urlencoded.
+    ///
+    /// SecOps: carries `client_secret` and `refresh_token` in clear. Wrapped so
+    /// the heap buffer is zeroed once the request is dispatched, and so an
+    /// accidental `Debug` of the caller's request builder does not leak it.
+    /// Note there is NO `scope` parameter: a refresh_token grant returns
+    /// whatever the user consented to at `application-default login`
+    /// (cloud-platform in practice) — which is why one grant serves GCS and
+    /// BigQuery alike.
+    pub(crate) fn refresh_grant_body(&self) -> Zeroizing<String> {
+        Zeroizing::new(format!(
+            "grant_type=refresh_token&client_id={}&client_secret={}&refresh_token={}",
+            urlenc(&self.client_id),
+            urlenc(&self.client_secret),
+            urlenc(&self.refresh_token),
+        ))
+    }
 }
 
 #[derive(Deserialize)]
@@ -55,10 +133,7 @@ struct TokenResponse {
 /// never refreshed — so exports longer than the ~1h TTL would die mid-run
 /// with 401s the RetryLayer cannot fix.)
 pub struct AdcUserTokenLoader {
-    client_id: String,
-    // SecOps: long-lived secrets; heap zeroed on drop, never logged.
-    client_secret: Zeroizing<String>,
-    refresh_token: Zeroizing<String>,
+    creds: AdcCredentials,
     minted: Mutex<Option<MintedToken>>,
 }
 
@@ -73,7 +148,7 @@ impl fmt::Debug for AdcUserTokenLoader {
         // SecOps: `GoogleTokenLoad` requires Debug; redact everything but the
         // (public) OAuth client id.
         f.debug_struct("AdcUserTokenLoader")
-            .field("client_id", &self.client_id)
+            .field("client_id", &self.creds.client_id)
             .finish_non_exhaustive()
     }
 }
@@ -90,15 +165,7 @@ impl AdcUserTokenLoader {
     async fn mint_token(&self, client: &reqwest::Client) -> Result<GoogleToken> {
         log::info!("GCS: refreshing access token from ADC authorized_user credentials");
 
-        // SecOps: the POST body carries `client_secret` and `refresh_token` in clear
-        // form-urlencoded. Wrap so the heap buffer is zeroed after the request is
-        // dispatched, and so accidental `Debug` logging of the builder does not leak.
-        let body = Zeroizing::new(format!(
-            "grant_type=refresh_token&client_id={}&client_secret={}&refresh_token={}",
-            urlenc(&self.client_id),
-            urlenc(&self.client_secret),
-            urlenc(&self.refresh_token),
-        ));
+        let body = self.creds.refresh_grant_body();
 
         let resp = client
             .post(GOOGLE_TOKEN_URL)
@@ -182,6 +249,21 @@ pub(crate) fn parse_token_response(data: &str) -> Result<(String, u64)> {
 /// credentials normally). No network I/O happens here — the first
 /// refresh_token grant runs on the first signed request.
 pub fn try_authorized_user_loader() -> Result<Option<AdcUserTokenLoader>> {
+    Ok(load_adc_credentials()?.map(|creds| AdcUserTokenLoader {
+        creds,
+        minted: Mutex::new(None),
+    }))
+}
+
+/// Read the well-known ADC file and return its `authorized_user` credentials.
+///
+/// `Ok(None)` when the file is absent or is not `authorized_user` type — the
+/// caller then falls back to whatever its API client does natively (OpenDAL for
+/// GCS; the `gcloud` CLI token for BigQuery REST). No network I/O.
+///
+/// The ONE reader of the ADC file: both token sources in this module go through
+/// it, so a credential shape rivet learns to read is learned once.
+pub(crate) fn load_adc_credentials() -> Result<Option<AdcCredentials>> {
     let path = match adc_path() {
         Some(p) if p.exists() => p,
         _ => return Ok(None),
@@ -193,19 +275,7 @@ pub fn try_authorized_user_loader() -> Result<Option<AdcUserTokenLoader>> {
         std::fs::read_to_string(&path)
             .with_context(|| format!("reading ADC file {}", path.display()))?,
     );
-    let fields =
-        parse_adc_file(&data).with_context(|| format!("parsing ADC file {}", path.display()))?;
-    let (client_id, client_secret, refresh_token) = match fields {
-        Some(f) => f,
-        None => return Ok(None),
-    };
-
-    Ok(Some(AdcUserTokenLoader {
-        client_id,
-        client_secret: Zeroizing::new(client_secret),
-        refresh_token: Zeroizing::new(refresh_token),
-        minted: Mutex::new(None),
-    }))
+    parse_adc_file(&data).with_context(|| format!("parsing ADC file {}", path.display()))
 }
 
 fn urlenc(s: &str) -> String {
@@ -243,7 +313,7 @@ pub(crate) fn adc_path() -> Option<PathBuf> {
 
 /// Parse ADC JSON and validate fields without making a network request.
 /// Returns `Ok(None)` when the file is not `authorized_user` type.
-pub(crate) fn parse_adc_file(data: &str) -> Result<Option<(String, String, String)>> {
+pub(crate) fn parse_adc_file(data: &str) -> Result<Option<AdcCredentials>> {
     let adc: AdcFile = serde_json::from_str(data).context("parsing ADC JSON")?;
     if adc.cred_type != "authorized_user" {
         return Ok(None);
@@ -257,7 +327,111 @@ pub(crate) fn parse_adc_file(data: &str) -> Result<Option<(String, String, Strin
     let refresh_token = adc
         .refresh_token
         .ok_or_else(|| anyhow::anyhow!("ADC authorized_user: missing refresh_token"))?;
-    Ok(Some((client_id, client_secret, refresh_token)))
+    Ok(Some(AdcCredentials {
+        client_id,
+        client_secret: Zeroizing::new(client_secret),
+        refresh_token: Zeroizing::new(refresh_token),
+        quota_project: adc.quota_project_id,
+    }))
+}
+
+/// Blocking sibling of [`AdcUserTokenLoader`] for the SYNCHRONOUS Google REST
+/// consumers (the BigQuery loader).
+///
+/// Same credentials, same grant body, same response parse, same freshness rule
+/// — only the transport differs (`reqwest::blocking` instead of the async
+/// client opendal hands its signer). Keeping it beside its async twin is what
+/// makes "rivet has one Google auth path" checkable by reading one file.
+pub(crate) struct BlockingAdcTokenSource {
+    creds: AdcCredentials,
+    http: reqwest::blocking::Client,
+    minted: Mutex<Option<MintedAccessToken>>,
+}
+
+/// A minted bearer token and the clock it was minted against — the same
+/// (token, minted_at, ttl) triple [`MintedToken`] caches for the async side,
+/// without reqsign's `GoogleToken` wrapper (the REST client sends a raw
+/// `Authorization: Bearer` header, no signer involved).
+struct MintedAccessToken {
+    token: Zeroizing<String>,
+    minted_at: Instant,
+    expires_in_secs: u64,
+}
+
+impl fmt::Debug for BlockingAdcTokenSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // SecOps: redact everything but the (public) OAuth client id — this
+        // type is reachable from a loader that derives Debug.
+        f.debug_struct("BlockingAdcTokenSource")
+            .field("client_id", &self.creds.client_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl BlockingAdcTokenSource {
+    pub(crate) fn new(creds: AdcCredentials, http: reqwest::blocking::Client) -> Self {
+        Self {
+            creds,
+            http,
+            minted: Mutex::new(None),
+        }
+    }
+
+    /// The project that pays for API quota when this user credential calls a
+    /// metered JSON API (`x-goog-user-project`). `None` when the ADC file
+    /// names none — the caller then decides whether to bill its own project.
+    pub(crate) fn quota_project(&self) -> Option<&str> {
+        self.creds.quota_project.as_deref()
+    }
+
+    /// A live access token: the cached one while it has more than
+    /// [`REFRESH_THRESHOLD`] of life left, otherwise a fresh refresh_token grant.
+    pub(crate) fn access_token(&self) -> Result<Zeroizing<String>> {
+        if let Some(t) = self.cached(Instant::now()) {
+            return Ok(t);
+        }
+        self.mint()
+    }
+
+    fn cached(&self, now: Instant) -> Option<Zeroizing<String>> {
+        let cache = self.minted.lock().expect("ADC token cache poisoned");
+        cache
+            .as_ref()
+            .filter(|c| token_still_fresh(c.minted_at, c.expires_in_secs, now))
+            .map(|c| c.token.clone())
+    }
+
+    fn mint(&self) -> Result<Zeroizing<String>> {
+        log::info!("BigQuery: refreshing access token from ADC authorized_user credentials");
+        let body = self.creds.refresh_grant_body();
+        let resp = self
+            .http
+            .post(GOOGLE_TOKEN_URL)
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .body(body.as_str().to_string())
+            .send()
+            .context("ADC token refresh request failed")?;
+
+        if !resp.status().is_success() {
+            // Do NOT surface the raw body: Google's OAuth error responses echo
+            // the submitted client_id/client_secret in some failure modes, and
+            // this message reaches `summary.error_message` → SQLite / Slack.
+            anyhow::bail!("ADC token refresh failed (HTTP {})", resp.status());
+        }
+
+        let payload = resp.text().context("reading token response")?;
+        let (access_token, expires_in) = parse_token_response(&payload)?;
+        let token = Zeroizing::new(access_token);
+        {
+            let mut cache = self.minted.lock().expect("ADC token cache poisoned");
+            *cache = Some(MintedAccessToken {
+                token: token.clone(),
+                minted_at: Instant::now(),
+                expires_in_secs: expires_in,
+            });
+        }
+        Ok(token)
+    }
 }
 
 #[cfg(test)]
@@ -287,8 +461,48 @@ mod tests {
             "client_secret": "csec",
             "refresh_token": "rtoken"
         }"#;
-        let result = parse_adc_file(json).unwrap();
-        assert_eq!(result, Some(("cid".into(), "csec".into(), "rtoken".into())));
+        let c = parse_adc_file(json).unwrap().expect("authorized_user");
+        assert_eq!(c.client_id, "cid");
+        assert_eq!(c.client_secret.as_str(), "csec");
+        assert_eq!(c.refresh_token.as_str(), "rtoken");
+        // An ADC file that names no quota project reads as None, never as a
+        // fabricated one — the BigQuery client then bills its own project.
+        assert_eq!(c.quota_project, None);
+    }
+
+    /// `gcloud auth application-default login` writes `quota_project_id`, and a
+    /// metered JSON API (BigQuery) rejects a USER token that does not name one.
+    /// Pins that the parser carries it through rather than dropping it.
+    #[test]
+    fn parse_adc_captures_the_quota_project() {
+        let json = r#"{
+            "type": "authorized_user",
+            "client_id": "cid",
+            "client_secret": "csec",
+            "refresh_token": "rtoken",
+            "quota_project_id": "my-billing-proj"
+        }"#;
+        let c = parse_adc_file(json).unwrap().expect("authorized_user");
+        assert_eq!(c.quota_project.as_deref(), Some("my-billing-proj"));
+    }
+
+    /// The grant body is the seam BOTH token sources send. It carries the three
+    /// credential fields url-encoded and — deliberately — NO `scope`, so the
+    /// returned token keeps every scope the user consented to (that is what lets
+    /// one grant serve GCS and BigQuery).
+    #[test]
+    fn refresh_grant_body_is_the_shared_refresh_token_grant() {
+        let c = parse_adc_file(
+            r#"{"type":"authorized_user","client_id":"c id","client_secret":"s/ec","refresh_token":"r+tok"}"#,
+        )
+        .unwrap()
+        .unwrap();
+        let body = c.refresh_grant_body();
+        assert_eq!(
+            body.as_str(),
+            "grant_type=refresh_token&client_id=c%20id&client_secret=s%2Fec&refresh_token=r%2Btok"
+        );
+        assert!(!body.contains("scope"), "{}", body.as_str());
     }
 
     #[test]
@@ -389,9 +603,7 @@ mod tests {
     #[test]
     fn cached_token_serves_fresh_and_rejects_near_expiry() {
         let loader = AdcUserTokenLoader {
-            client_id: "cid".into(),
-            client_secret: Zeroizing::new("csec".into()),
-            refresh_token: Zeroizing::new("rtoken".into()),
+            creds: AdcCredentials::for_test("cid", "csec", "rtoken"),
             minted: Mutex::new(None),
         };
         let now = Instant::now();
@@ -448,9 +660,7 @@ mod tests {
     #[test]
     fn adc_loader_debug_never_leaks_secrets() {
         let loader = AdcUserTokenLoader {
-            client_id: "cid".into(),
-            client_secret: Zeroizing::new("SECRETVALUE".into()),
-            refresh_token: Zeroizing::new("RTOKENVALUE".into()),
+            creds: AdcCredentials::for_test("cid", "SECRETVALUE", "RTOKENVALUE"),
             minted: Mutex::new(None),
         };
         let dbg = format!("{loader:?}");

--- a/src/destination/gcs_auth.rs
+++ b/src/destination/gcs_auth.rs
@@ -666,5 +666,20 @@ mod tests {
         let dbg = format!("{loader:?}");
         assert!(!dbg.contains("SECRETVALUE"), "client_secret leaked: {dbg}");
         assert!(!dbg.contains("RTOKENVALUE"), "refresh_token leaked: {dbg}");
+        // …and the POSITIVE half, without which the absence assertions above are
+        // satisfied by rendering NOTHING: the in-diff mutation gate found
+        // `Debug::fmt -> Ok(Default::default())` (an empty impl) alive here,
+        // because an empty string contains no secret either. A redaction test
+        // must pin what the impl still SHOWS, or it stops guarding the impl and
+        // only guards the string.
+        assert!(
+            dbg.contains("AdcUserTokenLoader"),
+            "Debug must still name the type — an empty impl passes the leak \
+             assertions while telling an operator nothing: {dbg}"
+        );
+        assert!(
+            dbg.contains("cid"),
+            "the PUBLIC client id is the one field this impl exists to render: {dbg}"
+        );
     }
 }

--- a/src/load/bigquery.rs
+++ b/src/load/bigquery.rs
@@ -67,15 +67,22 @@
 //! GROUP BY run, op, tbl ORDER BY run, bytes_billed DESC;
 //! ```
 //!
-//! Transport is the `bq` CLI (Google Cloud SDK) — the same tool the OSS
-//! BigQuery live tests use, so auth is whatever `bq` is configured with (ADC /
-//! service account) and no credentials touch this crate.
+//! Transport is BigQuery's REST API, in process (`bq_rest`) — `jobs.insert`
+//! plus a poll, on the blocking `reqwest` client. Auth comes from the SAME ADC
+//! seam the GCS destination signs with (`destination::gcs_auth`), so a laptop
+//! with `gcloud auth application-default login` and a CI box with a token both
+//! work without the Google Cloud SDK on PATH. The one credential shape rivet
+//! cannot mint in process (service-account JSON / external_account, which need
+//! JWT signing or an STS exchange) falls back to `gcloud auth
+//! print-access-token` — a TOKEN, not the transport; see
+//! `bq_rest::mint_token_via_gcloud_cli`.
 
 use super::TargetLoader;
+use super::bq_rest::BigQueryApi;
 use crate::types::target::TargetColumnSpec;
-use anyhow::{Context, Result, bail};
-use std::collections::HashMap;
-use std::process::{Command, Output};
+use anyhow::{Result, bail};
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, OnceLock};
 // ── BigQuery ─────────────────────────────────────────────────────────────────
 
 /// Maximum clustering columns BigQuery allows.
@@ -84,7 +91,7 @@ const MAX_CLUSTER_COLUMNS: usize = 4;
 /// BigQuery's hard cap on partitions modified by a single job.
 const DEFAULT_MAX_PARTITIONS_PER_JOB: usize = 4000;
 
-/// Loads Rivet Parquet into a BigQuery dataset via the `bq` CLI.
+/// Loads Rivet Parquet into a BigQuery dataset over the REST API.
 #[derive(Debug, Clone)]
 pub struct BigQueryLoader {
     pub project: String,
@@ -105,6 +112,12 @@ pub struct BigQueryLoader {
     /// this, the free load is split into several `LOAD DATA` jobs, each under
     /// the cap.
     pub max_partitions_per_job: usize,
+    /// The REST client, built on first use and shared by every clone — so one
+    /// access token serves a whole load instead of one per statement. Not part
+    /// of the loader's identity: constructing a loader must stay free of I/O
+    /// (the offline `materialize` refusal tests build one and never reach the
+    /// network).
+    api: Arc<OnceLock<BigQueryApi>>,
 }
 
 impl BigQueryLoader {
@@ -116,6 +129,7 @@ impl BigQueryLoader {
             cluster_by: Vec::new(),
             run_id: None,
             max_partitions_per_job: DEFAULT_MAX_PARTITIONS_PER_JOB,
+            api: Arc::new(OnceLock::new()),
         }
     }
 
@@ -135,48 +149,40 @@ impl BigQueryLoader {
         self
     }
 
-    /// Run `bq --project_id=<p> <args…>`. On failure, `bq` prints the actual
-    /// reason (e.g. "Too many partitions … allowed 4000") to **stdout** while
-    /// stderr carries only the "Waiting…/DONE" spinner — so the error detail
-    /// combines both streams (spinner lines stripped).
-    fn run_bq(&self, args: &[String]) -> Result<Output> {
-        let out = Command::new("bq")
-            .arg(format!("--project_id={}", self.project))
-            .args(args)
-            .output()
-            .context("failed to run `bq` — is the Google Cloud SDK installed and on PATH?")?;
-        if !out.status.success() {
-            let detail = [clean_bq_output(&out.stdout), clean_bq_output(&out.stderr)]
-                .into_iter()
-                .filter(|s| !s.is_empty())
-                .collect::<Vec<_>>()
-                .join(" | ");
-            bail!(
-                "bq {} failed: {detail}",
-                args.first()
-                    .map(String::as_str)
-                    .unwrap_or("<no-subcommand>"),
-            );
+    /// The REST client, built once per loader (and shared with its clones).
+    ///
+    /// `OnceLock::get_or_try_init` is unstable, so this is the hand-rolled
+    /// equivalent: a concurrent loser's client is simply dropped — both are
+    /// equivalent, and `set` never overwrites a winner.
+    fn api(&self) -> Result<&BigQueryApi> {
+        if let Some(api) = self.api.get() {
+            return Ok(api);
         }
-        Ok(out)
+        let built = BigQueryApi::new(&self.project)?;
+        let _ = self.api.set(built);
+        Ok(self.api.get().expect("the client was just set"))
     }
 
-    /// The automatic + user labels for a job, as repeated `--label k:v` args.
-    fn label_flags(&self, op: &str, table: &str) -> Vec<String> {
-        build_label_flags(op, table, self.run_id.as_deref())
+    /// The automatic + user labels for a job, keyed for `configuration.labels`.
+    fn labels(&self, op: &str, table: &str) -> BTreeMap<String, String> {
+        build_labels(op, table, self.run_id.as_deref())
     }
 
     /// Run a SQL statement (free `LOAD DATA` load job or a billed CTAS/query),
     /// tagged with `rivet_op:<op>` + `rivet_table:<table>` for cost attribution.
-    fn run_sql(&self, sql: &str, op: &str, table: &str) -> Result<Output> {
-        self.run_bq(&query_args(sql, &self.label_flags(op, table)))
+    fn run_sql(&self, sql: &str, op: &str, table: &str) -> Result<()> {
+        self.api()?
+            .run_query(sql, &self.labels(op, table))
             .map_err(augment_partition_limit)
+            .map(|_job_id| ())
     }
 
     fn count_rows(&self, fqtn: &str, table: &str) -> Result<u64> {
         // COUNT(*) reads table metadata — 0 bytes billed.
-        let out = self.run_bq(&count_args(fqtn, &self.label_flags("count", table)))?;
-        parse_count_csv(&String::from_utf8_lossy(&out.stdout))
+        self.api()?.run_query_scalar(
+            &format!("SELECT COUNT(*) AS n FROM `{fqtn}`"),
+            &self.labels("count", table),
+        )
     }
 
     /// Split `uris` into free-load batches that each stay under the per-job
@@ -464,47 +470,24 @@ fn build_load_data_sql(
     )
 }
 
-fn query_args(sql: &str, labels: &[String]) -> Vec<String> {
-    // Labels are flags — they MUST precede the positional SQL string.
-    let mut a = vec![
-        "query".into(),
-        "--use_legacy_sql=false".into(),
-        "--format=none".into(),
-    ];
-    a.extend_from_slice(labels);
-    a.push(sql.into());
-    a
-}
-
-fn count_args(fqtn: &str, labels: &[String]) -> Vec<String> {
-    let mut a = vec![
-        "query".into(),
-        "--use_legacy_sql=false".into(),
-        "--format=csv".into(),
-    ];
-    a.extend_from_slice(labels);
-    a.push(format!("SELECT COUNT(*) AS n FROM `{fqtn}`"));
-    a
-}
-
-/// Build `--label k:v` args: the automatic `managed_by:rivet` /
-/// `rivet_op:<op>` / `rivet_table:<table>` labels, the `rivet_run:<id>` label
-/// when a run id is set, plus any `extra` (user) labels. These land in
-/// `INFORMATION_SCHEMA.JOBS.labels` and the billing export, so cost can be
-/// attributed per run and per table.
-fn build_label_flags(op: &str, table: &str, run_id: Option<&str>) -> Vec<String> {
-    let mut labels: Vec<(String, String)> = vec![
-        ("managed_by".into(), "rivet".into()),
-        ("rivet_op".into(), sanitize_label(op)),
-        ("rivet_table".into(), sanitize_label(table)),
-    ];
+/// The job's label SET: the automatic `managed_by:rivet` / `rivet_op:<op>` /
+/// `rivet_table:<table>` labels, plus `rivet_run:<id>` when a run id is set.
+/// Sent as `configuration.labels`, which is what `INFORMATION_SCHEMA.JOBS.labels`
+/// and the billing export project — so cost stays attributable per run and per
+/// table exactly as the module docs' query describes.
+///
+/// (Was `--label k:v` flag pairs under the CLI transport. The keys and values
+/// are unchanged; only the wire shape moved.)
+fn build_labels(op: &str, table: &str, run_id: Option<&str>) -> BTreeMap<String, String> {
+    let mut labels = BTreeMap::from([
+        ("managed_by".to_string(), "rivet".to_string()),
+        ("rivet_op".to_string(), sanitize_label(op)),
+        ("rivet_table".to_string(), sanitize_label(table)),
+    ]);
     if let Some(id) = run_id {
-        labels.push(("rivet_run".into(), sanitize_label(id)));
+        labels.insert("rivet_run".to_string(), sanitize_label(id));
     }
     labels
-        .into_iter()
-        .flat_map(|(k, v)| ["--label".to_string(), format!("{k}:{v}")])
-        .collect()
 }
 
 /// Coerce a string into BigQuery's label charset: lowercase `[a-z0-9_-]`, other
@@ -528,31 +511,14 @@ fn sanitize_label(s: &str) -> String {
     out
 }
 
-/// Parse a `bq query --format=csv` count result: a `n` header line then the
-/// value. Take the last line that parses as an integer.
-fn parse_count_csv(stdout: &str) -> Result<u64> {
-    stdout
-        .lines()
-        .rev()
-        .find_map(|l| l.trim().parse::<u64>().ok())
-        .context("could not parse a row count from bq output")
-}
-
-/// Normalize `bq` output for an error message: split the `\r`-driven progress
-/// spinner into lines, drop the "Waiting…/Current status:" noise, and join the
-/// rest — leaving the real error `bq` printed (e.g. the partition-quota text).
-fn clean_bq_output(bytes: &[u8]) -> String {
-    String::from_utf8_lossy(bytes)
-        .replace('\r', "\n")
-        .lines()
-        .map(str::trim)
-        .filter(|l| !l.is_empty() && !l.starts_with("Waiting on") && !l.contains("Current status:"))
-        .collect::<Vec<_>>()
-        .join(" ")
-}
-
 /// Turn BigQuery's partition-quota failure into an actionable error.
-fn augment_partition_limit(e: anyhow::Error) -> anyhow::Error {
+///
+/// TEXT-MATCHED, deliberately: the quota comes back as an ordinary
+/// `invalidQuery` job error whose MESSAGE names the limit ("Too many
+/// partitions produced by query, allowed 4000, …") — the REST envelope carries
+/// no distinct machine-readable code for it, so there is nothing sharper to
+/// match on. `bq_rest` puts that message verbatim into the error this reads.
+pub(crate) fn augment_partition_limit(e: anyhow::Error) -> anyhow::Error {
     let s = e.to_string().to_lowercase();
     if s.contains("partition")
         && (s.contains("4000") || s.contains("quota") || s.contains("exceed"))
@@ -664,22 +630,6 @@ mod tests {
     }
 
     #[test]
-    fn count_csv_skips_header() {
-        assert_eq!(parse_count_csv("n\n42\n").unwrap(), 42);
-        assert_eq!(parse_count_csv("n\n0\n").unwrap(), 0);
-        assert!(parse_count_csv("n\n").is_err());
-    }
-
-    #[test]
-    fn clean_bq_output_drops_standalone_status_and_waiting_lines() {
-        // A bare "Waiting on" line (no status) AND a bare "Current status:" line
-        // (not part of a Waiting line) must BOTH be dropped — pins each `&&` in
-        // the filter (an `||` there would leak one of them into the message).
-        let raw = b"Waiting on bqjob_x\nCurrent status: RUNNING\nError: boom\n";
-        assert_eq!(clean_bq_output(raw), "Error: boom");
-    }
-
-    #[test]
     fn augment_partition_limit_fires_only_on_partition_plus_signal() {
         let aug = |m: &str| augment_partition_limit(anyhow::anyhow!("{m}")).to_string();
         // partition + exactly one of {4000, quota, exceed} → augmented (pins each `||`).
@@ -701,24 +651,48 @@ mod tests {
         );
     }
 
+    /// The label SET is the cost-attribution contract; the transport that
+    /// carries it is not. This asserted `--label k:v` CLI pairs before the REST
+    /// rewrite — same keys, same (sanitized) values, now read as a map.
     #[test]
     fn job_labels_tag_managed_by_op_and_table() {
-        let flags = build_label_flags("recover", "Orders", Some("Run-7"));
-        let kv: Vec<&String> = flags.iter().skip(1).step_by(2).collect();
-        assert!(kv.iter().any(|s| *s == "managed_by:rivet"));
-        assert!(kv.iter().any(|s| *s == "rivet_op:recover"));
-        assert!(kv.iter().any(|s| *s == "rivet_table:orders")); // sanitized to lowercase
-        assert!(kv.iter().any(|s| *s == "rivet_run:run-7")); // sanitized to lowercase
-        // Each label value is preceded by a `--label` flag.
-        assert!(flags.iter().step_by(2).all(|s| s == "--label"));
+        let labels = build_labels("recover", "Orders", Some("Run-7"));
+        assert_eq!(labels["managed_by"], "rivet");
+        assert_eq!(labels["rivet_op"], "recover");
+        assert_eq!(labels["rivet_table"], "orders"); // sanitized to lowercase
+        assert_eq!(labels["rivet_run"], "run-7"); // sanitized to lowercase
+        assert_eq!(
+            labels.len(),
+            4,
+            "no label beyond the documented four: {labels:?}"
+        );
     }
 
     #[test]
     fn no_run_id_omits_the_rivet_run_label() {
-        let flags = build_label_flags("load", "orders", None);
-        let kv: Vec<&String> = flags.iter().skip(1).step_by(2).collect();
-        assert!(kv.iter().any(|s| *s == "rivet_table:orders"));
-        assert!(!kv.iter().any(|s| s.starts_with("rivet_run:")));
+        let labels = build_labels("load", "orders", None);
+        assert_eq!(labels["rivet_table"], "orders");
+        assert!(!labels.contains_key("rivet_run"), "{labels:?}");
+    }
+
+    /// The labels the loader actually SENDS, taken from the loader (not
+    /// hand-built), and placed in the body BigQuery reads them from. The
+    /// producer-side half of the label contract: a run id that never reached
+    /// `configuration.labels` is a silent loss of cost attribution — every job
+    /// still runs, and the billing query returns nothing for the run.
+    #[test]
+    fn the_loader_sends_its_labels_in_the_job_configuration() {
+        let l = BigQueryLoader::new("p", "d").run_id("Run-9");
+        let body = crate::load::bq_rest::query_job_body(
+            "SELECT 1",
+            &l.labels("load", "Orders"),
+            "p",
+            None,
+        );
+        assert_eq!(body["configuration"]["labels"]["managed_by"], "rivet");
+        assert_eq!(body["configuration"]["labels"]["rivet_op"], "load");
+        assert_eq!(body["configuration"]["labels"]["rivet_table"], "orders");
+        assert_eq!(body["configuration"]["labels"]["rivet_run"], "run-9");
     }
 
     #[test]
@@ -733,24 +707,6 @@ mod tests {
         assert_eq!(sanitize_label(""), "unnamed");
         assert_eq!(sanitize_label("ok-name_1"), "ok-name_1");
         assert_eq!(sanitize_label(&"x".repeat(80)).len(), 63);
-    }
-
-    #[test]
-    fn clean_bq_output_keeps_real_error_drops_spinner() {
-        // Regression: bq prints the failure reason on STDOUT; stderr is just
-        // the spinner. run_bq must surface stdout so augment_partition_limit
-        // can see the quota text (live-caught: the reason was being dropped).
-        let stdout = b"Error in query string: Too many partitions produced by query, \
-                       allowed 4000, query produces at least 4200 partitions";
-        let cleaned = clean_bq_output(stdout);
-        assert!(cleaned.contains("Too many partitions") && cleaned.contains("4000"));
-        // The augment fires end-to-end on the cleaned stdout.
-        let augmented = augment_partition_limit(anyhow::anyhow!("{cleaned}")).to_string();
-        assert!(augmented.contains("split the"), "{augmented}");
-        // The stderr spinner collapses away.
-        let stderr = "Waiting on bqjob_x ... (0s) Current status: RUNNING\r\
-                      Waiting on bqjob_x ... (0s) Current status: DONE";
-        assert!(clean_bq_output(stderr.as_bytes()).is_empty());
     }
 
     /// THE foreign-table safety test. A table rivet did not create keeps its
@@ -800,7 +756,7 @@ mod tests {
     #[test]
     fn materialize_refuses_too_many_cluster_columns() {
         // A >4-column CLUSTER BY is a below-the-seam adapter limit (BigQuery's),
-        // caught in `materialize` before any `bq` call. (Empty-URI and Fail-spec
+        // caught in `materialize` before any BigQuery job is enqueued. (Empty-URI and Fail-spec
         // refusals are the driver's — see `load::tests`.)
         let l = BigQueryLoader::new("p", "d").cluster_by(vec![
             "a".into(),
@@ -820,7 +776,7 @@ mod tests {
     fn materialize_refuses_a_non_identifier_cluster_column() {
         // A clustering column splices raw into `CLUSTER BY <cols>`; a
         // non-identifier name is an injection vector and must be refused in
-        // `materialize` before any `bq` call — the sibling of the table/column/pk
+        // `materialize` before any BigQuery job is enqueued — the sibling of the table/column/pk
         // gate for the BigQuery shape clause.
         let l = BigQueryLoader::new("p", "d").cluster_by(vec!["id) FROM secrets; --".into()]);
         let err = l
@@ -940,6 +896,106 @@ mod tests {
             "expected rows, got {}",
             report.rows_loaded
         );
+    }
+
+    /// THE live proof of the REST transport, needing no GCS fixture: a real
+    /// query job through `jobs.insert` → poll → `getQueryResults`, then the
+    /// cost-attribution labels read back from BigQuery's OWN catalog
+    /// (`INFORMATION_SCHEMA.JOBS_BY_PROJECT`) rather than from the request body
+    /// this crate built — an independent oracle for the one contract the CLI
+    /// rewrite could silently drop. Also drives the failure path, so the error
+    /// mapping is exercised against a real `status.errorResult` and not only a
+    /// fixture. Drive it with:
+    ///
+    ///   BIGQUERY_TEST_PROJECT=rivet-data-tool RIVET_BQ_TEST_DATASET=rivet_type_lab \
+    ///   BIGQUERY_TEST_LOCATION=EU \
+    ///   cargo test --lib -- --ignored bigquery_rest_transport_live
+    #[test]
+    #[ignore = "live: needs a BigQuery project + ADC (no GCS fixture required)"]
+    fn bigquery_rest_transport_live_round_trips_a_query_job() {
+        // Soft-skip when unconfigured — see bigquery_live_load_round_trips.
+        let Ok(project) = std::env::var("BIGQUERY_TEST_PROJECT") else {
+            eprintln!("skipping bigquery_rest_transport_live: BIGQUERY_TEST_PROJECT unset");
+            return;
+        };
+        let dataset = std::env::var("RIVET_BQ_TEST_DATASET")
+            .or_else(|_| std::env::var("BIGQUERY_TEST_DATASET"))
+            .unwrap_or_else(|_| "rivet_test".to_string());
+        let region = std::env::var("BIGQUERY_TEST_LOCATION")
+            .unwrap_or_else(|_| "US".to_string())
+            .to_lowercase();
+
+        // A run id unique to this invocation, so the label read-back below is
+        // scoped to THIS run's jobs and cannot be satisfied by history.
+        let run_id = format!(
+            "rest-live-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis()
+        );
+        let table = "rivet_bq_rest_live";
+        let loader = BigQueryLoader::new(&project, &dataset).run_id(&run_id);
+        let fqtn = loader.fqtn(table);
+
+        // 1. A statement job: insert → poll → terminal verdict.
+        loader
+            .run_sql(
+                &format!("CREATE OR REPLACE TABLE `{fqtn}` AS SELECT 1 AS id UNION ALL SELECT 2"),
+                "create",
+                table,
+            )
+            .expect("CREATE OR REPLACE through the REST transport");
+
+        // 2. A scalar job: the getQueryResults leg, against a count this test
+        //    seeded itself (not one rivet reported).
+        assert_eq!(
+            loader.count_rows(&fqtn, table).expect("count over REST"),
+            2,
+            "the count must come back from getQueryResults"
+        );
+
+        // 3. The labels, read back from BigQuery's catalog. `run_id` is unique
+        //    per invocation, so a nonzero count can only come from the jobs
+        //    THIS test just ran.
+        let labelled = loader
+            .api()
+            .unwrap()
+            .run_query_scalar(
+                &format!(
+                    "SELECT COUNT(*) FROM `{project}`.`region-{region}`.INFORMATION_SCHEMA.JOBS_BY_PROJECT \
+                     WHERE creation_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR) \
+                     AND EXISTS (SELECT 1 FROM UNNEST(labels) WHERE key = 'rivet_run' AND value = '{run_id}') \
+                     AND EXISTS (SELECT 1 FROM UNNEST(labels) WHERE key = 'managed_by' AND value = 'rivet')",
+                ),
+                &loader.labels("audit", table),
+            )
+            .expect("reading INFORMATION_SCHEMA.JOBS_BY_PROJECT");
+        assert!(
+            labelled >= 2,
+            "the run's jobs must carry rivet_run:{run_id} + managed_by:rivet in \
+             configuration.labels — INFORMATION_SCHEMA saw {labelled}"
+        );
+
+        // 4. The failure path: a real `status.errorResult` must reach the caller
+        //    with BigQuery's own reason text, not a bare "failed".
+        let err = loader
+            .run_sql(
+                &format!("SELECT * FROM `{project}.{dataset}.no_such_table_ever`"),
+                "probe",
+                table,
+            )
+            .expect_err("a missing table must fail the job");
+        let rendered = format!("{err:#}");
+        assert!(
+            rendered.contains("Not found") && rendered.contains("no_such_table_ever"),
+            "the REST error detail must name the reason: {rendered}"
+        );
+
+        // 5. Clean up after ourselves.
+        loader
+            .run_sql(&format!("DROP TABLE IF EXISTS `{fqtn}`"), "drop", table)
+            .expect("dropping the live fixture table");
     }
 
     /// Live BigQuery CDC round-trip: append a change-log Parquet into

--- a/src/load/bq_rest.rs
+++ b/src/load/bq_rest.rs
@@ -1,0 +1,901 @@
+//! The BigQuery **REST transport** — `jobs.insert` + poll, in process.
+//!
+//! This is the seam that used to be one `Command::new("bq")`. Everything the
+//! loader does is a query job (a free `LOAD DATA`, a billed CTAS, a `COUNT(*)`
+//! metadata read), so one verb serves all of them:
+//!
+//! 1. `POST /bigquery/v2/projects/{project}/jobs` — insert the query job,
+//!    labels in `configuration.labels`.
+//! 2. `GET  /bigquery/v2/projects/{project}/jobs/{jobId}?location=…` — poll
+//!    until `status.state == "DONE"`; `status.errorResult` is the verdict.
+//! 3. `GET  /bigquery/v2/projects/{project}/queries/{jobId}?location=…` —
+//!    `getQueryResults`, only when the caller wants the rows back (the count).
+//!
+//! ## What decides success
+//!
+//! Exactly what `bq`'s exit status decided: the job's `status.errorResult`. A
+//! `status.errors[]` entry WITHOUT an `errorResult` is a non-fatal warning and
+//! stays non-fatal here — it only enriches the message when the job did fail.
+//!
+//! ## Location
+//!
+//! Not sent by default: BigQuery infers a query job's location from the
+//! datasets it references, exactly as the CLI relied on (verified live against
+//! an `EU` dataset — the insert response came back `jobReference.location:
+//! "EU"`). Polling then uses the `jobReference` the insert RETURNED, so a
+//! non-US job is found by its `jobs.get`. `RIVET_BQ_LOCATION` pins it for the
+//! case where inference cannot see a dataset.
+//!
+//! ## Retries
+//!
+//! Only the polling GETs are retried (they are idempotent). `jobs.insert` is
+//! NOT: a retried insert would create a SECOND job, and `LOAD DATA INTO` (the
+//! CDC change-log append) is not idempotent — a duplicate append is silent row
+//! inflation. A transport error on insert fails the load loudly instead.
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use serde_json::{Value, json};
+use zeroize::Zeroizing;
+
+use crate::destination::gcs_auth::{self, BlockingAdcTokenSource};
+
+/// BigQuery's JSON API root. Overridable so a live check can be pointed at a
+/// stub; not a config knob.
+const DEFAULT_ENDPOINT: &str = "https://bigquery.googleapis.com";
+
+/// Per-request ceiling. Generous: a `LOAD DATA` insert only ENQUEUES the job
+/// (the wait happens in the poll loop), but a large statement body plus a slow
+/// link should not trip a short timeout.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Poll backoff bounds. Starts tight so a metadata `COUNT(*)` (sub-second)
+/// returns promptly, and widens so a multi-minute load costs a handful of
+/// requests rather than hundreds.
+const POLL_MIN: Duration = Duration::from_millis(200);
+const POLL_MAX: Duration = Duration::from_secs(5);
+
+/// Consecutive transient failures (429 / 5xx / connection error) tolerated on
+/// one polling GET before the load gives up.
+const MAX_TRANSIENT_RETRIES: u32 = 5;
+
+// ── the client ───────────────────────────────────────────────────────────────
+
+/// A blocking BigQuery JSON-API client scoped to one project.
+pub(crate) struct BigQueryApi {
+    project: String,
+    /// `jobReference.location` for inserted jobs; `None` lets BigQuery infer it
+    /// from the referenced datasets (the CLI's behaviour).
+    location: Option<String>,
+    endpoint: String,
+    http: reqwest::blocking::Client,
+    auth: Auth,
+}
+
+impl std::fmt::Debug for BigQueryApi {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // SecOps: never render `auth` — it can hold a bearer token.
+        f.debug_struct("BigQueryApi")
+            .field("project", &self.project)
+            .field("location", &self.location)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Where a bearer token comes from, resolved once at client construction.
+enum Auth {
+    /// An operator-supplied token (`RIVET_BQ_ACCESS_TOKEN`) — impersonation,
+    /// CI, or any credential shape rivet cannot mint itself.
+    Static(Zeroizing<String>),
+    /// ADC `authorized_user`, minted through the shared `gcs_auth` seam.
+    Adc(BlockingAdcTokenSource),
+    /// Documented fallback for the credential shapes rivet has no in-process
+    /// minting path for (service-account JSON needs RS256 JWT signing;
+    /// external_account needs an STS exchange — neither has a dependency in
+    /// this crate). One token from the CLI, not the whole transport.
+    GcloudCli,
+}
+
+impl BigQueryApi {
+    /// Build a client for `project`, resolving the token source eagerly so a
+    /// missing credential is reported before the first job is enqueued.
+    pub(crate) fn new(project: &str) -> Result<Self> {
+        let http = reqwest::blocking::Client::builder()
+            .timeout(HTTP_TIMEOUT)
+            .build()
+            .context("building the BigQuery HTTP client")?;
+        Ok(Self {
+            project: project.to_string(),
+            location: std::env::var("RIVET_BQ_LOCATION")
+                .ok()
+                .filter(|s| !s.is_empty()),
+            endpoint: std::env::var("RIVET_BQ_API_ENDPOINT")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string()),
+            auth: Auth::resolve(&http)?,
+            http,
+        })
+    }
+
+    /// Run a query job to completion, tagged with `labels`. `Ok(job_id)` when
+    /// BigQuery reports no `errorResult`.
+    pub(crate) fn run_query(&self, sql: &str, labels: &BTreeMap<String, String>) -> Result<String> {
+        let job_ref = self.settle(self.insert_query_job(sql, labels)?)?;
+        Ok(job_ref.job_id)
+    }
+
+    /// Run a query job and read the first cell of its first row as a `u64` —
+    /// the `COUNT(*)` shape. Separate from [`BigQueryApi::run_query`] so the
+    /// ordinary statement path never pays a `getQueryResults` round trip.
+    pub(crate) fn run_query_scalar(
+        &self,
+        sql: &str,
+        labels: &BTreeMap<String, String>,
+    ) -> Result<u64> {
+        let job_ref = self.settle(self.insert_query_job(sql, labels)?)?;
+        let results = self.get_json(&self.query_results_url(&job_ref), "getQueryResults")?;
+        parse_scalar_u64(&results)
+    }
+
+    /// Take an inserted job to a terminal state. A short statement often
+    /// completes inside the insert call, so the body already in hand is graded
+    /// before a poll is spent.
+    fn settle(&self, job: Value) -> Result<JobRef> {
+        let job_ref = parse_job_reference(&job, &self.project)?;
+        match job_outcome(&job) {
+            JobOutcome::Done => Ok(job_ref),
+            JobOutcome::Failed(detail) => bail!("{}", job_failed_message(&job_ref.job_id, &detail)),
+            JobOutcome::Running => self.await_job(&job_ref).map(|_| job_ref),
+        }
+    }
+
+    fn insert_query_job(&self, sql: &str, labels: &BTreeMap<String, String>) -> Result<Value> {
+        let body = query_job_body(sql, labels, &self.project, self.location.as_deref());
+        let url = format!(
+            "{}/bigquery/v2/projects/{}/jobs",
+            self.endpoint, self.project
+        );
+        let resp = self
+            .authorized(self.http.post(&url))?
+            .json(&body)
+            .send()
+            .context("BigQuery jobs.insert request failed")?;
+        self.read_json(resp, "jobs.insert")
+    }
+
+    /// Poll `jobs.get` until the job reaches a terminal state.
+    fn await_job(&self, job_ref: &JobRef) -> Result<String> {
+        let url = self.job_url(job_ref);
+        for attempt in 0.. {
+            std::thread::sleep(poll_interval(attempt));
+            let job = self.get_json(&url, "jobs.get")?;
+            match job_outcome(&job) {
+                JobOutcome::Running => continue,
+                JobOutcome::Done => return Ok(job_ref.job_id.clone()),
+                JobOutcome::Failed(detail) => {
+                    bail!("{}", job_failed_message(&job_ref.job_id, &detail))
+                }
+            }
+        }
+        unreachable!("the poll loop only exits through a terminal state")
+    }
+
+    fn job_url(&self, job_ref: &JobRef) -> String {
+        format!(
+            "{}/bigquery/v2/projects/{}/jobs/{}{}",
+            self.endpoint,
+            job_ref.project,
+            job_ref.job_id,
+            location_query(job_ref.location.as_deref())
+        )
+    }
+
+    fn query_results_url(&self, job_ref: &JobRef) -> String {
+        format!(
+            "{}/bigquery/v2/projects/{}/queries/{}{}&maxResults=1",
+            self.endpoint,
+            job_ref.project,
+            job_ref.job_id,
+            // `?location=…` when set, else a bare `?` so `&maxResults` parses.
+            match job_ref.location.as_deref() {
+                Some(loc) => format!("?location={loc}"),
+                None => "?".to_string(),
+            }
+        )
+    }
+
+    /// An idempotent GET with transient-failure retries. `what` names the
+    /// endpoint in any error, so an operator reading the message knows whether
+    /// the poll or the result fetch was refused.
+    fn get_json(&self, url: &str, what: &str) -> Result<Value> {
+        let mut last: anyhow::Error = anyhow::anyhow!("no attempt made");
+        for attempt in 0..=MAX_TRANSIENT_RETRIES {
+            if attempt > 0 {
+                std::thread::sleep(poll_interval(attempt));
+            }
+            let sent = self.authorized(self.http.get(url))?.send();
+            match sent {
+                Ok(resp) if is_transient_status(resp.status().as_u16()) => {
+                    last = anyhow::anyhow!(
+                        "BigQuery replied HTTP {} (transient)",
+                        resp.status().as_u16()
+                    );
+                }
+                Ok(resp) => return self.read_json(resp, what),
+                // A connection reset mid-poll is the same class as a 503.
+                Err(e) => last = anyhow::Error::new(e).context("BigQuery request failed"),
+            }
+        }
+        Err(last).context(format!(
+            "BigQuery {what} kept failing after {MAX_TRANSIENT_RETRIES} retries"
+        ))
+    }
+
+    /// Turn a response into JSON, mapping a non-2xx into the API's own message.
+    fn read_json(&self, resp: reqwest::blocking::Response, what: &str) -> Result<Value> {
+        let status = resp.status().as_u16();
+        let body = resp.text().unwrap_or_default();
+        if !(200..300).contains(&status) {
+            bail!(
+                "BigQuery {what} failed: {}",
+                api_error_detail(status, &body)
+            );
+        }
+        serde_json::from_str(&body)
+            .with_context(|| format!("parsing the BigQuery {what} response as JSON"))
+    }
+
+    /// Attach the bearer token and, for a USER credential, the quota project
+    /// BigQuery bills the call to.
+    fn authorized(
+        &self,
+        req: reqwest::blocking::RequestBuilder,
+    ) -> Result<reqwest::blocking::RequestBuilder> {
+        let token = self.auth.access_token()?;
+        let mut req = req.header("Authorization", format!("Bearer {}", token.as_str()));
+        // ADC user credentials are not billable on their own: a metered JSON
+        // API rejects them without a quota project. Prefer the one the ADC file
+        // names, else bill the project being loaded into.
+        if let Auth::Adc(src) = &self.auth {
+            req = req.header(
+                "x-goog-user-project",
+                src.quota_project().unwrap_or(&self.project),
+            );
+        }
+        Ok(req)
+    }
+}
+
+/// Which token source wins, given what is available. Pure, so the precedence
+/// is graded offline — the resolution itself reads process env and an ADC file
+/// on disk, which no unit test can pin without racing its siblings.
+///
+/// An explicit token beats a discovered credential (that is the point of
+/// setting one); a BLANK one is treated as unset, since an empty
+/// `RIVET_BQ_ACCESS_TOKEN` from an unset shell variable must not shadow working
+/// ADC credentials with a guaranteed 401.
+pub(crate) fn choose_token_source(static_token: Option<&str>, has_adc: bool) -> TokenSourceKind {
+    match static_token {
+        Some(t) if !t.trim().is_empty() => TokenSourceKind::Static,
+        _ if has_adc => TokenSourceKind::Adc,
+        _ => TokenSourceKind::GcloudCli,
+    }
+}
+
+/// The choice [`choose_token_source`] makes, named so a test can assert it
+/// without holding a credential.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum TokenSourceKind {
+    Static,
+    Adc,
+    GcloudCli,
+}
+
+impl Auth {
+    fn resolve(http: &reqwest::blocking::Client) -> Result<Self> {
+        let static_token = std::env::var("RIVET_BQ_ACCESS_TOKEN").ok();
+        let adc = gcs_auth::load_adc_credentials()?;
+        match choose_token_source(static_token.as_deref(), adc.is_some()) {
+            TokenSourceKind::Static => Ok(Auth::Static(Zeroizing::new(
+                static_token.expect("a Static choice implies a token"),
+            ))),
+            TokenSourceKind::Adc => Ok(Auth::Adc(BlockingAdcTokenSource::new(
+                adc.expect("an Adc choice implies credentials"),
+                http.clone(),
+            ))),
+            TokenSourceKind::GcloudCli => Ok(Auth::GcloudCli),
+        }
+    }
+
+    fn access_token(&self) -> Result<Zeroizing<String>> {
+        match self {
+            Auth::Static(t) => Ok(t.clone()),
+            Auth::Adc(src) => src.access_token(),
+            Auth::GcloudCli => mint_token_via_gcloud_cli(),
+        }
+    }
+}
+
+/// The ONE place rivet still shells out for BigQuery, and only for a token.
+///
+/// Reached when the ADC file is absent or is not `authorized_user` — i.e. a
+/// service-account JSON (needs RS256 JWT signing) or an external_account /
+/// workload-identity credential (needs an STS exchange). Neither has a
+/// dependency in this crate, so minting them in process would mean adding a
+/// crypto stack; the honest subset is to ask `gcloud` for the token it already
+/// knows how to mint. Nothing else about the transport is a subprocess.
+fn mint_token_via_gcloud_cli() -> Result<Zeroizing<String>> {
+    let out = std::process::Command::new("gcloud")
+        .args(["auth", "print-access-token"])
+        .output()
+        .context(
+            "no ADC `authorized_user` credentials and `gcloud` is not on PATH — run \
+             `gcloud auth application-default login`, or set RIVET_BQ_ACCESS_TOKEN",
+        )?;
+    if !out.status.success() {
+        bail!(
+            "`gcloud auth print-access-token` failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    let token = Zeroizing::new(String::from_utf8_lossy(&out.stdout).trim().to_string());
+    if token.is_empty() {
+        bail!("`gcloud auth print-access-token` returned an empty token");
+    }
+    Ok(token)
+}
+
+// ── pure request / response shapes ───────────────────────────────────────────
+
+/// The `jobs.insert` body for a query job: the statement, `useLegacySql:false`
+/// (the CLI's `--use_legacy_sql=false`), and the cost-attribution labels in
+/// `configuration.labels` — where `INFORMATION_SCHEMA.JOBS.labels` reads them
+/// from, so the billing queries in the loader's docs keep working unchanged.
+///
+/// `jobReference` is emitted ONLY to pin a location; omitting it lets BigQuery
+/// generate the job id and infer the location from the referenced datasets.
+pub(crate) fn query_job_body(
+    sql: &str,
+    labels: &BTreeMap<String, String>,
+    project: &str,
+    location: Option<&str>,
+) -> Value {
+    let mut body = json!({
+        "configuration": {
+            "query": { "query": sql, "useLegacySql": false },
+            "labels": labels,
+        }
+    });
+    if let Some(loc) = location {
+        body["jobReference"] = json!({ "projectId": project, "location": loc });
+    }
+    body
+}
+
+/// The identity a job is polled by. `location` comes from what the insert
+/// RETURNED — `jobs.get` on a non-US job 404s without it.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct JobRef {
+    pub(crate) project: String,
+    pub(crate) job_id: String,
+    pub(crate) location: Option<String>,
+}
+
+/// Read the `jobReference` out of an inserted job. Falls back to the requesting
+/// project so a reply missing `projectId` still polls the right project.
+pub(crate) fn parse_job_reference(job: &Value, fallback_project: &str) -> Result<JobRef> {
+    let r = job.get("jobReference");
+    let job_id = r
+        .and_then(|r| r.get("jobId"))
+        .and_then(Value::as_str)
+        .context("BigQuery jobs.insert returned no jobReference.jobId")?;
+    Ok(JobRef {
+        project: r
+            .and_then(|r| r.get("projectId"))
+            .and_then(Value::as_str)
+            .unwrap_or(fallback_project)
+            .to_string(),
+        job_id: job_id.to_string(),
+        location: r
+            .and_then(|r| r.get("location"))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+    })
+}
+
+/// Where a polled job stands.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum JobOutcome {
+    Running,
+    Done,
+    Failed(String),
+}
+
+/// The success verdict, and the ONLY one: `status.errorResult`.
+///
+/// `status.errors[]` without an `errorResult` is BigQuery's non-fatal warning
+/// channel (it appears on jobs that succeeded), so it must not fail a load —
+/// the CLI's exit status did not, either. It only enriches a failure message.
+pub(crate) fn job_outcome(job: &Value) -> JobOutcome {
+    let status = job.get("status");
+    if let Some(err) = status.and_then(|s| s.get("errorResult")) {
+        return JobOutcome::Failed(job_error_detail(err, status.and_then(|s| s.get("errors"))));
+    }
+    match status.and_then(|s| s.get("state")).and_then(Value::as_str) {
+        Some("DONE") => JobOutcome::Done,
+        _ => JobOutcome::Running,
+    }
+}
+
+/// The user-visible reason a job failed: `errorResult.message`, then any
+/// `errors[]` message that says something new, `|`-joined — the same
+/// multi-part detail the CLI path assembled from stdout+stderr.
+fn job_error_detail(error_result: &Value, errors: Option<&Value>) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(m) = error_result.get("message").and_then(Value::as_str) {
+        parts.push(m.trim().to_string());
+    }
+    for m in errors
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|e| e.get("message").and_then(Value::as_str))
+    {
+        let m = m.trim().to_string();
+        if !parts.contains(&m) {
+            parts.push(m);
+        }
+    }
+    if parts.is_empty() {
+        // No message at all — surface the reason code rather than an empty
+        // "failed:" that tells the operator nothing.
+        parts.push(format!(
+            "reason: {}",
+            error_result
+                .get("reason")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown")
+        ));
+    }
+    parts.join(" | ")
+}
+
+/// The failure message a caller sees, naming the job so the operator can look
+/// it up in `INFORMATION_SCHEMA.JOBS` / the console.
+pub(crate) fn job_failed_message(job_id: &str, detail: &str) -> String {
+    format!("BigQuery job {job_id} failed: {detail}")
+}
+
+/// The reason behind a non-2xx JSON-API reply: `error.message`, plus any
+/// `error.errors[]` message that adds something. Falls back to the raw body
+/// (bounded) when the payload is not the standard error envelope — an HTML
+/// proxy error must still reach the operator.
+pub(crate) fn api_error_detail(status: u16, body: &str) -> String {
+    let parsed: Option<Value> = serde_json::from_str(body).ok();
+    let err = parsed.as_ref().and_then(|v| v.get("error"));
+    if let Some(err) = err {
+        let detail = job_error_detail(err, err.get("errors"));
+        if !detail.is_empty() {
+            return format!("HTTP {status}: {detail}");
+        }
+    }
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return format!("HTTP {status} (empty response body)");
+    }
+    format!("HTTP {status}: {}", truncate(trimmed, 500))
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let head: String = s.chars().take(max).collect();
+    format!("{head}…")
+}
+
+/// The first cell of the first row of a `getQueryResults` reply, as a `u64`.
+///
+/// BigQuery renders every cell as a STRING (`rows[0].f[0].v`), including
+/// INT64 — so this parses text, and an absent row is an error rather than a
+/// silent zero (a `COUNT(*)` that returns nothing means the query did not run,
+/// not that the table is empty).
+pub(crate) fn parse_scalar_u64(results: &Value) -> Result<u64> {
+    let cell = results
+        .get("rows")
+        .and_then(Value::as_array)
+        .and_then(|rows| rows.first())
+        .and_then(|row| row.get("f"))
+        .and_then(Value::as_array)
+        .and_then(|fields| fields.first())
+        .and_then(|f| f.get("v"))
+        .context("BigQuery getQueryResults returned no rows[0].f[0].v")?;
+    match cell {
+        Value::String(s) => s
+            .parse::<u64>()
+            .with_context(|| format!("BigQuery returned a non-numeric count: {s}")),
+        Value::Number(n) => n
+            .as_u64()
+            .context("BigQuery returned a count that is not a non-negative integer"),
+        other => bail!("BigQuery returned a count of an unexpected JSON type: {other}"),
+    }
+}
+
+/// `?location=<loc>` when the job has one, else empty.
+fn location_query(location: Option<&str>) -> String {
+    location
+        .map(|l| format!("?location={l}"))
+        .unwrap_or_default()
+}
+
+/// Backoff for poll attempt `n`: exponential from [`POLL_MIN`], capped at
+/// [`POLL_MAX`]. Attempt 0 waits the minimum, so a sub-second metadata job is
+/// not billed a full second of latency.
+fn poll_interval(attempt: u32) -> Duration {
+    let scaled = POLL_MIN.saturating_mul(1u32 << attempt.min(16));
+    scaled.min(POLL_MAX)
+}
+
+/// HTTP statuses worth retrying an IDEMPOTENT request on: rate limiting and
+/// any server-side fault. Everything else (401, 403, 404, 400) is a decision
+/// BigQuery has made and repeating it changes nothing.
+fn is_transient_status(code: u16) -> bool {
+    code == 429 || (500..600).contains(&code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn labels() -> BTreeMap<String, String> {
+        BTreeMap::from([
+            ("managed_by".to_string(), "rivet".to_string()),
+            ("rivet_op".to_string(), "load".to_string()),
+        ])
+    }
+
+    /// The insert body must put the statement where BigQuery reads it, disable
+    /// legacy SQL (the CLI's `--use_legacy_sql=false`), and put the labels in
+    /// `configuration.labels` — the field `INFORMATION_SCHEMA.JOBS.labels`
+    /// projects. A label map written anywhere else costs cost-attribution
+    /// silently: the job runs, the billing query returns nothing.
+    #[test]
+    fn query_job_body_carries_sql_and_labels_where_bigquery_reads_them() {
+        let b = query_job_body("SELECT 1", &labels(), "proj", None);
+        assert_eq!(b["configuration"]["query"]["query"], "SELECT 1");
+        assert_eq!(b["configuration"]["query"]["useLegacySql"], false);
+        assert_eq!(b["configuration"]["labels"]["managed_by"], "rivet");
+        assert_eq!(b["configuration"]["labels"]["rivet_op"], "load");
+        // No location asked for ⇒ no jobReference at all, so BigQuery both
+        // generates the job id and infers the location from the datasets.
+        assert!(b.get("jobReference").is_none(), "{b}");
+    }
+
+    #[test]
+    fn query_job_body_pins_the_location_when_one_is_configured() {
+        let b = query_job_body("SELECT 1", &labels(), "proj", Some("EU"));
+        assert_eq!(b["jobReference"]["location"], "EU");
+        assert_eq!(b["jobReference"]["projectId"], "proj");
+        // Still no jobId — a client-side id would collide across runs.
+        assert!(b["jobReference"].get("jobId").is_none(), "{b}");
+    }
+
+    /// Polling a non-US job by id alone 404s, so the location the insert
+    /// RETURNED has to survive into the JobRef. Fixture is the shape verified
+    /// live against an EU dataset (2026-08-22).
+    #[test]
+    fn job_reference_keeps_the_location_the_insert_returned() {
+        let job = json!({"jobReference": {
+            "projectId": "rivet-data-tool", "jobId": "job_abc", "location": "EU"
+        }});
+        assert_eq!(
+            parse_job_reference(&job, "other").unwrap(),
+            JobRef {
+                project: "rivet-data-tool".into(),
+                job_id: "job_abc".into(),
+                location: Some("EU".into()),
+            }
+        );
+    }
+
+    #[test]
+    fn job_reference_falls_back_to_the_requesting_project_and_errors_without_an_id() {
+        let job = json!({"jobReference": {"jobId": "job_abc"}});
+        let r = parse_job_reference(&job, "fallback-proj").unwrap();
+        assert_eq!(r.project, "fallback-proj");
+        assert_eq!(r.location, None);
+        assert!(parse_job_reference(&json!({"status": {"state": "DONE"}}), "p").is_err());
+    }
+
+    #[test]
+    fn a_running_job_is_not_terminal() {
+        assert_eq!(
+            job_outcome(&json!({"status": {"state": "RUNNING"}})),
+            JobOutcome::Running
+        );
+        assert_eq!(
+            job_outcome(&json!({"status": {"state": "PENDING"}})),
+            JobOutcome::Running
+        );
+        // No status at all is NOT success — poll again rather than declare done.
+        assert_eq!(job_outcome(&json!({})), JobOutcome::Running);
+    }
+
+    #[test]
+    fn a_done_job_without_an_error_result_succeeds() {
+        assert_eq!(
+            job_outcome(&json!({"status": {"state": "DONE"}})),
+            JobOutcome::Done
+        );
+    }
+
+    /// THE verdict test. `errorResult` fails the job; `errors[]` WITHOUT an
+    /// `errorResult` is BigQuery's non-fatal warning channel and must stay
+    /// non-fatal — treating it as failure would fail loads the `bq` exit status
+    /// passed, which is exactly the "don't silently change what counts as
+    /// success" line.
+    #[test]
+    fn error_result_fails_the_job_but_a_bare_errors_list_does_not() {
+        let failed = json!({"status": {
+            "state": "DONE",
+            "errorResult": {"reason": "notFound", "message": "Not found: Table p:d.t"},
+            "errors": [{"reason": "notFound", "message": "Not found: Table p:d.t"}]
+        }});
+        // The duplicate `errors[]` copy is folded away, not repeated.
+        assert_eq!(
+            job_outcome(&failed),
+            JobOutcome::Failed("Not found: Table p:d.t".into())
+        );
+
+        let warned = json!({"status": {
+            "state": "DONE",
+            "errors": [{"reason": "stopped", "message": "a non-fatal warning"}]
+        }});
+        assert_eq!(job_outcome(&warned), JobOutcome::Done);
+    }
+
+    /// A distinct `errors[]` entry ADDS detail; the old CLI path joined its two
+    /// streams with " | " and this keeps that shape.
+    #[test]
+    fn distinct_error_messages_are_pipe_joined() {
+        let job = json!({"status": {
+            "state": "DONE",
+            "errorResult": {"reason": "invalid", "message": "top level"},
+            "errors": [
+                {"message": "top level"},
+                {"message": "the underlying cause"}
+            ]
+        }});
+        assert_eq!(
+            job_outcome(&job),
+            JobOutcome::Failed("top level | the underlying cause".into())
+        );
+    }
+
+    /// A failure with no message must not render as "failed: " — the reason
+    /// code is the last informative thing left.
+    #[test]
+    fn a_messageless_failure_still_names_its_reason() {
+        let job = json!({"status": {"state": "DONE", "errorResult": {"reason": "backendError"}}});
+        assert_eq!(
+            job_outcome(&job),
+            JobOutcome::Failed("reason: backendError".into())
+        );
+    }
+
+    /// The partition-quota augmentation is the one error-mapping the loader
+    /// promises by name. This drives BigQuery's REAL job-failure envelope
+    /// through the outcome mapper into `augment_partition_limit`, proving the
+    /// reason survives the REST transport the way it used to survive `bq`'s
+    /// stdout. TEXT-MATCHED: the quota surfaces as an ordinary `invalidQuery`
+    /// errorResult whose MESSAGE names the limit — there is no distinct
+    /// machine-readable reason code for it, so the augmenter matches the words.
+    #[test]
+    fn the_partition_quota_reason_survives_the_rest_transport_and_is_augmented() {
+        let job = json!({"status": {
+            "state": "DONE",
+            "errorResult": {
+                "reason": "invalidQuery",
+                "message": "Too many partitions produced by query, allowed 4000, \
+                            query produces at least 4200 partitions"
+            }
+        }});
+        let JobOutcome::Failed(detail) = job_outcome(&job) else {
+            panic!("expected a failed job");
+        };
+        assert!(detail.contains("Too many partitions") && detail.contains("4000"));
+        let err = crate::load::bigquery::augment_partition_limit(anyhow::anyhow!(
+            "{}",
+            job_failed_message("job_x", &detail)
+        ));
+        assert!(err.to_string().contains("split the"), "{err}");
+        // The augmentation is a `.context()`, so the reason and the job id live
+        // in the CHAIN — the rendering an operator sees (`{:#}`), not the
+        // headline alone.
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("job_x"),
+            "the job id must reach the operator: {chain}"
+        );
+        assert!(chain.contains("Too many partitions"), "{chain}");
+    }
+
+    /// HTTP-level rejections carry a different envelope than job failures.
+    /// Fixture is the shape verified live (a bad label key, 2026-08-22).
+    #[test]
+    fn http_error_detail_reads_the_api_error_envelope() {
+        let body = r#"{"error": {"code": 400,
+            "message": "Label key \"BAD KEY\" has invalid characters.",
+            "errors": [{"message": "Label key \"BAD KEY\" has invalid characters.",
+                        "reason": "invalid"}],
+            "status": "INVALID_ARGUMENT"}}"#;
+        let d = api_error_detail(400, body);
+        assert!(d.contains("HTTP 400"), "{d}");
+        assert!(d.contains("Label key"), "{d}");
+        // The duplicated `errors[]` copy folds away.
+        assert_eq!(d.matches("Label key").count(), 1, "{d}");
+    }
+
+    /// A proxy / load balancer answers with HTML, not the API envelope. The
+    /// operator still needs to see it — dropping an unparseable body is how a
+    /// "failed: " with no reason reaches a bug report.
+    #[test]
+    fn http_error_detail_falls_back_to_a_bounded_raw_body() {
+        let d = api_error_detail(502, "<html>Bad Gateway</html>");
+        assert!(d.contains("HTTP 502") && d.contains("Bad Gateway"), "{d}");
+        assert_eq!(
+            api_error_detail(503, "   "),
+            "HTTP 503 (empty response body)"
+        );
+        let long = api_error_detail(500, &"x".repeat(2000));
+        assert!(long.len() < 700 && long.ends_with('…'), "{}", long.len());
+    }
+
+    /// BigQuery renders every cell as a STRING, so the count arrives as `"42"`.
+    /// Fixture is the shape verified live (2026-08-22).
+    #[test]
+    fn scalar_count_parses_the_string_cell() {
+        let r = json!({"rows": [{"f": [{"v": "42"}]}], "totalRows": "1"});
+        assert_eq!(parse_scalar_u64(&r).unwrap(), 42);
+        assert_eq!(
+            parse_scalar_u64(&json!({"rows": [{"f": [{"v": "0"}]}]})).unwrap(),
+            0
+        );
+    }
+
+    /// A reply with no rows means the query did not produce one — that must be
+    /// an ERROR, never a silent 0. A `COUNT(*)` that reads as 0 when nothing
+    /// ran would let the load driver's row gate pass on a missing table.
+    #[test]
+    fn scalar_count_refuses_to_invent_a_zero() {
+        assert!(parse_scalar_u64(&json!({"totalRows": "0"})).is_err());
+        assert!(parse_scalar_u64(&json!({"rows": []})).is_err());
+        assert!(parse_scalar_u64(&json!({"rows": [{"f": []}]})).is_err());
+        assert!(parse_scalar_u64(&json!({"rows": [{"f": [{"v": "abc"}]}]})).is_err());
+        // NULL cell (`{"v": null}`) is not a count either.
+        assert!(parse_scalar_u64(&json!({"rows": [{"f": [{"v": null}]}]})).is_err());
+    }
+
+    /// The full precedence truth table. The blank-token row is the one that
+    /// bites in practice: `RIVET_BQ_ACCESS_TOKEN=""` (an unset shell variable
+    /// expanded into the environment) must fall THROUGH to ADC, not pin an
+    /// empty bearer token that 401s every job.
+    #[test]
+    fn an_explicit_token_wins_but_a_blank_one_falls_through_to_adc() {
+        use TokenSourceKind::*;
+        assert_eq!(choose_token_source(Some("ya29.x"), true), Static);
+        assert_eq!(choose_token_source(Some("ya29.x"), false), Static);
+        assert_eq!(choose_token_source(Some(""), true), Adc);
+        assert_eq!(choose_token_source(Some("   "), true), Adc);
+        assert_eq!(choose_token_source(None, true), Adc);
+        // Nothing rivet can mint in process ⇒ the documented CLI token fallback.
+        assert_eq!(choose_token_source(None, false), GcloudCli);
+        assert_eq!(choose_token_source(Some(""), false), GcloudCli);
+    }
+
+    #[test]
+    fn poll_interval_grows_from_the_floor_to_the_ceiling() {
+        assert_eq!(poll_interval(0), POLL_MIN);
+        assert_eq!(poll_interval(1), POLL_MIN * 2);
+        assert_eq!(poll_interval(3), POLL_MIN * 8);
+        // Capped, and never longer than the cap however far the loop runs.
+        assert_eq!(poll_interval(9), POLL_MAX);
+        assert_eq!(poll_interval(1_000), POLL_MAX);
+        assert!(
+            poll_interval(0) < poll_interval(2),
+            "must actually back off"
+        );
+    }
+
+    /// Retrying a 4xx repeats a decision BigQuery already made; retrying a 5xx
+    /// or a 429 is the only thing that survives a blip. Pins both sides — a
+    /// predicate that returned `true` for 403 would spin on a permission error.
+    #[test]
+    fn only_rate_limits_and_server_faults_are_transient() {
+        for code in [429, 500, 502, 503, 504] {
+            assert!(is_transient_status(code), "{code} should retry");
+        }
+        for code in [200, 400, 401, 403, 404, 409] {
+            assert!(!is_transient_status(code), "{code} must not retry");
+        }
+    }
+
+    #[test]
+    fn location_query_is_empty_when_unset() {
+        assert_eq!(location_query(Some("EU")), "?location=EU");
+        assert_eq!(location_query(None), "");
+    }
+
+    /// The `getQueryResults` URL must keep `maxResults` parseable whether or not
+    /// a location is present — a `?location=…&maxResults=1` and a bare
+    /// `?&maxResults=1` are both valid; `…queries/id&maxResults=1` is not.
+    #[test]
+    fn query_results_url_always_opens_a_query_string() {
+        let api = BigQueryApi {
+            project: "p".into(),
+            location: None,
+            endpoint: "https://e".into(),
+            http: reqwest::blocking::Client::new(),
+            auth: Auth::Static(Zeroizing::new("t".into())),
+        };
+        let with_loc = api.query_results_url(&JobRef {
+            project: "p".into(),
+            job_id: "j".into(),
+            location: Some("EU".into()),
+        });
+        assert_eq!(
+            with_loc,
+            "https://e/bigquery/v2/projects/p/queries/j?location=EU&maxResults=1"
+        );
+        let without = api.query_results_url(&JobRef {
+            project: "p".into(),
+            job_id: "j".into(),
+            location: None,
+        });
+        assert_eq!(
+            without,
+            "https://e/bigquery/v2/projects/p/queries/j?&maxResults=1"
+        );
+    }
+
+    #[test]
+    fn job_url_addresses_the_jobs_get_endpoint() {
+        let api = BigQueryApi {
+            project: "p".into(),
+            location: None,
+            endpoint: "https://e".into(),
+            http: reqwest::blocking::Client::new(),
+            auth: Auth::Static(Zeroizing::new("t".into())),
+        };
+        let url = api.job_url(&JobRef {
+            project: "other".into(),
+            job_id: "j".into(),
+            location: Some("EU".into()),
+        });
+        // Polls the job's OWN project, not the client's.
+        assert_eq!(
+            url,
+            "https://e/bigquery/v2/projects/other/jobs/j?location=EU"
+        );
+    }
+
+    /// SecOps: the client is reachable from a `Debug`-derived loader, so its
+    /// rendering must never contain a bearer token.
+    #[test]
+    fn debug_never_renders_the_token() {
+        let api = BigQueryApi {
+            project: "p".into(),
+            location: Some("EU".into()),
+            endpoint: DEFAULT_ENDPOINT.into(),
+            http: reqwest::blocking::Client::new(),
+            auth: Auth::Static(Zeroizing::new("ya29.SECRET-TOKEN".into())),
+        };
+        let rendered = format!("{api:?}");
+        assert!(!rendered.contains("SECRET"), "{rendered}");
+        assert!(rendered.contains("EU"), "{rendered}");
+    }
+}

--- a/src/load/mod.rs
+++ b/src/load/mod.rs
@@ -14,6 +14,7 @@ use crate::types::target::{TargetColumnSpec, TargetStatus};
 use anyhow::{Context, Result, bail};
 
 mod bigquery;
+mod bq_rest;
 pub mod cdc;
 pub mod orchestrate;
 pub mod plan;


### PR DESCRIPTION
## What

`src/load/bigquery.rs` funnelled every BigQuery interaction through one
`Command::new("bq")` inside `run_bq`. That funnel is replaced by
`src/load/bq_rest.rs` — BigQuery's JSON API on the blocking `reqwest` client
already in the tree. No async runtime, no new dependency, no Google Cloud SDK
on PATH. Caller shapes (`run_sql`, `count_rows`, `materialize`,
`append_changelog`, `create_view`) are unchanged.

| | |
|---|---|
| `POST /bigquery/v2/projects/{p}/jobs` | `jobs.insert` — the query job, labels in `configuration.labels` |
| `GET /bigquery/v2/projects/{p}/jobs/{id}` | `jobs.get` — the poll, `status.errorResult` is the verdict |
| `GET /bigquery/v2/projects/{p}/queries/{id}` | `getQueryResults` — only for the `COUNT(*)` |

Every response shape was **captured live** from `rivet-data-tool` before the
fixtures were written — the insert reply, a failed job's `status`, an HTTP-level
`error` envelope, and a `getQueryResults` row — so the offline fixtures are
recordings, not guesses.

## Auth — reused, not rewritten

`lib.rs::google_auth` already framed `destination/gcs_auth.rs` as rivet's one
Google auth path ("never hand-roll a second auth path"), but the minting was
welded to the async opendal signer. The credential, the grant body, the response
parse and the freshness rule are now that file's own seam
(`AdcCredentials::refresh_grant_body`, `load_adc_credentials`,
`parse_token_response`, `token_still_fresh`), and **both** consumers call them:
the async `AdcUserTokenLoader` (GCS) and the new blocking
`BlockingAdcTokenSource` (BigQuery). Only the reqwest flavour differs.

New: the ADC file's `quota_project_id` is parsed and sent as
`x-goog-user-project` — a metered JSON API requires it of a user credential;
GCS did not.

## Preserved

- **Labels.** `--label k:v` pairs became a `BTreeMap` in `configuration.labels`.
  Same four keys, same `sanitize_label` values. The two tests that asserted CLI
  args were adapted to read the label set (same claims), and a new test takes
  the labels from the loader into the request body.
- **Error detail.** `status.errorResult.message` + any distinct
  `status.errors[]` message, `|`-joined like the old stdout/stderr join, now
  naming the job id. `augment_partition_limit` is unchanged and still fires; its
  doc now says it is **text-matched**, because the quota arrives as an ordinary
  `invalidQuery` errorResult whose message names the limit.
- **Success semantics.** `errorResult` decides, exactly as the exit status did.
  A bare `errors[]` (BigQuery's non-fatal warning channel) stays non-fatal.

## Testing

21 new offline tests, inline beside the code, no network: request-body
construction, job reference + location, outcome verdict, error folding, HTTP
envelope + raw-body fallback, scalar parsing, poll backoff, transient
classification, URL construction, Debug redaction, token-source precedence, ADC
quota project, the shared grant body.

**20 mutants applied and reverted**, each killing exactly the tests it should —
the full table is in the commit message. Includes the `_ => Done` verdict
collapse, `parse_scalar_u64` inventing a zero, `api_error_detail` discarding the
API message, and `Debug` leaking a bearer token.

**Live**, against `rivet-data-tool` / `rivet_type_lab` / EU:
`bigquery_rest_transport_live_round_trips_a_query_job` does CTAS → count →
label read-back → a failing job → DROP. It passed, and
`INFORMATION_SCHEMA.JOBS_BY_PROJECT` confirmed each run's five jobs carrying
`rivet_op` + `rivet_run`, with `total_bytes_billed = 0` on the CTAS and the
count. **RED-proven live**: with `build_labels` dropping the run id the same
test failed with `INFORMATION_SCHEMA saw 0` — the oracle is BigQuery's catalog,
not the request rivet sent. Fixture table dropped; dataset left empty.

## Gaps, recorded rather than faked

- **Service-account JSON / external_account** cannot be minted in process (RS256
  JWT signing / an STS exchange; neither dependency is in this crate). They fall
  back to `gcloud auth print-access-token` in the clearly-named
  `mint_token_via_gcloud_cli` — one *token*, not the transport. A GCE/GKE
  metadata token source is not implemented; that shape uses the same fallback.
- **`jobs.insert` is not retried** on a transport error. `bq` could, because it
  generated the job id client-side; a bare retry here would create a second job
  and `LOAD DATA INTO` (the CDC append) is not idempotent. Failing loudly is the
  honest trade. Polling GETs retry 429/5xx.
- **Location** is inferred by BigQuery from the referenced datasets, as the CLI
  relied on; `RIVET_BQ_LOCATION` pins it otherwise. Verified live on an EU
  dataset.
- **No `.cargo/mutants.toml` exclusion** for the network glue: CI already
  partitions in-diff mutants by measured offline reach and reports the
  zero-execution class rather than blocking, so claiming a triage would assert
  something unmeasured. Every *decision* in those bodies is a named pure
  predicate with a truth table.

`clean_bq_output` and `parse_count_csv` were deleted with the CLI transport, so
their three tests went too; their intent is carried at equal or greater strength
by the REST error-mapping and scalar-parsing tests.

## Proof

`cargo build` · `cargo test -q --lib` (2566 passed) · `cargo test -q --test
offline_suite` (281 passed) · `cargo clippy --all-targets -D warnings` ·
`cargo fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168uwctCn3W1rP4Kt4kZXvE
