### PR TITLE
fix(mutation-gate): scope the P2 audit's oracle to the P2 class

### DIFF
--- a/.github/scripts/mutants_classify.py
+++ b/.github/scripts/mutants_classify.py
@@ -63,6 +63,14 @@ Usage:
         silently un-grading P1 mutants is the exact defect
         `mutants_exclusions.py` exists to catch in the hand-written list.
 
+  mutants_classify.py audit <p2-list> <caught-list>
+        Grade the P2-AUDIT run's kills AGAINST the P2 class. Exits 1 (the
+        `oracle-lied` state) only when a mutant that is genuinely in the
+        report-only class was caught offline. A kill on anything else is a P1
+        mutant that LEAKED into the audit corpus — reported, never counted as
+        evidence about a class it was never in. See `audit`'s docstring for the
+        measured leak this exists for.
+
   mutants_classify.py --states     the state vocabulary, one per line
   mutants_classify.py --self-test
 """
@@ -245,9 +253,51 @@ def verify(expected: list[str], actual: list[str]) -> list[str]:
         errors.append(
             f"::error::{len(got - want)} mutant(s) survived the exclusions that were meant to "
             "be deprioritised — the restriction did not take, so the run below would not be "
-            f"the class it reports:\n  {sample}"
+            f"the class it reports. An over-broad pattern is one cause; the other is a mutant "
+            "cargo-mutants cannot filter AT ALL (see `audit` below — `Genre::StructField`, the "
+            f"`delete field X from struct Y expression` shape, bypasses `--exclude-re`):\n  {sample}"
         )
     return errors
+
+
+def audit(p2: list[str], caught: list[str]) -> tuple[list[str], list[str]]:
+    """(in-class kills, leaked) over the P2-audit run's `caught.txt`.
+
+    The audit runs the corpus with the P1 exclusions applied and asks whether
+    the offline suite can kill anything left — a kill would falsify "this class
+    is unkillable offline" and make the split unsound (`oracle-lied`). That is
+    only true of a mutant the run actually CLASSIFIED P2. What survives the P1
+    exclusions is not automatically P2, and on 2026-08-22 it was not: PR #265's
+    audit caught four mutants, all of them P1, none of them in the P2 list the
+    same run had just printed.
+
+    Measured cause, in cargo-mutants 27.1.0 (`src/visit.rs`): every genre is
+    created through `collect_mutant`, which gates on `options.allows_mutant()` —
+    except `Genre::StructField` (`delete field X from struct Y expression`),
+    which is pushed straight onto `self.mutants`. So `--exclude-re` cannot
+    remove one, from the CLI or from `.cargo/mutants.toml`. Probed directly on
+    the branch: `cargo mutants --list --file src/load/plan.rs` yields 56 names,
+    and `--exclude-re .` — a pattern matching every one of them — leaves 4, all
+    `StructField`. Those four leaked into the audit corpus, were caught (they
+    sit in `table_load_prefix`, which `load::plan::tests` covers), and were read
+    as "a mutant classified unkillable was killed".
+
+    So the oracle is SCOPED to the class it audits rather than to whatever the
+    exclusions happened to leave. This narrows nothing the gate was entitled to:
+    a genuinely-P2 kill still trips `oracle-lied`. The leak in the other
+    direction — an unexcludable mutant that IS in P2, so the MAIN run cannot
+    deprioritise it — is already fail-closed by `verify`, which sees it survive
+    the P2 exclusions, discards them, and grades the whole diff.
+    """
+    want = {strip_ansi(n).strip() for n in p2 if strip_ansi(n).strip()}
+    in_class: list[str] = []
+    leaked: list[str] = []
+    for name in caught:
+        name = strip_ansi(name).strip()
+        if not name:
+            continue
+        (in_class if name in want else leaked).append(name)
+    return in_class, leaked
 
 
 # --------------------------------------------------------------------------
@@ -307,6 +357,28 @@ _COV = {
     ],
 }
 
+# PR #265's P2-audit, verbatim from the `Mutants (changed lines)` log of run
+# 32570267943. `_AUDIT_LEAK` is the whole of that run's `caught.txt` — four
+# lines, two distinct mutants, each listed twice because `src/main.rs` declares
+# the same modules as `src/lib.rs` and cargo-mutants walks both target roots.
+#
+# Not one of them was in the P2 list the same run printed (that list was ten
+# distinct mutants in `src/preflight/`, two of which are `_AUDIT_P2` here).
+# They are `Genre::StructField` mutants, which cargo-mutants 27.1.0 cannot
+# filter — so they leaked past the audit's P1 exclusions and were caught, and
+# the gate read four kills in code the offline suite demonstrably executes as
+# proof that its zero-coverage measurement had lied.
+_AUDIT_P2 = [
+    "src/preflight/type_report.rs:333:5: replace print_table with ()",
+    "src/preflight/mod.rs:542:51: delete ! in check",
+]
+_AUDIT_LEAK = [
+    "src/load/plan.rs:378:13: delete field destination_type from struct "
+    "crate::config::DestinationConfig expression in table_load_prefix",
+    "src/load/plan.rs:379:13: delete field prefix from struct "
+    "crate::config::DestinationConfig expression in table_load_prefix",
+] * 2
+
 
 def self_test() -> int:
     """Grade the classifier over the shapes it must judge.
