### PR TITLE
fix(gate): gc_survival's running marker was staged under ONE name for three concurrent engines

### DIFF
--- a/dev/release_oracle/bigquery.py
+++ b/dev/release_oracle/bigquery.py
@@ -254,24 +254,36 @@ def verify_gc_survival(led: Ledger, *, bucket: str, pfx: str, cfg_text: str,
 
     fails: list[str] = []
 
-    def _gc_load_ok(tries: int = 3) -> bool:
-        # `rivet load` here hits REAL BigQuery/GCS, so a transient Google-side hiccup
-        # is an infra blip, not a gc-logic failure — retry like seed_engine/doctor
-        # (measured: one mssql arm-2 load flaked once and cleared on the very next run).
-        # A real gc failure fails every attempt.
+    def _gc_load_why(tries: int = 3) -> str:
+        """The empty string when the load succeeded, else WHY it did not.
+
+        A boolean here cost a whole investigation. When arm 2 failed on ONE engine
+        (2026-08-22, mssql), the cell reported `gc-load-failed-with-a-running-marker`
+        and nothing else — the load's own error, which named the cause in one
+        sentence, went to a `Proc` that was reduced to `p.ok` and dropped. The
+        message IS the finding; carry its tail into the ledger detail.
+
+        `rivet load` here hits REAL BigQuery/GCS, so a transient Google-side hiccup
+        is an infra blip, not a gc-logic failure — retry like seed_engine/doctor.
+        A real gc failure fails every attempt (and the text below says which).
+        """
         p = rivet("load", "-c", str(gc_cfg), env=child, timeout=None)
         for _ in range(tries - 1):
             if p.ok:
                 break
             time.sleep(2.0)
             p = rivet("load", "-c", str(gc_cfg), env=child, timeout=None)
-        return p.ok
+        if p.ok:
+            return ""
+        why = (p.stderr or p.stdout or "").strip()
+        return " / ".join(why.splitlines()[-2:]) if why else f"exit {p.returncode}"
 
     # ── arm 1: no live run → the unmanifested part is debris → collected ──
     dead = plant_orphan("orphan-crash-debris.parquet")
-    if not _gc_load_ok():
+    why = _gc_load_why()
+    if why:
         led.failed(engine, "-", "gc_survival", "-",
-                   f"gc_survival[{engine}]: the gc load itself failed", "load")
+                   f"gc_survival[{engine}]: the gc load itself failed — {why}", "load")
         return
     if exists(dead):
         fails.append("debris-survived(no live run, yet the unmanifested part was kept) ")
@@ -287,13 +299,46 @@ def verify_gc_survival(led: Ledger, *, bucket: str, pfx: str, cfg_text: str,
     # started_at must be NEWER than every other manifest of this export, or the
     # marker reads as SUPERSEDED — a crashed run's leftover, not a live signal.
     marker["started_at"] = "2099-01-01T00:00:00Z"
-    mk_local = work / f"manifest-gc-survival-probe.json"
+    # ENGINE-KEYED, like every other file this stage stages into `work`
+    # (`bqload_{engine}.yaml`, `gc_{engine}.yaml`): `work` is ONE directory shared
+    # by the three engine legs, which `run_bigquery_golden` runs CONCURRENTLY.
+    # A single `manifest-gc-survival-probe.json` is written by all three, and the
+    # window between `write_text` and the `gcloud cp` that READS it is a whole
+    # subprocess spawn (~1-2 s) — so a sibling leg passing through the same lines
+    # overwrites the file mid-copy and this engine uploads the SIBLING'S manifest
+    # into its own prefix. rivet then (correctly) refuses the load: "the load
+    # prefix holds manifests from 2 DIFFERENT SOURCES (mssql:…, mysql:…)" — a
+    # two-source prefix is exactly the silent warehouse-clobber `ensure_single_
+    # source` exists to stop. The cell recorded that refusal as a gc failure.
+    # Measured on the 2026-08-22 gate: mssql and mysql ran 0.12 s apart (their
+    # arm-1 loads land at 08:55:16.207 / .329 in `load_run`), mssql's arm-2 load
+    # failed all three attempts and wrote no ledger row at all — it never reached
+    # the loader — while postgres, 13 s out of step, passed.
+    mk_local = work / f"manifest-gc-survival-probe-{engine}.json"
     mk_local.write_text(json.dumps(marker))
     mk_remote = f"{base}/manifest-gc-survival-probe.json"
     run(["gcloud", "storage", "cp", str(mk_local), mk_remote], timeout=300)
 
-    if not _gc_load_ok():
-        fails.append("gc-load-failed-with-a-running-marker ")
+    # The fixture is not inert, and it is not a SIBLING'S: read the marker back
+    # from the bucket — the copy `rivet load` will actually read — and demand it
+    # is this engine's, `running`. Without this the two ways the plant can go
+    # wrong (no marker at all → arm 2 degenerates into arm 1 and passes for the
+    # wrong reason; a foreign marker → a load refusal misread as a gc failure)
+    # are both invisible.
+    back = json.loads(run(["gcloud", "storage", "cat", mk_remote], timeout=300).stdout or "{}")
+    planted = (back.get("source") or {}).get("engine")
+    if planted != engine or back.get("status") != "running":
+        run(["gcloud", "storage", "rm", mk_remote, live], timeout=300)
+        led.failed(engine, "-", "gc_survival", "-",
+                   f"gc_survival[{engine}]: the planted running marker is "
+                   f"engine={planted!r} status={back.get('status')!r}, not this engine's live "
+                   "marker — the FIXTURE is wrong (a sibling engine leg overwrote the staged "
+                   "file), so arm 2 graded nothing about gc", "fixture")
+        return
+
+    why = _gc_load_why()
+    if why:
+        fails.append(f"gc-load-failed-with-a-running-marker[{why}] ")
     elif not exists(live):
         fails.append("inflight-part-DELETED(a live run's unmanifested part was collected) ")
 

--- a/tests/offline/release_oracle_entrypoint_guard.rs
+++ b/tests/offline/release_oracle_entrypoint_guard.rs
@@ -375,3 +375,73 @@ fn the_prev_release_child_harnesses_are_launched_through_the_sigint_first_runner
         );
     }
 }
