### PR TITLE
ci: merge queue, one run per PR, and a sound mutation-outcome cache

### DIFF
--- a/.github/scripts/mutants_cache.py
+++ b/.github/scripts/mutants_cache.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Replay mutation outcomes that were already measured for THIS EXACT code.
+
+Why a cache is sound only under a whole-world key
+-------------------------------------------------
+Whether a mutant is caught depends on the entire tree, not on the function it
+mutates: a test in another file may be the only thing that kills it, and a
+change three modules away can stop that test from reaching it. So there is no
+honest per-file key. The cache is therefore keyed — by the workflow, through
+`hashFiles` — on `src/**`, `tests/**`, `Cargo.lock` and `.cargo/mutants.toml`
+together. A hit means "the same code, graded by the same suite, under the same
+exclusions", and nothing weaker may be treated as a hit.
+
+What that buys, stated honestly: it does NOT make an ordinary PR cheaper. It
+removes the RE-runs — a re-run of the same commit after an infra flake, a push
+that touches only docs or the workflow itself, a rebase onto a main whose
+changes did not land in `src/` or `tests/`. When main does touch the code, the
+world changes and every mutant is measured again, which is the correct answer
+rather than a fast one.
+
+ALL-OR-NOTHING on purpose. Reusing SOME outcomes and running the rest would
+change the counts (`count`, `p1`, `p2`) that `Mutants (coverage verdict)`
+audits against its own independent measurement, and a gate whose two halves
+disagree about how much was graded is the exact failure this repo's mutation
+plumbing exists to prevent. Either every mutant in the graded set is known, or
+the run happens in full.
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+
+def _load(path: str) -> dict:
+    try:
+        with open(path, encoding="utf-8") as fh:
+            doc = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return doc if isinstance(doc, dict) else {}
+
+
+def _lines(path: str) -> list[str]:
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return [ln.strip() for ln in fh if ln.strip()]
+    except OSError:
+        return []
+
+
+def replay(cache_path: str, wanted_path: str) -> int:
+    """Print the rc the run WOULD have produced, or refuse.
+
+    Exit 0 + `0`/`2` on stdout when every wanted mutant is known; exit 1 (and
+    nothing on stdout) otherwise, which the caller reads as "run it".
+    """
+    cache = _load(cache_path).get("outcomes", {})
+    wanted = _lines(wanted_path)
+    if not wanted:
+        # Nothing to grade is not a cache hit — let the run reach its own
+        # "no mutants in this diff" conclusion rather than inventing one.
+        return 1
+    outcomes = []
+    for m in wanted:
+        if m not in cache:
+            return 1
+        outcomes.append(cache[m])
+    # `missed` is the gate's failure (cargo-mutants exit 2); a timeout is NOT
+    # replayable as either — it says the measurement did not finish, so a run
+    # that timed out once must be re-run rather than frozen into a verdict.
+    if any(o == "timeout" for o in outcomes):
+        return 1
+    print(2 if any(o == "missed" for o in outcomes) else 0)
+    return 0
+
+
+def record(cache_path: str, caught_path: str, missed_path: str, timeout_path: str) -> int:
+    doc = _load(cache_path)
+    outcomes = doc.get("outcomes", {})
+    if not isinstance(outcomes, dict):
+        outcomes = {}
+    for path, label in ((caught_path, "caught"), (missed_path, "missed"), (timeout_path, "timeout")):
+        for m in _lines(path):
+            outcomes[m] = label
+    doc["outcomes"] = outcomes
+    with open(cache_path, "w", encoding="utf-8") as fh:
+        json.dump(doc, fh, indent=1, sort_keys=True)
+    print(len(outcomes))
+    return 0
+
+
+def self_test() -> int:
+    import tempfile
+    import os
+
+    failures = []
+
+    def check(name: str, got, want):
+        if got != want:
+            failures.append(f"{name}: got {got!r}, want {want!r}")
+
+    with tempfile.TemporaryDirectory() as d:
+        cache = os.path.join(d, "c.json")
+        w = os.path.join(d, "want.txt")
+        caught = os.path.join(d, "caught.txt")
+        missed = os.path.join(d, "missed.txt")
+        tmo = os.path.join(d, "timeout.txt")
+
+        open(caught, "w").write("src/a.rs:1:1: replace f -> ()\n")
+        open(missed, "w").write("src/b.rs:2:2: replace g -> ()\n")
+        open(tmo, "w").write("src/c.rs:3:3: replace h -> ()\n")
+        import contextlib as _c
+        import io as _io
+
+        with _c.redirect_stdout(_io.StringIO()):   # `record` prints its tally
+            record(cache, caught, missed, tmo)
+        check("recorded", len(_load(cache)["outcomes"]), 3)
+
+        # a mutant nobody measured must NOT be answered from cache
+        open(w, "w").write("src/z.rs:9:9: replace q -> ()\n")
+        check("unknown mutant refuses", replay(cache, w), 1)
+
+        # The rc a hit REPLAYS is the whole safety property: a cache that
+        # answers "pass" for a set containing a missed mutant is a gate that
+        # lies, and it would lie silently. Capture stdout, do not just check
+        # that a hit happened.
+        import contextlib
+        import io
+
+        def replayed(path: str):
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                code = replay(cache, path)
+            return code, buf.getvalue().strip()
+
+        open(w, "w").write("src/a.rs:1:1: replace f -> ()\n")
+        check("all caught -> hit, rc 0", replayed(w), (0, "0"))
+
+        # one missed among known mutants replays the FAILING rc, never 0
+        open(w, "w").write("src/a.rs:1:1: replace f -> ()\nsrc/b.rs:2:2: replace g -> ()\n")
+        check("a missed mutant -> hit, rc 2", replayed(w), (0, "2"))
+
+        # a timeout is not a verdict — it must force a real run
+        open(w, "w").write("src/c.rs:3:3: replace h -> ()\n")
+        check("timeout refuses", replay(cache, w), 1)
+
+        # an empty wanted set is not a hit
+        open(w, "w").write("")
+        check("empty set refuses", replay(cache, w), 1)
+
+        # a corrupt cache is a MISS, never an answer
+        open(cache, "w").write("{not json")
+        open(w, "w").write("src/a.rs:1:1: replace f -> ()\n")
+        check("corrupt cache refuses", replay(cache, w), 1)
+
+    if failures:
+        for f in failures:
+            print(f"FAIL {f}", file=sys.stderr)
+        return 1
+    print("mutants_cache.py self-test: ok")
+    return 0
+
+
+def main() -> int:
+    if "--self-test" in sys.argv:
+        return self_test()
+    if len(sys.argv) >= 2 and sys.argv[1] == "replay":
+        return replay(sys.argv[2], sys.argv[3])
+    if len(sys.argv) >= 2 and sys.argv[1] == "record":
+        return record(sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5])
+    print(__doc__, file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,13 +110,17 @@ jobs:
         with: { fetch-depth: 0 }
       - name: New schema keys must appear in tests
         run: |
-          git fetch origin ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }} --depth=1
+          # `fetch-depth: 0` above normally means the base is already here; fetch
+          # only if it is not, and never with --depth on a full clone.
+          BASE_SHA='${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}'
+          git rev-parse --verify --quiet "$BASE_SHA^{commit}" >/dev/null \
+            || git fetch --no-tags origin "$BASE_SHA"
           # Only PROPERTY names (keys directly under a "properties" object) —
           # definition/type names (e.g. CdcInitialMode) are not user-facing
           # config keys and false-positived on the gate's own first run.
           KEYS='[paths | select(length>=2 and .[-2]=="properties") | .[-1] | select(type=="string")] | unique | .[]'
           NEW_KEYS=$(diff \
-            <(git show ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}:schemas/rivet.schema.json | jq -r "$KEYS" 2>/dev/null || true) \
+            <(git show "$BASE_SHA":schemas/rivet.schema.json | jq -r "$KEYS" 2>/dev/null || true) \
             <(jq -r "$KEYS" schemas/rivet.schema.json) \
             | grep '^>' | awk '{print $2}' || true)
           FAIL=0
