### PR TITLE
ADR-0029: the commit ledger splits by truth condition and COMPUTES Form-B coverage

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -50,6 +50,36 @@ exclude_globs = [
 ]
 
 exclude_re = [
+    # The two chunk-CHECKPOINT runners' whole-body stubs. Both are live-only by
+    # construction (they need a real source, a destination and a state DB, so the
+    # `--lib --bins` run this gate does never executes a line of them), and the
+    # gate measured exactly that: reach = 0 executions, so the classifier put
+    # them in the report-only class. Then the offline suite CAUGHT them, and the
+    # coverage verdict correctly refused the contradiction (`P2_AUDIT:
+    # oracle-lied`, PR #273).
+    #
+    # The killer is `tests/offline/chunking_matrix_guard.rs`, which DERIVES the
+    # set of commit loops by scanning the TEXT of `src/pipeline` for
+    # `commit::record_part(` — deliberately, so a new runner cannot arrive
+    # without a matrix column. cargo-mutants rewrites the body ON DISK, the
+    # needle vanishes from the file, the derivation loses the name and the guard
+    # fails — WITHOUT executing one instruction of the mutant. That kill is an
+    # artifact of reading the source, not evidence any assertion noticed the
+    # behaviour change, and leaving it in place would let a text scan
+    # counterfeit execution coverage for every live-only runner it names.
+    #
+    # Live oracle, RED-proven by hand before excluding (2026-08-23), each against
+    # a SINGLE exact test whose baseline was green in the same worktree — the
+    # sibling mysql/mssql cases fail there on the worktree guard, so a filter that
+    # matched all three would have graded nothing:
+    #   * sequential — `chunked_checkpoint_resume_suppresses_form_b_so_validate_
+    #     does_not_false_fail` (live_chunked_recovery.rs): pass -> FAIL,
+    #   * parallel — `parallel_chunked_crash_after_chunk_complete_resume_finishes_
+    #     with_no_duplicates` (same file, postgres variant): pass -> FAIL.
+    # Both read the DESTINATION back, so the stub's "success with nothing
+    # exported" cannot pass as an outcome.
+    "replace run_chunked_parallel_checkpoint",
+    "replace run_chunked_sequential_checkpoint",
     # 64*1024 is a streaming READ BUFFER size in compute_part_checksums —
     # any chunking yields byte-identical digests; 64+1024 only changes I/O
     # granularity. Verified by hand (matrix audit, 2026-07-13).

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -68,16 +68,20 @@ exclude_re = [
     # behaviour change, and leaving it in place would let a text scan
     # counterfeit execution coverage for every live-only runner it names.
     #
-    # Live oracle, RED-proven by hand before excluding (2026-08-23), each against
-    # a SINGLE exact test whose baseline was green in the same worktree — the
-    # sibling mysql/mssql cases fail there on the worktree guard, so a filter that
-    # matched all three would have graded nothing:
-    #   * sequential — `chunked_checkpoint_resume_suppresses_form_b_so_validate_
-    #     does_not_false_fail` (live_chunked_recovery.rs): pass -> FAIL,
-    #   * parallel — `parallel_chunked_crash_after_chunk_complete_resume_finishes_
-    #     with_no_duplicates` (same file, postgres variant): pass -> FAIL.
-    # Both read the DESTINATION back, so the stub's "success with nothing
-    # exported" cannot pass as an outcome.
+    # Live oracle, RED-proven by hand before excluding (2026-08-23), on ALL THREE
+    # engines, from the MAIN checkout so the independent DuckDB/ClickHouse oracle
+    # containers read the directory they bind-mount (from a worktree the mysql and
+    # mssql legs abort on that guard, so a proof run there covers postgres only —
+    # which is what the first pass at this entry wrongly generalised from):
+    #   * parallel  — `parallel_chunked_crash_after_chunk_complete_resume_
+    #     finishes_with_no_duplicates` × {postgres, mysql, mssql}: 3 passed ->
+    #     3 FAILED with the body stubbed to `Ok(())`;
+    #   * sequential — `chunked_crash_after_first_chunk_complete_resume_finishes_
+    #     export` × the same three: 3 passed -> 3 FAILED, and 3 passed again on
+    #     revert (a clean tree confirmed, so the red is the stub and not drift).
+    # The oracle is the destination re-read through DuckDB, not rivet's own exit
+    # status or summary — so "success with nothing exported" cannot pass as an
+    # outcome on any engine.
     "replace run_chunked_parallel_checkpoint",
     "replace run_chunked_sequential_checkpoint",
     # 64*1024 is a streaming READ BUFFER size in compute_part_checksums —

--- a/docs/adr/0029-commit-ledger-coverage-is-computed.md
+++ b/docs/adr/0029-commit-ledger-coverage-is-computed.md
@@ -1,6 +1,10 @@
 # ADR-0029: The commit ledger separates observations from integrity, and computes coverage rather than trusting it
 
-**Status**: Proposed (design accepted; implementation not started)
+**Status**: Accepted — implemented 2026-08-23. `Observations` / `Integrity` split,
+`UnitId`-keyed contributions, coverage computed over `summary.manifest_parts`, both
+manual `column_checksums_incomplete` sites retired, `check_post_run_invariants`
+strengthened. See *Implementation notes* below for the four places the design
+above needed correcting.
 **Date**: 2026-08
 **Relates to**: ADR-0028 (the finalize seam this ledger feeds), ADR-0012 (manifest durability ordering)
 
@@ -129,3 +133,68 @@ remains attractive for the OBSERVATION half. It does not work for checksums:
 they arrive per range/page at a different moment than the parts, so hanging them
 on `record_part` would force the same premature publication the first alternative
 was rejected for.
+
+---
+
+## Implementation notes (2026-08-23) — where the design above was wrong
+
+Recorded because each of these is a thing the next reader would otherwise
+re-derive, and two of them were only found by running the code.
+
+**1. `PartKind` is the JOURNAL id, not the commit unit — a separate `UnitId` was
+needed.** The decision says "key each checksum contribution by the SAME unit
+identifier the parts already carry — `PartKind` is already `File { part_index }` /
+`Chunk { chunk_index }` / `Page { page_index, .. }`". That is false for exactly the
+runner this ADR exists for. Parallel keyset passes `PartKind::Page { page_index:
+<flat drain index> }`, which is neither the page nor the range; its commit unit is
+the RANGE (parts publish per page, checksums per committed range). And `single`
+has no per-part unit at all — ONE sink accumulates the checksums of every part it
+writes, so its unit is the whole invocation. So `commit::UnitId { Run, Chunk, Page,
+Range }` is a separate argument to `record_part` beside `kind`, stated at every
+call site. Re-using `PartKind` would have reported every healthy parallel-keyset
+range short, i.e. shipped the ADR's own named risk on day one.
+
+**2. Coverage is compared over `summary.manifest_parts`, keyed on `part_id`.** The
+decision says "the unit set of the recorded parts", which reads as "the parts
+`record_part` saw". Keying it that way makes the resume case — the one point 3 of
+the decision claims to SUBSUME — invisible, because `rehydrate_manifest_parts_from_
+file_log` and the M8 `Skip` clone push straight into `manifest_parts` and never call
+`record_part`. The manifest is the right subject: it is the list the Form-B record
+claims to cover, and it holds the hydrated parts too. `part_id` is the key (4 bytes,
+unique by M4, stable across a dedup) rather than the path, so this costs no second
+copy of every part name; `record_committed_part_with_fingerprint` now returns
+`RecordedPart { deduped, part_id }` instead of a bare bool.
+
+**3. The empty-accumulator path had to be reached too — this shipped a live
+regression.** The pre-existing `harvest_column_checksums` early-returns when the
+accumulator is empty. Leaving that return above the new coverage computation broke
+four live tests (`parallel_keyset_crash_recovery_{postgres,mysql}`, and two
+siblings): a crash resume whose ranges were ALL already `done` re-runs nothing, so
+there is no checksum to weigh, the computation was skipped, and the run reached
+`finalize_manifest` with hydrated parts and no suppression flag — where the
+pre-existing Form-B telltale panicked it. Pre-ADR-0029 that flag came from the
+manual `resume_m8.rs` assignment this ADR retires. So: compute coverage FIRST, and
+early-return on an empty accumulator only once coverage is COMPLETE (that case is a
+format fact — a CSV/JSONL sink computes no value checksums — and must leave the flag
+clear so the telltale still catches a runner that harvested nothing).
+
+**4. The strengthened invariant needed a second recorded field, not just the
+existing flag.** "Form B is absent stops being ambiguous … because the second is now
+a recorded verdict" is right, but `column_checksums_incomplete` alone cannot carry
+it: a legitimate resume and a runner's unit-id mismatch both set it.
+`RunSummary::column_checksums_short_cover` records the half that is never legitimate
+on a successful run — a part this run RECORDED whose unit contributed nothing — and
+`check_post_run_invariants` fails on it. That is resume-safe by construction with no
+exemption to remember, because a hydrated part is *foreign*, not *uncovered*.
+
+**Scope correction on the observation half.** The context says three parallel
+runners lose their observations on the failure path. Only ONE of them actually did:
+parallel keyset, which has no direct `summary.schema_fingerprint` assignment. Both
+chunked parallel runners already set `summary.schema_fingerprint` from their
+`shared_fingerprint` ABOVE the bail, and the chunked family deliberately feeds NO
+drift schema at all (its gate is pre-chunk, ADR-0021) — do not "fix" that. The
+second real loser was not in the list: `single`, whose `drain_tail_into` sat after
+a write loop whose per-part `write_part_file(…)?` can escape, so a run that failed
+mid-write pinned the stale baseline onto a Failed manifest listing parts written
+under the observed schema. It now drains its observations the moment the read
+completes.

--- a/docs/adr/0029-commit-ledger-coverage-is-computed.md
+++ b/docs/adr/0029-commit-ledger-coverage-is-computed.md
@@ -1,0 +1,131 @@
+# ADR-0029: The commit ledger separates observations from integrity, and computes coverage rather than trusting it
+
+**Status**: Proposed (design accepted; implementation not started)
+**Date**: 2026-08
+**Relates to**: ADR-0028 (the finalize seam this ledger feeds), ADR-0012 (manifest durability ordering)
+
+---
+
+## Context
+
+ADR-0028 introduced `CommitLedger`: runners FEED it as they commit, and one seam
+(`finalize::finalize_export`) APPLIES the tail — schema-fingerprint pin, the
+`on_schema_drift` gate, the Form-B checksum harvest, the shape-drift warn. A
+later fix added `finalize_export_records`, so a run whose RUNNER FAILED still
+records what it observed: a Failed manifest must describe its durable debris
+with the OBSERVED fingerprint, never the stale open-time baseline.
+
+An interaction bughunt found that half of this does not work. Three parallel
+runners — `keyset.rs`, `chunked/exec.rs`, `chunked/parallel_checkpoint.rs` —
+record durable parts ABOVE their error bail but feed the ledger BELOW it, so on
+the failure path `finalize_export_records` receives an EMPTY ledger. Keyset is
+the worst case: it has no direct `summary.schema_fingerprint` assignment at all,
+so the ledger is its only path and a failed parallel-keyset run records an
+actively wrong fingerprint.
+
+The obvious fix — move the feed above the bail — is WRONG, and the reason is the
+whole point of this ADR. `keyset.rs` says it out loud at its part-publishing
+site:
+
+> Cursor (`rmax`) and checksums stay commit-gated below — those feed the SUMMARY
+> and must reflect only committed data — but the durability count must reflect
+> what is physically on disk.
+
+So parts and checksums have DIFFERENT truth conditions BY DESIGN. Parts are
+published per PAGE (a durability count must show what is on disk, or the retry
+guard reads zero over durable parquet — the #200-1 fix). Checksums are published
+per COMMITTED RANGE. On a failure, `parts_mx` therefore holds pages of a range
+that never committed while `checksums_mx` does not. Harvesting that pair yields
+a Form-B record covering a strict SUBSET of the manifest's parts — precisely the
+partial-and-lying integrity record `harvest_column_checksums` already suppresses
+via `column_checksums_incomplete`, and `validate --depth full` would then report
+a FALSE mismatch on correctly-written data. Worse than the bug it fixes.
+
+The design flaw is upstream of both: **the ledger holds facts with different
+truth conditions in one structure with one lifecycle, fed at one moment.**
+
+| fact | true when | fed today |
+|---|---|---|
+| durable parts | the bytes are on disk | above the bail |
+| Form-B checksums | the unit COMMITTED | below the bail |
+| schema fingerprint | the first batch was SEEN | below the bail |
+| shape bytes | a batch was seen | below the bail |
+
+The schema fingerprint is the accident. It has no coverage requirement at all —
+it describes what the runner READ — yet it rides in the same feed as the
+checksums and is lost with them. That is the reported defect.
+
+## Decision
+
+**1. Split the ledger by truth condition.**
+
+*Observations* (`drift_schema`, `column_max_bytes`) describe what the runner
+SAW. They carry no coverage obligation, they are monotonic, and recording one
+early can never be wrong. They are fed EAGERLY — at first sight, above any bail
+— and `finalize_export_records` applies them on the failure path unconditionally.
+
+*Integrity* (Form-B checksums + key column) is only meaningful as a set that
+covers EXACTLY the parts the manifest lists. It stays commit-gated.
+
+**2. Compute coverage; do not trust the feed order.**
+
+Today the parts/checksums correspondence is maintained by CONVENTION (each
+runner remembers to feed only committed units) plus a manually-set
+`column_checksums_incomplete` flag for the checkpoint-resume case. Both are
+vigilance, and vigilance is what this codebase keeps paying for.
+
+Instead: key each checksum contribution by the SAME unit identifier the parts
+already carry — `PartKind` is already `File { part_index }` / `Chunk {
+chunk_index }` / `Page { page_index, .. }`. At harvest, the seam compares the
+unit set of the contributions against the unit set of the recorded parts:
+
+- every recorded part's unit has a contribution → COMPLETE, record Form B;
+- any part without one → INCOMPLETE, set `column_checksums_incomplete` and
+  suppress, exactly as the resume path does today.
+
+A runner then CANNOT publish a lying Form-B, because the seam sees the shortfall
+itself rather than being told about it.
+
+**3. This subsumes the resume case.** A checkpoint resume rehydrates pre-crash
+parts whose per-column checksums are unrecoverable; today it must remember to set
+`column_checksums_incomplete`. Under the computed rule those parts simply have no
+contribution, so incompleteness follows from the data. One mechanism, not two.
+
+## Consequences
+
+* The reported defect is fixed at its root: a failed run records the fingerprint
+  it observed, because observations never depended on commit in the first place.
+* Form-B cannot become partial-and-lying by a feed-order mistake — the failure
+  mode that made the naive fix unshippable.
+* The manual `column_checksums_incomplete` flag becomes a computed result. Its
+  call sites (`resume_m8.rs`, the rehydrate paths) lose a thing to remember.
+* `record_part` must make the unit id available to the ledger, and each runner's
+  checksum feed must carry the unit it belongs to — the one real cost. It is
+  mechanical: every feed site already sits next to the code that knows the unit.
+* The telltale invariants in `check_post_run_invariants` get STRONGER rather than
+  replaced: "Form B is absent" stops being ambiguous between "nothing computed
+  it" and "coverage was short", because the second is now a recorded verdict.
+* Risk: a unit-id mismatch between the part and its checksum contribution would
+  read as incompleteness and silently suppress Form B on a HEALTHY run. That is
+  the fail-safe direction (absent, not lying), but it must be caught — the
+  implementation needs a test asserting a complete run really does record Form B,
+  not only that a short one suppresses it. An absence-only assertion here would
+  repeat the redaction-test defect this repo has already paid for twice.
+
+## Alternatives rejected
+
+**Move the checksum feed above the bail.** Publishes a checksum over a subset of
+the manifest's parts; `validate --depth full` then reports a false mismatch on
+correct data. Rejected on the evidence above.
+
+**Have each runner set `column_checksums_incomplete` on its failure path.** This
+is the existing mechanism extended, i.e. more vigilance in exactly the places
+that already forgot once. It also cannot express partial coverage — only "all or
+nothing" — so a run that committed 9 of 10 ranges would either lie or discard
+nine ranges' worth of verification.
+
+**Feed the ledger from inside `record_part`.** ADR-0028 considered this and it
+remains attractive for the OBSERVATION half. It does not work for checksums:
+they arrive per range/page at a different moment than the parts, so hanging them
+on `record_part` would force the same premature publication the first alternative
+was rejected for.

--- a/docs/runner-coverage-matrix.yaml
+++ b/docs/runner-coverage-matrix.yaml
@@ -240,7 +240,7 @@ scenarios:
     mongo_parallel: { na: "advisory, single-batch-only by design — no run-wide max-bytes aggregate across workers" }
 
   - id: value_checksum_form_b
-    what: "Form B — the sink's per-column value checksums are harvested into summary.column_checksums so finalize_manifest RECORDS them and `rivet validate` can re-read the parts and verify the Arrow→Parquet encode. The sink COMPUTES them for every runner (track_checksum in on_batch); since ADR-0028 every runner FEEDS them into summary.ledger (merge_checksums, order-independent) and the HARVEST happens once at the finalize_export seam — no runner calls harvest itself (round-9 had fixed the computed-then-discarded bug per runner; the seam removes the per-runner call entirely). The test cells grade the feed + seam end-to-end."
+    what: "Form B — the sink's per-column value checksums are harvested into summary.column_checksums so finalize_manifest RECORDS them and `rivet validate` can re-read the parts and verify the Arrow→Parquet encode. The sink COMPUTES them for every runner (track_checksum in on_batch); since ADR-0028 every runner FEEDS them into summary.ledger and the HARVEST happens once at the finalize_export seam — no runner calls harvest itself (round-9 had fixed the computed-then-discarded bug per runner; the seam removes the per-runner call entirely). ADR-0029 then made the feed KEYED and the coverage COMPUTED: a runner contributes under a UnitId (its commit unit — Run for single, Chunk for chunked/checkpoint/mongo_parallel, Page for keyset-sequential, Range for keyset-PARALLEL, whose parts publish per page but whose checksums publish per committed range), commit::record_part registers the same UnitId for every manifest part, and the seam compares the two sets — full cover records, any uncovered or hydrated part suppresses. So the cells below grade MORE than before: each asserts its runner RECORDS column_checksums in the destination manifest, and a runner that paired its part and its checksum under different UnitIds now suppresses and turns its cell RED. The structural backstop grew the matching half — check_post_run_invariants rejects a state_backed success carrying column_checksums_short_cover (a part this run recorded whose unit contributed nothing, which on a SUCCESS can only be a mis-pairing), so the fail-safe-but-silent direction is loud on every runner under debug_assertions, the build live tests use."
     single:         { test: pg_type_matrix_value_checksum_guard }
     chunked:        { test: chunked_export_records_form_b_checksums_and_validate_passes }
     # The load-bearing half is that test's BASELINE arm: a clean parallel-checkpoint
@@ -248,10 +248,16 @@ scenarios:
     # manifest AND `rivet validate` (Full) must re-read it — the test says so in its
     # own body ("so the suppression below is not vacuous"). The SEQUENTIAL checkpoint
     # runner feeds the ledger inside its per-chunk loop (sequential_checkpoint.rs,
-    # merge_checksums) with no dedicated live cell; its
-    # backstop is structural (check_post_run_invariants rejects a state_backed parquet
-    # success with empty, un-flagged column_checksums; finalize.rs panics on it under
-    # debug_assertions, which is the build live tests run).
+    # contribute_checksums under UnitId::Chunk(chunk_index)) with no dedicated live
+    # cell; its backstop is structural (check_post_run_invariants rejects a
+    # state_backed parquet success with empty, un-flagged column_checksums, and since
+    # ADR-0029 also one carrying column_checksums_short_cover; finalize.rs panics on
+    # either under debug_assertions, which is the build live tests run).
+    # The RESUME arm of this cell is the one ADR-0029 changed most: the suppression
+    # it asserts is no longer a flag resume_m8.rs SETS, it is computed from the
+    # hydrated parts having no commit unit — see
+    # commit::tests::harvest_flags_a_hydration_only_resume_that_re_ran_nothing_and_has_no_checksums,
+    # the unit case the live keyset-crash-recovery tests caught first.
     chunked_checkpoint: { test: chunked_checkpoint_resume_suppresses_form_b_so_validate_does_not_false_fail }
     keyset:         { test: keyset_export_records_form_b_checksums_and_validate_passes }
     mongo_parallel: { test: mongo_parallel_export_records_form_b_checksum }

--- a/src/pipeline/chunked/exec.rs
+++ b/src/pipeline/chunked/exec.rs
@@ -153,6 +153,9 @@ pub(crate) fn run_chunked_sequential(
                     super::super::commit::PartKind::Chunk {
                         chunk_index: i as i64,
                     },
+                    // ADR-0029: the chunk is this runner's commit unit — the
+                    // feed below is the same loop iteration over the same sink.
+                    super::super::commit::UnitId::Chunk(i as i64),
                 );
             }
         } else {
@@ -171,12 +174,11 @@ pub(crate) fn run_chunked_sequential(
         // drift gate PRE-chunk from type_mappings (ADR-0021), so feeding the
         // sink schema here would make the seam re-check post-run and overwrite
         // the pre-chunk verdict.
-        summary
-            .ledger
-            .merge_checksums(&std::mem::take(&mut sink.column_checksums));
-        summary
-            .ledger
-            .note_key_column(sink.checksum_key_col.and(sink.cursor_column.clone()));
+        summary.ledger.contribute_checksums(
+            super::super::commit::UnitId::Chunk(i as i64),
+            &std::mem::take(&mut sink.column_checksums),
+            sink.checksum_key_col.and(sink.cursor_column.clone()),
+        );
     }
 
     pb.finish(summary.total_rows);
@@ -250,7 +252,7 @@ pub(crate) fn run_chunked_parallel(
     // a parallel chunked manifest records Form B like single mode.
     #[allow(clippy::type_complexity)]
     let checksums_shared: std::sync::Mutex<
-        Vec<(std::collections::BTreeMap<String, u64>, Option<String>)>,
+        Vec<(i64, std::collections::BTreeMap<String, u64>, Option<String>)>,
     > = std::sync::Mutex::new(Vec::new());
     // Schema fingerprint captured by whichever worker resolves the dest
     // schema first.  ADR-0012 M3 — stays None for empty runs (no chunk
@@ -408,8 +410,13 @@ pub(crate) fn run_chunked_parallel(
                         drop(records);
                         // Form B: hand this chunk's checksums to the parent to XOR-combine.
                         let key = sink.checksum_key_col.and(sink.cursor_column.clone());
-                        poison::lock_recover(checksums_shared)
-                            .push((std::mem::take(&mut sink.column_checksums), key));
+                        // ADR-0029: tagged with the chunk — the same unit the
+                        // parent's `record_part` drain records these parts under.
+                        poison::lock_recover(checksums_shared).push((
+                            i as i64,
+                            std::mem::take(&mut sink.column_checksums),
+                            key,
+                        ));
                     }
 
                     let done = completed.fetch_add(1, Ordering::Relaxed) + 1;
@@ -464,6 +471,7 @@ pub(crate) fn run_chunked_parallel(
             Some(state),
             &rec,
             super::super::commit::PartKind::Chunk { chunk_index },
+            super::super::commit::UnitId::Chunk(chunk_index),
         );
     }
 
@@ -477,11 +485,16 @@ pub(crate) fn run_chunked_parallel(
         );
     }
 
-    // ADR-0028: feed every worker's chunk checksums into the run ledger
-    // (order-independent merge); the seam harvests once, at the dispatcher.
-    for (part, key) in poison::into_recover(checksums_shared) {
-        summary.ledger.merge_checksums(&part);
-        summary.ledger.note_key_column(key);
+    // ADR-0028/0029: feed every worker's chunk checksums into the run ledger
+    // (order-independent merge) under the SAME chunk unit the drain above
+    // recorded that chunk's parts with; the seam harvests once, at the
+    // dispatcher, and computes the coverage itself.
+    for (chunk_index, part, key) in poison::into_recover(checksums_shared) {
+        summary.ledger.contribute_checksums(
+            super::super::commit::UnitId::Chunk(chunk_index),
+            &part,
+            key,
+        );
     }
 
     log::info!(

--- a/src/pipeline/chunked/parallel_checkpoint.rs
+++ b/src/pipeline/chunked/parallel_checkpoint.rs
@@ -130,7 +130,7 @@ pub(crate) fn run_chunked_parallel_checkpoint(
     // records Form B like exec.rs's parallel path (graph-surfaced runner-bypass).
     #[allow(clippy::type_complexity)]
     let checksums_shared: std::sync::Mutex<
-        Vec<(std::collections::BTreeMap<String, u64>, Option<String>)>,
+        Vec<(i64, std::collections::BTreeMap<String, u64>, Option<String>)>,
     > = std::sync::Mutex::new(Vec::new());
     // ADR-0012 M3: schema fingerprint captured once across workers.  None
     // until any worker exports a non-empty chunk and resolves the dest schema.
@@ -493,9 +493,14 @@ pub(crate) fn run_chunked_parallel_checkpoint(
                                     records.push((rec, chunk_index));
                                 }
                                 drop(records);
-                                // Form B: hand this chunk's checksums to the parent.
-                                poison::lock_recover(checksums_shared)
-                                    .push((chunk_checksums, chunk_key));
+                                // Form B: hand this chunk's checksums to the parent,
+                                // tagged with the chunk — ADR-0029's coverage unit,
+                                // the same one the parent's record_part drain uses.
+                                poison::lock_recover(checksums_shared).push((
+                                    chunk_index,
+                                    chunk_checksums,
+                                    chunk_key,
+                                ));
                                 Some(first)
                             };
                             // Mirror of the sequential checkpoint hooks (search for
@@ -581,6 +586,7 @@ pub(crate) fn run_chunked_parallel_checkpoint(
             None,
             &rec,
             super::super::commit::PartKind::Chunk { chunk_index },
+            super::super::commit::UnitId::Chunk(chunk_index),
         );
     }
 
@@ -606,11 +612,16 @@ pub(crate) fn run_chunked_parallel_checkpoint(
         );
     }
 
-    // ADR-0028: feed every worker's chunk checksums into the run ledger; the
-    // seam harvests once, at the dispatcher, before finalize writes the manifest.
-    for (part, key) in poison::into_recover(checksums_shared) {
-        summary.ledger.merge_checksums(&part);
-        summary.ledger.note_key_column(key);
+    // ADR-0028/0029: feed every worker's chunk checksums into the run ledger under
+    // the SAME chunk unit the drain above recorded that chunk's parts with; the
+    // seam harvests once, at the dispatcher, before finalize writes the manifest,
+    // and computes the coverage rather than trusting this feed's order.
+    for (chunk_index, part, key) in poison::into_recover(checksums_shared) {
+        summary.ledger.contribute_checksums(
+            super::super::commit::UnitId::Chunk(chunk_index),
+            &part,
+            key,
+        );
     }
 
     state.finalize_chunk_run_completed(&run_id)?;

--- a/src/pipeline/chunked/resume_m8.rs
+++ b/src/pipeline/chunked/resume_m8.rs
@@ -793,6 +793,7 @@ mod tests {
         let rows_before = summary.total_rows;
         let committed_before = summary.files_committed;
         let produced_before = summary.files_produced;
+        let bytes_before = summary.bytes_written;
 
         let n = rehydrate_manifest_parts_from_file_log(&state, run_id, &mut summary).unwrap();
 
@@ -835,6 +836,19 @@ mod tests {
             summary.files_committed - committed_before,
             2,
             "both reconstructed siblings count as committed files"
+        );
+        // BYTES, the third aggregate this function folds and the one the first
+        // pass at these assertions MISSED — I read the surviving mutant's
+        // column as `files_produced` without opening the line, closed a real
+        // but different gap, and `+= -> *=` on THIS statement survived a second
+        // 73-minute run. 4096 + 2048 over a zero base, so the mutant computes 0
+        // and cannot hide behind the fold.
+        assert_eq!(
+            summary.bytes_written - bytes_before,
+            6144,
+            "byte aggregate is the SUM of both siblings' real sizes — a manifest \
+             whose declared parts and whose byte total disagree misreports every \
+             throughput number downstream"
         );
         assert_eq!(
             summary.files_produced - produced_before,

--- a/src/pipeline/chunked/resume_m8.rs
+++ b/src/pipeline/chunked/resume_m8.rs
@@ -256,11 +256,15 @@ pub(crate) fn rehydrate_manifest_parts_from_file_log(
         summary.files_produced += rehydrated;
         summary.total_rows += rehydrated_rows;
         summary.bytes_written += rehydrated_bytes;
-        // These parts carry NO per-column checksum (file_log stores none), so the
-        // run-wide Form B XOR this run harvests cannot cover them. Mark it
-        // incomplete so harvest_column_checksums suppresses Form B rather than
-        // record a partial XOR that `validate` would flag as a false mismatch.
-        summary.column_checksums_incomplete = true;
+        // ADR-0029: these parts carry NO per-column checksum (file_log stores
+        // none), so the run-wide Form B this run harvests cannot cover them —
+        // and nothing here has to SAY so any more. They enter `manifest_parts`
+        // without going through `commit::record_part`, so the seam's coverage
+        // computation finds no commit unit for them and suppresses Form B by
+        // itself. The manual flag that used to live here was the vigilance
+        // ADR-0029 replaced; setting it now would only pre-empt a verdict the
+        // harvest reaches from the data (and would hide whether the shortfall
+        // was hydration or a runner's unit-id mismatch).
         log::info!(
             "resume: reconstructed {rehydrated} committed part(s) ({rehydrated_rows} rows, \
              {rehydrated_bytes} bytes) into the manifest from the state DB file_log (no \
@@ -454,12 +458,12 @@ pub(crate) fn apply_m8_resume_decisions(
                 // and the manifest-authoritative `rivet load` lost its rows.
                 if let Some(p) = manifest_part_by_path.get(path.as_str()) {
                     summary.manifest_parts.push((*p).clone());
-                    // A skipped part's per-column checksum contribution is gone
-                    // (the prior manifest kept only the run-wide XOR, not per-part),
-                    // so this run's harvested XOR would cover only the re-exported
-                    // parts. Mark Form B incomplete → suppressed at harvest, never a
-                    // partial XOR that `validate --depth full` false-flags.
-                    summary.column_checksums_incomplete = true;
+                    // ADR-0029: a skipped part's per-column checksum contribution
+                    // is gone (the prior manifest kept only the run-wide sum, not
+                    // per-part) — and, like the file_log rehydration above, this
+                    // clone never goes through `commit::record_part`, so the seam
+                    // sees a manifest part with no commit unit and suppresses Form
+                    // B itself. No flag to remember here any more.
                 }
             }
             // Rewrite / Quarantine RE-EXPORT the owning chunk, so they DO need
@@ -818,12 +822,36 @@ mod tests {
             50,
             "row aggregate bumped by the union"
         );
-        // Finding #10: rehydrated parts carry no per-column checksum, so Form B
-        // must be flagged incomplete — harvest_column_checksums then suppresses it
-        // rather than record a partial XOR that `validate` would false-flag.
+        // Finding #10 / ADR-0029: rehydrated parts carry no per-column checksum,
+        // so the run-wide Form B cannot cover the manifest. Pre-ADR-0029 this
+        // function SET `column_checksums_incomplete` and the assertion here read
+        // that flag back — a test of the flag, not of the outcome. Now the verdict
+        // is COMPUTED at the harvest from these parts having no commit unit, so
+        // assert the OUTCOME through the real seam: even with a full run-wide
+        // checksum accumulator in hand, Form B must come out suppressed.
+        //
+        // RED against restoring a coverage rule that trusts the feed (Form B is
+        // then recorded over a manifest whose two rehydrated parts it does not
+        // cover — the partial record `validate --depth full` false-flags).
+        let mut integrity = crate::pipeline::commit::Integrity::default();
+        integrity
+            .column_checksums
+            .insert("id".to_string(), 0xdead_beef_u64);
+        crate::pipeline::commit::harvest_column_checksums(&mut summary, integrity);
+        assert!(
+            summary.column_checksums.is_empty(),
+            "rehydrated pre-crash parts have no commit unit, so the harvest must SUPPRESS \
+             Form B rather than publish a record covering only the re-exported parts"
+        );
         assert!(
             summary.column_checksums_incomplete,
-            "rehydrating pre-crash parts must mark Form B incomplete (suppressed at harvest)"
+            "and the suppression must be RECORDED, so the Form-B telltale in \
+             check_post_run_invariants can tell it from a runner that harvested nothing"
+        );
+        assert!(
+            !summary.column_checksums_short_cover,
+            "a hydration is not a runner defect — short_cover must stay clear or every \
+             crash-recovery resume fails the ADR-0029 invariant"
         );
     }
 
@@ -837,7 +865,9 @@ mod tests {
     // manifest lists 80 rows.
     #[test]
     fn parallel_resume_accumulates_rows_onto_rehydrated_base_not_clobbers() {
-        use crate::pipeline::commit::{PartKind, PartRecord, accumulate_run_rows, record_part};
+        use crate::pipeline::commit::{
+            PartKind, PartRecord, UnitId, accumulate_run_rows, record_part,
+        };
 
         let state_dir = tempfile::tempdir().unwrap();
         let state =
@@ -895,6 +925,7 @@ mod tests {
                 md5: String::new(),
             },
             PartKind::Chunk { chunk_index: 2 },
+            UnitId::Chunk(2),
         );
 
         let parts_rows: i64 = summary.manifest_parts.iter().map(|p| p.rows).sum();

--- a/src/pipeline/chunked/resume_m8.rs
+++ b/src/pipeline/chunked/resume_m8.rs
@@ -791,6 +791,8 @@ mod tests {
         let mut summary =
             crate::pipeline::summary::RunSummary::stub_for_testing(run_id, String::from("orders"));
         let rows_before = summary.total_rows;
+        let committed_before = summary.files_committed;
+        let produced_before = summary.files_produced;
 
         let n = rehydrate_manifest_parts_from_file_log(&state, run_id, &mut summary).unwrap();
 
@@ -821,6 +823,24 @@ mod tests {
             summary.total_rows - rows_before,
             50,
             "row aggregate bumped by the union"
+        );
+        // Both FILE counters, in delta form, because the manifest this resume hands
+        // downstream is graded on them: `files_committed` feeds the reconcile gate
+        // and the run card, `files_produced` the coherence invariant. Asserting the
+        // parts alone left `files_produced += rehydrated` unguarded — a surviving
+        // `*=` mutant, and over a 0 base with 2 siblings that is a REAL divergence
+        // (0*2=0 vs 0+2=2): a manifest whose declared parts and whose own
+        // aggregates disagree. Delta form so a non-zero base cannot hide it.
+        assert_eq!(
+            summary.files_committed - committed_before,
+            2,
+            "both reconstructed siblings count as committed files"
+        );
+        assert_eq!(
+            summary.files_produced - produced_before,
+            2,
+            "…and as produced files — the two counters move together, or the \
+             manifest disagrees with its own aggregates"
         );
         // Finding #10 / ADR-0029: rehydrated parts carry no per-column checksum,
         // so the run-wide Form B cannot cover the manifest. Pre-ADR-0029 this

--- a/src/pipeline/chunked/sequential_checkpoint.rs
+++ b/src/pipeline/chunked/sequential_checkpoint.rs
@@ -332,8 +332,13 @@ pub(crate) fn run_chunked_sequential_checkpoint(
                 // ADR-0028: feed the run ledger; the seam harvests once, at
                 // the dispatcher (chunked's drift gate stays pre-chunk, ADR-0021,
                 // so no schema is fed here).
-                summary.ledger.merge_checksums(&chunk_checksums);
-                summary.ledger.note_key_column(key);
+                // ADR-0029: contributed under the chunk this loop iteration
+                // just committed — the unit its record_part calls use below.
+                summary.ledger.contribute_checksums(
+                    super::super::commit::UnitId::Chunk(chunk_index),
+                    &chunk_checksums,
+                    key,
+                );
                 // Shared commit path for the non-empty branch (I2/M1 + counters
                 // + ChunkCompleted journal + I7 file-log + fault hooks).
                 // Empty chunks have no file to record but still need to journal
@@ -354,6 +359,7 @@ pub(crate) fn run_chunked_sequential_checkpoint(
                             Some(state),
                             rec,
                             super::super::commit::PartKind::Chunk { chunk_index },
+                            super::super::commit::UnitId::Chunk(chunk_index),
                         );
                     }
                     // chunk_task carries one file name; for a rotation-split

--- a/src/pipeline/commit.rs
+++ b/src/pipeline/commit.rs
@@ -66,6 +66,85 @@ pub(in crate::pipeline) fn accumulate_run_rows(summary: &mut RunSummary, this_ru
     summary.total_rows += this_run_rows;
 }
 
+/// ADR-0029: the COMMIT UNIT a durable part and its Form-B checksum
+/// contribution both belong to — the key the seam computes coverage on.
+///
+/// It is deliberately the unit each RUNNER commits at, not "a part": a part is
+/// what lands on disk, a unit is what the runner declares complete. The two
+/// differ, and that difference is the whole reason this type exists — the
+/// parallel keyset runner publishes parts per PAGE (durability must show what
+/// is physically on disk, the #200-1 fix) but publishes checksums per committed
+/// RANGE, so its unit is [`UnitId::Range`] while `PartKind` still journals the
+/// page. Pairing them by page would report every healthy range short.
+///
+/// Which unit a runner uses is stated at its `record_part` call site AND at its
+/// checksum feed; the two must agree, and `check_post_run_invariants` fails the
+/// run in debug builds when they do not (a mismatch would otherwise suppress
+/// Form B on a healthy run — silently, and in the fail-safe direction, which is
+/// exactly the shape this repo has shipped twice).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum UnitId {
+    /// The whole runner invocation. `single` reads once into ONE sink that
+    /// accumulates the checksums of every part it writes, so the sink's drain
+    /// covers all of them or (on a mid-write bail) none — there is no smaller
+    /// unit to key on, and pretending there is would be a lie about the sink.
+    Run,
+    /// A chunk window — the chunked runners (sequential / parallel / both
+    /// checkpoint twins) and a `mongo_parallel` worker range.
+    Chunk(i64),
+    /// A keyset PAGE — the sequential keyset runner, which feeds the page's
+    /// checksums and records the page's parts in the same loop iteration.
+    Page(i64),
+    /// A keyset RANGE — the parallel keyset runner (see the type doc).
+    Range(i64),
+}
+
+/// ADR-0029 half 1 — facts that describe what the runner SAW.
+///
+/// They carry NO coverage obligation, they are monotonic, and recording one
+/// early can never be wrong — so runners feed them EAGERLY, above any error
+/// bail, and `finalize_export_records` applies them unconditionally on the
+/// failure path. Before the split they rode in the same feed as the checksums
+/// and were lost with them: a failed parallel-keyset run recorded the STALE
+/// open-time fingerprint over durable parquet carrying the observed schema.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct Observations {
+    /// The run's dest schema (first non-empty page/sink wins) — drives the
+    /// manifest fingerprint pin and the post-run `on_schema_drift` gate.
+    /// `None` on runners whose drift gate runs elsewhere by design (chunked
+    /// checks pre-chunk via `check_from_type_mappings`, ADR-0021).
+    pub(in crate::pipeline) drift_schema: Option<arrow::datatypes::Schema>,
+    /// Max observed byte length per column (shape-drift warn input); merged
+    /// by max so worker/part order is irrelevant.
+    pub(in crate::pipeline) column_max_bytes: std::collections::HashMap<String, u64>,
+}
+
+/// ADR-0029 half 2 — the integrity record, which is only meaningful as a set
+/// covering EXACTLY the parts the manifest lists.
+///
+/// Stays commit-gated (a runner feeds a unit's checksums only once that unit
+/// committed), and the seam no longer TRUSTS that gating: it computes coverage
+/// from [`Integrity::part_units`] vs [`Integrity::covered_units`] and suppresses
+/// Form B itself when a recorded part's unit contributed nothing.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct Integrity {
+    /// Run-wide sum-combined per-column value checksums (Form B input).
+    pub(in crate::pipeline) column_checksums: std::collections::BTreeMap<String, u64>,
+    /// The key column the checksums are keyed to (first runner-reported wins).
+    pub(in crate::pipeline) checksum_key_column: Option<String>,
+    /// `manifest_parts.part_id` → the commit unit that produced it, written by
+    /// [`record_part`] for every part it records. Keyed on the manifest's own
+    /// part_id (not the path) so it is O(8 bytes) per part rather than a second
+    /// copy of every path, and so a DEDUPED re-read (which keeps the existing
+    /// part_id) re-registers the same entry instead of double-counting.
+    pub(in crate::pipeline) part_units: std::collections::BTreeMap<u32, UnitId>,
+    /// The units that actually contributed checksums. A unit is registered even
+    /// when its map is EMPTY (a CSV/JSONL sink computes none, a zero-row chunk
+    /// has none): the unit did its part, and the absence of a checksum is a
+    /// FORMAT fact, not a coverage fact.
+    pub(in crate::pipeline) covered_units: std::collections::BTreeSet<UnitId>,
+}
+
 /// ADR-0028: the run-wide tail ledger, filled by the runners as they commit and
 /// APPLIED once by [`crate::pipeline::finalize::finalize_export`] — the one seam
 /// the dispatcher calls between the runner returning and `finalize_manifest`.
@@ -79,55 +158,130 @@ pub(in crate::pipeline) fn accumulate_run_rows(summary: &mut RunSummary, this_ru
 /// computed — and the APPLICATION lives in exactly one place, ordering encoded
 /// once. The telltale invariants in `check_post_run_invariants` (drift verdict
 /// present, Form-B harvested-or-flagged) go RED if a runner feeds nothing.
+///
+/// ADR-0029 split it in two by TRUTH CONDITION, because holding facts with
+/// different truth conditions in one structure with one lifecycle, fed at one
+/// moment, is what made the failure path lose the fingerprint: an
+/// [`Observations`] is true the moment the runner SEES it, an [`Integrity`]
+/// record is only true of a unit that COMMITTED. They are fed at different
+/// moments now, and the seam computes the integrity half's coverage rather than
+/// trusting the order it was fed in.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct CommitLedger {
-    /// Run-wide sum-combined per-column value checksums (Form B input).
-    pub(in crate::pipeline) column_checksums: std::collections::BTreeMap<String, u64>,
-    /// The key column the checksums are keyed to (first runner-reported wins).
-    pub(in crate::pipeline) checksum_key_column: Option<String>,
-    /// The run's dest schema (first non-empty page/sink wins) — drives the
-    /// manifest fingerprint pin and the post-run `on_schema_drift` gate.
-    /// `None` on runners whose drift gate runs elsewhere by design (chunked
-    /// checks pre-chunk via `check_from_type_mappings`, ADR-0021).
-    pub(in crate::pipeline) drift_schema: Option<arrow::datatypes::Schema>,
-    /// Max observed byte length per column (shape-drift warn input); merged
-    /// by max so worker/part order is irrelevant.
-    pub(in crate::pipeline) column_max_bytes: std::collections::HashMap<String, u64>,
+    /// What the runner SAW — fed eagerly, applied on both paths.
+    pub(in crate::pipeline) observed: Observations,
+    /// What COMMITTED — commit-gated, coverage computed at harvest.
+    pub(in crate::pipeline) integrity: Integrity,
 }
 
 impl CommitLedger {
     /// First-wins schema note (idempotent run-wide, like the fingerprint pin).
+    /// An OBSERVATION: feed it as soon as a schema is in hand, above any bail.
     pub(in crate::pipeline) fn note_schema(&mut self, schema: &arrow::datatypes::Schema) {
-        if self.drift_schema.is_none() {
-            self.drift_schema = Some(schema.clone());
+        if self.observed.drift_schema.is_none() {
+            self.observed.drift_schema = Some(schema.clone());
         }
     }
 
-    /// Fold one part/page/worker's per-column checksums into the run-wide map
-    /// (commutative wrapping add — see [`accumulate_column_checksums`]).
-    pub(in crate::pipeline) fn merge_checksums(
-        &mut self,
-        part: &std::collections::BTreeMap<String, u64>,
-    ) {
-        accumulate_column_checksums(&mut self.column_checksums, part);
-    }
-
-    /// First-wins key-column note (all pages/workers of a run share one key).
-    pub(in crate::pipeline) fn note_key_column(&mut self, key: Option<String>) {
-        if self.checksum_key_column.is_none() {
-            self.checksum_key_column = key;
-        }
-    }
-
-    /// Max-merge one sink's observed per-column byte lengths.
+    /// Max-merge one sink's observed per-column byte lengths. An OBSERVATION.
     pub(in crate::pipeline) fn merge_shape(
         &mut self,
         max_bytes: &std::collections::HashMap<String, u64>,
     ) {
         for (col, len) in max_bytes {
-            let e = self.column_max_bytes.entry(col.clone()).or_insert(0);
+            let e = self
+                .observed
+                .column_max_bytes
+                .entry(col.clone())
+                .or_insert(0);
             *e = (*e).max(*len);
         }
+    }
+
+    /// ADR-0029: contribute one COMMITTED unit's Form-B checksums, keyed by the
+    /// unit so the seam can compare them against the parts that unit recorded.
+    ///
+    /// This is the ONLY way checksums enter the ledger — there is no unkeyed
+    /// merge, because an unkeyed contribution is exactly the "trust the feed
+    /// order" the ADR removes. Registering the unit is unconditional (see
+    /// [`Integrity::covered_units`]); the checksum fold is commutative
+    /// (wrapping add — see [`accumulate_column_checksums`]) so worker order and
+    /// a re-contribution of the same unit both behave.
+    pub(in crate::pipeline) fn contribute_checksums(
+        &mut self,
+        unit: UnitId,
+        part: &std::collections::BTreeMap<String, u64>,
+        key_column: Option<String>,
+    ) {
+        self.integrity.covered_units.insert(unit);
+        accumulate_column_checksums(&mut self.integrity.column_checksums, part);
+        // First-Some-wins key column (all pages/workers of a run share one key).
+        if self.integrity.checksum_key_column.is_none() {
+            self.integrity.checksum_key_column = key_column;
+        }
+    }
+
+    /// ADR-0029: note which commit unit a just-recorded manifest part belongs
+    /// to. Called only from [`record_part`], so no runner can record a part
+    /// without declaring its unit.
+    fn note_part(&mut self, part_id: u32, unit: UnitId) {
+        self.integrity.part_units.insert(part_id, unit);
+    }
+}
+
+/// ADR-0029 — the computed coverage verdict for one run's Form-B record.
+///
+/// `complete` is the only thing that decides whether Form B is recorded;
+/// `short_cover` distinguishes the two reasons it can be short, and that
+/// distinction is what turns "Form B is absent" from ambiguous into a recorded
+/// verdict (ADR-0029 Consequences):
+///
+/// * a part with NO ledger entry at all — it did not go through `record_part`
+///   this run, i.e. a checkpoint-resume rehydration or an M8 `Skip` clone of a
+///   prior manifest's part. Legitimate and expected; Form B is suppressed
+///   because its per-column contribution is genuinely unrecoverable.
+/// * a part whose unit contributed NOTHING (`short_cover`) — the unit never
+///   committed (a failed keyset range, a mid-write bail), or the runner paired
+///   the part and the checksum under DIFFERENT unit ids. On a run whose runner
+///   SUCCEEDED the first cannot happen, so `short_cover` there is the unit-id
+///   mismatch ADR-0029 names as its own risk, and `check_post_run_invariants`
+///   fails the run rather than let it suppress Form B in silence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::pipeline) struct Coverage {
+    pub(in crate::pipeline) complete: bool,
+    pub(in crate::pipeline) short_cover: bool,
+    /// Parts recorded this run whose unit contributed no checksums.
+    pub(in crate::pipeline) uncovered_parts: usize,
+    /// Parts in the manifest that this run never recorded (rehydrated / cloned).
+    pub(in crate::pipeline) foreign_parts: usize,
+}
+
+/// ADR-0029 — compare the contributions' unit set against the RECORDED PARTS'
+/// unit set, over the manifest itself.
+///
+/// The manifest is the subject on purpose: it is the list the Form-B record
+/// claims to cover, and it is the only list that also holds the parts a resume
+/// hydrated without ever calling `record_part`. Keying the comparison on
+/// `record_part` calls alone would have missed exactly those, which is the case
+/// the manual `column_checksums_incomplete` flag existed for.
+pub(in crate::pipeline) fn compute_coverage(
+    parts: &[crate::manifest::ManifestPart],
+    integrity: &Integrity,
+) -> Coverage {
+    let mut uncovered_parts = 0usize;
+    let mut foreign_parts = 0usize;
+    for p in parts {
+        match integrity.part_units.get(&p.part_id) {
+            None => foreign_parts += 1,
+            Some(unit) if !integrity.covered_units.contains(unit) => uncovered_parts += 1,
+            Some(_) => {}
+        }
+    }
+    Coverage {
+        complete: uncovered_parts == 0 && foreign_parts == 0,
+        short_cover: uncovered_parts > 0,
+        uncovered_parts,
+        foreign_parts,
     }
 }
 
@@ -160,38 +314,59 @@ pub(in crate::pipeline) fn accumulate_column_checksums(
 /// the multi-part runners pass the accumulated map).
 pub(in crate::pipeline) fn harvest_column_checksums(
     summary: &mut RunSummary,
-    acc: std::collections::BTreeMap<String, u64>,
-    key_column: Option<String>,
+    integrity: Integrity,
 ) {
-    if acc.is_empty() {
-        return;
-    }
-    // A checkpoint resume that hydrated pre-crash parts (Skip clone / file_log
-    // rehydrate) whose per-column checksums are unrecoverable makes the run-wide
-    // XOR cover ONLY the re-exported parts, while the manifest lists ALL parts.
-    // Recording that partial XOR would make `validate --depth full` re-read every
-    // part, recompute the full XOR, and report a FALSE mismatch on correctly
-    // resumed data (and the authoritative manifest's integrity record would be
-    // objectively wrong). Suppress Form B instead — absent, not partial-and-lying,
-    // the same graceful degradation a rehydrated part's empty md5 gets.
-    if summary.column_checksums_incomplete {
+    // ADR-0029: COMPUTE the coverage rather than trust the feed order. A record
+    // that covers only SOME of the manifest's parts would make `validate --depth
+    // full` re-read every part, recompute the full sum, and report a FALSE
+    // mismatch on correctly-written data — the authoritative manifest's integrity
+    // record would be objectively wrong. Suppress instead: absent, not
+    // partial-and-lying, the same graceful degradation a rehydrated part's empty
+    // md5 gets. Pre-ADR-0029 this decision was a bool the resume paths had to
+    // remember to SET; now it follows from the data (a rehydrated part simply has
+    // no contribution), and the flag is the RESULT.
+    let cov = compute_coverage(&summary.manifest_parts, &integrity);
+    if !cov.complete {
+        summary.column_checksums_incomplete = true;
+        summary.column_checksums_short_cover |= cov.short_cover;
         log::warn!(
-            "export '{}': Form B value-checksums suppressed — a checkpoint resume hydrated \
-             pre-crash parts whose per-column checksums are not recoverable, so the run-wide \
-             checksum would cover only the re-exported parts. `validate` will size-verify parts \
-             but skip the Form B value re-read for this run.",
-            summary.export_name
+            "export '{}': Form B value-checksums suppressed — the run-wide checksum covers \
+             only part of this manifest ({} part(s) hydrated from a prior run and carrying no \
+             per-column checksum, {} part(s) whose commit unit contributed none). `validate` \
+             will size-verify parts but skip the Form B value re-read for this run.",
+            summary.export_name,
+            cov.foreign_parts,
+            cov.uncovered_parts,
         );
         return;
     }
-    summary.column_checksums = acc
+    // Coverage is COMPLETE and there is nothing to record: no unit computed a
+    // value checksum at all. That is a FORMAT fact, not an integrity shortfall —
+    // the sink's `track_checksum` skips non-Parquet by design, so a CSV/JSONL
+    // export legitimately lands here with every unit registered and an empty
+    // map. Leave the flag CLEAR on purpose: `check_post_run_invariants`'s Form-B
+    // telltale ("empty and not flagged incomplete") is what catches a parquet
+    // runner that harvested nothing, and flagging here would excuse exactly that.
+    //
+    // The ORDER matters and cost a live regression to learn: this early return
+    // used to sit ABOVE the coverage computation, and a parallel-keyset crash
+    // resume that re-ran ZERO ranges then had an empty accumulator, skipped the
+    // computation, and reached finalize with rehydrated parts and no suppression
+    // flag — the telltale panicked. Pre-ADR-0029 the flag came from the manual
+    // `rehydrate_manifest_parts_from_file_log` assignment this ADR retires, so
+    // the computed rule must be reached on the empty-accumulator path too.
+    if integrity.column_checksums.is_empty() {
+        return;
+    }
+    summary.column_checksums = integrity
+        .column_checksums
         .into_iter()
         .map(|(name, checksum)| crate::manifest::ColumnChecksum {
             name,
             checksum: checksum.to_string(),
         })
         .collect();
-    summary.checksum_key_column = key_column;
+    summary.checksum_key_column = integrity.checksum_key_column;
 }
 
 /// A part written to the destination, ready to be recorded. Produced by
@@ -357,12 +532,20 @@ pub(crate) fn part_indexed_name(base: &str, idx: usize, count: usize) -> String 
 /// Returns `true` iff the part was DEDUPED (a re-read overwrote a rehydrated part of the same
 /// path); the caller (the keyset page loop) then skips the per-page `total_rows` bump because
 /// rehydration already counted that page.
+///
+/// ADR-0029: `unit` is the COMMIT UNIT this part belongs to, and it must be the
+/// SAME [`UnitId`] the runner passes to `CommitLedger::contribute_checksums` for
+/// that unit — the seam compares the two sets to decide whether the Form-B
+/// record covers the manifest. It is a separate argument from `kind` because the
+/// two genuinely differ on one runner (parallel keyset journals a page and
+/// commits a range); everywhere else they coincide and the call site says so.
 pub(crate) fn record_part(
     plan: &ResolvedRunPlan,
     summary: &mut RunSummary,
     state: Option<&StateStore>,
     part: &PartRecord,
     kind: PartKind,
+    unit: UnitId,
 ) -> bool {
     // ADR-0001 I2→I3 crash window: file at destination, manifest not yet updated.
     crate::test_hook::maybe_panic_at("after_file_write");
@@ -373,7 +556,7 @@ pub(crate) fn record_part(
     // not inflate files_committed / bytes_written past manifest_parts.len() (which would trip the
     // run-integrity invariant). total_rows is a per-page loop counter; the keyset runner reconciles
     // it to the manifest sum after the loop.
-    let deduped = manifest_writer::record_committed_part_with_fingerprint(
+    let recorded = manifest_writer::record_committed_part_with_fingerprint(
         summary,
         part.file_name.clone(),
         part.rows,
@@ -381,11 +564,18 @@ pub(crate) fn record_part(
         part.fingerprint.clone(),
         part.md5.clone(),
     );
+    let deduped = recorded.deduped;
     if !deduped {
         summary.bytes_written += part.bytes;
         summary.files_produced += 1;
         summary.files_committed += 1;
     }
+    // ADR-0029: register the part → unit pairing the seam computes coverage on.
+    // Keyed by the manifest's own part_id, so a DEDUPED re-read (same part_id,
+    // refreshed payload) re-registers the same entry — a re-read of a rehydrated
+    // page therefore turns that part from foreign into covered, which is exactly
+    // what happened: this run really did compute its checksums.
+    summary.ledger.note_part(recorded.part_id, unit);
 
     match &kind {
         PartKind::File { part_index } => summary.journal.record(RunEvent::FileWritten {
@@ -474,6 +664,9 @@ mod tests {
     /// four (schema, checksums, key, shape) and the sink was emptied.
     #[test]
     fn drain_tail_into_moves_schema_checksums_key_and_shape_to_the_ledger() {
+        // ADR-0029 split the one drain in two; this pins BOTH halves together,
+        // since the sink is the only feeder that owns schema, checksums, key and
+        // shape at once and a half-wired runner is the bug it guards.
         use arrow::datatypes::{DataType, Field, Schema};
         let plan = test_plan();
         let mut sink = crate::pipeline::sink::ExportSink::new(&plan).expect("sink");
@@ -488,16 +681,25 @@ mod tests {
         sink.column_max_bytes = [("id".to_string(), 8u64)].into();
 
         let mut led = CommitLedger::default();
-        sink.drain_tail_into(&mut led);
+        sink.drain_observations_into(&mut led);
+        sink.drain_integrity_into(UnitId::Run, &mut led);
 
         assert_eq!(
-            led.drift_schema.as_ref().map(|s| s.field(0).name().clone()),
+            led.observed
+                .drift_schema
+                .as_ref()
+                .map(|s| s.field(0).name().clone()),
             Some("id".to_string()),
             "the sink's dest schema must reach the ledger"
         );
-        assert_eq!(led.column_checksums.get("id"), Some(&41u64));
-        assert_eq!(led.checksum_key_column.as_deref(), Some("id"));
-        assert_eq!(led.column_max_bytes.get("id"), Some(&8u64));
+        assert_eq!(led.integrity.column_checksums.get("id"), Some(&41u64));
+        assert_eq!(led.integrity.checksum_key_column.as_deref(), Some("id"));
+        assert_eq!(led.observed.column_max_bytes.get("id"), Some(&8u64));
+        assert!(
+            led.integrity.covered_units.contains(&UnitId::Run),
+            "the integrity drain must REGISTER its commit unit, or the seam reads \
+             every part single wrote as uncovered and suppresses Form B"
+        );
         assert!(
             sink.column_checksums.is_empty() && sink.column_max_bytes.is_empty(),
             "drain must TAKE the sink's accumulators, not copy them"
@@ -515,27 +717,38 @@ mod tests {
         led.note_schema(&a);
         led.note_schema(&b);
         assert_eq!(
-            led.drift_schema.as_ref().map(|s| s.field(0).name().clone()),
+            led.observed
+                .drift_schema
+                .as_ref()
+                .map(|s| s.field(0).name().clone()),
             Some("id".to_string()),
             "note_schema is first-wins — a later page/worker schema must not replace the run's"
         );
 
         // first-Some-wins key: a None feed leaves it open for a later Some.
-        led.note_key_column(None);
-        led.note_key_column(Some("id".into()));
-        led.note_key_column(Some("late".into()));
-        assert_eq!(led.checksum_key_column.as_deref(), Some("id"));
-
-        // commutative wrapping-add merge — two parts with the same column SUM,
-        // never overwrite (an overwrite would silently drop part 1's coverage).
+        // commutative wrapping-add merge — two units with the same column SUM,
+        // never overwrite (an overwrite would silently drop unit 1's coverage).
         let p1: std::collections::BTreeMap<String, u64> = [("v".to_string(), 7u64)].into();
         let p2: std::collections::BTreeMap<String, u64> = [("v".to_string(), 5u64)].into();
-        led.merge_checksums(&p1);
-        led.merge_checksums(&p2);
+        led.contribute_checksums(UnitId::Chunk(0), &Default::default(), None);
+        led.contribute_checksums(UnitId::Chunk(1), &p1, Some("id".into()));
+        led.contribute_checksums(UnitId::Chunk(2), &p2, Some("late".into()));
+        assert_eq!(led.integrity.checksum_key_column.as_deref(), Some("id"));
         assert_eq!(
-            led.column_checksums.get("v"),
+            led.integrity.column_checksums.get("v"),
             Some(&12u64),
             "checksum merge must fold (wrapping add), not overwrite"
+        );
+        // ADR-0029: every contribution registers its unit — including the EMPTY
+        // one. A zero-row chunk / a CSV sink computes no checksums and still
+        // COMMITTED; reading that as "uncovered" would suppress Form B on the
+        // next parquet run that happens to contain an empty chunk.
+        assert_eq!(
+            led.integrity.covered_units,
+            [UnitId::Chunk(0), UnitId::Chunk(1), UnitId::Chunk(2)]
+                .into_iter()
+                .collect::<std::collections::BTreeSet<_>>(),
+            "an empty contribution still covers its unit"
         );
 
         // shape is max-merge: order-independent, the larger observation wins.
@@ -543,7 +756,7 @@ mod tests {
         let s2: std::collections::HashMap<String, u64> = [("t".to_string(), 40u64)].into();
         led.merge_shape(&s1);
         led.merge_shape(&s2);
-        assert_eq!(led.column_max_bytes.get("t"), Some(&100u64));
+        assert_eq!(led.observed.column_max_bytes.get("t"), Some(&100u64));
     }
 
     fn test_plan() -> ResolvedRunPlan {
@@ -744,6 +957,7 @@ mod tests {
             None,
             &part,
             PartKind::File { part_index: 0 },
+            UnitId::Run,
         );
 
         assert_eq!(summary.bytes_written, part.bytes);
@@ -781,6 +995,7 @@ mod tests {
             None,
             &part,
             PartKind::Chunk { chunk_index: 7 },
+            UnitId::Chunk(7),
         );
 
         let events = summary.journal.chunk_events();
@@ -818,6 +1033,7 @@ mod tests {
             Some(&state),
             &part,
             PartKind::Chunk { chunk_index: 0 },
+            UnitId::Chunk(0),
         );
 
         let files = state.get_files(Some(&plan.export_name), 16).unwrap();
@@ -841,6 +1057,7 @@ mod tests {
             None,
             &part,
             PartKind::Chunk { chunk_index: 0 },
+            UnitId::Chunk(0),
         );
 
         assert_eq!(summary.files_committed, 1);
@@ -892,6 +1109,7 @@ mod tests {
                 PartKind::Chunk {
                     chunk_index: i as i64,
                 },
+                UnitId::Chunk(i as i64),
             );
         }
 
@@ -937,6 +1155,7 @@ mod tests {
             None,
             &part,
             PartKind::Chunk { chunk_index: 0 },
+            UnitId::Chunk(0),
         );
         summary.status = "success".into();
 
@@ -952,33 +1171,378 @@ mod tests {
         );
     }
 
-    // Finding #10: on a checkpoint resume that hydrated pre-crash parts, the
-    // run-wide Form B XOR would cover only the re-exported parts while the
-    // manifest lists ALL parts — a partial XOR that `validate --depth full`
-    // false-flags. harvest_column_checksums must SUPPRESS Form B (leave it empty)
-    // when the summary is flagged incomplete, never record the partial XOR. RED
-    // against a harvest that ignores the flag.
-    #[test]
-    fn harvest_suppresses_form_b_when_resume_left_checksums_incomplete() {
-        let plan = test_plan();
-        let mut acc = std::collections::BTreeMap::new();
-        acc.insert("id".to_string(), 0xdead_beefu64);
+    // ── ADR-0029: computed Form-B coverage ───────────────────────────────────
+    //
+    // These drive the REAL seam (`record_part` writes the part → unit map,
+    // `contribute_checksums` writes the covered set, `harvest_column_checksums`
+    // compares them over `summary.manifest_parts`) rather than hand-setting the
+    // verdict. Both directions are here on purpose: an absence-only suite would
+    // pass against a harvest that suppresses ALWAYS, which is precisely the
+    // fail-safe-but-silent failure ADR-0029 names as its own risk.
 
-        // Normal run: the accumulated checksums are recorded.
-        let mut ok = test_summary(&plan);
-        harvest_column_checksums(&mut ok, acc.clone(), Some("id".into()));
+    /// Feed the ledger the way a runner does: N parts under one commit unit,
+    /// then that unit's checksums. Returns the summary the seam would see.
+    fn run_one_unit(plan: &ResolvedRunPlan, unit: UnitId, parts: &[PartRecord]) -> RunSummary {
+        let mut summary = test_summary(plan);
+        for p in parts {
+            record_part(
+                plan,
+                &mut summary,
+                None,
+                p,
+                PartKind::Chunk { chunk_index: 0 },
+                unit,
+            );
+        }
+        summary.ledger.contribute_checksums(
+            unit,
+            &[("id".to_string(), 0xdead_beefu64)].into(),
+            Some("id".into()),
+        );
+        summary
+    }
+
+    /// THE positive. A run whose every manifest part belongs to a unit that
+    /// contributed must RECORD Form B — checksums and key column both.
+    ///
+    /// Mandatory rather than optional (ADR-0029 "Risk"): the whole mechanism
+    /// fails SAFE, so a unit-id mismatch, an off-by-one in the part_id key, or a
+    /// coverage rule that simply always returns "short" all present as an absent
+    /// Form B on healthy data — which no suppression test can see. RED against
+    /// `Coverage.complete = false` (unconditional suppression) and against a
+    /// `record_part` that skips `note_part` (every part then reads foreign).
+    #[test]
+    fn harvest_records_form_b_when_every_manifest_part_s_unit_contributed() {
+        let plan = test_plan();
+        // 3 parts under the unit: with ONE part a coverage rule that only looks
+        // at the first manifest entry is indistinguishable from one that checks
+        // them all.
+        let parts = synthetic_parts(3);
+        let mut summary = run_one_unit(&plan, UnitId::Chunk(0), &parts);
+        assert_eq!(summary.manifest_parts.len(), 3, "fixture: 3 parts recorded");
+
+        let integrity = std::mem::take(&mut summary.ledger).integrity;
+        harvest_column_checksums(&mut summary, integrity);
+
+        assert_eq!(
+            summary
+                .column_checksums
+                .iter()
+                .map(|c| (c.name.as_str(), c.checksum.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("id", "3735928559")],
+            "a fully-covered run must RECORD Form B, not merely fail to suppress it"
+        );
+        assert_eq!(summary.checksum_key_column.as_deref(), Some("id"));
         assert!(
-            !ok.column_checksums.is_empty(),
-            "a complete run must record Form B"
+            !summary.column_checksums_incomplete && !summary.column_checksums_short_cover,
+            "a fully-covered run must be flagged neither incomplete nor short-cover"
+        );
+    }
+
+    /// A part RECORDED by this run whose unit contributed nothing — the failed
+    /// keyset range / mid-write bail shape, and the shape a runner's unit-id
+    /// mismatch produces. Form B is suppressed AND `short_cover` is set, which is
+    /// what `check_post_run_invariants` reads to tell a mismatch from a
+    /// legitimate resume. RED against a coverage rule that ignores
+    /// `covered_units`: it then records a Form B covering a strict SUBSET of the
+    /// manifest — the partial-and-lying record `validate --depth full` would
+    /// false-flag on correctly-written data.
+    #[test]
+    fn harvest_suppresses_form_b_when_a_recorded_part_s_unit_contributed_nothing() {
+        let plan = test_plan();
+        let parts = synthetic_parts(2);
+        let mut summary = run_one_unit(&plan, UnitId::Chunk(0), &parts);
+        // A SECOND unit commits a part and never publishes its checksums.
+        let orphan = PartRecord {
+            file_name: "uncommitted_range.parquet".into(),
+            rows: 10,
+            bytes: 64,
+            fingerprint: "xxh3:000000000000dead".into(),
+            md5: String::new(),
+        };
+        record_part(
+            &plan,
+            &mut summary,
+            None,
+            &orphan,
+            PartKind::Chunk { chunk_index: 1 },
+            UnitId::Chunk(1),
         );
 
-        // Resume that hydrated pre-crash parts: Form B is suppressed, not partial.
-        let mut resumed = test_summary(&plan);
-        resumed.column_checksums_incomplete = true;
-        harvest_column_checksums(&mut resumed, acc, Some("id".into()));
+        let integrity = std::mem::take(&mut summary.ledger).integrity;
+        harvest_column_checksums(&mut summary, integrity);
+
         assert!(
-            resumed.column_checksums.is_empty(),
-            "an incomplete-checksum resume must suppress Form B, never record a partial XOR"
+            summary.column_checksums.is_empty(),
+            "one uncovered part must suppress the WHOLE Form-B record, never publish a \
+             checksum covering a subset of the manifest"
+        );
+        assert!(summary.column_checksums_incomplete);
+        assert!(
+            summary.column_checksums_short_cover,
+            "a part this run RECORDED but did not cover is the never-legitimate half — it \
+             must be distinguishable from a resume hydration, or the invariant cannot fire"
+        );
+    }
+
+    /// The resume case, which ADR-0029 SUBSUMES: a part hydrated into the
+    /// manifest without going through `record_part` (file_log rehydration / an M8
+    /// `Skip` clone of a prior manifest's part) has no commit unit at all, so the
+    /// seam suppresses without anyone setting a flag — the two
+    /// `column_checksums_incomplete = true` assignments this ADR retired from
+    /// `resume_m8.rs`. `short_cover` stays FALSE (hydration is expected, not a
+    /// runner defect), which is what keeps the new invariant resume-safe with no
+    /// exemption to remember.
+    ///
+    /// RED against a coverage rule keyed on `record_part` CALLS instead of on the
+    /// MANIFEST: the hydrated part is invisible to such a rule, Form B is
+    /// published over a manifest it covers only in part, and retiring the two
+    /// manual sites becomes silent corruption of the integrity record.
+    #[test]
+    fn harvest_suppresses_form_b_for_a_hydrated_part_with_no_commit_unit() {
+        let plan = test_plan();
+        let parts = synthetic_parts(2);
+        let mut summary = run_one_unit(&plan, UnitId::Chunk(0), &parts);
+        // What `rehydrate_manifest_parts_from_file_log` / the M8 Skip clone do:
+        // push straight into the manifest — no record_part, no checksums.
+        summary.manifest_parts.push(crate::manifest::ManifestPart {
+            part_id: 99,
+            path: "precrash_chunk7.parquet".into(),
+            rows: 100,
+            size_bytes: 4096,
+            content_fingerprint: String::new(),
+            content_md5: String::new(),
+            status: crate::manifest::PartStatus::Committed,
+        });
+
+        let integrity = std::mem::take(&mut summary.ledger).integrity;
+        harvest_column_checksums(&mut summary, integrity);
+
+        assert!(
+            summary.column_checksums.is_empty(),
+            "a hydrated pre-crash part carries no per-column checksum, so the run-wide record \
+             cannot cover the manifest — suppress, never publish a partial"
+        );
+        assert!(summary.column_checksums_incomplete);
+        assert!(
+            !summary.column_checksums_short_cover,
+            "hydration is LEGITIMATE — flagging it short-cover would fail every crash-recovery \
+             resume through check_post_run_invariants"
+        );
+    }
+
+    /// The same hydration case with an EMPTY accumulator — a resume that re-ran
+    /// NOTHING, so no unit contributed and there is not a single checksum to
+    /// weigh. The suppression verdict must STILL be recorded.
+    ///
+    /// This is the one the unit suite missed and the live suite caught: with the
+    /// empty-accumulator early return placed ABOVE the coverage computation, a
+    /// parallel-keyset crash resume whose ranges were all already `done` reached
+    /// `finalize_manifest` with rehydrated parts, an empty Form B and NO flag —
+    /// and the pre-existing Form-B telltale panicked the run
+    /// (`parallel_keyset_crash_recovery_postgres`, plus 3 siblings). Pre-ADR-0029
+    /// the flag came from the manual `rehydrate_manifest_parts_from_file_log`
+    /// assignment this ADR retires, which is exactly why retiring it has to be
+    /// proven on the empty-accumulator path and not only the populated one.
+    ///
+    /// RED against restoring that order.
+    #[test]
+    fn harvest_flags_a_hydration_only_resume_that_re_ran_nothing_and_has_no_checksums() {
+        let plan = test_plan();
+        let mut summary = test_summary(&plan);
+        summary.manifest_parts.push(crate::manifest::ManifestPart {
+            part_id: 1,
+            path: "precrash_chunk0.parquet".into(),
+            rows: 100,
+            size_bytes: 4096,
+            content_fingerprint: String::new(),
+            content_md5: String::new(),
+            status: crate::manifest::PartStatus::Committed,
+        });
+        summary.files_committed = 1;
+        summary.files_produced = 1;
+
+        // Nothing re-ran: the ledger is untouched, so the accumulator is empty.
+        let integrity = std::mem::take(&mut summary.ledger).integrity;
+        assert!(
+            integrity.column_checksums.is_empty(),
+            "fixture: no checksums"
+        );
+        harvest_column_checksums(&mut summary, integrity);
+
+        assert!(
+            summary.column_checksums_incomplete,
+            "a resume that hydrated parts and re-ran nothing must still RECORD the \
+             suppression, or the Form-B telltale reads an unexplained empty record and \
+             panics a legitimate crash-recovery run"
+        );
+        assert!(!summary.column_checksums_short_cover);
+        summary.state_backed = true;
+        summary.status = "success".into();
+        summary.format = "parquet".into();
+        summary.schema_changed = Some(false);
+        assert!(
+            summary.check_post_run_invariants(true).is_ok(),
+            "and the telltales must then PASS the resume: {:?}",
+            summary.check_post_run_invariants(true)
+        );
+    }
+
+    /// A hydrated part that this run RE-READ and overwrote (the keyset
+    /// mid-page-crash fallback) dedupes in place, keeping its part_id — and
+    /// `record_part` re-registers that id against the re-reading unit, so the
+    /// part stops being foreign and coverage can be complete again.
+    ///
+    /// This is why the part → unit map is keyed on `part_id` and not on a COUNT
+    /// of `record_part` calls (which dedup makes wrong) — a count would leave the
+    /// run permanently suppressed even after it re-computed every checksum. RED
+    /// against keying `part_units` on anything the dedup path does not preserve.
+    #[test]
+    fn a_deduped_re_read_of_a_hydrated_part_becomes_covered() {
+        let plan = test_plan();
+        let mut summary = test_summary(&plan);
+        // Pre-crash part hydrated into the manifest with part_id 1.
+        summary.manifest_parts.push(crate::manifest::ManifestPart {
+            part_id: 1,
+            path: "part_0.parquet".into(),
+            rows: 100,
+            size_bytes: 1024,
+            content_fingerprint: String::new(),
+            content_md5: String::new(),
+            status: crate::manifest::PartStatus::Committed,
+        });
+        // This run re-reads that same page: same path → dedup in place.
+        let parts = synthetic_parts(1);
+        let deduped = record_part(
+            &plan,
+            &mut summary,
+            None,
+            &parts[0],
+            PartKind::Chunk { chunk_index: 0 },
+            UnitId::Chunk(0),
+        );
+        assert!(deduped, "fixture: the re-read must dedup, not append");
+        assert_eq!(summary.manifest_parts.len(), 1);
+        summary.ledger.contribute_checksums(
+            UnitId::Chunk(0),
+            &[("id".to_string(), 7u64)].into(),
+            Some("id".into()),
+        );
+
+        let integrity = std::mem::take(&mut summary.ledger).integrity;
+        harvest_column_checksums(&mut summary, integrity);
+
+        assert!(
+            !summary.column_checksums.is_empty(),
+            "a re-read part IS covered by this run's checksums — suppressing here would make \
+             every mid-page-crash resume lose Form B for no reason"
+        );
+    }
+
+    /// `compute_coverage` counts BOTH shortfall kinds independently, over a mixed
+    /// manifest — the arithmetic the two flags are derived from. The fixture puts
+    /// ≥2 of each kind in, so a rule that stops at the first offender is
+    /// distinguishable from one that tallies; and it ends with the COMPLETE case,
+    /// so "always short" is excluded.
+    #[test]
+    fn compute_coverage_counts_foreign_and_uncovered_parts_separately() {
+        let part = |id: u32| crate::manifest::ManifestPart {
+            part_id: id,
+            path: format!("p{id}.parquet"),
+            rows: 1,
+            size_bytes: 1,
+            content_fingerprint: String::new(),
+            content_md5: String::new(),
+            status: crate::manifest::PartStatus::Committed,
+        };
+        let mut integrity = Integrity::default();
+        // ids 1,2 → a covered unit; 3,4 → an uncovered unit; 5,6 → no unit at all.
+        for id in [1u32, 2] {
+            integrity.part_units.insert(id, UnitId::Chunk(0));
+        }
+        for id in [3u32, 4] {
+            integrity.part_units.insert(id, UnitId::Chunk(1));
+        }
+        integrity.covered_units.insert(UnitId::Chunk(0));
+        let parts: Vec<_> = (1u32..=6).map(part).collect();
+
+        let cov = compute_coverage(&parts, &integrity);
+        assert_eq!(
+            (
+                cov.complete,
+                cov.short_cover,
+                cov.uncovered_parts,
+                cov.foreign_parts
+            ),
+            (false, true, 2, 2)
+        );
+
+        integrity.covered_units.insert(UnitId::Chunk(1));
+        let cov = compute_coverage(&parts[..4], &integrity);
+        assert_eq!(
+            (
+                cov.complete,
+                cov.short_cover,
+                cov.uncovered_parts,
+                cov.foreign_parts
+            ),
+            (true, false, 0, 0)
+        );
+    }
+
+    /// The unit-id MISMATCH, end to end through the two real seams — a runner
+    /// that records under one `UnitId` and contributes under another.
+    ///
+    /// Scope honesty: this proves the mechanism REACTS to a mismatch, not that
+    /// any particular runner is paired correctly. That half needs a real source
+    /// and destination, so its oracle is the live suite's per-runner Form-B cells
+    /// (`docs/runner-coverage-matrix.yaml` row `value_checksum_form_b`), each of
+    /// which asserts the destination manifest RECORDS `column_checksums` — a
+    /// mis-paired runner suppresses and its cell goes RED — plus this test's
+    /// second half: `check_post_run_invariants` FAILS the run, and it runs under
+    /// `debug_assertions`, the build the live suite uses. So a mismatch is loud on
+    /// every runner rather than silent on one.
+    #[test]
+    fn a_unit_id_mismatch_suppresses_form_b_and_fails_the_run_instead_of_going_silent() {
+        let plan = test_plan();
+        let parts = synthetic_parts(1);
+        let mut summary = test_summary(&plan);
+        record_part(
+            &plan,
+            &mut summary,
+            None,
+            &parts[0],
+            PartKind::Chunk { chunk_index: 0 },
+            UnitId::Chunk(0),
+        );
+        // The mis-pairing itself: recorded under Chunk(0), contributed as Chunk(1).
+        summary.ledger.contribute_checksums(
+            UnitId::Chunk(1),
+            &[("id".to_string(), 1u64)].into(),
+            None,
+        );
+        let integrity = std::mem::take(&mut summary.ledger).integrity;
+        harvest_column_checksums(&mut summary, integrity);
+        assert!(
+            summary.column_checksums.is_empty() && summary.column_checksums_short_cover,
+            "a UnitId mismatch must suppress AND reach the flag check_post_run_invariants reads"
+        );
+
+        summary.state_backed = true;
+        summary.status = "success".into();
+        summary.format = "parquet".into();
+        // The drift telltale is a SEPARATE invariant and fires first; satisfy it
+        // so this test grades the coverage telltale and not that one.
+        summary.schema_changed = Some(false);
+        let verdict = summary.check_post_run_invariants(false);
+        assert!(
+            verdict
+                .as_ref()
+                .err()
+                .is_some_and(|m| m.contains("UnitId mismatch")),
+            "the backstop must FAIL a successful state_backed run carrying short coverage, \
+             naming the mismatch; got {verdict:?}"
         );
     }
 }

--- a/src/pipeline/finalize.rs
+++ b/src/pipeline/finalize.rs
@@ -64,23 +64,19 @@ pub(super) fn finalize_export(
     // first is the truthful thing", the rule mongo_parallel's pre-seam drain
     // already followed). Pre-fix the gate's `?` skipped the harvest and a
     // drift-FAILED keyset/mongo run wrote a Failed manifest with no Form-B.
-    if let Some(schema) = &ledger.drift_schema {
+    if let Some(schema) = &ledger.observed.drift_schema {
         // Fingerprint pin is idempotent (first call wins) — uniform across
         // runners now, so keyset/mongo manifests carry the fingerprint single
         // mode always recorded.
         super::manifest_writer::record_run_schema_fingerprint(summary, schema);
     }
     // Form B: record the run-wide checksums so the manifest carries them.
-    // `harvest_column_checksums` itself suppresses on
-    // `column_checksums_incomplete` (checkpoint-resume hydration) — that
+    // `harvest_column_checksums` itself COMPUTES the coverage (ADR-0029) — a
+    // manifest part with no contribution suppresses the record — and that
     // decision stays in the harvest, not here.
-    super::commit::harvest_column_checksums(
-        summary,
-        ledger.column_checksums,
-        ledger.checksum_key_column,
-    );
+    super::commit::harvest_column_checksums(summary, ledger.integrity);
 
-    if let (Some(schema), Some(st)) = (&ledger.drift_schema, state) {
+    if let (Some(schema), Some(st)) = (&ledger.observed.drift_schema, state) {
         super::schema_drift::check_from_sink_schema(
             st,
             &plan.export_name,
@@ -95,12 +91,12 @@ pub(super) fn finalize_export(
     // sink tracks them; a runner that starts feeding them gets the warn for
     // free — born `na`, per ADR-0028).
     if plan.shape_drift_warn_factor > 0.0
-        && !ledger.column_max_bytes.is_empty()
+        && !ledger.observed.column_max_bytes.is_empty()
         && let Some(st) = state
     {
         match st.detect_shape_drift(
             &plan.export_name,
-            &ledger.column_max_bytes,
+            &ledger.observed.column_max_bytes,
             plan.shape_drift_warn_factor,
         ) {
             Ok(warnings) => {
@@ -144,16 +140,22 @@ pub(super) fn finalize_export(
 /// pre-seam vanish. GATES (drift policy, shape warn) are deliberately NOT run
 /// here: the run is already failing with the runner's own error, and a gate
 /// error would mask it.
+///
+/// ADR-0029 is what makes the fingerprint half actually WORK. Three parallel
+/// runners record their durable parts ABOVE their error bail and used to feed
+/// the whole ledger BELOW it, so this function received an EMPTY ledger on the
+/// failure path and pinned nothing (parallel keyset worst: the ledger is its
+/// only fingerprint path). The schema is an OBSERVATION — it describes what the
+/// runner READ, it has no coverage obligation — so it is now fed eagerly, above
+/// every bail, and arrives here. The Form-B half stays commit-gated and its
+/// coverage is computed inside the harvest, so a failed run's partial feed
+/// suppresses rather than publishes a record covering a subset of the debris.
 pub(super) fn finalize_export_records(summary: &mut RunSummary) {
     let ledger = std::mem::take(&mut summary.ledger);
-    if let Some(schema) = &ledger.drift_schema {
+    if let Some(schema) = &ledger.observed.drift_schema {
         super::manifest_writer::record_run_schema_fingerprint(summary, schema);
     }
-    super::commit::harvest_column_checksums(
-        summary,
-        ledger.column_checksums,
-        ledger.checksum_key_column,
-    );
+    super::commit::harvest_column_checksums(summary, ledger.integrity);
 }
 
 /// Write `.rivet/runs/<run_id>/{summary.md,summary.json}` and surface a
@@ -1131,10 +1133,11 @@ mod tests {
         summary
             .ledger
             .note_schema(&Schema::new(vec![Field::new("id", DataType::Int64, false)]));
-        summary
-            .ledger
-            .merge_checksums(&[("id".to_string(), 5u64)].into());
-        summary.ledger.note_key_column(Some("id".into()));
+        summary.ledger.contribute_checksums(
+            crate::pipeline::commit::UnitId::Run,
+            &[("id".to_string(), 5u64)].into(),
+            Some("id".into()),
+        );
 
         finalize_export_records(&mut summary);
 
@@ -1152,7 +1155,7 @@ mod tests {
             "a FAILED run must still harvest Form-B for its durable parts"
         );
         assert!(
-            summary.ledger.column_checksums.is_empty(),
+            summary.ledger.integrity.column_checksums.is_empty(),
             "ledger is taken"
         );
     }
@@ -1162,10 +1165,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let plan = fin_plan(dir.path());
         let mut summary = crate::pipeline::summary::RunSummary::default();
-        summary
-            .ledger
-            .merge_checksums(&[("v".to_string(), 9u64)].into());
-        summary.ledger.note_key_column(Some("id".into()));
+        summary.ledger.contribute_checksums(
+            crate::pipeline::commit::UnitId::Run,
+            &[("v".to_string(), 9u64)].into(),
+            Some("id".into()),
+        );
 
         finalize_export(&plan, None, &mut summary).expect("state-free seam must succeed");
 
@@ -1180,7 +1184,7 @@ mod tests {
         );
         assert_eq!(summary.checksum_key_column.as_deref(), Some("id"));
         assert!(
-            summary.ledger.column_checksums.is_empty(),
+            summary.ledger.integrity.column_checksums.is_empty(),
             "the seam must TAKE the ledger — a second application must find nothing"
         );
 

--- a/src/pipeline/job.rs
+++ b/src/pipeline/job.rs
@@ -780,6 +780,7 @@ pub(crate) fn synthetic_failed_summary(export_name: &str, err: &anyhow::Error) -
         apply_context: None,
         column_checksums: Vec::new(),
         column_checksums_incomplete: false,
+        column_checksums_short_cover: false,
         checksum_key_column: None,
         journal,
     }

--- a/src/pipeline/keyset.rs
+++ b/src/pipeline/keyset.rs
@@ -495,10 +495,21 @@ fn run_keyset_parallel(
     let cmp_label = plan.compression.label();
 
     let rows = AtomicI64::new(0);
-    let parts_mx: Mutex<Vec<super::commit::PartRecord>> = Mutex::new(Vec::new());
+    // ADR-0029: both accumulators carry the RANGE index — the commit unit this
+    // runner publishes checksums at. Parts are published per PAGE (durability
+    // must reflect what is on disk, #200-1) while checksums are published per
+    // committed RANGE, so the range is the only id the two can agree on, and
+    // the seam needs them keyed alike to compute Form-B coverage.
     #[allow(clippy::type_complexity)]
-    let checksums_mx: Mutex<Vec<(std::collections::BTreeMap<String, u64>, Option<String>)>> =
-        Mutex::new(Vec::new());
+    let parts_mx: Mutex<Vec<(usize, super::commit::PartRecord)>> = Mutex::new(Vec::new());
+    #[allow(clippy::type_complexity)]
+    let checksums_mx: Mutex<
+        Vec<(
+            usize,
+            std::collections::BTreeMap<String, u64>,
+            Option<String>,
+        )>,
+    > = Mutex::new(Vec::new());
     let fingerprint: std::sync::OnceLock<arrow::datatypes::Schema> = std::sync::OnceLock::new();
     // Per-range high-water key, indexed by range_index (done ranges stay None —
     // they are not re-run). cursor_high = the highest populated range's max; on a
@@ -669,7 +680,10 @@ fn run_keyset_parallel(
                     // (`rmax`) and checksums stay commit-gated below — those feed
                     // the SUMMARY and must reflect only committed data — but the
                     // durability count must reflect what is physically on disk.
-                    parts_r.lock().unwrap().extend(page.parts);
+                    parts_r
+                        .lock()
+                        .unwrap()
+                        .extend(page.parts.into_iter().map(|p| (ridx, p)));
                     local_checks.push((page.column_checksums, page.checksum_key_column));
                     let last_page = page.rows < page_size;
                     if !last_page {
@@ -747,7 +761,10 @@ fn run_keyset_parallel(
                 // on the checkpoint commit so a failed commit leaves no half-merged
                 // summary (the parts count is intentionally NOT gated: it must show
                 // on-disk debris even for a range that failed to commit).
-                checks_r.lock().unwrap().extend(local_checks);
+                checks_r
+                    .lock()
+                    .unwrap()
+                    .extend(local_checks.into_iter().map(|(m, k)| (ridx, m, k)));
             });
         }
     });
@@ -781,7 +798,7 @@ fn run_keyset_parallel(
     // so the merge must write it — matching the sequential keyset path.
     let file_log_state = if checkpoint { None } else { state };
     let parts = parts_mx.into_inner().unwrap();
-    for (idx, rec) in parts.iter().enumerate() {
+    for (idx, (ridx, rec)) in parts.iter().enumerate() {
         super::commit::record_part(
             plan,
             summary,
@@ -794,6 +811,14 @@ fn run_keyset_parallel(
                 // cursor-atomic reconcile — None.
                 cursor_high: None,
             },
+            // ADR-0029: the JOURNAL id stays the drain index (unchanged on-disk
+            // shape) while the COVERAGE unit is the range that committed — or
+            // failed to. A range that never committed published no checksums,
+            // so its pages are recorded-but-uncovered and the seam suppresses
+            // Form B rather than publish a record covering a strict subset of
+            // this manifest. That suppression is the whole reason the naive
+            // "move the feed above the bail" fix was rejected.
+            super::commit::UnitId::Range(*ridx as i64),
         );
     }
     summary.total_rows += rows.into_inner();
@@ -803,6 +828,18 @@ fn run_keyset_parallel(
     // failed?). The shared drain_into (which poison-recovers, unlike the old into_inner().unwrap()
     // here) makes this identical to the chunked runner — the drift the copy re-introduced twice.
     governor.drain_into(summary);
+
+    // ADR-0029 (the reported defect): the schema is an OBSERVATION — the workers
+    // converged on ONE run schema and it describes what they READ, with no
+    // coverage obligation — so feed it ABOVE the bail. This runner has no direct
+    // `summary.schema_fingerprint` assignment at all, so the ledger is its only
+    // path: fed below the bail, a FAILED parallel-keyset run pinned the stale
+    // open-time baseline onto a Failed manifest listing parts whose parquet
+    // carries the observed schema. The seam pins the fingerprint on BOTH paths
+    // and runs the drift gate only on success.
+    if let Some(sc) = fingerprint.get() {
+        summary.ledger.note_schema(sc);
+    }
 
     if !errs.is_empty() {
         anyhow::bail!(
@@ -817,11 +854,6 @@ fn run_keyset_parallel(
     // runner's per-page path, folded run-wide).
     if plan.validate {
         summary.validated = Some(true);
-    }
-    // ADR-0028: the workers converged on ONE run schema; feed it to the ledger —
-    // the seam pins the fingerprint and runs the drift gate.
-    if let Some(sc) = fingerprint.get() {
-        summary.ledger.note_schema(sc);
     }
     // cursor_high = the highest populated range's max (forensics v18); see range_max.
     summary.cursor_high = highest_range_max(range_max.into_inner().unwrap());
@@ -839,11 +871,14 @@ fn run_keyset_parallel(
     {
         super::chunked::rehydrate_manifest_parts_from_file_log(st, &run_id, summary)?;
     }
-    // ADR-0028: feed every committed range's Form-B checksums to the ledger
-    // (commit-gated — a failed range published none). The seam harvests once.
-    for (m, k) in checksums_mx.into_inner().unwrap() {
-        summary.ledger.merge_checksums(&m);
-        summary.ledger.note_key_column(k);
+    // ADR-0028/0029: feed every committed range's Form-B checksums to the ledger
+    // under the SAME `UnitId::Range` its parts were recorded with (commit-gated —
+    // a failed range published none, and the seam then sees the shortfall itself
+    // instead of being told about it). The seam harvests once.
+    for (ridx, m, k) in checksums_mx.into_inner().unwrap() {
+        summary
+            .ledger
+            .contribute_checksums(super::commit::UnitId::Range(ridx as i64), &m, k);
     }
 
     log::info!(
@@ -1086,10 +1121,14 @@ pub(crate) fn run_keyset(
         if let Some(sc) = &page.schema {
             summary.ledger.note_schema(sc);
         }
-        summary.ledger.merge_checksums(&page.column_checksums);
-        summary
-            .ledger
-            .note_key_column(page.checksum_key_column.clone());
+        // ADR-0029: the sequential runner's commit unit is the PAGE — this feed
+        // and the `record_part` calls below are the same loop iteration over the
+        // same page, so the two sets agree by construction.
+        summary.ledger.contribute_checksums(
+            super::commit::UnitId::Page(pages as i64),
+            &page.column_checksums,
+            page.checksum_key_column.clone(),
+        );
         if plan.validate {
             summary.validated = Some(true);
         }
@@ -1125,6 +1164,7 @@ pub(crate) fn run_keyset(
                         None
                     },
                 },
+                super::commit::UnitId::Page(pages as i64),
             );
             any_new_part |= !deduped;
         }

--- a/src/pipeline/manifest_writer.rs
+++ b/src/pipeline/manifest_writer.rs
@@ -331,14 +331,28 @@ pub fn record_run_schema_fingerprint(
     summary.schema_fingerprint = Some(crate::state::schema_fingerprint(&columns));
 }
 
+/// What [`record_committed_part_with_fingerprint`] did to the manifest.
+///
+/// `part_id` is returned (not just the dedup verdict) because ADR-0029 keys the
+/// part → commit-unit map on it: it is stable across a dedup, unique within the
+/// manifest by M4, and 4 bytes rather than a second copy of every part path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RecordedPart {
+    /// True iff an existing entry with the same path was refreshed in place.
+    pub deduped: bool,
+    /// The manifest id of the entry (existing on a dedup, freshly minted else).
+    pub part_id: u32,
+}
+
 /// Same as [`record_committed_part`] but with a precomputed fingerprint.
 ///
 /// Used by parallel-chunked aggregation, where workers compute fingerprints
 /// inside their thread (the local tmp file is dropped at thread exit) and
 /// the parent iterates over the shared `file_records` collection.
-/// Returns `true` iff the part was DEDUPED in place (a re-read overwrote a rehydrated part of the
-/// same path) — the caller must then NOT double-count the run aggregates for it; `false` on a
-/// normal first-time push.
+/// Returns the entry's [`RecordedPart`]: `deduped` is true iff the part was DEDUPED in place (a
+/// re-read overwrote a rehydrated part of the same path) — the caller must then NOT double-count
+/// the run aggregates for it — and `part_id` is the manifest id of the entry either way, which
+/// ADR-0029 uses to key the part → commit-unit map the Form-B coverage is computed on.
 #[must_use]
 pub fn record_committed_part_with_fingerprint(
     summary: &mut RunSummary,
@@ -347,7 +361,7 @@ pub fn record_committed_part_with_fingerprint(
     size_bytes: u64,
     content_fingerprint: String,
     content_md5: String,
-) -> bool {
+) -> RecordedPart {
     // ADR-0012 M4: part_id must be unique within the manifest.  Before the
     // M8 resume-hydration work, `summary.manifest_parts.len() + 1` was a
     // safe ordinal because the list was always built from scratch this run.
@@ -373,7 +387,11 @@ pub fn record_committed_part_with_fingerprint(
         existing.content_fingerprint = content_fingerprint;
         existing.content_md5 = content_md5;
         existing.status = PartStatus::Committed;
-        return true; // deduped in place — the caller must NOT double-count the aggregates
+        // deduped in place — the caller must NOT double-count the aggregates
+        return RecordedPart {
+            deduped: true,
+            part_id: existing.part_id,
+        };
     }
     let part_id = summary
         .manifest_parts
@@ -391,7 +409,10 @@ pub fn record_committed_part_with_fingerprint(
         content_md5,
         status: PartStatus::Committed,
     });
-    false
+    RecordedPart {
+        deduped: false,
+        part_id,
+    }
 }
 
 /// Outcome of a manifest-write attempt.

--- a/src/pipeline/mongo_parallel.rs
+++ b/src/pipeline/mongo_parallel.rs
@@ -133,8 +133,15 @@ pub(crate) fn run_mongo_parallel(
         if let Some(sc) = &out.schema {
             summary.ledger.note_schema(sc);
         }
-        summary.ledger.merge_checksums(&out.column_checksums);
-        summary.ledger.note_key_column(out.checksum_key_column);
+        // ADR-0029: the worker RANGE is this runner's commit unit, and a worker
+        // hands back what it made durable even when it failed part-way — so the
+        // feed and the record_part drain below pair on the same unit and a
+        // failed worker's parts are covered by the checksums it did compute.
+        summary.ledger.contribute_checksums(
+            commit::UnitId::Chunk(w as i64),
+            &out.column_checksums,
+            out.checksum_key_column,
+        );
         if plan.validate && out.rows > 0 {
             summary.validated = Some(true);
         }
@@ -147,6 +154,7 @@ pub(crate) fn run_mongo_parallel(
                 commit::PartKind::Chunk {
                     chunk_index: w as i64,
                 },
+                commit::UnitId::Chunk(w as i64),
             );
         }
     }

--- a/src/pipeline/single.rs
+++ b/src/pipeline/single.rs
@@ -317,6 +317,16 @@ pub(super) fn run_single_export(
         w.finish()?;
     }
 
+    // ADR-0029: feed the OBSERVATION half of the ledger the moment the read is
+    // done — the dest schema this run SAW and the shape bytes it measured carry
+    // no coverage obligation, so recording them early can never be wrong. Every
+    // `?` below (the quality gate, `RunnerFrame::open`, and above all the
+    // per-part `write_part_file` inside the commit loop) used to escape ABOVE
+    // the single tail drain, so a run that failed mid-write pinned the STALE
+    // open-time fingerprint onto a Failed manifest describing parts written
+    // under the observed schema. The INTEGRITY half stays below the loop.
+    sink.drain_observations_into(&mut summary.ledger);
+
     summary.total_rows += sink.total_rows as i64;
     log::info!(
         "export '{}': {} rows written",
@@ -443,6 +453,12 @@ pub(super) fn run_single_export(
             super::commit::PartKind::File {
                 part_index: part_idx,
             },
+            // ADR-0029: single's commit unit is the whole invocation — ONE sink
+            // accumulated the checksums of every part in this loop, so the
+            // drain below either covers them all or (on a mid-loop bail, which
+            // skips it) none. Keying per part_index would claim a per-part
+            // correspondence the sink does not have.
+            super::commit::UnitId::Run,
         );
     }
 
@@ -471,11 +487,13 @@ pub(super) fn run_single_export(
         summary.cursor_high = Some(last_val.clone());
     }
 
-    // ADR-0028: feed the run ledger — the seam (`finalize::finalize_export`,
-    // called by the dispatcher) applies the fingerprint pin, the
-    // `on_schema_drift` gate, the Form-B harvest and the shape-drift warn.
-    // The application no longer lives in any runner.
-    sink.drain_tail_into(&mut summary.ledger);
+    // ADR-0028/0029: feed the INTEGRITY half — every part of this run is now
+    // committed and recorded under `UnitId::Run`, so the sink's accumulated
+    // Form-B checksums cover exactly them. The seam
+    // (`finalize::finalize_export`, called by the dispatcher) applies the
+    // fingerprint pin, the `on_schema_drift` gate, the Form-B harvest and the
+    // shape-drift warn; the application lives in no runner.
+    sink.drain_integrity_into(super::commit::UnitId::Run, &mut summary.ledger);
 
     // "data phase complete", not "completed successfully": the post-run gates
     // (drift policy, quality) run at the dispatcher AFTER this returns — a run

--- a/src/pipeline/sink/mod.rs
+++ b/src/pipeline/sink/mod.rs
@@ -126,26 +126,38 @@ pub(in crate::pipeline) struct RowProgress {
 }
 
 impl ExportSink {
-    /// ADR-0028: drain this sink's tail state into the run ledger — the dest
-    /// schema it resolved, the Form-B checksums it accumulated (keyed to the
-    /// cursor/key column when the key survived into the dest batch), and the
-    /// per-column shape bytes. Runners call this instead of applying the
-    /// fingerprint/drift/harvest/shape features themselves; the application
-    /// happens once, in `finalize::finalize_export`.
-    pub(in crate::pipeline) fn drain_tail_into(
+    /// ADR-0029 (splitting ADR-0028's `drain_tail_into`) — the OBSERVATION half
+    /// of this sink's tail: the dest schema it resolved and the per-column shape
+    /// bytes it saw. Neither carries a coverage obligation, so drain them as
+    /// soon as the read is done and BEFORE any fallible write — a run that then
+    /// fails still records the fingerprint it OBSERVED instead of the stale
+    /// open-time baseline. Applied by `finalize::finalize_export{,_records}`.
+    pub(in crate::pipeline) fn drain_observations_into(
         &mut self,
         ledger: &mut crate::pipeline::commit::CommitLedger,
     ) {
         if let Some(schema) = self.dest_schema.as_deref() {
             ledger.note_schema(schema);
         }
+        ledger.merge_shape(&std::mem::take(&mut self.column_max_bytes));
+    }
+
+    /// ADR-0029 — the INTEGRITY half: the Form-B checksums this sink
+    /// accumulated (keyed to the cursor/key column when the key survived into
+    /// the dest batch), contributed under `unit`, the commit unit whose parts
+    /// they cover. Drain it only once that unit's parts are committed; the seam
+    /// compares `unit` against the units `record_part` registered and suppresses
+    /// Form B itself if the two sets disagree.
+    pub(in crate::pipeline) fn drain_integrity_into(
+        &mut self,
+        unit: crate::pipeline::commit::UnitId,
+        ledger: &mut crate::pipeline::commit::CommitLedger,
+    ) {
         // Same keying rule the single tail used: the checksums are keyed only
         // when the key column is present in the dest batch (`checksum_key_col`
         // is its index there).
         let key = self.checksum_key_col.and(self.cursor_column.clone());
-        ledger.note_key_column(key);
-        ledger.merge_checksums(&std::mem::take(&mut self.column_checksums));
-        ledger.merge_shape(&std::mem::take(&mut self.column_max_bytes));
+        ledger.contribute_checksums(unit, &std::mem::take(&mut self.column_checksums), key);
     }
 
     pub fn new(plan: &ResolvedRunPlan) -> Result<Self> {

--- a/src/pipeline/summary.rs
+++ b/src/pipeline/summary.rs
@@ -136,7 +136,27 @@ pub struct RunSummary {
     /// as a false mismatch — mirroring how a rehydrated part's empty md5 degrades
     /// to a size-only check. An incomplete integrity record must be ABSENT, not
     /// partial-and-lying.
+    ///
+    /// ADR-0029: this is now a COMPUTED result, not a flag the resume paths must
+    /// remember to set. `harvest_column_checksums` compares the manifest's parts
+    /// against the commit units that contributed checksums and sets it when any
+    /// part is uncovered — a rehydrated part has no contribution, so the resume
+    /// case follows from the data.
     pub column_checksums_incomplete: bool,
+    /// ADR-0029: WHY the coverage was short, when it was — set only for the half
+    /// that is never legitimate on a successful run: a part this run RECORDED
+    /// (through `commit::record_part`) whose commit unit contributed no
+    /// checksums. The other half — a part the manifest lists but this run never
+    /// recorded (a checkpoint rehydration, an M8 `Skip` clone) — is expected and
+    /// leaves this false.
+    ///
+    /// It exists so "Form B is absent" stops being ambiguous between "nothing
+    /// computed it", "a resume hydrated parts" and "the runner paired its part
+    /// and its checksum under DIFFERENT unit ids". The last one suppresses Form
+    /// B on perfectly healthy data — fail-safe, but silent — which is the risk
+    /// ADR-0029 names against itself; `check_post_run_invariants` turns it into
+    /// a loud failure instead.
+    pub column_checksums_short_cover: bool,
     /// ADR-0028: the run-wide tail ledger the runners FEED as they commit
     /// (schema seen, per-part checksums, shape bytes) and that
     /// `finalize::finalize_export` — called once by the dispatcher — APPLIES:
@@ -304,6 +324,7 @@ impl RunSummary {
             apply_context: None,
             column_checksums: Vec::new(),
             column_checksums_incomplete: false,
+            column_checksums_short_cover: false,
             ledger: Default::default(),
             checksum_key_column: None,
             cursor_column: None,
@@ -379,6 +400,7 @@ impl RunSummary {
             apply_context: None,
             column_checksums: Vec::new(),
             column_checksums_incomplete: false,
+            column_checksums_short_cover: false,
             ledger: Default::default(),
             checksum_key_column: None,
             cursor_column: None,
@@ -904,6 +926,34 @@ impl RunSummary {
                     "state_backed success committed parts but column_checksums is empty \
                      and not flagged incomplete — Form-B was never harvested (no runner \
                      called harvest_column_checksums). Runner-bypass class."
+                        .to_string(),
+                );
+            }
+            // ADR-0029 — the telltale the computed coverage makes possible, and
+            // the guard against the risk that ADR names against ITSELF. Before
+            // it, "Form B is absent" was ambiguous (nothing computed it / a
+            // resume hydrated parts / the runner mis-keyed its units) and the
+            // branch above excused all three alike. Now the harvest records WHY,
+            // and exactly one of the three can never be legitimate on a run
+            // whose runner SUCCEEDED: a part this run recorded itself, whose
+            // commit unit contributed no checksums. On a success every commit
+            // unit that recorded a part also completed, so this can only mean
+            // `record_part`'s UnitId and the checksum feed's UnitId disagree —
+            // which suppresses Form B on healthy data, in the fail-safe
+            // direction, in silence. Resume-safe by CONSTRUCTION, with no
+            // exemption to remember: a rehydrated / M8-cloned part never went
+            // through record_part, so it is foreign, not uncovered, and leaves
+            // this flag false.
+            if self.column_checksums_short_cover {
+                return Err(
+                    "state_backed success committed parts whose commit unit contributed NO \
+                     Form-B checksums, so the harvest suppressed the record (ADR-0029 \
+                     computed coverage). On a successful run every unit that recorded a part \
+                     also committed it, so this is a UnitId mismatch between \
+                     commit::record_part and CommitLedger::contribute_checksums in the \
+                     runner — pair them on the same unit. Suppressing here is fail-safe but \
+                     SILENT: `validate --depth full` would stop re-reading values for every \
+                     run of this runner."
                         .to_string(),
                 );
             }

--- a/tests/live/live_keyset_parallel.rs
+++ b/tests/live/live_keyset_parallel.rs
@@ -1100,3 +1100,127 @@ fn parallel_keyset_resume_with_changed_worker_count_postgres() {
     assert_eq!(keys, (1..=2000i64).collect::<BTreeSet<i64>>());
     let _ = c.execute(&format!("DROP TABLE IF EXISTS {table}"), &[]);
 }
+
+/// ADR-0029, the ORIGINALLY-REPORTED defect: a parallel-keyset run that FAILS
+/// must record in its Failed manifest the schema fingerprint it OBSERVED, not
+/// the stale baseline the state DB held before the run.
+///
+/// This runner records durable parts ABOVE its error bail and used to feed the
+/// whole `CommitLedger` BELOW it, so `finalize_export_records` — the failure half
+/// of the ADR-0028 seam, whose entire job is "a Failed manifest must describe its
+/// debris honestly" — received an EMPTY ledger. Parallel keyset is the worst case
+/// because it has no direct `summary.schema_fingerprint` assignment at all (its
+/// three siblings set one from their own `shared_fingerprint`), so the ledger is
+/// its ONLY path. ADR-0029's split fixes it: the schema is an OBSERVATION — it
+/// describes what the runner READ and carries no coverage obligation — so it is
+/// fed above the bail while the Form-B checksums stay commit-gated below, the
+/// asymmetry `keyset.rs` states at its part-publishing site, now expressed in the
+/// ledger's shape instead of left to feed order.
+///
+/// THE FIXTURE IS THE WHOLE TEST, and two earlier drafts of it proved nothing —
+/// both measured GREEN with the fix reverted:
+///
+/// * "the Failed manifest carries a real fingerprint, not the `unavailable`
+///   placeholder" is fix-INVARIANT: the fallback `finalize_manifest` uses when the
+///   ledger is empty is `get_stored_schema`, and `capture_open_forensics` stores
+///   the schema (`store_schema_if_absent`) at run OPEN — so the fallback answers
+///   with the same schema the run observed.
+/// * making the source DRIFT between two runs is not enough either, if the second
+///   run gets a FRESH `Rig`: the rig owns its tempdir, so it owns its state DB,
+///   and a new rig has no baseline to be stale. The failing run stored the drifted
+///   schema itself at open and the fallback answered with it.
+///
+/// So the subject must be ONE rig (one state DB) run TWICE across a schema change:
+///
+///   1. same rig, clean run over `(id, payload)` — manifest gives fingerprint A,
+///      and A becomes this export's stored baseline;
+///   2. `ALTER TABLE ADD COLUMN` — the source is now schema B;
+///   3. a separate rig, clean run over the ALTERED table: an independent oracle
+///      for fingerprint B;
+///   4. the SAME rig again, failed by a worker error. Its stored baseline is still
+///      A (`store_schema_if_absent` will not overwrite, and the drift gate that
+///      would refresh it does not run on a failure), so a manifest carrying A is
+///      the fallback and a manifest carrying B is the observation.
+///
+/// RED against feeding `note_schema` below the bail: the Failed manifest carries
+/// A while its durable parquet is schema B — actively wrong forensics about data
+/// sitting on the prefix.
+#[test]
+#[ignore = "live: requires docker compose up -d postgres"]
+fn a_failed_parallel_keyset_run_records_the_observed_schema_fingerprint_postgres() {
+    require_alive(LiveService::Postgres);
+    let table = unique_name("pk_fpfail");
+    let mut c = pg_connect();
+    c.batch_execute(&format!(
+        "DROP TABLE IF EXISTS {table};
+         CREATE TABLE {table} (id BIGINT PRIMARY KEY, payload INT NOT NULL);
+         INSERT INTO {table} SELECT g, g FROM generate_series(1, 2000) g;"
+    ))
+    .unwrap();
+
+    // (1) The SUBJECT rig — reused for run 4, so its state DB carries the baseline.
+    let subject = parallel_keyset(Rig::pg_batch(&format!("public.{table}")));
+    let r1 = subject.run();
+    assert!(
+        r1.status.success(),
+        "baseline run must succeed; stderr:\n{}",
+        String::from_utf8_lossy(&r1.stderr)
+    );
+    let fp_a = manifest_schema_fingerprint(&subject.out_dir());
+
+    // (2) The source moves to schema B.
+    c.batch_execute(&format!("ALTER TABLE {table} ADD COLUMN note TEXT;"))
+        .unwrap();
+
+    // (3) Independent oracle for B: its own rig, its own state DB, clean run.
+    let oracle = parallel_keyset(Rig::pg_batch(&format!("public.{table}")));
+    let r2 = oracle.run();
+    assert!(
+        r2.status.success(),
+        "oracle run must succeed; stderr:\n{}",
+        String::from_utf8_lossy(&r2.stderr)
+    );
+    let fp_b = manifest_schema_fingerprint(&oracle.out_dir());
+    assert_ne!(
+        fp_a, fp_b,
+        "fixture is inert: adding a column did not change the fingerprint, so the stale \
+         baseline and the observation are indistinguishable and this test grades nothing"
+    );
+
+    // (4) Same rig, same state DB (baseline still A), source now B, failed by a
+    // worker error after other ranges have already committed parts.
+    let out = subject.run_with_env("RIVET_TEST_ERROR_AT", "keyset_parallel_worker:2");
+    assert!(
+        !out.status.success(),
+        "a worker error must fail the run — otherwise this is not the failure path"
+    );
+    assert!(
+        !files_with_extension(&subject.out_dir(), "parquet").is_empty(),
+        "fixture is inert: the surviving ranges wrote no parts, so the Failed manifest \
+         has no debris to describe"
+    );
+
+    let recorded = manifest_schema_fingerprint(&subject.out_dir());
+    assert_eq!(
+        recorded, fp_b,
+        "a FAILED parallel-keyset run must pin the fingerprint it OBSERVED ({fp_b}); it \
+         recorded {recorded}, and the stale pre-ALTER baseline is {fp_a} — a Failed manifest \
+         describing durable parquet with the wrong schema is actively wrong forensics"
+    );
+
+    let mut c2 = pg_connect();
+    let _ = c2.batch_execute(&format!("DROP TABLE IF EXISTS {table};"));
+}
+
+/// `manifest.json`'s recorded schema fingerprint, for either a Success or a
+/// Failed manifest (ADR-0012 M7 writes the manifest either way; only `_SUCCESS`
+/// is success-only).
+fn manifest_schema_fingerprint(dir: &std::path::Path) -> String {
+    let text = std::fs::read_to_string(dir.join("manifest.json"))
+        .unwrap_or_else(|e| panic!("read {}/manifest.json: {e}", dir.display()));
+    let v: serde_json::Value = serde_json::from_str(&text).expect("parse manifest.json");
+    v["schema_fingerprint"]
+        .as_str()
+        .unwrap_or_else(|| panic!("manifest.json has no schema_fingerprint: {text}"))
+        .to_string()
+}


### PR DESCRIPTION
Carries two commits: **ADR-0029** itself and its implementation.

## What ADR-0029 says, and what it fixes

`CommitLedger` (ADR-0028) held facts with **different truth conditions** in one
structure with one lifecycle, fed at one moment. Three parallel runners record
durable parts ABOVE their error bail and fed the ledger BELOW it, so
`finalize_export_records` — the failure half of the seam, whose whole job is "a
Failed manifest must describe its debris honestly" — got an EMPTY ledger. Parallel
keyset is worst: it has no direct `summary.schema_fingerprint` assignment at all,
so a failed run pinned the **stale open-time baseline** onto a Failed manifest
listing parts whose parquet carries the observed schema.

The obvious fix (move the feed up) was rejected in the ADR: parts publish per PAGE
and checksums per committed RANGE **by design**, so hoisting the feed publishes a
Form-B covering a strict subset of the manifest and `validate --depth full` reports
a FALSE mismatch on correct data.

## The two halves shipped here

**1. Split by truth condition.** `CommitLedger { observed: Observations, integrity:
Integrity }`. Observations (`drift_schema`, `column_max_bytes`) describe what the
runner SAW — no coverage obligation, monotonic — so they are fed eagerly, above
every bail, and applied on the failure path. Integrity stays commit-gated.

**2. Coverage computed, not trusted.** Each contribution is keyed by `UnitId` (the
unit that runner COMMITS at); `record_part` registers the same `UnitId` per manifest
part; the seam compares the sets over `summary.manifest_parts`. Full cover records
Form B, any uncovered or hydrated part suppresses it. Both manual
`column_checksums_incomplete = true` sites in `resume_m8.rs` are **retired** — those
parts never go through `record_part`, so incompleteness follows from the data.

Units: `Run` (single — one sink covers every part it writes), `Chunk` (chunked ×2,
both checkpoint twins, mongo_parallel worker), `Page` (keyset sequential), `Range`
(keyset parallel).

`check_post_run_invariants` gets **stronger**: the new
`column_checksums_short_cover` records the one shortfall that can never be
legitimate on a successful run — a part this run RECORDED whose unit contributed
nothing — and the telltale fails on it. Resume-safe by construction with no
exemption, because a hydrated part is *foreign*, not *uncovered*. That is the guard
for the risk the ADR names against itself: a unit-id mismatch would suppress Form B
on HEALTHY data, fail-safe but silent.

## Where the ADR was wrong (new *Implementation notes* section)

1. **`PartKind` is the JOURNAL id, not the commit unit.** The ADR says to reuse it.
   Parallel keyset passes a flat drain index there and commits at the RANGE; `single`
   has no per-part unit at all. Reusing `PartKind` would have reported every healthy
   parallel-keyset range short — shipping the ADR's own named risk on day one.
2. **Coverage is compared over `manifest_parts`, keyed on `part_id`.** Keying it on
   `record_part` calls makes the resume case the ADR claims to SUBSUME invisible.
3. **The empty-accumulator early return had to move below the computation** — this
   shipped a live regression (below).
4. **The strengthened invariant needed a second recorded field**, since a legitimate
   resume and a unit-id mismatch both set the existing flag.

Scope correction: only ONE of the three named runners actually lost observations.
Both chunked parallel runners already set `schema_fingerprint` above their bail, and
the chunked family deliberately feeds no drift schema (pre-chunk gate, ADR-0021).
The second real loser was not in the ADR's list: **`single`**.

## Proof

Every new test RED-proven against its mutant (applied, observed failing, reverted);
the full list with which tests caught which mutant is in the commit message. The
positive direction is covered on purpose — an absence-only suite passes against a
harvest that suppresses ALWAYS, which is exactly this mechanism's silent failure.

Two drafts of the live test were **fix-invariant** and are written up in its doc:
"not the `unavailable` placeholder" passes because `capture_open_forensics` stores
the schema at OPEN, and a schema-drift fixture passes if the failing run gets a
FRESH `Rig` (the rig owns its state DB, so a new rig has no baseline to be stale).
The subject has to be ONE rig run twice across an `ALTER TABLE`. RED: the failed run
recorded `xxh3:a2c34c1f1935293b` (stale) where the observed schema is
`xxh3:3e5de0bf41523f8a`.

One real regression this branch shipped and the **live suite caught first**: with
the empty-accumulator early return above the coverage computation, a parallel-keyset
crash resume whose ranges were all already `done` re-runs nothing, so there is no
checksum to weigh — the computation was skipped and the run reached finalize with
hydrated parts and no flag, where the pre-existing Form-B telltale panicked it (4
live tests RED). Fixed, and a unit case added so the unit suite catches it next time.

**Live**: full `live_suite` 674 passed / 11 failed, every failure environmental and
pre-existing (10 × `mc mb` on MinIO buckets created 2026-08-01 that still exist —
reproduced by hand, and the panic is in `tests/common/storage.rs:33` before any
rivet code, in a file this branch does not touch; 1 × `service "postgres-cdc" is not
running`). Per runner: keyset 53/53, chunked + both checkpoint twins 19/19, crash
recovery + soak 7/7, mongo 24/24, resume 12/12, mssql chunked 8/8, governor 14/14.

**Offline**: `--lib` 2583, `offline_suite` 282, clippy `-D warnings` clean, fmt applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168uwctCn3W1rP4Kt4kZXvE