+
+/// Every file the BigQuery stage stages into its SHARED `work` directory must
+/// carry `{engine}` in its name.
+///
+/// `run_bigquery_golden` builds ONE `work` dir and hands the same `Path` to all
+/// three engine legs, which it then runs CONCURRENTLY in a `ThreadPoolExecutor`.
+/// So a staged file whose name is a constant has three writers and three
+/// subprocess readers: whoever `write_text`s last wins the file, and a sibling's
+/// content is uploaded under THIS engine's prefix.
+///
+/// Not hypothetical. `verify_gc_survival` staged its `running`-marker manifest as
+/// a constant `manifest-gc-survival-probe.json`; on the 2026-08-22 gate the mssql
+/// and mysql legs ran 0.12 s apart (their arm-1 loads land at 08:55:16.207/.329
+/// in the `load_run` ledger), mssql uploaded MYSQL'S manifest into `bq/mssql/`,
+/// and `rivet load` refused the prefix — correctly, with "holds manifests from 2
+/// DIFFERENT SOURCES (mssql:…, mysql:…)", the guard that stops one source's rows
+/// from replacing another's in a warehouse table. The cell recorded
+/// `gc-load-failed-with-a-running-marker` and dropped the sentence explaining it.
+///
+/// Scope, said out loud: the subject is `bigquery.py` — the one gate module whose
+/// `work` dir is shared ACROSS concurrently-running engine legs (`blessed_flow` /
+/// `blessed_path` build a `work` per cell). It grades string LITERALS after
+/// `work /`; a name computed into a variable escapes it, which is why the
+/// non-vacuity floor insists the scan really found the staged files.
+#[test]
+fn every_file_the_concurrent_bigquery_legs_stage_into_the_shared_work_dir_is_engine_keyed() {
+    let raw = fs::read_to_string(format!("{}/dev/release_oracle/bigquery.py", root()))
+        .expect("read bigquery.py");
+    // Comments and docstrings FIRST: this guard's own reason is written in prose
+    // right above the code it grades, and prose is not evidence.
+    let src = strip_python_comments(&raw);
+    assert!(
+        src.contains("ThreadPoolExecutor"),
+        "the BigQuery stage no longer runs its engine legs concurrently — if that is \
+         deliberate, this guard's premise (one `work` dir, three writers) is gone and it \
+         should be deleted rather than left passing for the wrong reason"
+    );
+
+    let mut seen: Vec<String> = Vec::new();
+    let mut offenders: Vec<String> = Vec::new();
+    let mut rest = src.as_str();
+    while let Some(at) = rest.find("work / ") {
+        let tail = &rest[at + "work / ".len()..];
+        rest = tail;
+        let tail = tail.strip_prefix('f').unwrap_or(tail);
+        let Some(tail) = tail.strip_prefix('"') else {
+            continue; // not a literal (a variable, a nested call) — see the scope note
+        };
+        let Some(end) = tail.find('"') else { continue };
+        let lit = tail[..end].to_string();
+        if !lit.contains("{engine}") {
+            offenders.push(lit.clone());
+        }
+        seen.push(lit);
+    }
+    assert!(
+        seen.len() >= 3,
+        "found only {} `work / \"…\"` literal(s) in bigquery.py — the scan is reading the \
+         wrong shape and grades nothing (it must see at least the export config, the gc \
+         config and the gc-survival marker)",
+        seen.len()
+    );
+    assert!(
+        offenders.is_empty(),
+        "these files are staged into the BigQuery stage's SHARED work dir under a name that is \
+         the SAME for all three concurrent engine legs: {offenders:?}. The last writer wins the \
+         local file and a sibling's content is uploaded into this engine's prefix — key the \
+         name on the engine, as bqload_<engine>.yaml and gc_<engine>.yaml already do"
+    );
+}