@@ -299,19 +303,25 @@ jobs:
         id: scope
         run: |
           set -euo pipefail
+          # A SHA, not a branch name, because merge_group carries no base_ref.
+          # It is therefore used as a REVISION directly: `origin/<sha>` is not a
+          # thing, and asking for it is how the first version of this change
+          # failed — the guard below caught it and refused to guess, which is
+          # what it is for.
           base="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}"
-          if ! git fetch --no-tags origin "$base"; then
-            echo "::error::could not fetch the base branch '$base' — refusing to guess this PR's scope. A failed fetch used to read as a docs-only PR and skip every check in this job."
+          if ! git rev-parse --verify --quiet "$base^{commit}" >/dev/null \
+             && ! git fetch --no-tags origin "$base"; then
+            echo "::error::could not obtain the base commit '$base' — refusing to guess this PR's scope. A failed fetch used to read as a docs-only PR and skip every check in this job."
             exit 1
           fi
-          if ! git rev-parse --verify --quiet "origin/$base^{commit}" >/dev/null; then
-            echo "::error::'origin/$base' does not resolve after a successful fetch — every diff below would be empty, which this gate would otherwise mistake for a docs-only PR."
+          if ! git rev-parse --verify --quiet "$base^{commit}" >/dev/null; then
+            echo "::error::'$base' does not resolve even after fetching — every diff below would be empty, which this gate would otherwise mistake for a docs-only PR."
             exit 1
           fi
