### PR TITLE
feat(load): fan a multiplex `tables:` CDC export out to one load plan per table (closes #252)

### DIFF
--- a/docs/cdc-bigquery-load.md
+++ b/docs/cdc-bigquery-load.md
@@ -154,6 +154,36 @@ refinements over the sketch — on MySQL the binlog file is parsed numerically
 rather than vanishing. See the matrix cells `cdc_backfill_snapshot_{mysql,pg,mongo}`
 and the Snowflake parity `mongo_cdc_delete_flag_snowflake`.
 
+### A whole schema: one stream, one warehouse table per source table
+
+`rivet init --mode cdc` over a whole schema emits ONE multiplex export — every
+table through one change stream (one PostgreSQL slot / one MySQL binlog
+connection), rather than one export and one slot per table:
+
+```yaml
+exports:
+  - name: cdc
+    tables: [orders, customers, line_items]
+    mode: cdc
+    cdc: { initial: snapshot, until_current: true, checkpoint: /var/lib/rivet/cdc.ckpt }
+    destination: { type: gcs, bucket: my-bucket, prefix: cdc/ }
+load:
+  target: bigquery
+  project: my-proj
+  dataset: analytics
+  pk: [id]
+```
+
+The capture fans each table out under `<prefix>/<table>/` (its own
+`manifest.json` + `_SUCCESS`, with `initial: snapshot` nested a level below as
+`<prefix>/<table>/snapshot/`), and `rivet load` follows that layout: **one
+`<table>__changes` + one dedup view per SOURCE table**, each loaded from its own
+sub-prefix only. `pk:` and the rest of the `load:` block are shared by every
+table of the stream; `rivet check --target bigquery` prints one resolver document
+per table (`Export: cdc/orders`), so you see each table's native schema before
+loading it. Live-verified against BigQuery over a 3-table PostgreSQL stream
+(#252).
+
 **Bottom line:** yes — rivet can ingest CDC into BigQuery **and** expose a
 deduplicated current state entirely for free (append + view). The only
 unavoidable cost is *materializing* current state, which we defer to read time

--- a/docs/load-mode-matrix.yaml
+++ b/docs/load-mode-matrix.yaml
@@ -91,6 +91,12 @@ scenarios:
     incremental: { na: "incremental resumes from its cursor in the state DB, not a snapshot marker" }
     cdc:         { test: snapshot_plan_all_done_snapshots_nothing_but_keeps_resume_evidence }
 
+  - id: multiplex_tables_one_plan_per_table
+    what: "a multiplex `tables:` export (N source tables through ONE stream) builds one LoadPlan per TABLE — own warehouse table, own `<prefix>/<table>/` sub-prefix — not one per export"
+    full:        { na: "`tables:` is refused at config-load outside `mode: cdc` — a batch export is always one unit" }
+    incremental: { na: "`tables:` is refused at config-load outside `mode: cdc` — an incremental export is always one unit" }
+    cdc:         { test: build_plans_fans_a_multiplex_tables_export_out_to_one_plan_per_table }
+
   - id: cleanup_source_safe_end_to_end
     what: "cleanup_source: true wipes the staged Parquet after a recorded load without losing data — proven live end to end"
     full:        { test: smoke_batch_mysql }

--- a/src/config/export.rs
+++ b/src/config/export.rs
@@ -404,6 +404,24 @@ impl ExportConfig {
             .unwrap_or_else(|| self.name.clone())
     }
 
+    /// The tables of a MULTIPLEX capture — a `mode: cdc` export whose `tables:`
+    /// list drives several tables through one change stream — or `None` when this
+    /// export is a single unit (one `table:`/`query:`, or any batch mode).
+    ///
+    /// Every consumer of the multiplex layout answers the same question first
+    /// ("is this export one table or N?"), and they must answer it identically:
+    /// `rivet validate` descends one sub-prefix per table, the type resolver
+    /// produces one document per table, and `rivet load` builds one plan per
+    /// table. A `tables:` list on a non-CDC export is already refused at
+    /// config-load, and an empty one is refused too — the filter here is
+    /// belt-and-suspenders so a caller can never fan out over nothing.
+    pub fn multiplex_tables(&self) -> Option<&[String]> {
+        if self.mode != ExportMode::Cdc {
+            return None;
+        }
+        self.tables.as_deref().filter(|t| !t.is_empty())
+    }
+
     /// Resolve the effective `(CompressionType, level)` for this export.
     /// `compression_profile` takes precedence over `compression` + `compression_level`.
     ///
@@ -945,6 +963,45 @@ mod tests {
             e.family(),
             "daily",
             "a split sub-export must fold to the parent family for the merge-back"
+        );
+    }
+
+    // ── ExportConfig::multiplex_tables ──────────────────────────────────────
+
+    /// The one decision "is this export ONE unit or N?" — read by `rivet
+    /// validate` (descend a sub-prefix per table), the type resolver (one
+    /// resolver document per table) and `rivet load` (one plan per table). All
+    /// three must answer the same, which is why they all call THIS.
+    ///
+    /// Both negative arms matter: a `tables:` list on a non-CDC export is not a
+    /// multiplex (config-load refuses it outright), and an empty list must never
+    /// present as one — a fan-out over zero tables produces zero plans and loads
+    /// nothing, silently.
+    #[test]
+    fn multiplex_tables_is_some_only_for_a_cdc_export_with_a_non_empty_list() {
+        let mut e = sample_export("cdc");
+        assert_eq!(e.multiplex_tables(), None, "no `tables:` → not a multiplex");
+
+        e.tables = Some(vec!["orders".into(), "customers".into()]);
+        assert_eq!(
+            e.multiplex_tables(),
+            None,
+            "`mode: full` is never a multiplex, whatever `tables:` says"
+        );
+
+        e.mode = ExportMode::Cdc;
+        assert_eq!(
+            e.multiplex_tables(),
+            Some(&["orders".to_string(), "customers".to_string()][..]),
+            "a `mode: cdc` export with `tables:` is N units"
+        );
+
+        e.tables = Some(vec![]);
+        assert_eq!(
+            e.multiplex_tables(),
+            None,
+            "an EMPTY list must not present as a multiplex — fanning out over zero \
+             tables plans zero loads and moves no data, silently"
         );
     }
 

--- a/src/load/plan.rs
+++ b/src/load/plan.rs
@@ -355,6 +355,35 @@ fn resolve_load_prefix(
     Ok(format!("gs://{bucket}/{base}"))
 }
 
+/// The load prefix of ONE table of a multiplex `tables:` CDC stream, given the
+/// export's resolved base prefix.
+///
+/// The extract fans each captured table out under `<base>/<table>/` — one
+/// `manifest.json` + `_SUCCESS` per table, with the initial snapshot nested a
+/// level below as `<base>/<table>/snapshot/` — and `rivet validate` descends
+/// exactly that. So the load must list exactly that too, and the sub-prefix is
+/// produced by the WRITER's own function ([`crate::pipeline::cdc_job::dest_for_table`])
+/// rather than a second concatenation rule here: a cloud prefix is a LITERAL key
+/// prefix (the destination concatenates `prefix + key` with no separator), so a
+/// sub-prefix that forgets to supply its own slashes lists a mangled flat key and
+/// finds nothing — the silent "up to date, loaded nothing" shape.
+///
+/// Applied AFTER [`resolve_load_prefix`] rather than to the raw destination, so
+/// the placeholder expansion and the `{partition}` strip both see the base the
+/// export wrote, and the table segment can never land below a stripped token.
+fn table_load_prefix(base_uri: &str, table: &str) -> Result<String> {
+    let (bucket, base) = crate::load::split_gs_uri(base_uri)?;
+    let sub = crate::pipeline::cdc_job::dest_for_table(
+        &crate::config::DestinationConfig {
+            destination_type: crate::config::DestinationType::Gcs,
+            prefix: Some(base.to_string()),
+            ..Default::default()
+        },
+        table,
+    );
+    Ok(format!("gs://{bucket}/{}", sub.prefix.unwrap_or_default()))
+}
+
 pub fn plan_loads(config_path: &str) -> Result<Vec<LoadPlan>> {
     // `Config::load`, not a raw `from_yaml`: it resolves `${VAR}`/`--param`
     // placeholders exactly as the `rivet check` child did. The old code parsed
@@ -418,10 +447,20 @@ fn build_plans(
                     report.export
                 )
             })?;