@@ -325,6 +397,10 @@ def self_test() -> int:
         corpus full of `->`, `*`, `+`, `(` and `[`;
       * `function_extents` returning `[]` instead of raising on a shape it does
         not know — an unreadable report reads as "nothing is covered".
+      * `audit` attributing every kill to the report-only class (`return
+        list(caught), []`, which is what the workflow's `[ -s caught.txt ]`
+        test did before 2026-08-22) — PR #265's four leaked `StructField`
+        kills go back to reading as `oracle-lied`.
     """
     extents_rows = function_extents(_COV, root="/repo")
     ext = load_extents([f"{f}\t{lo}\t{hi}\t{c}" for (f, lo, hi, c) in extents_rows])
@@ -387,6 +463,31 @@ def self_test() -> int:
     errs = verify(corpus[:1], corpus)
     assert errs and "survived the exclusions" in errs[0], errs
 
+    # The P2 AUDIT is scoped to the P2 class, over PR #265's real numbers.
+    #
+    # A mutant that cargo-mutants cannot exclude sits in the audit corpus
+    # whatever the P1 exclusions say, so "the audit caught something" and "a
+    # report-only mutant was killed" are different statements. Grading the
+    # first as the second is what failed that PR with `oracle-lied` while its
+    # own code was clean (0 missed of 68 graded).
+    in_class, leaked = audit(_AUDIT_P2, _AUDIT_LEAK)
+    assert in_class == [], (
+        "a kill on a mutant that was never in the report-only class is not evidence about "
+        f"that class — the audit still reads it as an oracle break: {in_class}"
+    )
+    assert len(leaked) == 4, leaked
+
+    # …and the oracle still bites where it is supposed to. One genuinely-P2
+    # kill among the leak is `oracle-lied`, which is the whole point of running
+    # the class instead of trusting the measurement.
+    in_class, leaked = audit(_AUDIT_P2, _AUDIT_LEAK + [_AUDIT_P2[0]])
+    assert in_class == [_AUDIT_P2[0]], in_class
+    assert len(leaked) == 4, leaked
+
+    # An audit that killed nothing is the ordinary healthy case; so is an
+    # absent/empty caught.txt, which the CLI passes through as [].
+    assert audit(_AUDIT_P2, []) == ([], [])
+
     # A report shape this script does not know is an ERROR, never an empty
     # coverage set — the difference between "the prioritisation did not run"
     # and "no function in this crate is executed".
@@ -423,7 +524,8 @@ def self_test() -> int:
     print(
         "self-test ok: executed / zero-coverage / unmeasured-file / uncovered-line / "
         "unparseable classification, the no-coverage fallback, exact exclusions, "
-        "both verify directions, and six rejected report shapes"
+        "both verify directions, six rejected report shapes, and the P2 audit scoped "
+        "to the P2 class over PR #265's leaked StructField kills"
     )
     return 0
 
@@ -497,6 +599,49 @@ def main(argv: list[str]) -> int:
         for line in errors:
             print(line)
         return 1 if errors else 0
+
+    if len(argv) == 4 and argv[1] == "audit":
+        # The P2 list must be READABLE. Without it every kill would look like a
+        # leak and the audit would report `oracle-holds` having compared
+        # nothing — fail-open on exactly the check that keeps the report-only
+        # class honest. Unreadable is therefore a break, like any other.
+        try:
+            p2 = Path(argv[2]).read_text().splitlines()
+        except OSError as e:
+            print(
+                f"::error::cannot read the report-only class {argv[2]}: {e}. The audit has "
+                "nothing to compare its kills against, and an audit that compares nothing "
+                "must not report that the classification held.",
+            )
+            return 1
+        # An absent caught.txt is the ordinary "the audit killed nothing" case:
+        # cargo-mutants writes the file only once it has a kill to record, and
+        # the run is invoked with `|| true` so a broken audit lands here too.
+        caught = Path(argv[3]).read_text().splitlines() if Path(argv[3]).exists() else []
+        in_class, leaked = audit(p2, caught)
+        if leaked:
+            print(
+                f"::notice::{len(leaked)} mutant(s) were caught in the P2-audit run that are "
+                "NOT in the report-only class. They are graded-class mutants cargo-mutants "
+                "could not exclude from the audit corpus — `Genre::StructField` (`delete field "
+                "X from struct Y expression`) bypasses `--exclude-re` entirely in 27.1.0 — so "
+                "their being caught says nothing about the classification. They are graded on "
+                f"their own account in the run above:\n  " + "\n  ".join(sorted(set(leaked))[:5])
+            )
+        if in_class:
+            print(
+                f"::error::the offline suite CAUGHT {len(in_class)} mutant(s) this run had "
+                "classified as unkillable offline. The coverage measurement and the test run "
+                "disagree, so the report-only class is not safe and nothing may be "
+                f"deprioritised on it:\n  " + "\n  ".join(sorted(set(in_class))[:10])
+            )
+            return 1
+        print(
+            f"ok: the report-only class held — {len(p2)} mutant(s) classified unkillable "
+            f"offline, none of them killed by the offline suite ({len(leaked)} unexcludable "
+            "graded-class mutant(s) ran alongside them and were ignored)."
+        )
+        return 0
 
     print(__doc__, file=sys.stderr)
     return 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -545,18 +545,37 @@ jobs:
           # checks its own oracle with it. Past the budget the audit is skipped
           # and SAID to be skipped — that is the trade the prioritisation buys,
           # and it is named rather than implied.
+          #
+          # The kills are graded AGAINST p2.txt, not against "whatever survived
+          # the P1 exclusions". Those are not the same set, and on 2026-08-22
+          # (PR #265) the difference failed a clean PR: the audit caught four
+          # mutants, all of them P1, none of them in the P2 list the same run
+          # had just printed — and the old `[ -s caught.txt ]` test read that as
+          # `oracle-lied`. Measured cause, cargo-mutants 27.1.0 `src/visit.rs`:
+          # every genre goes through `collect_mutant`, which gates on
+          # `options.allows_mutant()`, EXCEPT `Genre::StructField` (`delete
+          # field X from struct Y expression`) which is pushed straight onto
+          # `self.mutants`. `--exclude-re` cannot remove one — probed on that
+          # branch, `--exclude-re .` over `src/load/plan.rs` left exactly the 4
+          # StructField mutants of 56. So the audit corpus always contains any
+          # unexcludable P1 mutant, and a kill on one is not evidence about a
+          # class it was never in. Scoping the oracle is the fix; it takes
+          # nothing away, since a genuinely-P2 kill still fails the gate.
+          #
+          # The mirror-image leak — an unexcludable mutant that IS in P2, which
+          # the MAIN run therefore cannot deprioritise — is already fail-closed
+          # one step up: `verify` sees it survive the P2 exclusions, discards
+          # them, and the whole diff is graded.
           if [ "$P2" -gt 0 ]; then
             if [ $((P1 + P2)) -le "$MUTANTS_DIFF_BUDGET" ]; then
               DROP_P1=()
               while IFS= read -r pat; do DROP_P1+=(--exclude-re "$pat"); done < drop-p1.txt
               cargo mutants --in-diff pr.diff ${DROP_P1[@]+"${DROP_P1[@]}"} -j 2 \
                 -o p2-audit -- --lib --bins || true
-              if [ -s p2-audit/mutants.out/caught.txt ]; then
-                say p2_audit oracle-lied
-                echo "::error::the offline suite CAUGHT $(grep -c . p2-audit/mutants.out/caught.txt) mutant(s) this run had classified as unkillable offline. The coverage measurement and the test run disagree, so the report-only class is not safe and nothing may be deprioritised on it:"
-                sed -n '1,10p' p2-audit/mutants.out/caught.txt >&2
-              else
+              if python3 "$CLASSIFY" audit p2.txt p2-audit/mutants.out/caught.txt; then
                 say p2_audit oracle-holds
+              else
+                say p2_audit oracle-lied
               fi
             else
               say p2_audit skipped-over-budget
@@ -1055,6 +1074,11 @@ jobs:
       # covered". Everything it does not know must land in the graded class;
       # that fallback is the only thing standing between this split and "it
       # wasn't covered, so it doesn't count".
+      #
+      # It also grades the P2-AUDIT's oracle, over PR #265's four real kills:
+      # a mutant caught in the audit run that was never CLASSIFIED P2 says
+      # nothing about the report-only class, and reading it as `oracle-lied`
+      # failed a PR whose own diff was clean.
       - name: The mutant prioritiser fails closed
         run: python3 .github/scripts/mutants_classify.py --self-test
       # The harness thermometer's SHAPING, over fixtures of counts: an unknown

--- a/tests/offline/mutation_gate_priority_guard.rs
+++ b/tests/offline/mutation_gate_priority_guard.rs
@@ -121,9 +121,11 @@ fn job_shell(job: &str, floor: usize) -> String {
 /// branch inside one, function measured at zero, unmentioned file, uncovered
 /// line, unparseable name), the no-coverage fallback, the exactness of the
 /// generated `--exclude-re` patterns, both directions of the post-exclusion
-/// verification, and six coverage-report shapes it must REFUSE rather than read
-/// as "nothing is covered". Each case is RED-provable against one named mutant
-/// in the script; the mutants are listed in its `self_test` docstring.
+/// verification, six coverage-report shapes it must REFUSE rather than read
+/// as "nothing is covered", and the P2-audit's oracle scoped to the P2 class
+/// (over PR #265's four real leaked kills). Each case is RED-provable against
+/// one named mutant in the script; the mutants are listed in its `self_test`
+/// docstring.
 #[test]
 fn the_mutant_prioritiser_passes_its_own_self_test() {
     let out = classify(&["--self-test"]);
@@ -261,11 +263,13 @@ fn only_a_function_measured_at_zero_leaves_the_graded_class() {
 /// the job's `run:` shell with comments stripped, so the long comment blocks
 /// above each command — which name these very invocations — cannot satisfy it.
 ///
-/// RED-proven three times, each with the rest of this file staying green:
+/// RED-proven four times, each with the rest of this file staying green:
 /// replacing the MEASURED partition branch with `true` (the workflow still
 /// calls the classifier and still grades one undifferentiated pile — caught on
 /// `--extents fn-extents.tsv`); turning the post-exclusion `verify` into
-/// `if false`; and deleting the `--self-test` step from `gate-scripts`.
+/// `if false`; restoring the audit's `[ -s p2-audit/mutants.out/caught.txt ]`
+/// test in place of the scoped `audit p2.txt`; and deleting the `--self-test`
+/// step from `gate-scripts`.
 #[test]
 fn the_mutation_gate_actually_invokes_the_prioritiser() {
     let mutate = job_shell("mutants-in-diff", 40);
@@ -293,6 +297,20 @@ fn the_mutation_gate_actually_invokes_the_prioritiser() {
             "verify p1.txt p1-check.txt",
             "the check that the generated exclusions removed exactly the report-only class; \
              without it an over-broad pattern silently un-grades blocking mutants",
+        ),
+        (
+            // The audit's oracle must be SCOPED to p2.txt. Reading
+            // `caught.txt` directly (`[ -s ... ]`, as this step did until
+            // 2026-08-22) grades kills on mutants that were never in the
+            // report-only class: cargo-mutants 27.1.0 cannot exclude a
+            // `Genre::StructField` mutant at all, so any the diff contains
+            // leak into the audit corpus whatever the P1 exclusions say. PR
+            // #265 failed `oracle-lied` on four such leaks with 0 of its 68
+            // graded mutants missed.
+            "audit p2.txt",
+            "the P2-audit's oracle, scoped to the class it audits; reading the audit run's \
+             caught.txt directly counts kills on mutants cargo-mutants could not exclude \
+             from that run as proof the classification lied",
         ),
     ] {
         super::nonvacuity::require_needle(


### PR DESCRIPTION
PR #265's `Mutants (coverage verdict)` failed `P2_AUDIT: oracle-lied` on a diff
whose own code was clean (`68 graded / 0 missed`). The gate's error text named
two candidate causes — "either the reach measurement is measuring the wrong test
scope, or the classifier is putting reachable code in the report-only class".
Both were checked and **neither is what happened.** The classifier was right;
its *audit* was reading the wrong file.

## What the run actually said

That run's own output classified 20 mutants P2 and printed every one of them:
ten distinct names, all in `src/preflight/`. The four the audit then "caught"
were `src/load/plan.rs:378:13` and `:379:13` — not in that list, classified
**P1** by the same run, and correctly so (`table_load_prefix` is covered by
`load::plan::tests`).

The reach hypothesis is ruled out by the workflow itself: the coverage step
already runs `cargo llvm-cov --lib --bins`, the same scope as `cargo mutants …
-- --lib --bins`. Both sides measure one suite.

## The real cause

The audit lists the corpus with the **P1** `--exclude-re` patterns applied and
treats whatever is left as P2. cargo-mutants 27.1.0 cannot honour that for one
genre. In `src/visit.rs`, every mutant is created through `collect_mutant`,
which gates on `options.allows_mutant()` — **except `Genre::StructField`**
(`delete field X from struct Y expression`), which is pushed straight onto
`self.mutants`. So no `--exclude-re`, from the CLI or `.cargo/mutants.toml`, can
remove one.

Probed directly on the branch:

```
$ cargo mutants --list --file src/load/plan.rs --colors=never | wc -l
56
$ cargo mutants --list --file src/load/plan.rs --exclude-re '.' | wc -l
4          # all four are StructField
```

Those four leaked into the audit corpus whatever the exclusions said, were
caught (they are well-tested P1 code), and `[ -s p2-audit/mutants.out/caught.txt ]`
read four kills in code the offline suite demonstrably executes as proof that
the zero-coverage measurement had lied.

## The fix

A new `mutants_classify.py audit <p2-list> <caught-list>` grades the audit's
kills **against `p2.txt`**, not against whatever survived the exclusions.

* a kill inside the report-only class is still `oracle-lied` — the oracle keeps
  all its teeth;
* a kill on anything else is a graded-class mutant that leaked: reported as a
  `::notice::` naming the cargo-mutants limitation, and ignored, because it is
  already graded on its own account in the main run;
* an unreadable `p2.txt` is a break, not a pass — an audit that compares nothing
  must not report that the classification held.

`partition`'s asymmetry is untouched: P2 is still entered only on positive
evidence (a function extent containing the line, measured at zero executions),
and every "don't know" is still P1. Nothing is excused that was not excused
before; the oracle is narrowed to the class it was always claiming to be about.

The mirror-image leak — an unexcludable mutant that **is** in P2, so the main
run cannot deprioritise it — needed no change: `verify` sees it survive the P2
exclusions, discards them, and grades the whole diff. Its message now names the
unexcludable genre as a second cause, so an operator does not go hunting for an
over-broad pattern that is not there.

## RED proofs

Both halves, each with the rest of the module green:

1. **`mutants_classify.py --self-test`** grows the audit case, built from PR
   #265's four caught names verbatim. Reverting `audit` to the pre-fix rule
   (`return list(caught), []` — exactly what `[ -s caught.txt ]` did) fails it:
   *"a kill on a mutant that was never in the report-only class is not evidence
   about that class"*, listing all four.
2. **`the_mutation_gate_actually_invokes_the_prioritiser`** grows an
   `audit p2.txt` call-site needle. Restoring the
   `[ -s p2-audit/mutants.out/caught.txt ]` test in `ci.yml` fails it
   (`0 occurrence(s) … floor 1`) while the other 7 tests in the module stay
   green — registration is a claim, the call site is the evidence.

## End-to-end, on a real corpus

Not a fixture: `cargo mutants --list` over `src/load/plan.rs` on #265's tree,
partitioned by the real classifier.

| | |
|---|---|
| corpus | 56 |
| P1 / P2 | 54 / 2 |
| audit corpus after 54 P1 exclusions | **6** (P2 is 2) |
| leaked past `--exclude-re` | 4, all `StructField` |
| old rule | `oracle-lied` |
| new rule | `oracle-holds` |

## Blocking-class impact

None — no mutant moves from P2 into P1 or back. The change is confined to how
the audit *reads* its results. The only behavioural delta is that a false
`oracle-lied` stops blocking merges; a true one still does.

## Local verification

* `cargo test -q --test offline_suite` — 281 passed
* `mutants_classify.py --self-test`, `mutants_exclusions.py --self-test`,
  `harness_metrics.py --self-test` — all green
* `cargo fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168uwctCn3W1rP4Kt4kZXvE