-          changed=$(git diff --name-only "origin/$base...HEAD")
+          changed=$(git diff --name-only "$base...HEAD")
           if [ -z "$changed" ]; then
             echo "code=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::the diff against origin/$base is empty (the base has caught up with this branch) — nothing to mutate."
+            echo "::notice::the diff against $base is empty (the base has caught up with this branch) — nothing to mutate."
           elif printf '%s\n' "$changed" | grep -qvE '^(docs/|.*\.md$|\.githooks/)'; then
             echo "code=true" >> "$GITHUB_OUTPUT"
           else
@@ -713,20 +723,26 @@ jobs:
         id: scope
         run: |
           set -euo pipefail
+          # A SHA, not a branch name, because merge_group carries no base_ref.
+          # It is therefore used as a REVISION directly: `origin/<sha>` is not a
+          # thing, and asking for it is how the first version of this change
+          # failed — the guard below caught it and refused to guess, which is
+          # what it is for.
           base="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}"
-          if ! git fetch --no-tags origin "$base"; then
-            echo "::error::could not fetch the base branch '$base' — refusing to guess this PR's scope. A failed fetch used to read as a docs-only PR and skip every check in this job."
+          if ! git rev-parse --verify --quiet "$base^{commit}" >/dev/null \
+             && ! git fetch --no-tags origin "$base"; then
+            echo "::error::could not obtain the base commit '$base' — refusing to guess this PR's scope. A failed fetch used to read as a docs-only PR and skip every check in this job."
             exit 1
           fi
-          if ! git rev-parse --verify --quiet "origin/$base^{commit}" >/dev/null; then
-            echo "::error::'origin/$base' does not resolve after a successful fetch — every diff below would be empty, which this gate would otherwise mistake for a docs-only PR."
+          if ! git rev-parse --verify --quiet "$base^{commit}" >/dev/null; then
+            echo "::error::'$base' does not resolve even after fetching — every diff below would be empty, which this gate would otherwise mistake for a docs-only PR."
             exit 1
           fi
-          changed=$(git diff --name-only "origin/$base...HEAD")
+          changed=$(git diff --name-only "$base...HEAD")
           if [ -z "$changed" ]; then
             echo "code=false" >> "$GITHUB_OUTPUT"
             echo "expected_state=docs-only" >> "$GITHUB_OUTPUT"
-            echo "::notice::the diff against origin/$base is empty (the base has caught up with this branch) — nothing to grade."
+            echo "::notice::the diff against $base is empty (the base has caught up with this branch) — nothing to grade."
           elif printf '%s\n' "$changed" | grep -qvE '^(docs/|.*\.md$|\.githooks/)'; then
             echo "code=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,28 @@ on:
     branches: [master, main]
   pull_request:
     branches: [master, main]