-        let table = warehouse_table_name(
-            &export.table.clone().unwrap_or_else(|| export.name.clone()),
-            &export.name,
-        );
+        // A multiplex `tables:` CDC export is N tables through ONE export, and the
+        // resolver hands us one report per table (`report.table`). Each is its own
+        // warehouse table under its own `<base>/<table>/` sub-prefix — which is why
+        // the fan-out has to happen HERE and not be left to the export name: a
+        // single plan per export would point every table at one warehouse table and
+        // one BASE prefix, whose recursive manifest listing sweeps in every sibling
+        // table's parts. That merges N source tables into one warehouse table with
+        // every count agreeing (#252).
+        let source_table = report
+            .table
+            .clone()
+            .or_else(|| export.table.clone())
+            .unwrap_or_else(|| export.name.clone());
+        let table = warehouse_table_name(&source_table, &export.name);
 
         let dest = &export.destination;
         let bucket = dest.bucket.as_deref().with_context(|| {
@@ -430,7 +469,11 @@ fn build_plans(
                 export.name
             )
         })?;
-        let gcs_prefix = resolve_load_prefix(dest, &export.name, bucket)?;
+        let base_prefix = resolve_load_prefix(dest, &export.name, bucket)?;
+        let gcs_prefix = match &report.table {
+            Some(t) => table_load_prefix(&base_prefix, t)?,
+            None => base_prefix,
+        };
 
         // The report row IS the resolver's `TargetColumnSpec`, split across the
         // report's optional fields — so rebuild the whole spec, not the two
@@ -715,10 +758,21 @@ mod tests {
     fn report(export: &str, columns: Vec<TypeReportRow>) -> ExportTypeReport {
         ExportTypeReport {
             export: export.into(),
+            table: None,
             columns,
             violations: vec![],
             target_failures: false,
             recovery_sql: None,
+        }
+    }
+
+    /// One TABLE'S report of a multiplex `tables:` export, as the resolver
+    /// returns one per captured table (`table: Some(..)`, `export` still the
+    /// export's own name).
+    fn table_report(export: &str, table: &str, columns: Vec<TypeReportRow>) -> ExportTypeReport {
+        ExportTypeReport {
+            table: Some(table.into()),
+            ..report(export, columns)
         }
     }
 
@@ -887,6 +941,132 @@ load:
             ts.target_type, "TIMESTAMP",
             "resolved through the per-target resolver, not hardcoded — BigQuery's \
              instant type for a Timestamp(us, UTC)"
+        );
+    }
+
+    /// A multiplex `tables:` CDC config — the shape `rivet init --mode cdc`
+    /// emits for a whole schema (#252).
+    fn multiplex_cfg() -> crate::config::Config {
+        crate::config::Config::from_yaml(
+            r#"
+source:
+  type: postgres
+  url: "postgresql://localhost/test"
+exports:
+  - name: cdc
+    tables: [orders, customers, line_items]
+    mode: cdc
+    format: parquet
+    cdc:
+      checkpoint: ./cdc.ckpt
+      initial: snapshot
+    destination:
+      type: gcs
+      bucket: b
+      prefix: exports/{export}/
+load:
+  target: bigquery
+  project: p
+  dataset: d
+  pk: [id]
+"#,
+        )
+        .unwrap()
+    }
+
+    /// A multiplex `tables:` CDC export is N source tables through ONE export,
+    /// and `rivet load` must build ONE PLAN PER TABLE (#252).
+    ///
+    /// The two halves this pins are the two ways the fan-out can be dropped, and
+    /// each fails differently:
+    ///
+    /// - drop `report.table` from the warehouse-table resolution and all N
+    ///   collapse onto the EXPORT's name — three source tables merged into one
+    ///   BigQuery table (here caught by `reject_duplicate_target_tables`, but
+    ///   only because the collision is exact);
+    /// - drop the per-table sub-prefix and all N point at the export BASE, whose
+    ///   manifest listing is RECURSIVE — so every plan sweeps in every sibling
+    ///   table's parts and loads them all into its own table, with every count
+    ///   agreeing on the way through. That one is silent, which is why the prefix
+    ///   assertion is per-table and exact, not a `contains`.
+    ///
+    /// The `Some(table)` values are NOT hand-typed: they come from
+    /// `ExportConfig::multiplex_tables()`, the one function that decides whether
+    /// an export is one unit or N — so a mutant there (returning `None`, dropping
+    /// the CDC-mode gate) turns this red at the producer, not just the consumer.
+    #[test]
+    fn build_plans_fans_a_multiplex_tables_export_out_to_one_plan_per_table() {
+        let cfg = multiplex_cfg();
+        let load: LoadSection = serde_json::from_value(cfg.load.clone().unwrap()).unwrap();
+        let tables = cfg.exports[0]
+            .multiplex_tables()
+            .expect("a `mode: cdc` export with `tables:` IS a multiplex")
+            .to_vec();
+        assert_eq!(tables.len(), 3, "fixture must cross the fan-out threshold");
+
+        let reports: Vec<_> = tables
+            .iter()
+            .map(|t| table_report("cdc", t, vec![col("id", TargetStatus::Ok)]))
+            .collect();
+        let plans = build_plans(&cfg, &load, reports).unwrap();
+
+        assert_eq!(
+            plans.len(),
+            3,
+            "one plan per captured table, not one per export"
+        );
+        assert_eq!(
+            plans.iter().map(|p| p.table.as_str()).collect::<Vec<_>>(),
+            vec!["orders", "customers", "line_items"],
+            "the warehouse table is the SOURCE table, not the export name"
+        );
+        // Each table's own sub-prefix — the layout the extract wrote
+        // (`cdc_job::dest_for_table`) and `rivet validate` descends. The `{export}`
+        // token still expands first, so the base is the export's, not the literal.
+        assert_eq!(
+            plans
+                .iter()
+                .map(|p| p.gcs_prefix.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "gs://b/exports/cdc/orders/",
+                "gs://b/exports/cdc/customers/",
+                "gs://b/exports/cdc/line_items/",
+            ],
+            "each plan must list ONLY its own table's prefix — a shared base lists \
+             every sibling's parts recursively and merges them into one table"
+        );
+        for p in &plans {
+            assert_eq!(p.mode, LoadMode::Cdc);
+            assert_eq!(
+                p.export_name, "cdc",
+                "the plans still address the EXPORT the operator wrote"
+            );
+            assert_eq!(p.load.pk, vec!["id"], "the shared `load:` applies to each");
+        }
+    }
+
+    /// The multiplex sub-prefix rule itself: the table becomes ONE path segment
+    /// under the resolved base, with both slashes supplied — a cloud prefix is a
+    /// literal key prefix, so a missing separator lists a mangled flat key
+    /// (`…/cdccdc-0.parquet`) and the load silently reports "up to date".
+    #[test]
+    fn table_load_prefix_appends_one_slash_delimited_segment() {
+        assert_eq!(
+            table_load_prefix("gs://b/exports/cdc/", "orders").unwrap(),
+            "gs://b/exports/cdc/orders/"
+        );
+        // A base written without its trailing slash must not fuse the segment on.
+        assert_eq!(
+            table_load_prefix("gs://b/exports/cdc", "orders").unwrap(),
+            "gs://b/exports/cdc/orders/"
+        );
+        // A schema-qualified table stays VERBATIM in the path — the dot is folded
+        // only in the warehouse NAME (`warehouse_table_name`); the extract wrote
+        // the raw name as its directory.
+        assert_eq!(
+            table_load_prefix("gs://b/e/", "public.orders").unwrap(),
+            "gs://b/e/public.orders/"
         );
     }
 

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -8,9 +8,10 @@
 
 mod aggregate;
 mod apply_cmd;