### PR DESCRIPTION
## The failure

The 2026-08-22 `make release-oracle-full` on main:

```
✓ gc_survival[postgres]: debris collected, live run's unmanifested part spared, manifested parts untouched
✓ gc_survival[mysql]:    (same)
✗ gc_survival[mssql]:    gc-load-failed-with-a-running-marker
```

Same scenario, one engine red. **It is a fixture defect, not a rivet defect** —
and the asymmetry is the whole tell.

## Cause

`verify_gc_survival` stages arm 2's `running` marker at
`WORK/manifest-gc-survival-probe.json` — a **constant** name in the **one** `work`
directory `run_bigquery_golden` hands to all three engine legs, which it runs
**concurrently** in a `ThreadPoolExecutor`. The window between `write_text` and
the `gcloud storage cp` that reads it is a whole subprocess spawn (~1-2 s), so a
sibling leg passing the same lines overwrites the file mid-copy and this engine
uploads the **sibling's** manifest into its own prefix.

`rivet load` then refuses the prefix — correctly:

```
the load prefix holds manifests from 2 DIFFERENT SOURCES
(mssql:rivet_type_matrix, mysql:rivet_type_matrix) under one export name.
```

That is `ensure_single_source`, the guard that stops one source's rows from
replacing another's in a warehouse table. The cell recorded the refusal as a gc
failure and swallowed the sentence that explained it.

## Evidence (from the failing run's own artifacts, not from reasoning)

* **The gate's `load_run` ledger**: three loads for postgres and mysql (initial +
  arm 1 + arm 2), only **two** for mssql. Arm 2's three attempts wrote no row at
  all → they failed inside `prepare_load`, before the loader ran. A BigQuery-side
  failure would have recorded `status=failed`.
* **Timing**: mssql and mysql ran in lockstep — arm-1 loads land 0.12 s apart
  (`08:55:16.207` / `.329`) — while postgres was 13 s out of step. The two legs
  whose write→copy windows overlap are exactly the two the shared file can cross;
  the one that could not is the one that passed.
* **Causal repro** against the real stand: planting a mysql manifest as the mssql
  prefix's running marker fails `rivet load` **3/3** with that exact message
  (which is why the probe's 3-attempt retry could not clear it — the poison is in
  the bucket, not in the network).
* Ruled out: the ledger-side conflicting-source check (`loaded_source_run` holds
  only `mssql:rivet_type_matrix` for that target, so it could not have fired at
  arm 2 while arm 1 passed), and a transient (a transient does not fail 3/3, and
  would have failed inside the BQ job where a `failed` row is written).

## No product change

rivet's refusal is the safe, documented behaviour, and the shape the probe
fabricated — another engine's manifest under this export's prefix — is not one a
rivet run can write. The guard stays exactly as armed as it was.

## What the cell was accidentally testing

For the poisoned engine, arm 2 was measuring "does the load refuse a two-source
prefix" (it does) and reporting that as a gc verdict. gc's three-way
classification was never exercised for that engine.

## Fix (probe only)

* stage the marker as `manifest-gc-survival-probe-{engine}.json`, matching
  `bqload_{engine}.yaml` / `gc_{engine}.yaml` beside it — the remote key is
  already per-prefix and is unchanged;
* **read the marker back from the bucket** and demand it is this engine's,
  `running`, before grading anything: a plant that lands wrong is now a named
  FIXTURE failure, and a marker that never landed can no longer let arm 2
  degenerate into arm 1 and pass for the wrong reason;
* `_gc_load_ok` → `_gc_load_why`: the failing load's own message reaches the
  ledger detail. The boolean is what turned a one-sentence diagnosis into an
  investigation.

## Guard

`every_file_the_concurrent_bigquery_legs_stage_into_the_shared_work_dir_is_engine_keyed`
(`tests/offline/release_oracle_entrypoint_guard.rs`) — RED-proven against the
pre-fix constant name, non-vacuity floor on the literals it finds, and it asserts
the stage still runs its legs concurrently so it cannot pass for the wrong reason
if that premise ever changes. Scope is stated in the test: `bigquery.py` is the
one gate module whose `work` dir is shared across concurrent engine legs
(`blessed_flow` / `blessed_path` build a `work` per cell — verified).

## Verification

* Full BigQuery stage re-run, three engines concurrent, fixed probe:
  `gc_survival` **PASS** on postgres, mysql and mssql (3 arms each); goldens
  matched.
* `cargo build`, `cargo test -q --lib` (2575), `cargo test -q --test offline_suite` (282) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168uwctCn3W1rP4Kt4kZXvE