+  # The MERGE QUEUE's own trigger. Without it a queued PR waits forever for
+  # checks that never start, so this line must land BEFORE the queue is turned
+  # on in the repository settings, never after.
+  #
+  # The queue is what lets `strict` (require-branches-up-to-date) go off. With
+  # `strict` on, merging one PR forced every other open PR to pull main, which
+  # is a new head SHA and therefore a full re-run of all 18 required checks —
+  # `Mutants (changed lines)` among them at ~60 minutes. N open PRs cost N^2
+  # mutation runs, none of which graded anything that had changed. The queue
+  # tests the would-be-merged state once, at merge time, instead.
+  merge_group:
+
+# One in-flight run per PR. A second push used to leave the first mutation run
+# grinding to completion on code nobody would merge — two hours of a 2-core
+# runner for an answer about a superseded commit.
+#
+# `cancel-in-progress` is deliberately PULL-REQUEST ONLY. Cancelling a
+# merge_group run breaks the merge it was gating, and cancelling a push-to-main
+# run loses the only mutation signal main ever gets.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -82,19 +104,19 @@ jobs:
   config-key-composition:
     name: New config keys carry tests
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: contains(fromJSON('["pull_request", "merge_group"]'), github.event_name)
     steps:
       - uses: actions/checkout@v7
         with: { fetch-depth: 0 }
       - name: New schema keys must appear in tests
         run: |
-          git fetch origin ${{ github.base_ref }} --depth=1
+          git fetch origin ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }} --depth=1
           # Only PROPERTY names (keys directly under a "properties" object) —
           # definition/type names (e.g. CdcInitialMode) are not user-facing
           # config keys and false-positived on the gate's own first run.
           KEYS='[paths | select(length>=2 and .[-2]=="properties") | .[-1] | select(type=="string")] | unique | .[]'
           NEW_KEYS=$(diff \
-            <(git show origin/${{ github.base_ref }}:schemas/rivet.schema.json | jq -r "$KEYS" 2>/dev/null || true) \
+            <(git show ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}:schemas/rivet.schema.json | jq -r "$KEYS" 2>/dev/null || true) \
             <(jq -r "$KEYS" schemas/rivet.schema.json) \
             | grep '^>' | awk '{print $2}' || true)
           FAIL=0
@@ -197,7 +219,7 @@ jobs:
   mutants-in-diff:
     name: Mutants (changed lines)
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: contains(fromJSON('["pull_request", "merge_group"]'), github.event_name)
     # First live run: 52 mutants took 42m on the 2-core runner (cold baseline
     # build 270s + ~80s/mutant) — 45m was one flaky rebuild away from a
     # spurious timeout on a large PR. Raised 90 -> 120 when the offline-REACH
@@ -277,7 +299,7 @@ jobs:
         id: scope
         run: |
           set -euo pipefail
-          base="${{ github.base_ref }}"
+          base="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}"
           if ! git fetch --no-tags origin "$base"; then
             echo "::error::could not fetch the base branch '$base' — refusing to guess this PR's scope. A failed fetch used to read as a docs-only PR and skip every check in this job."
             exit 1
@@ -304,6 +326,18 @@ jobs:
         if: steps.scope.outputs.code == 'true'
         with:
           key: mutants
+      # Outcomes already measured for THIS EXACT code. The key is the whole
+      # world the answer depends on — a mutant is killed by the SUITE, not by
+      # its own file, so there is no honest per-file key (see the script's
+      # header). A hit therefore removes RE-runs (an infra flake, a docs-only
+      # push, a rebase onto a main that did not touch src/ or tests/), never
+      # the first grading of a change.
+      - name: Restore mutation outcomes
+        if: steps.scope.outputs.code == 'true'
+        uses: actions/cache/restore@v4
+        with:
+          path: .mutants-cache
+          key: mutants-outcomes-v1-${{ hashFiles('src/**/*.rs', 'tests/**/*.rs', 'Cargo.lock', '.cargo/mutants.toml') }}
       - name: Install cargo-mutants
         if: steps.scope.outputs.code == 'true'
         run: cargo install cargo-mutants --locked