-#[cfg(not(test))]
-mod cdc_job;
-#[cfg(test)]
+// `pub(crate)`: the multiplex destination layout (`dest_for_table` — one
+// sub-prefix per captured table) is written HERE and read by everything that has
+// to find those files again — `rivet validate`, and the warehouse load planner.
+// One definition of where a table's parts live, not one per reader.
 pub(crate) mod cdc_job;
 pub(crate) mod chunked;
 mod cli;

--- a/src/pipeline/validate_cmd.rs
+++ b/src/pipeline/validate_cmd.rs
@@ -145,11 +145,7 @@ pub fn run_validate_command(
         // manifest of its own — so descend per table (using the writer's builder)
         // rather than verifying the base, which would read back "legacy_run" and
         // fail the `__pos` check on a missing part.
-        let multiplex = if export.mode == crate::config::ExportMode::Cdc {
-            export.tables.as_deref().filter(|t| !t.is_empty())
-        } else {
-            None
-        };
+        let multiplex = export.multiplex_tables();
         let has_snapshot = export.mode == crate::config::ExportMode::Cdc
             && export.cdc.as_ref().and_then(|c| c.initial)
                 == Some(crate::config::CdcInitialMode::Snapshot);

--- a/src/preflight/mod.rs
+++ b/src/preflight/mod.rs
@@ -433,7 +433,10 @@ pub fn check(
             let config_dir = std::path::Path::new(config_path)
                 .parent()
                 .unwrap_or_else(|| std::path::Path::new("."));
-            match type_report::collect_report(
+            // One report per UNIT, not per export: a multiplex `tables:` CDC
+            // export resolves one document per captured table (#252), each of
+            // which is a separate warehouse table downstream.
+            match type_report::collect_reports(
                 &config,
                 export,
                 &column_overrides,
@@ -442,41 +445,43 @@ pub fn check(
                 config_dir,
                 params,
             ) {
-                Ok(report) => {
-                    if report.has_fatal() {
-                        any_fatal = true;
-                    }
-                    if let Some(t) = eff_target
-                        && report.has_target_fail()
-                    {
-                        any_fatal = true;
-                        target_fail_cols += report
-                            .columns
-                            .iter()
-                            .filter(|c| c.target_status == Some(TargetStatus::Fail))
-                            .count();
-                        target_fail_label.get_or_insert(t.label());
-                    }
-                    if json_output {
-                        // `--json` + `--type-report` interaction (DESIGN):
-                        // emit BOTH, nested. Each export gets ONE JSON object
-                        // (NDJSON, one per line, unchanged) keeping the
-                        // top-level type-report keys (`export`/`columns`/
-                        // `violations`) so existing consumers and the
-                        // `check_json_flag_outputs_type_report_as_json` test
-                        // stay green — and we attach the per-export DIAGNOSTIC
-                        // verdict under a new `"diagnostic"` key. This is the
-                        // least-surprising shape because `check --json` already
-                        // emitted one type-report object per export; we simply
-                        // enrich each with its verdict rather than printing a
-                        // second, separate JSON value (which would break a
-                        // single-`from_str` parse of stdout).
-                        print_report_json_with_diagnostic(
-                            &report,
-                            diag_by_export.get(export.name.as_str()).copied(),
-                        )?;
-                    } else {
-                        type_report::print_table(&report, eff_target);
+                Ok(reports) => {
+                    for report in &reports {
+                        if report.has_fatal() {
+                            any_fatal = true;
+                        }
+                        if let Some(t) = eff_target
+                            && report.has_target_fail()
+                        {
+                            any_fatal = true;
+                            target_fail_cols += report
+                                .columns
+                                .iter()
+                                .filter(|c| c.target_status == Some(TargetStatus::Fail))
+                                .count();
+                            target_fail_label.get_or_insert(t.label());
+                        }
+                        if json_output {
+                            // `--json` + `--type-report` interaction (DESIGN):
+                            // emit BOTH, nested. Each export gets ONE JSON object
+                            // (NDJSON, one per line, unchanged) keeping the
+                            // top-level type-report keys (`export`/`columns`/
+                            // `violations`) so existing consumers and the
+                            // `check_json_flag_outputs_type_report_as_json` test
+                            // stay green — and we attach the per-export DIAGNOSTIC
+                            // verdict under a new `"diagnostic"` key. This is the
+                            // least-surprising shape because `check --json` already
+                            // emitted one type-report object per export; we simply
+                            // enrich each with its verdict rather than printing a
+                            // second, separate JSON value (which would break a
+                            // single-`from_str` parse of stdout).
+                            print_report_json_with_diagnostic(
+                                report,
+                                diag_by_export.get(export.name.as_str()).copied(),
+                            )?;
+                        } else {
+                            type_report::print_table(report, eff_target);
+                        }
                     }
                 }
                 Err(e) => {
@@ -561,30 +566,33 @@ pub fn collect_type_reports(
     let config_dir = std::path::Path::new(config_path)
         .parent()
         .unwrap_or_else(|| std::path::Path::new("."));
-    config
-        .exports
-        .iter()
-        .map(|export| {
-            let column_overrides =
-                crate::plan::parse_column_overrides_pub(&export.columns, &export.name)?;
-            type_report::collect_report(
-                config,
-                export,
-                &column_overrides,
-                &policy,
-                Some(target),
-                config_dir,
-                None,
+    let mut out = Vec::with_capacity(config.exports.len());
+    for export in &config.exports {
+        let column_overrides =
+            crate::plan::parse_column_overrides_pub(&export.columns, &export.name)?;
+        // One report per UNIT: a multiplex `tables:` CDC export yields one per
+        // captured table, because each is a separate warehouse table with its own
+        // sub-prefix and its own column set (#252). Flattened rather than nested
+        // so the load planner keeps mapping report → plan one-to-one.
+        let reports = type_report::collect_reports(
+            config,
+            export,
+            &column_overrides,
+            &policy,
+            Some(target),
+            config_dir,
+            None,
+        )
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "export '{}': resolving column types for the {} load: {e:#}",
+                export.name,
+                target.label()
             )
-            .map_err(|e| {
-                anyhow::anyhow!(
-                    "export '{}': resolving column types for the {} load: {e:#}",
-                    export.name,
-                    target.label()
-                )
-            })
-        })
-        .collect()
+        })?;
+        out.extend(reports);
+    }
+    Ok(out)
 }
 
 /// Emit one export's `--json` line: the type report (`export`/`columns`/
@@ -882,6 +890,7 @@ mod tests {
     fn empty_report(export: &str) -> type_report::ExportTypeReport {
         type_report::ExportTypeReport {
             export: export.to_string(),
+            table: None,
             columns: Vec::new(),
             violations: Vec::new(),
             target_failures: false,

--- a/src/preflight/mod.rs
+++ b/src/preflight/mod.rs
@@ -225,6 +225,59 @@ fn target_fail_note(n: usize, target_label: &str) -> String {
     )
 }
 
+/// The `--target` epilogue's inputs, folded across every REPORT of every export.
+///
+/// Extracted from [`check`]'s render loop rather than accumulated inline,
+/// because the sum IS the epilogue's honesty: `check` prints "N column(s) FAIL
+/// …" and still exits 0 without `--strict`, so an under-count silently retracts
+/// the warning the "fail ✗" glyph already made — and inline in a function that
+/// needs a live database, no offline test can observe the arithmetic at all (the
+/// in-diff mutation gate graded `+=` → `*=`/`-=` on that line as MISSED).
+///
+/// The fold now crosses TABLES as well as exports: a multiplex `tables:` export
+/// contributes one report PER CAPTURED TABLE, so a tally that stopped at the
+/// first report of an export would under-count a whole schema to one table's
+/// worth.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct TargetFailTally {
+    /// Columns the target refuses outright, summed over every report.
+    columns: usize,
+    /// The label of the FIRST target that refused anything — the note names one
+    /// warehouse, and a config can set `target:` per export.
+    label: Option<&'static str>,
+    /// Any fatal policy violation, or any target-refused column: what `--strict`
+    /// bails on.
+    any_fatal: bool,
+}
+
+impl TargetFailTally {
+    /// Fold ONE export's reports in — all of them, `target` being the export's
+    /// effective target (`None` when nothing was resolved against one, in which
+    /// case a report can carry no target failure to count).
+    fn add_export(
+        &mut self,
+        target: Option<ExportTarget>,
+        reports: &[type_report::ExportTypeReport],
+    ) {
+        for report in reports {
+            if report.has_fatal() {
+                self.any_fatal = true;
+            }
+            if let Some(t) = target
+                && report.has_target_fail()
+            {
+                self.any_fatal = true;
+                self.columns += report
+                    .columns
+                    .iter()
+                    .filter(|c| c.target_status == Some(TargetStatus::Fail))
+                    .count();
+                self.label.get_or_insert(t.label());
+            }
+        }
+    }
+}
+
 /// Build one [`ExportDiagnostic`] per export via `diagnose`, collecting them (or
 /// short-circuiting on the first error). Single-sources the connect → loop →
 /// return contract every engine's `check_*` shares — only the per-export
@@ -401,14 +454,12 @@ pub fn check(
             TypePolicy::warn_only()
         };
 
-        let mut any_fatal = false;
         // Count hard target-FAIL columns (and remember which target) so that —
         // when --strict was NOT passed and the exit code is therefore 0 — we can
         // print a note. The "fail ✗" glyph in the table implies a hard failure,
         // but exit is gated only by --strict; without this note an operator or CI
         // reading the glyph alone would be misled into thinking rc != 0.
-        let mut target_fail_cols = 0usize;
-        let mut target_fail_label: Option<&'static str> = None;
+        let mut tally = TargetFailTally::default();
         for export in &exports {
             let column_overrides =
                 crate::plan::parse_column_overrides_pub(&export.columns, &export.name)?;
@@ -446,21 +497,8 @@ pub fn check(
                 params,
             ) {
                 Ok(reports) => {
+                    tally.add_export(eff_target, &reports);
                     for report in &reports {
-                        if report.has_fatal() {
-                            any_fatal = true;
-                        }
-                        if let Some(t) = eff_target
-                            && report.has_target_fail()
-                        {
-                            any_fatal = true;
-                            target_fail_cols += report
-                                .columns
-                                .iter()
-                                .filter(|c| c.target_status == Some(TargetStatus::Fail))
-                                .count();
-                            target_fail_label.get_or_insert(t.label());
-                        }
                         if json_output {
                             // `--json` + `--type-report` interaction (DESIGN):
                             // emit BOTH, nested. Each export gets ONE JSON object
@@ -499,16 +537,16 @@ pub fn check(
             }
         }
 
-        if strict && any_fatal {
+        if strict && tally.any_fatal {
             anyhow::bail!("strict mode: unsafe type mappings found (see report above)");
-        } else if !strict && target_fail_cols > 0 && !json_output {
+        } else if !strict && tally.columns > 0 && !json_output {
             // The table showed "fail ✗" but rc is 0 — say so explicitly. Skipped
             // under --json so NDJSON output stays one object per line.
             clean = false;
             println!();
             println!(
                 "{}",
-                target_fail_note(target_fail_cols, target_fail_label.unwrap_or("target"))
+                target_fail_note(tally.columns, tally.label.unwrap_or("target"))
             );
         }
     }
@@ -896,6 +934,90 @@ mod tests {
             target_failures: false,
             recovery_sql: None,
         }
+    }
+
+    /// A report of one multiplex TABLE with `n` target-refused columns.
+    fn failing_table_report(export: &str, table: &str, n: usize) -> type_report::ExportTypeReport {
+        let columns = (0..n)
+            .map(|i| type_report::TypeReportRow {
+                column: format!("c{i}"),
+                source_type: "-".into(),
+                rivet_type: "-".into(),
+                arrow_type: "-".into(),
+                fidelity: crate::types::TypeFidelity::Exact,
+                warnings: vec![],
+                target_type: Some("BIGNUMERIC".into()),
+                target_status: Some(TargetStatus::Fail),
+                target_note: None,
+                autoload_type: None,
+                cast_sql: None,
+            })
+            .collect();
+        type_report::ExportTypeReport {
+            table: Some(table.into()),
+            columns,
+            target_failures: true,
+            ..empty_report(export)
+        }
+    }
+
+    /// The `--target` epilogue's count must be the EXACT number of refused
+    /// columns across every report of every export.
+    ///
+    /// `check` prints "N column(s) FAIL <target> compatibility" and still exits 0
+    /// without `--strict`, so the number IS the warning — an under-count retracts
+    /// what the "fail ✗" glyph already promised, and a zero suppresses the note
+    /// entirely. The arithmetic used to live inline in `check`, which needs a live
+    /// database: the in-diff mutation gate graded `+=` → `*=` and `+=` → `-=`
+    /// there as MISSED, and both are silent (`*=` pins the total at 0 forever,
+    /// since it starts at 0).
+    ///
+    /// The fixture crosses BOTH folds — two exports, and two reports within the
+    /// first, because a multiplex `tables:` export now contributes one report per
+    /// captured table. A single-report fixture cannot distinguish the operators.
+    #[test]
+    fn target_fail_tally_sums_every_refused_column_across_tables_and_exports() {
+        let mut tally = TargetFailTally::default();
+        // One export, two TABLES (a multiplex stream): 2 + 1 refused columns.
+        tally.add_export(
+            Some(ExportTarget::BigQuery),
+            &[
+                failing_table_report("cdc", "orders", 2),
+                failing_table_report("cdc", "customers", 1),
+            ],
+        );
+        assert_eq!(
+            tally.columns, 3,
+            "every captured table's refused columns count — stopping at the first \
+             report under-counts a whole schema to one table"
+        );
+        // A second export adds to the same total.
+        tally.add_export(
+            Some(ExportTarget::BigQuery),
+            &[failing_table_report("events", "events", 4)],
+        );
+        assert_eq!(
+            tally,
+            TargetFailTally {
+                columns: 7,
+                label: Some("bigquery"),
+                any_fatal: true
+            },
+            "7 refused columns, the FIRST target's label, and --strict must bail"
+        );
+
+        // A clean export adds nothing and does not clear what came before.
+        tally.add_export(Some(ExportTarget::BigQuery), &[empty_report("clean")]);
+        assert_eq!(tally.columns, 7, "a clean export is a no-op, not a reset");
+
+        // No target resolved ⇒ nothing to refuse, whatever the report says.
+        let mut untargeted = TargetFailTally::default();
+        untargeted.add_export(None, &[failing_table_report("cdc", "orders", 2)]);
+        assert_eq!(
+            untargeted,
+            TargetFailTally::default(),
+            "without a target there is no target-compatibility verdict to report"
+        );
     }
 
     #[test]

--- a/src/preflight/type_report.rs
+++ b/src/preflight/type_report.rs
@@ -175,6 +175,52 @@ pub fn collect_reports(
         .collect()
 }
 
+/// #32 (column-applicability): downgrade every overridden column whose override
+/// *narrows* the autodetected source type to [`TypeFidelity::Lossy`].
+///
+/// A `columns:` override like `price numeric(10,2)` → `decimal(20,0)` drops the
+/// two fractional digits at `run`, but `derive_fidelity` only ever sees the
+/// RESOLVED (overridden) type and labels it `exact` — so `check` disagrees with
+/// what `run` actually does. Re-probing the source WITHOUT overrides is what
+/// makes the narrowing visible; we downgrade only when autodetect resolved the
+/// source type confidently, never on a guess, so we don't fabricate a loss we
+/// can't prove.
+///
+/// `reprobe` is a closure rather than the `&mut dyn Source` itself so the
+/// EARLY-RETURN guard is testable without a database. That guard is not a
+/// micro-optimisation: it is one saved round-trip per report, and since a
+/// multiplex `tables:` export produces one report per captured table, a
+/// 154-table schema pays it 154 times. Losing it the other way is worse —
+/// skipping the block when overrides ARE present turns a lossy override back
+/// into a confident `exact`, which is the #32 bug returning. Both directions are
+/// pinned by `narrowing_downgrade_reprobes_only_when_overrides_exist`.
+fn downgrade_narrowing_overrides(
+    mappings: &mut [crate::types::TypeMapping],
+    column_overrides: &ColumnOverrides,
+    reprobe: impl FnOnce() -> Result<Vec<crate::types::TypeMapping>>,
+) -> Result<()> {
+    if column_overrides.is_empty() {
+        return Ok(());
+    }
+    let source_mappings = reprobe()?;
+    let source_by_name: std::collections::HashMap<&str, &crate::types::RivetType> = source_mappings
+        .iter()
+        .map(|m| (m.column_name.as_str(), &m.rivet_type))
+        .collect();
+    for m in mappings {
+        if !column_overrides.contains_key(&m.column_name) {
+            continue;
+        }
+        if let Some(&src_type) = source_by_name.get(m.column_name.as_str())
+            && let Some(reason) = override_narrows(src_type, &m.rivet_type)
+        {
+            m.fidelity = TypeFidelity::Lossy;
+            m.warnings.push(reason);
+        }
+    }
+    Ok(())
+}
+
 /// One unit's report, against an already-open source connection.
 fn collect_one(
     src: &mut dyn source::Source,
@@ -187,35 +233,9 @@ fn collect_one(
 ) -> Result<ExportTypeReport> {
     let mut mappings = src.type_mappings(query, column_overrides)?;
 
-    // #32 (column-applicability): a `columns:` override that *narrows* the
-    // source type — e.g. `price numeric(10,2)` → `decimal(20,0)` — drops the
-    // two fractional digits at `run`, but `derive_fidelity` only sees the
-    // resolved (overridden) `RivetType` and labels it `exact`. That makes
-    // `check --type-report` disagree with what `run` actually does (a
-    // check↔run gap). Re-probe the *autodetected* source types (no overrides)
-    // and downgrade any overridden column whose override narrows scale or
-    // integer-digit capacity to `Lossy`, with a warning that says why. We only
-    // downgrade when the source type is confidently known (autodetect resolved
-    // it) — never on a guess, so we don't fabricate a loss we can't prove.
-    if !column_overrides.is_empty() {
-        let source_mappings = src.type_mappings(query, &ColumnOverrides::new())?;
-        let source_by_name: std::collections::HashMap<&str, &crate::types::RivetType> =
-            source_mappings
-                .iter()
-                .map(|m| (m.column_name.as_str(), &m.rivet_type))
-                .collect();
-        for m in &mut mappings {
-            if !column_overrides.contains_key(&m.column_name) {
-                continue;
-            }
-            if let Some(&src_type) = source_by_name.get(m.column_name.as_str())
-                && let Some(reason) = override_narrows(src_type, &m.rivet_type)
-            {
-                m.fidelity = TypeFidelity::Lossy;
-                m.warnings.push(reason);
-            }
-        }
-    }
+    downgrade_narrowing_overrides(&mut mappings, column_overrides, || {
+        src.type_mappings(query, &ColumnOverrides::new())
+    })?;
 
     let mut violations = policy.validate(&mappings);
 
@@ -524,6 +544,102 @@ fn rivet_type_label(t: &crate::types::RivetType) -> String {
 mod tests {
     use super::*;
     use crate::types::{RivetType, TypeFidelity};
+
+    // ── downgrade_narrowing_overrides (#32) ──────────────────────────────────
+
+    fn mapping(column: &str, native: &str, t: RivetType) -> crate::types::TypeMapping {
+        crate::types::TypeMapping {
+            column_name: column.into(),
+            source_native_type: native.into(),
+            rivet_type: t,
+            arrow_type: None,
+            // `Exact` on purpose: that is exactly what `derive_fidelity` labels a
+            // resolved override, and what makes the #32 gap silent.
+            fidelity: TypeFidelity::Exact,
+            nullable: true,
+            warnings: vec![],
+        }
+    }
+
+    /// Both directions of the re-probe guard, and the downgrade itself.
+    ///
+    /// The guard was untestable while it lived inline in `collect_one`, which
+    /// needs a live database — the in-diff mutation gate graded `delete !` on it
+    /// as MISSED. Deleting the negation is a two-sided bug and both sides are
+    /// pinned here: with overrides present the block must RUN (or a lossy
+    /// override reports `exact`, the #32 bug back), and with none it must NOT
+    /// (or every report pays a second full type probe — 154 of them for a
+    /// 154-table multiplex).
+    ///
+    /// The re-probe is observed through a flag rather than inferred from the
+    /// result, because "no overrides" is precisely the case where running the
+    /// block changes NOTHING about the output: every column `continue`s. A test
+    /// that only compared mappings would be green against the mutant.
+    #[test]
+    fn narrowing_downgrade_reprobes_only_when_overrides_exist() {
+        let source = || {
+            vec![
+                mapping("price", "numeric(10,2)", dec(10, 2)),
+                mapping("id", "int8", RivetType::Int64),
+            ]
+        };
+
+        // No overrides → the source is never re-probed, and nothing is touched.
+        let mut untouched = source();
+        let probed = std::cell::Cell::new(false);
+        downgrade_narrowing_overrides(&mut untouched, &ColumnOverrides::new(), || {
+            probed.set(true);
+            Ok(source())
+        })
+        .unwrap();
+        assert!(
+            !probed.get(),
+            "no `columns:` overrides ⇒ no second type probe — the round-trip is \
+             per REPORT, and a multiplex export has one per captured table"
+        );
+        assert!(
+            untouched.iter().all(|m| m.fidelity == TypeFidelity::Exact),
+            "nothing to downgrade without an override"
+        );
+
+        // A narrowing override → re-probed, and the narrowed column is Lossy with
+        // a reason. `id` is overridden too but WIDENS, so it must stay exact —
+        // otherwise the test passes against a mutant that downgrades everything.
+        let mut overrides = ColumnOverrides::new();
+        overrides.insert("price".into(), dec(20, 0));
+        overrides.insert("id".into(), RivetType::Int64);
+        let mut mapped = vec![
+            mapping("price", "numeric(10,2)", dec(20, 0)),
+            mapping("id", "int8", RivetType::Int64),
+        ];
+        let probed = std::cell::Cell::new(false);
+        downgrade_narrowing_overrides(&mut mapped, &overrides, || {
+            probed.set(true);
+            Ok(source())
+        })
+        .unwrap();
+        assert!(
+            probed.get(),
+            "an override present ⇒ the source IS re-probed"
+        );
+        assert_eq!(
+            mapped[0].fidelity,
+            TypeFidelity::Lossy,
+            "decimal(20,0) over numeric(10,2) drops two fractional digits at run \
+             — reporting it `exact` is the check↔run gap #32 closed"
+        );
+        assert!(
+            mapped[0].warnings.iter().any(|w| w.contains("scale")),
+            "the downgrade must say WHY: {:?}",
+            mapped[0].warnings
+        );
+        assert_eq!(
+            mapped[1].fidelity,
+            TypeFidelity::Exact,
+            "a non-narrowing override is not downgraded — the rule is narrowing, \
+             not overridden-at-all"
+        );
+    }
 
     // ── report_units (#252: the multiplex `tables:` fan-out) ─────────────────
 

--- a/src/preflight/type_report.rs
+++ b/src/preflight/type_report.rs
@@ -42,10 +42,16 @@ pub struct TypeReportRow {
     pub cast_sql: Option<String>,
 }
 
-/// One export's type-report data.
+/// One export's type-report data — or, for a multiplex `tables:` CDC export, ONE
+/// TABLE'S (see [`collect_reports`]).
 #[derive(Serialize)]
 pub struct ExportTypeReport {
     pub export: String,
+    /// The source table this report describes. `Some` only for one table of a
+    /// multiplex `tables:` stream, where the export is N tables and each gets its
+    /// own document; `None` when the export IS the unit (`table:` / `query:`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub table: Option<String>,
     pub columns: Vec<TypeReportRow>,
     pub violations: Vec<PolicyViolation>,
     /// True when any column failed target-compatibility.
@@ -67,10 +73,63 @@ impl ExportTypeReport {
     pub fn has_target_fail(&self) -> bool {
         self.target_failures
     }
+
+    /// How this report addresses itself in operator-facing output: the export
+    /// name, or `<export>/<table>` for one table of a multiplex stream — the same
+    /// addressing `rivet validate` prints for the same layout, so an operator
+    /// reading `check` and `validate` side by side sees one naming scheme.
+    pub fn display_name(&self) -> String {
+        match &self.table {
+            Some(t) => format!("{}/{}", self.export, t),
+            None => self.export.clone(),
+        }
+    }
 }
 
-/// Collect type mappings for one export from a live connection.
-pub fn collect_report(
+/// The `(table, query)` units one export resolves to for type resolution.
+///
+/// A multiplex `tables:` CDC export drives N tables through ONE change stream,
+/// and each lands in its own destination sub-prefix and its own warehouse table
+/// — so it needs one resolver document PER TABLE. It also has no `query:` /
+/// `table:` at all, so asking it for one is not merely coarse: `resolve_query`
+/// bails ("must specify exactly one of 'query', 'query_file', or 'table'"),
+/// which is how a multiplex export got NO type report at all (#252).
+///
+/// The probe query is the same `SELECT * FROM {table}` the CDC capture itself
+/// uses for each table's schema (`source::cdc::CdcSchemaResolver::resolve`),
+/// through the same identifier guard — config-load gates a `tables:` entry only
+/// for FILENAME safety, which is weaker than SQL interpolation needs.
+fn report_units(
+    export: &ExportConfig,
+    config_dir: &std::path::Path,
+    params: Option<&std::collections::HashMap<String, String>>,
+) -> Result<Vec<(Option<String>, String)>> {
+    match export.multiplex_tables() {
+        Some(tables) => tables
+            .iter()
+            .map(|t| {
+                crate::source::cdc::validate_table_ident(t)?;
+                Ok((Some(t.clone()), format!("SELECT * FROM {t}")))
+            })
+            .collect(),
+        // Resolve the effective query the same way the export pipeline does, so
+        // the `table:` shortcut (and `query_file:` / `${var}` params) produce a
+        // real query instead of an empty string.
+        None => Ok(vec![(None, export.resolve_query(config_dir, params)?)]),
+    }
+}
+
+/// Collect type mappings for one export from a live connection — **one report
+/// per unit**: one for an ordinary export, one PER TABLE for a multiplex
+/// `tables:` CDC stream (see [`report_units`]).
+///
+/// The fan-out lives here rather than at each caller because both callers need
+/// it and neither can be trusted to re-derive it: `rivet check --target` renders
+/// these documents and `rivet load` PLANS from them, so a caller that saw one
+/// document per export would load N tables into one warehouse table (or, before
+/// #252, fail outright). One connection serves every table — a 154-table
+/// multiplex must not open 154 of them.
+pub fn collect_reports(
     config: &Config,
     export: &ExportConfig,
     column_overrides: &ColumnOverrides,
@@ -78,13 +137,10 @@ pub fn collect_report(
     target: Option<ExportTarget>,
     config_dir: &std::path::Path,
     params: Option<&std::collections::HashMap<String, String>>,
-) -> Result<ExportTypeReport> {
+) -> Result<Vec<ExportTypeReport>> {
+    let units = report_units(export, config_dir, params)?;
     let url = config.source.resolve_url()?;
     let tls = config.source.tls.as_ref();
-    // Resolve the effective query the same way the export pipeline does, so the
-    // `table:` shortcut (and `query_file:` / `${var}` params) produce a real
-    // query instead of an empty string.
-    let query = export.resolve_query(config_dir, params)?;
 
     let mut src: Box<dyn source::Source> = match config.source.source_type {
         SourceType::Postgres => Box::new(source::postgres::PostgresSource::connect_with_tls(
@@ -95,7 +151,41 @@ pub fn collect_report(
         SourceType::Mongo => Box::new(source::mongo::MongoSource::connect(&url, tls, None)?),
     };
 
-    let mut mappings = src.type_mappings(&query, column_overrides)?;
+    units
+        .into_iter()
+        .map(|(table, query)| {
+            // A `columns:` override on a multiplex export can be qualified
+            // (`orders.amount`) or bare — narrow it to THIS table exactly the way
+            // the capture does, so `check`/`load` type a table the same way `run`
+            // writes it.
+            let overrides = match &table {
+                Some(t) => crate::types::overrides_for_table(column_overrides, t),
+                None => column_overrides.clone(),
+            };
+            collect_one(
+                src.as_mut(),
+                export,
+                table,
+                &query,
+                &overrides,
+                policy,
+                target,
+            )
+        })
+        .collect()
+}
+
+/// One unit's report, against an already-open source connection.
+fn collect_one(
+    src: &mut dyn source::Source,
+    export: &ExportConfig,
+    table: Option<String>,
+    query: &str,
+    column_overrides: &ColumnOverrides,
+    policy: &TypePolicy,
+    target: Option<ExportTarget>,
+) -> Result<ExportTypeReport> {
+    let mut mappings = src.type_mappings(query, column_overrides)?;
 
     // #32 (column-applicability): a `columns:` override that *narrows* the
     // source type — e.g. `price numeric(10,2)` → `decimal(20,0)` — drops the
@@ -108,7 +198,7 @@ pub fn collect_report(
     // downgrade when the source type is confidently known (autodetect resolved
     // it) — never on a guess, so we don't fabricate a loss we can't prove.
     if !column_overrides.is_empty() {
-        let source_mappings = src.type_mappings(&query, &ColumnOverrides::new())?;
+        let source_mappings = src.type_mappings(query, &ColumnOverrides::new())?;
         let source_by_name: std::collections::HashMap<&str, &crate::types::RivetType> =
             source_mappings
                 .iter()
@@ -202,11 +292,15 @@ pub fn collect_report(
     // L5 recovery SQL (ADR-0014): a post-load transform for operators whose
     // bare autoload would degrade types. `None` for DuckDB (faithful autoload)
     // or when no target is set.
-    let recovery_sql =
-        target.and_then(|t| t.recovery_sql(&t.resolve_table(&mappings), &export.name));
+    // The recovery SQL names the table it recovers — for a multiplex unit that is
+    // THIS table, not the export (154 tables all pointed at a `cdc` table would be
+    // a hint the operator cannot run).
+    let sql_table = table.as_deref().unwrap_or(&export.name);
+    let recovery_sql = target.and_then(|t| t.recovery_sql(&t.resolve_table(&mappings), sql_table));
 
     Ok(ExportTypeReport {
         export: export.name.clone(),
+        table,
         columns: rows,
         violations,
         target_failures,
@@ -224,9 +318,13 @@ pub fn print_table(report: &ExportTypeReport, target: Option<ExportTarget>) {
 
     println!();
     if let Some(tgt) = target {
-        println!("Export: {}  [target: {}]", report.export, tgt.label());
+        println!(
+            "Export: {}  [target: {}]",
+            report.display_name(),
+            tgt.label()
+        );
     } else {
-        println!("Export: {}", report.export);
+        println!("Export: {}", report.display_name());
     }
 
     if target.is_some() {
@@ -426,6 +524,105 @@ fn rivet_type_label(t: &crate::types::RivetType) -> String {
 mod tests {
     use super::*;
     use crate::types::{RivetType, TypeFidelity};
+
+    // ── report_units (#252: the multiplex `tables:` fan-out) ─────────────────
+
+    fn cfg_from(yaml: &str) -> Config {
+        Config::from_yaml(yaml).unwrap()
+    }
+
+    /// A multiplex `tables:` CDC export must resolve ONE unit per captured table.
+    ///
+    /// Before #252 it resolved none at all: the export carries no `table:` and no
+    /// `query:`, so `resolve_query` bailed ("must specify exactly one of 'query',
+    /// 'query_file', or 'table'") and `rivet check --target` fell through to a
+    /// diagnostic-only line while `rivet load` failed outright — for a config
+    /// shape `rivet init --mode cdc` emits by default.
+    ///
+    /// The probe query must be the SAME `SELECT * FROM {table}` the capture uses
+    /// for that table's schema; a per-table query that differs would type the
+    /// table differently from the way `run` writes it.
+    #[test]
+    fn report_units_yields_one_unit_per_multiplex_table() {
+        let config = cfg_from(
+            r#"
+source:
+  type: postgres
+  url: "postgresql://localhost/test"
+exports:
+  - name: cdc
+    tables: [orders, customers, line_items]
+    mode: cdc
+    format: parquet
+    cdc:
+      checkpoint: ./cdc.ckpt
+    destination:
+      type: local
+      path: /tmp/x
+"#,
+        );
+        let units = report_units(&config.exports[0], std::path::Path::new("."), None).unwrap();
+        assert_eq!(
+            units,
+            vec![
+                (Some("orders".into()), "SELECT * FROM orders".to_string()),
+                (Some("customers".into()), "SELECT * FROM customers".into()),
+                (Some("line_items".into()), "SELECT * FROM line_items".into()),
+            ],
+            "each captured table is its own resolver unit, probed the way the \
+             capture probes it"
+        );
+    }
+
+    /// The other side of the same branch: a single-table export is ONE unit whose
+    /// `table` is `None` — the export IS the unit, so nothing downstream starts
+    /// fanning out an ordinary export into per-table plans.
+    #[test]
+    fn report_units_leaves_a_single_table_export_as_one_unnamed_unit() {
+        let config = cfg_from(
+            r#"
+source:
+  type: postgres
+  url: "postgresql://localhost/test"
+exports:
+  - name: orders
+    table: public.orders
+    mode: full
+    format: parquet
+    destination:
+      type: local
+      path: /tmp/x
+"#,
+        );
+        let units = report_units(&config.exports[0], std::path::Path::new("."), None).unwrap();
+        assert_eq!(
+            units,
+            vec![(None, "SELECT * FROM public.orders".to_string())],
+            "a `table:` export resolves its own query, unnamed — the export is the unit"
+        );
+    }
+
+    /// `display_name` is what an operator reads in the type-report header, and it
+    /// must distinguish the N documents a multiplex export now emits — otherwise
+    /// 154 tables print 154 blocks all headed `Export: cdc`. Matches the
+    /// `<export>/<table>` addressing `rivet validate` already prints.
+    #[test]
+    fn display_name_addresses_a_multiplex_unit_by_export_and_table() {
+        let base = ExportTypeReport {
+            export: "cdc".into(),
+            table: None,
+            columns: vec![],
+            violations: vec![],
+            target_failures: false,
+            recovery_sql: None,
+        };
+        assert_eq!(base.display_name(), "cdc");
+        let unit = ExportTypeReport {
+            table: Some("orders".into()),
+            ..base
+        };
+        assert_eq!(unit.display_name(), "cdc/orders");
+    }
 
     // ── override_narrows (#32: lossy scale/precision narrowing) ──────────────
 

--- a/src/source/cdc/mod.rs
+++ b/src/source/cdc/mod.rs
@@ -952,7 +952,12 @@ pub(crate) fn resolve_cdc_columns(
 /// The table name is interpolated into `SELECT * FROM {table}` for the schema
 /// probe — refuse anything but a plain `[schema.]table` identifier (no quote,
 /// paren, semicolon, or space can break out).
-fn validate_table_ident(table: &str) -> Result<()> {
+///
+/// `pub(crate)` because the type-report resolver builds the SAME probe query for
+/// each table of a `tables:` stream: config-load only gates those names for
+/// FILENAME safety (they become destination path segments), which is a weaker
+/// alphabet than SQL interpolation needs.
+pub(crate) fn validate_table_ident(table: &str) -> Result<()> {
     if table.is_empty()
         || !table
             .chars()

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -2249,6 +2249,105 @@ fn pg_cdc_multi_table_stream_uses_one_slot_and_resumes() {
     assert_eq!(manifest_rows(&out.join(&t2)), 0, "no re-read for table 2");
 }
 
+// #252, half 1: `check --target` on a multiplex `tables:` export must emit one
+// RESOLVER document per captured table, not one per export.
+//
+// A multiplex export has no `table:` and no `query:`, so resolving "the export's
+// query" bailed and the type report was dropped with a `warn` — under `--json`
+// the export's line was the TUNING diagnostic (`export_name`, no `columns`)
+// instead. That is what `rivet load` consumes for the native schema, so a whole
+// schema captured through one stream could not be loaded at all.
+//
+// Driven through the real binary (the resolver runs in-process for `load` too),
+// and the per-table `columns:` narrowing is asserted alongside: a multiplex unit
+// must be typed with THIS table's overrides — bare keys everywhere, a
+// `"<table>.<column>"` key only on its own table — the same precedence the
+// capture applies, or `check` and `run` describe different Parquet.
+#[test]
+#[ignore = "live: requires docker compose postgres (wal_level=logical)"]
+fn pg_cdc_multi_table_check_target_emits_one_resolver_document_per_table() {
+    use postgres::NoTls;
+    let t1 = unique_name("rivet_cdc_tr_a");
+    let t2 = unique_name("rivet_cdc_tr_b");
+    let slot = unique_name("rivet_tr_slot");
+    let mut c = postgres::Client::connect(POSTGRES_CDC_URL, NoTls).expect("connect postgres");
+    for t in [&t1, &t2] {
+        c.batch_execute(&format!(
+            "DROP TABLE IF EXISTS {t}; CREATE TABLE {t} (id INT PRIMARY KEY, v INT)"
+        ))
+        .unwrap();
+    }
+    let (_g1, _g2) = (
+        PgTable::adopt_on(POSTGRES_CDC_URL, t1.clone()),
+        PgTable::adopt_on(POSTGRES_CDC_URL, t2.clone()),
+    );
+
+    // No `run` here: the report is resolved from the source catalog, so this
+    // needs no slot, no capture and no destination bytes.
+    let rig = Rig::pg_cdc(&t1, &slot)
+        .tables(&[&t1, &t2])
+        .export_named("app_cdc")
+        .export_line(&format!("columns: {{ \"{t2}.v\": text }}"));
+    let out = rig.cli(&["check", "--target", "bigquery", "--json"]);
+    assert!(
+        out.status.success(),
+        "check --target must succeed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    // NDJSON: the type-report lines are the ones carrying `columns`. A
+    // diagnostic-only line (the pre-fix shape) has none, so this filter is
+    // exactly the assertion — it counts documents the loader could USE.
+    let docs: Vec<serde_json::Value> = stdout
+        .lines()
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .filter(|v| v.get("columns").is_some())
+        .collect();
+    assert_eq!(
+        docs.len(),
+        2,
+        "one resolver document per captured table — got {} from:\n{stdout}",
+        docs.len()
+    );
+    let by_table = |t: &str| {
+        docs.iter()
+            .find(|d| d["table"] == serde_json::json!(t))
+            .unwrap_or_else(|| panic!("no resolver document for table {t} in:\n{stdout}"))
+    };
+    for t in [&t1, &t2] {
+        let d = by_table(t);
+        assert_eq!(
+            d["export"],
+            serde_json::json!("app_cdc"),
+            "each document still names the EXPORT the operator wrote"
+        );
+        let cols: Vec<&str> = d["columns"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|c| c["column"].as_str().unwrap())
+            .collect();
+        assert_eq!(cols, vec!["id", "v"], "table {t} columns");
+    }
+    // The qualified override lands on t2 ONLY: BigQuery STRING there, INT64 on
+    // the table it does not name. A unit typed with the export's whole override
+    // map would make both STRING.
+    let target_of = |t: &str| {
+        by_table(t)["columns"].as_array().unwrap()[1]["target_type"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    };
+    assert_eq!(target_of(&t1), "INT64", "bare table keeps its source type");
+    assert_eq!(
+        target_of(&t2),
+        "STRING",
+        "the `<table>.<column>` override applies to its own table only — the \
+         same precedence the capture uses"
+    );
+}
+
 // MySQL flavour of the multi-table stream: one binlog connection + one
 // checkpoint for both tables, idle-first-run pin included.
 #[test]

--- a/tests/offline/live_only_purity_gate.rs
+++ b/tests/offline/live_only_purity_gate.rs
@@ -158,7 +158,11 @@ const BASELINE: &[(&str, usize, usize, usize, usize)] = &[
     // `check` diagnoses every export against a live source. The `==` in its
     // overlay export-match loop is already a named mutants.toml entry
     // (`replace == with != in check$`, anchored) — same story as run_pool.
-    ("src/preflight/mod.rs::check", 6, 0, 7, 2),
+    // 6→5 `and`: the target-FAIL tally (`if let Some(t) = eff_target && report
+    // .has_target_fail()`, plus the `+=` it guarded) moved out to the pure
+    // `TargetFailTally::add_export`, where the in-diff gate's `+=` → `*=`/`-=`
+    // mutants are graded instead of MISSED.
+    ("src/preflight/mod.rs::check", 5, 0, 7, 2),
 ];
 
 // ── reading the live-only set out of the mutation config ─────────────────


### PR DESCRIPTION
Closes #252.

A `mode: cdc` export with `tables:` — the config `rivet init --mode cdc` emits for a whole schema — could not be loaded into a warehouse at all.

## The failure, as it actually is today

The issue's repro is stale: #263 removed the `rivet check --json` subprocess from the load path, so its `missing field 'export'` JSON-parse error can no longer occur. Reproduced on current `main` before touching anything:

```
$ rivet load -c mux.yaml
Error: export 'cdc': resolving column types for the bigquery load:
       export 'cdc': must specify exactly one of 'query', 'query_file', or 'table'
```

and, on the same config:

```
$ rivet check -c mux.yaml --target bigquery --json
WARN type report for 'cdc' failed: must specify exactly one of 'query', 'query_file', or 'table'
{"export_name":"cdc","strategy":"cdc",...}      # the TUNING diagnostic — no `columns`
```

Different error, same two halves the issue named. Both are real.

## Half 1 — the type resolver fans out per table

A multiplex export carries no `table:` and no `query:`, so asking it for "the export's query" bails; the type report was dropped with a `warn` and the export's `--json` line degraded to the tuning diagnostic — which is exactly what `rivet load` reads for the native schema.

`collect_report` becomes `collect_reports`, returning **one document per UNIT**: one for an ordinary export, one **per table** for a multiplex stream. Each table is probed with the same `SELECT * FROM {table}` the capture uses for its schema, through the same identifier guard, with the export's `columns:` overrides narrowed per table (`overrides_for_table`) the way the capture narrows them. One source connection serves every table — a 154-table multiplex must not open 154.

`ExportTypeReport` gains `table: Option<String>` (skipped when absent, so the NDJSON wire shape is unchanged for every existing config) and `display_name()` → `cdc/orders`, matching the addressing `rivet validate` already prints.

Replacing `collect_report` rather than adding a sibling is deliberate: both callers need the fan-out, and a caller that can still reach the un-fanned version is the runner-bypass class.

## Half 2 — one `LoadPlan` per table

`build_plans` mapped report→export 1:1. Each report now carries its table, so a multiplex export produces one plan per table: its own warehouse table, and its own `<base>/<table>/` staging prefix built by the **writer's own** function (`cdc_job::dest_for_table`) rather than a second concatenation rule — the same layout `rivet validate` descends.

The prefix is the load-critical half. The manifest listing is **recursive**, so N plans sharing the base prefix would each sweep in every sibling table's parts and merge N source tables into one warehouse table, with every count agreeing on the way through.

`ExportConfig::multiplex_tables()` is now the one place "is this export one unit or N?" is decided; `validate_cmd` reads it too instead of re-deriving the rule.

## Tests — every one RED-proven against its own mutant

| test | mutant it goes RED against |
| --- | --- |
| `report_units_yields_one_unit_per_multiplex_table` | `multiplex_tables()` forced to `None` (the pre-fix behaviour) — 0 units for a 3-table stream |
| `build_plans_fans_a_multiplex_tables_export_out_to_one_plan_per_table` | drop `report.table` → all three collapse onto `cdc` (duplicate-target bail); drop the sub-prefix → `["gs://b/exports/cdc/"; 3]` |
| `table_load_prefix_appends_one_slash_delimited_segment` | naive `{base}{table}/` concat → `gs://b/exports/cdcorders/` |
| `multiplex_tables_is_some_only_for_a_cdc_export_with_a_non_empty_list` | drop the CDC gate (`mode: full` presents as a multiplex); drop the empty-list filter (`Some([])` — a fan-out over nothing) |
| `pg_cdc_multi_table_check_target_emits_one_resolver_document_per_table` (live) | the pre-fix resolver — `got 0` resolver documents |

The plan test's `Some(table)` values come from `multiplex_tables()`, the real producer, not hand-typed — so a mutant in the producer turns it red, not only one in the consumer.

The live test also asserts a `"<table>.<column>"` override retypes **only** its own table (BigQuery STRING vs INT64), pinning the per-table override narrowing.

## Live end-to-end, graded by BigQuery itself

3-table PostgreSQL multiplex (one slot) → GCS → BigQuery. Every number below is `bq query` answering, never rivet's own `rows_appended`.

Run 1 + load 1 — `INFORMATION_SCHEMA.TABLES` shows exactly one `<table>__changes` BASE TABLE + one dedup VIEW **per source table**:

| table | rows | distinct id | source |
| --- | --- | --- | --- |
| `mux252_orders` | 5 | 5 | 5 |
| `mux252_customers` | 4 | 4 | 4 |
| `mux252_items` | 3 | 3 | 3 |

Then an UPDATE+INSERT / DELETE / UPDATE+INSERT round, run 2 + load 2:

- `mux252_orders` — 6 rows, `id=1` at `999.99`, `id=6` present
- `mux252_items` — 4 rows, `id=2` at `qty=42`, `id=4` present
- `mux252_customers` — `id=4` survives as `__is_deleted = true` (the documented tombstone semantics, untouched)

`rivet validate` PASSED on all six sub-prefixes (three tables plus their nested `snapshot/`).

## Also

- `docs/cdc-bigquery-load.md` — a whole-schema section documenting the layout and what `load` builds from it.
- `docs/load-mode-matrix.yaml` — a `multiplex_tables_one_plan_per_table` row (`na` on full/incremental: `tables:` is refused outside `mode: cdc`).
- `pipeline::cdc_job` is `pub(crate)` unconditionally (it was `pub(crate)` only under `cfg(test)`), so the load layer reads the destination layout from where it is written.

`cargo build`, `cargo test --lib` (2560), `cargo test --test offline_suite` (281), `cargo clippy --all-targets -D warnings`, and the touched live suites are green. The 19 `live_cdc` tests that fail here fail on the pre-existing worktree guard (`tests/common/env.rs:154` — the duckdb/clickhouse oracle bind-mounts the main checkout), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168uwctCn3W1rP4Kt4kZXvE