@@ -353,7 +387,11 @@ jobs:
         env:
           # Mutants never need debuginfo — halves build dirs, speeds links.
           CARGO_PROFILE_DEV_DEBUG: "0"
-          BASE_REF: ${{ github.base_ref }}
+          # merge_group carries no `base_ref`; it carries the base SHA the queue
+          # built this group on. A three-dot diff against either is the same
+          # set — merge-base(base, HEAD)..HEAD — so one expression serves both
+          # events, and the gate grades the PR's own changes in the queue too.
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
         run: |
           set -euo pipefail
           # Everything this step decides is PUBLISHED, because the job's
@@ -394,7 +432,7 @@ jobs:
               exit 1
             fi
           }
-          git diff "origin/$BASE_REF"...HEAD > pr.diff
+          git diff "$BASE_SHA"...HEAD > pr.diff
           # BUDGET GUARD. Every mutant is its own incremental build — ~80s on a
           # 2-core runner at -j2, so the job's ceiling grades roughly 120
           # ($MUTANTS_DIFF_BUDGET). A five-round branch like #230 yields 416
@@ -519,7 +557,29 @@ jobs:
           # measure against every offline test target, then triage what's left.
           say state in-budget
           rc=0
-          cargo mutants --in-diff pr.diff ${DROP_P2[@]+"${DROP_P2[@]}"} -j 2 -- --lib --bins || rc=$?
+          # ALL-OR-NOTHING replay. Reusing SOME outcomes would change `count` /
+          # `p1` / `p2`, which `Mutants (coverage verdict)` audits against its
+          # OWN independent measurement — the two halves of the gate disagreeing
+          # about how much was graded is precisely the failure this plumbing
+          # exists to prevent. Either every graded mutant is known, or the run
+          # happens in full. A timeout is never replayed: it records that a
+          # measurement did not finish, which is not a verdict.
+          CACHED_RC=""
+          if [ -f .mutants-cache/outcomes.json ]; then
+            CACHED_RC=$(python3 .github/scripts/mutants_cache.py replay \
+                          .mutants-cache/outcomes.json p1.txt) || CACHED_RC=""
+          fi
+          if [ -n "$CACHED_RC" ]; then
+            rc="$CACHED_RC"
+            say cache hit
+            echo "::notice::every mutant this diff grades was already measured against identical src/, tests/, Cargo.lock and .cargo/mutants.toml — replaying rc=$rc rather than re-running. A RE-run saved, not a grading skipped."
+          else
+            say cache miss
+            cargo mutants --in-diff pr.diff ${DROP_P2[@]+"${DROP_P2[@]}"} -j 2 -- --lib --bins || rc=$?
+            mkdir -p .mutants-cache
+            python3 .github/scripts/mutants_cache.py record .mutants-cache/outcomes.json \
+              mutants.out/caught.txt mutants.out/missed.txt mutants.out/timeout.txt >/dev/null || true
+          fi
           verdict "$rc"
           # The run's own tally, published for the harness-metrics THERMOMETER
           # (see the `harness-metrics` job). Nothing gates on these; they exist
@@ -587,6 +647,15 @@ jobs:
       # the step above never ran at all. Without this, "the run was skipped
       # because the scope step broke" and "there was nothing to grade" arrive at
       # the blocking job as the same empty value.
+      - name: Save mutation outcomes
+        # `always()`: a run that ends in MISSED mutants still measured them, and
+        # that measurement is exactly what a re-run of the same commit should
+        # not have to pay for again.
+        if: always() && steps.scope.outputs.code == 'true' && hashFiles('.mutants-cache/outcomes.json') != ''
+        uses: actions/cache/save@v4
+        with:
+          path: .mutants-cache
+          key: mutants-outcomes-v1-${{ hashFiles('src/**/*.rs', 'tests/**/*.rs', 'Cargo.lock', '.cargo/mutants.toml') }}
       - name: Publish this run's verdict
         id: report
         if: always()
@@ -620,7 +689,7 @@ jobs:
   mutants-gate-sanity:
     name: Mutants (gate sanity)
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: contains(fromJSON('["pull_request", "merge_group"]'), github.event_name)
     timeout-minutes: 30
     outputs:
       # The audited picture of this diff, for the verdict job to compare the
@@ -644,7 +713,7 @@ jobs:
         id: scope
         run: |
           set -euo pipefail
-          base="${{ github.base_ref }}"
+          base="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}"
           if ! git fetch --no-tags origin "$base"; then
             echo "::error::could not fetch the base branch '$base' — refusing to guess this PR's scope. A failed fetch used to read as a docs-only PR and skip every check in this job."
             exit 1
@@ -713,10 +782,14 @@ jobs:
         id: graded
         if: steps.scope.outputs.code == 'true'
         env:
-          BASE_REF: ${{ github.base_ref }}
+          # merge_group carries no `base_ref`; it carries the base SHA the queue
+          # built this group on. A three-dot diff against either is the same
+          # set — merge-base(base, HEAD)..HEAD — so one expression serves both
+          # events, and the gate grades the PR's own changes in the queue too.
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
         run: |
           set -euo pipefail
-          git diff "origin/$BASE_REF"...HEAD > pr.diff
+          git diff "$BASE_SHA"...HEAD > pr.diff
           # No `|| true` anywhere near these two: under `set -e` a cargo-mutants
           # failure ends the step, which is the whole difference between "the
           # tool found nothing" and "the tool broke". The counting below runs on
@@ -754,7 +827,7 @@ jobs:
             #    touching live-only files, or worse, to pad diffs with mutable
             #    noise. It passes, LOUDLY: the notice says outright that offline
             #    mutation says nothing about this diff.
-            if git diff --name-only "origin/$BASE_REF"...HEAD | grep -qx '.cargo/mutants.toml'; then
+            if git diff --name-only "$BASE_SHA"...HEAD | grep -qx '.cargo/mutants.toml'; then
               echo "::error::the mutation gate would grade NOTHING: this diff yields \
           $all mutants, .cargo/mutants.toml removes every one — and this SAME diff \
           edits mutants.toml. A PR must not excuse itself from the gate unreviewed \
@@ -788,7 +861,11 @@ jobs:
         id: coverage
         if: steps.scope.outputs.code == 'true'
         env:
-          BASE_REF: ${{ github.base_ref }}
+          # merge_group carries no `base_ref`; it carries the base SHA the queue
+          # built this group on. A three-dot diff against either is the same
+          # set — merge-base(base, HEAD)..HEAD — so one expression serves both
+          # events, and the gate grades the PR's own changes in the queue too.
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
         run: |
           set -euo pipefail
           state() { echo "expected_state=$1" >> "$GITHUB_OUTPUT"; }
@@ -863,7 +940,7 @@ jobs:
     name: Mutants (coverage verdict)
     runs-on: ubuntu-latest
     needs: [mutants-in-diff, mutants-gate-sanity, gate-scripts]
-    if: always() && github.event_name == 'pull_request'
+    if: always() && contains(fromJSON('["pull_request", "merge_group"]'), github.event_name)
     timeout-minutes: 10
     steps:
       - name: The per-diff mutation run did what the audit says it must
@@ -1066,6 +1143,12 @@ jobs:
       # is gone.
       - name: The exclusion checker's own site/function keying
         run: python3 .github/scripts/mutants_exclusions.py --self-test
+      # The outcome cache decides whether a mutation run happens at all, so its
+      # own logic is gated the same way. Its self-test RED-proves the one thing
+      # that would be catastrophic and silent: a cache replaying PASS for a set
+      # that contains a missed mutant.
+      - name: Mutation outcome cache self-test
+        run: python3 .github/scripts/mutants_cache.py --self-test
       # The PRIORITISER's classification, graded over a coverage export copied
       # from a real `cargo llvm-cov --lib --bins --json` run: an executed
       # function, an untaken branch inside one, a function measured at zero, a

--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ __pycache__/
 # in .githooks/pre-commit, which refuses a commit that stages .rlib/.rmeta/
 # fingerprint/incremental paths or an implausible number of files.
 /target-*/
+.mutants-cache/


### PR DESCRIPTION
ci: merge queue, one run per PR, and a sound mutation-outcome cache

Mutation testing is the longest job in CI (~60 min), and most of what it spends
is re-measuring code nobody changed. Three causes, three fixes.

1. `strict` (require-branches-up-to-date) makes N open PRs cost N^2 runs.
   Merging one PR puts every other one "behind"; each must pull main, which is
   a new head SHA and therefore a full re-run of all 18 required checks. The
   fix is the merge queue, which tests the would-be-merged state once at merge
   time — so this adds the `merge_group:` trigger the queue needs. It MUST land
   before the queue is switched on: a queued PR waits forever for checks that
   never start.

   That in turn forces something worth stating: every REQUIRED check has to run
   in the queue, or the queue hangs on it. Two were pull_request-only —
   `Mutants (changed lines)` and `New config keys carry tests` — so all four
   PR-only jobs are now merge_group-capable. Their diff base moves from
   `origin/$BASE_REF` (merge_group carries no base_ref) to the base SHA the
   event provides; a three-dot diff against either is the same set.

   Checked before assuming, because the plan depended on it: `Mutants (changed
   lines)` reports `conclusion=failure` despite `continue-on-error: true`
   (measured on run 32621026079), so it really does block today. Had it been
   vacuous the whole reshuffle would have been a different change.

2. No `concurrency` group at all: a second push left the first mutation run
   grinding to completion on a superseded commit. Now one in-flight run per PR,
   with `cancel-in-progress` deliberately restricted to pull_request —
   cancelling a merge_group run breaks the merge it gates, and cancelling
   push-to-main loses the only mutation signal main ever gets.

3. An outcome cache, keyed on the whole world (`src/**`, `tests/**`,
   `Cargo.lock`, `.cargo/mutants.toml`). There is no honest per-file key: a
   mutant is killed by the SUITE, so a change three modules away can decide its
   fate. Be plain about what that buys — it does NOT make an ordinary PR
   cheaper; it removes RE-runs (an infra flake, a docs-only push, a rebase onto
   a main that missed src/ and tests/). When main touches the code, everything
   is measured again, which is correct rather than fast.

   ALL-OR-NOTHING, because partial reuse would change `count`/`p1`/`p2` — the
   numbers `Mutants (coverage verdict)` audits against its own independent
   measurement, and two halves of the gate disagreeing about how much was
   graded is the exact failure this plumbing exists to prevent. A `timeout` is
   never replayed: it records that a measurement did not finish.

   The script carries a self-test, registered in `Gate scripts (self-tests)`
   beside the exclusions one, and it RED-proves the catastrophic-and-silent
   case: stubbing the verdict to always print PASS makes it fail with
   `got (0, '0'), want (0, '2')`.

Measured while diagnosing, and reported because it contradicts what I expected:
`CARGO_PROFILE_DEV_DEBUG=0` is worth ~6% on this workload (3 mutants: 238.9s
-> 223.7s), not the lever it looked like. It is already set on the mutation
step; the per-mutant cost is the incremental rebuild itself.

Settings are NOT changed by this commit. Turning the queue on, dropping
`strict`, and swapping the required mutation check are repository settings, and
they must follow a green merge_group run — not precede it.

---
**Settings steps, to run only AFTER this merges and a merge_group run is green.** In this order:

1. Settings → Branches → `main`: enable **Require merge queue**.
2. Same page: turn **Require branches to be up to date before merging** (`strict`) OFF. This is the setting that caused the N² re-runs.
3. Required status checks: replace `Mutants (changed lines)` with `Mutants (coverage verdict)`. The run fails directly on MISSED; the verdict job is the one that reasons about the honest cases (over-budget-ungraded, docs-only) and is the right thing to block on.

A backup of the current protection JSON is saved locally in case a rollback is wanted.

**Watch the first queued merge.** merge_group behaviour cannot be exercised from a PR, so the first one is the real test — if checks do not start, disable the queue immediately and the repo is back to today's behaviour with no code change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168uwctCn3W1rP4Kt4kZXvE