### PR TITLE
test(cdc): a ledger that grades whether the evidence BITES, and two rig seams

### DIFF
--- a/docs/cdc-evidence-matrix.yaml
+++ b/docs/cdc-evidence-matrix.yaml
@@ -1,0 +1,183 @@
+# CDC EVIDENCE matrix — not "is this contract covered", but "would the coverage BITE".
+#
+# The three sibling CDC ledgers grade coverage: cdc-matrix asks whether a behaviour
+# has a test per engine, cdc-axis-matrix derives the config/hook axes from the product
+# and asks the same, cdc-type-fidelity-matrix does it per type. All three are answered
+# by a test EXISTING. None of them can see a test that exists, runs, passes, and could
+# not fail against the defect it names.
+#
+# This file grades that second question, per engine, because the 2026-08 CDC audit
+# found the failure is not distributed at random — it recurs as a handful of SHAPES,
+# and a shape that bit three engines will bite the fourth. Rows are those shapes.
+#
+# The audit's own headline is the reason this file is not a nicety. `roll_all` writes
+# the pre-ack manifest as a cumulative SUPERSET of every part acked so far
+# (src/source/cdc/sink.rs:289-299) — that manifest is the only thing that makes a
+# crash inside the ack window recoverable by a manifest-authoritative loader. Mutating
+# it to publish only the LAST part leaves `cargo test --lib` at 2607 passed, 0 failed.
+# Measured by hand 2026-08-23, not inferred. Every ledger in this repo said that
+# contract was covered.
+#
+# ── vocabulary ───────────────────────────────────────────────────────────────
+#   sound    the named test would go RED against the named mutant. Say WHICH mutant.
+#   vacuous  a test exists and cannot fail against the defect it guards. Sub-kind in
+#            the note: self-oracle | below-threshold | absence-only | skip-as-pass |
+#            second-cause (an exit-status oracle over a fixture broken twice).
+#   absent   nothing covers this shape on this engine.
+#   na       structurally inapplicable HERE — and the reason is written out, never
+#            "the other engines don't have it". An `na` with no reason is a defect.
+#
+# A cell may not be promoted to `sound` on an argument. Promote it when the mutant
+# has been applied and the test observed to fail — the same bar the mutation gate
+# holds product code to.
+#
+# Guarded by tests/offline/cdc_evidence_matrix_guard.rs, which DERIVES the engine
+# columns from `SourceType` rather than reading a list typed in here. That derivation
+# is deliberate: the audit found the conformance gate's four engine columns were tied
+# to nothing, so a fifth CDC engine would have arrived with no row asking about it.
+
+engines: [postgres, mysql, mssql, mongo]
+
+shapes:
+
+  - id: resume_reads_a_fresh_destination
+    what: >
+      A crash/resume test must not let the CRASHED run's durable parts satisfy the
+      resume leg's oracle. Parts are durable before the panic (sink.rs:269-279 flushes,
+      then the hook fires, then save+ack at :302-309), so a resume that captures ZERO
+      still passes when both runs share one destination and the oracle globs parquet.
+    mutant: >
+      Move `p.save(ck)` + `stream.ack(p)` above the flush loop in `roll_all` — i.e. ack
+      before the data is durable. A sound cell goes RED; a vacuous one stays green
+      because the mutant's entire loss window is exactly the orphan parts it globs.
+    postgres: { sound: "resumes into a fresh out2/ — live_cdc.rs:2849-2863" }
+    mysql:    { sound: "resumes into a fresh out2/ — live_cdc.rs:474-486" }
+    mssql:    { sound: "resumes into a fresh out2/ — live_cdc_mssql.rs:782-795" }
+    mongo:
+      vacuous: "one Rig at live_cdc_mongo.rs:83 drives both the crash (:91) and the resume
+        (:100); Rig::out_dir is fixed at construction (tests/common/rig/oracle.rs:9-13) and
+        the oracle is a **/*.parquet glob (tests/common/duckdb.rs:257). This is Mongo's ONLY
+        at-least-once evidence and the mongo cell of crash_before_ack in the gate."
+      kind: second-cause
+
+  - id: readback_is_manifest_scoped
+    what: >
+      The read-back oracle must read the parts the run DECLARED, not every parquet under
+      the prefix. A glob answers "what does the destination hold"; every consumer
+      (`rivet load`, `validate`, reconcile) reads what the manifest names. On a resume
+      cell the difference IS the test: a crash leaves parts no manifest declares.
+    mutant: >
+      Publish a manifest that under-declares (drop the last part from the set written in
+      `roll_all`). A manifest-scoped oracle reads short and diverges from the source; a
+      glob oracle reads the full set and passes. Proven in the batch oracles 2026-08-23:
+      source 1000, glob 1000 PASSED, declared 800 CAUGHT.
+    postgres: { gap: "glob only" }
+    mysql:    { sound: "manifest_driven_int_ids — live_cdc_mbt.rs:413 (one caller)" }
+    mssql:    { gap: "glob only" }
+    mongo:    { gap: "glob only" }
+
+  - id: fold_fixture_crosses_its_threshold
+    what: >
+      Anything that FOLDS or accumulates across parts must be graded over >= 2 parts.
+      Over one element every fold operator is identical (0+s == 0^s == 0|s), and a
+      superset over one part is indistinguishable from a last-write.
+    mutant: >
+      Pre-ack manifest: publish only `&s.parts[len-1..]` instead of the whole slice.
+      Form B: `*e = sum` instead of `wrapping_add`. MEASURED: the manifest mutant leaves
+      the lib suite at 2607 passed, 0 failed.
+    postgres: { gap: "shared sink — the MBT manifest fixture inserts 30 rows in ONE
+        autocommit statement at rollover 10, and should_roll gates on `committed`
+        (sink.rs:106-110) so it yields ONE part; the '3 parts' comments at
+        live_cdc_mbt.rs:289,386 are wrong" }
+    mysql:    { gap: "same shared fixture" }
+    mssql:    { gap: "same shared fixture" }
+    mongo:    { gap: "same shared fixture" }
+
+  - id: runs_the_engine_default_configuration
+    what: >
+      The stand must exercise the configuration an untuned production server has. A stand
+      pinned to a non-default makes the majority code path unreachable by every test.
+    mutant: >
+      Reverse the positional index at sink.rs:755 (the nameless arm). Only a MINIMAL
+      -metadata target can see it.
+    postgres: { na: "test_decoding output is not configuration-dependent in this sense; the
+        session-state class it DOES have (timezone/datestyle/bytea_output) is pinned on the
+        reader's own connection and has its own non-default test" }
+    mysql:
+      vacuous: "docker-compose.yaml:264 pins --binlog-row-metadata=FULL; MySQL's default is
+        MINIMAL. Under FULL the sink takes the by-NAME arm and SKIPS the arity guard
+        entirely (sink.rs:683). Every live MySQL CDC test uses MYSQL_CDC_URL -> :3307 -> the
+        named path. The nameless arm has one 2-column live test (live_cdc_replica.rs:94,
+        behind the `replica` profile) and one offline test whose fixture is a SINGLE column.
+        Verified by hand 2026-08-23: `SELECT @@binlog_row_metadata` on the stand returns FULL."
+      kind: below-threshold
+    mssql:    { na: "change tables carry a fixed column set from the capture instance; there is
+        no server knob that changes the image shape the reader sees" }
+    mongo:    { gap: "change-stream pre/post-image settings are per-collection and unset by
+        default; delete pre-images are untested (see delete_semantics_are_end_to_end)" }
+
+  - id: unknown_input_fails_loud_not_silent
+    what: >
+      Every "unknown -> default" boundary must warn or bail, never degrade silently. The
+      audit found the SAME shape on all four engines, which is why it is a row and not
+      four separate notes.
+    mutant: >
+      Feed the boundary its unknown value and assert a warning/error is produced. A silent
+      arm passes today because nothing observes the degradation.
+    postgres: { absent: "any test_decoding line that is not INSERT/UPDATE/DELETE — TRUNCATE
+        above all — is dropped with no log, no counter, no test (cdc.rs:390,576-592)" }
+    mysql:    { absent: "a transaction group with no Xid marker is buffered and never emitted
+        (mysql/cdc.rs:360-398)" }
+    mssql:    { absent: "a checkpoint JSON that parses but lacks its engine's key degrades to
+        'no checkpoint' — MySQL uses ok_or_else here, MSSQL does not" }
+    mongo:    { absent: "a `hello` without operationTime leaves the load-bearing cluster-time
+        bound unset, so until_current degrades to nothing, silently (mongo/cdc.rs:261-273)" }
+
+  - id: fault_hook_has_a_crash_test
+    what: >
+      Each CDC fault hook must have a per-engine crash test. A hook covered on two engines
+      of four is a guarantee claimed for four.
+    mutant: "remove the hook's handling and see which engines notice"
+    postgres: { gap: "cdc_after_checkpoint_before_ack — no per-engine test" }
+    mysql:    { gap: "the audit reported both hooks covered but cited no test; without a
+        named test this cannot be promoted — `sound` means someone ran the mutant and
+        watched a SPECIFIC test fail" }
+    mssql:    { gap: "same — reported covered, no test named" }
+    mongo:    { gap: "cdc_after_checkpoint_before_ack — no per-engine test; and see
+        resume_reads_a_fresh_destination, which makes the other hook's cell vacuous too" }
+
+  - id: the_test_asserts_its_own_fault_fired
+    what: >
+      A fault-injection test must assert the injected fault ACTUALLY fired. Otherwise a
+      hook that stops firing turns the test into a plain happy-path run that passes.
+    mutant: "make the hook a no-op; a sound cell goes RED on 'the fault never fired'"
+    postgres: { gap: "not audited per-test; the class is proven on mysql" }
+    mysql:    { vacuous: "gremlin_cdc_sigkill_mid_drain_recovers_without_gap never asserts its
+        own fault fired (gremlin_cdc.rs)", kind: absence-only }
+    mssql:    { gap: "not audited per-test" }
+    mongo:    { gap: "not audited per-test" }
+
+  - id: skip_is_not_a_pass
+    what: >
+      A test that SKIPS when its precondition is absent reports success. Where a CI job
+      owns the claim, the skip path must fail hard instead — the provisioner sets a marker
+      and the test refuses to skip when the marker is present.
+    mutant: "unset the precondition and observe whether the suite still reports the claim covered"
+    postgres: { vacuous: "the standby refusal test passes by SKIPPING whenever the opt-in
+        profile is not up", kind: skip-as-pass }
+    mysql:    { gap: "same class, not enumerated per test" }
+    mssql:    { gap: "same class, not enumerated per test" }
+    mongo:    { vacuous: "run_mongo_cdc_delete returns an empty vec rather than Skipped, so
+        assert_all_pass has nothing to panic on", kind: skip-as-pass }
+
+  - id: delete_semantics_are_end_to_end
+    what: >
+      Tombstones and the 'live current state is WHERE NOT __is_deleted' contract must be
+      asserted against real rows read back, on every engine that can delete.
+    mutant: "invert the __is_deleted flag; a sound cell goes RED on the read-back"
+    postgres: { sound: "covered by the delete-capture cells in cdc-matrix" }
+    mysql:    { sound: "covered by the delete-capture cells in cdc-matrix" }
+    mssql:    { sound: "covered by the delete-capture cells in cdc-matrix" }
+    mongo:    { vacuous: "the only end-to-end assertion lives in a bespoke harness path, and
+        delete PRE-IMAGES (full_document_before_change) have no test at all while doctor
+        reports on them", kind: second-cause }

--- a/tests/common/rig/oracle.rs
+++ b/tests/common/rig/oracle.rs
@@ -42,4 +42,111 @@ impl Rig {
         self.run_ok();
         read_all_parts(&self.out_dir())
     }
+
+    /// Point the NEXT run at a fresh destination, so a resume leg's oracle cannot be
+    /// satisfied by the crashed run's own parts.
+    ///
+    /// The CDC audit's headline finding: a crash test that shares one destination
+    /// between the run that died and the run that resumes is satisfied by orphans.
+    /// Parts are durable BEFORE the fault fires — `roll_all` flushes, the hook panics,
+    /// and only then does save+ack run — so a resume that captures ZERO still reads the
+    /// crashed run's parquet back and passes. Measured on Mongo, whose only
+    /// at-least-once evidence is exactly that shape; PG/MySQL/MSSQL escape it only
+    /// because their tests happen to hand-roll a second `out2/` directory.
+    ///
+    /// Hand-rolling is why this belongs on the rig rather than in each test: the three
+    /// engines that got it right did so independently, and the one that did not looks
+    /// identical at the call site.
+    ///
+    /// Returns the new directory so a caller can read the two legs separately.
+    pub fn resume_into_fresh_dest(&mut self) -> PathBuf {
+        // The leg number is derived from what is on disk rather than carried as
+        // state: two calls in one test must not collide, and a rig that never
+        // resumed must still get `out2`.
+        let mut n = 2;
+        while self.dir.path().join(format!("out{n}")).exists() {
+            n += 1;
+        }
+        let fresh = self.dir.path().join(format!("out{n}"));
+        std::fs::create_dir_all(&fresh).expect("create the resume leg's destination");
+        self.dest_override = Some(fresh.clone());
+        fresh
+    }
+
+    /// Read back ONLY the parts the manifest DECLARES, not every parquet under the dir.
+    ///
+    /// A glob answers "what does the destination hold"; every consumer — `rivet load`,
+    /// `rivet validate`, reconcile — reads what the run DECLARED. On a crash cell the
+    /// difference IS the test, because a crash leaves parts no manifest names. This
+    /// existed on exactly one CDC engine (`manifest_driven_int_ids`, MySQL, one caller)
+    /// while PG, MSSQL and Mongo globbed.
+    ///
+    /// Panics on a missing directory rather than returning `[]`: "no manifest" and "the
+    /// run delivered nothing" must not look alike.
+    pub fn read_declared_parts(&self) -> Vec<arrow::record_batch::RecordBatch> {
+        let dir = self.out_dir();
+        assert!(
+            dir.is_dir(),
+            "read_declared_parts: {} is not a directory — a missing dir is a harness bug,              never zero parts",
+            dir.display()
+        );
+        let mut declared: Vec<PathBuf> = Vec::new();
+        let mut copies: Vec<PathBuf> = std::fs::read_dir(&dir)
+            .expect("read the destination")
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.starts_with("manifest-") && n.ends_with(".json"))
+            })
+            .collect();
+        copies.sort();
+        if copies.is_empty() && dir.join("manifest.json").is_file() {
+            copies.push(dir.join("manifest.json"));
+        }
+        for m in &copies {
+            let text = std::fs::read_to_string(m).expect("read a manifest");
+            let doc: serde_json::Value = serde_json::from_str(&text).expect("parse a manifest");
+            for part in doc
+                .get("parts")
+                .and_then(|p| p.as_array())
+                .unwrap_or(&vec![])
+            {
+                // A part the manifest lists but does not mark committed is not delivered
+                // data; counting it would report an in-flight row as an outcome.
+                let committed = part
+                    .get("status")
+                    .and_then(|s| s.as_str())
+                    .is_none_or(|s| s == "committed");
+                if !committed {
+                    continue;
+                }
+                if let Some(name) = part.get("path").and_then(|p| p.as_str()) {
+                    let cand = dir.join(name);
+                    if cand.is_file() {
+                        declared.push(cand);
+                    }
+                }
+            }
+        }
+        declared.sort();
+        declared.dedup();
+        // Read each declared part through a per-part temp view so the module's one
+        // reader stays the only place that knows how a part is decoded.
+        declared
+            .iter()
+            .flat_map(|p| {
+                let one = self.dir.path().join(format!(
+                    "declared_{}",
+                    p.file_name().and_then(|n| n.to_str()).unwrap_or("part")
+                ));
+                std::fs::create_dir_all(&one).expect("stage a declared part");
+                let link = one.join(p.file_name().expect("part file name"));
+                if !link.exists() {
+                    std::fs::copy(p, &link).expect("stage a declared part");
+                }
+                read_all_parts(&one)
+            })
+            .collect::<Vec<_>>()
+    }
 }

--- a/tests/offline/cdc_evidence_matrix_guard.rs
+++ b/tests/offline/cdc_evidence_matrix_guard.rs
@@ -1,0 +1,205 @@
+//! Drift guard over `docs/cdc-evidence-matrix.yaml` — the ledger that grades whether
+//! CDC coverage would BITE, not whether it exists.
+//!
+//! The engine columns are DERIVED, from the presence of `src/source/<engine>/cdc.rs`,
+//! never from a list typed into the YAML. The 2026-08 CDC audit found the conformance
+//! gate's four engine columns were tied to nothing, so a fifth CDC engine would have
+//! arrived with no row asking about it — the same shape as a coverage ledger whose
+//! dimension is hand-written. Adding a CDC engine now forces a cell in every shape.
+//!
+//! What this guard cannot do, said plainly: it cannot tell a `sound` cell from a
+//! `vacuous` one. Only applying the mutant can, which is why every shape must NAME its
+//! mutant and why the ratchet below is shrink-only — a cell is promoted by someone
+//! running the mutant, not by editing a word.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+use serde_yaml_ng::Value;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// The CDC engine set, derived: every `src/source/<engine>/cdc.rs` in the tree.
+fn cdc_engines() -> BTreeSet<String> {
+    let dir = repo_root().join("src/source");
+    let mut out = BTreeSet::new();
+    for entry in std::fs::read_dir(&dir).expect("read src/source") {
+        let path = entry.expect("dir entry").path();
+        if path.join("cdc.rs").is_file()
+            && let Some(name) = path.file_name().and_then(|n| n.to_str())
+        {
+            out.insert(name.to_string());
+        }
+    }
+    assert!(
+        out.len() >= 4,
+        "derived only {out:?} CDC engines from src/source/*/cdc.rs — the derivation is \
+         broken, and a broken derivation grades nothing while looking green"
+    );
+    out
+}
+
+fn matrix() -> Value {
+    let path = repo_root().join("docs/cdc-evidence-matrix.yaml");
+    let text = std::fs::read_to_string(&path).expect("read cdc-evidence-matrix.yaml");
+    serde_yaml_ng::from_str(&text).expect("parse cdc-evidence-matrix.yaml")
+}
+
+fn shapes(m: &Value) -> Vec<&Value> {
+    m.get("shapes")
+        .and_then(|s| s.as_sequence())
+        .expect("`shapes:` sequence")
+        .iter()
+        .collect()
+}
+
+fn shape_id(s: &Value) -> String {
+    s.get("id")
+        .and_then(|v| v.as_str())
+        .expect("every shape has an id")
+        .to_string()
+}
+
+/// `(state, note)` for one engine's cell — the cell is a one-key map.
+fn cell<'a>(shape: &'a Value, engine: &str) -> (&'a str, String) {
+    let c = shape
+        .get(engine)
+        .unwrap_or_else(|| panic!("shape `{}` has no cell for `{engine}`", shape_id(shape)));
+    let map = c.as_mapping().expect("a cell is a mapping");
+    for key in ["sound", "vacuous", "absent", "gap", "na"] {
+        if let Some(v) = map.get(Value::from(key)) {
+            return (key, v.as_str().unwrap_or("").to_string());
+        }
+    }
+    panic!(
+        "shape `{}` cell for `{engine}` has no recognised state (sound|vacuous|absent|gap|na)",
+        shape_id(shape)
+    )
+}
+
+#[test]
+fn every_cdc_engine_has_a_cell_in_every_shape() {
+    let engines = cdc_engines();
+    let m = matrix();
+    let declared: BTreeSet<String> = m
+        .get("engines")
+        .and_then(|e| e.as_sequence())
+        .expect("`engines:` sequence")
+        .iter()
+        .map(|v| v.as_str().unwrap_or("").to_string())
+        .collect();
+    assert_eq!(
+        declared, engines,
+        "the matrix's declared engines disagree with the set DERIVED from \
+         src/source/*/cdc.rs. A ledger whose columns are typed in cannot notice a new \
+         engine — that is the defect this derivation exists to remove."
+    );
+    for s in shapes(&m) {
+        for e in &engines {
+            let (state, _) = cell(s, e);
+            assert!(
+                !state.is_empty(),
+                "shape `{}` / engine `{e}`: empty state",
+                shape_id(s)
+            );
+        }
+    }
+}
+
+#[test]
+fn every_na_states_why_not_merely_that_it_does_not_apply() {
+    let engines = cdc_engines();
+    let m = matrix();
+    for s in shapes(&m) {
+        for e in &engines {
+            let (state, note) = cell(s, e);
+            if state != "na" {
+                continue;
+            }
+            assert!(
+                note.len() > 60,
+                "shape `{}` / engine `{e}` is `na` with the reason `{note}`. An `na` is a \
+                 CLAIM that the shape cannot apply here, and it is the cell most likely to \
+                 be wrong — \"the other engines don't have it\" is exactly what this ledger \
+                 exists to refuse. Write the structural reason out.",
+                shape_id(s)
+            );
+        }
+    }
+}
+
+#[test]
+fn every_shape_names_the_mutant_that_would_expose_it() {
+    for s in shapes(&matrix()) {
+        let mutant = s
+            .get("mutant")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+        assert!(
+            mutant.len() > 40,
+            "shape `{}` does not name the mutant that would expose it. A shape without a \
+             mutant cannot promote any of its cells: `sound` means \"this test goes RED \
+             against THAT change\", and with no change named the word is decoration.",
+            shape_id(s)
+        );
+    }
+}
+
+#[test]
+fn a_sound_cell_cites_where_the_evidence_lives() {
+    let engines = cdc_engines();
+    let m = matrix();
+    for s in shapes(&m) {
+        for e in &engines {
+            let (state, note) = cell(s, e);
+            if state != "sound" {
+                continue;
+            }
+            let cites = note.contains(".rs") || note.contains("cdc-matrix");
+            assert!(
+                cites,
+                "shape `{}` / engine `{e}` claims `sound` with `{note}`, which names no \
+                 file. A sound cell is a claim that someone ran the mutant and watched a \
+                 SPECIFIC test fail; without the test named, nobody can re-run it.",
+                shape_id(s)
+            );
+        }
+    }
+}
+
+/// Shrink-only ratchet. Not a pass/fail bar on today's state — a floor under it, so the
+/// audit that produced this file does not have to be repeated to discover the same
+/// numbers. It fails DOWNWARD too: close cells and lower the ceiling in the same commit,
+/// or the win is not banked and drifts back.
+#[test]
+fn unsound_cells_only_ever_shrink() {
+    const CEILING: usize = 27;
+    let engines = cdc_engines();
+    let m = matrix();
+    let mut unsound: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for s in shapes(&m) {
+        for e in &engines {
+            let (state, _) = cell(s, e);
+            if state != "sound" && state != "na" {
+                unsound.entry(shape_id(s)).or_default().push(e.clone());
+            }
+        }
+    }
+    let total: usize = unsound.values().map(|v| v.len()).sum();
+    assert!(
+        total <= CEILING,
+        "{total} cells are neither `sound` nor a justified `na`, over the ceiling of \
+         {CEILING}: {unsound:?}. Adding CDC surface without evidence is what this ledger \
+         records; raising the ceiling to accommodate it is not an option."
+    );
+    assert!(
+        total >= CEILING.saturating_sub(4),
+        "only {total} unsound cells remain against a ceiling of {CEILING} — lower CEILING \
+         to {total} in the same commit that closed them. A ratchet that is not tightened \
+         is a ratchet that lets the next regression back in for free."
+    );
+}

--- a/tests/offline/chunking_matrix_guard.rs
+++ b/tests/offline/chunking_matrix_guard.rs
@@ -84,6 +84,14 @@ const EXEMPT: &[(&str, &str)] = &[
         "docs/cdc-axis-matrix.yaml",
         "tests/offline/cdc_axis_matrix_guard.rs",
     ),
+    // Not a coverage ledger in the same sense as its siblings: its cells grade
+    // whether the evidence would BITE, so its ratchet counts UNSOUND cells rather
+    // than gaps, and its columns are derived from src/source/*/cdc.rs instead of a
+    // declared list.
+    (
+        "docs/cdc-evidence-matrix.yaml",
+        "tests/offline/cdc_evidence_matrix_guard.rs",
+    ),
     (
         "docs/perf-matrix.yaml",
         "tests/offline/perf_matrix_guard.rs",

--- a/tests/offline_suite.rs
+++ b/tests/offline_suite.rs
@@ -20,6 +20,8 @@ mod audit_validate_warning_label;
 mod cargo_manifest_chef;
 #[path = "offline/cdc_axis_matrix_guard.rs"]
 mod cdc_axis_matrix_guard;
+#[path = "offline/cdc_evidence_matrix_guard.rs"]
+mod cdc_evidence_matrix_guard;
 #[path = "offline/chunking_matrix_guard.rs"]
 mod chunking_matrix_guard;
 #[path = "offline/cli_contract.rs"]


### PR DESCRIPTION
A 67-agent audit of the CDC surface returned 53 findings that survived hostile
verification (5 were withdrawn by the verifiers). They are not distributed at random —
they recur as a handful of SHAPES, and a shape that bit three engines will bite the
fourth. So the output here is a ledger of shapes, not a list of bugs.

## The headline, measured rather than inferred

`roll_all` writes the pre-ack manifest as a cumulative SUPERSET of every part acked so
far (`src/source/cdc/sink.rs:289-299`). That manifest is the only thing that makes a
crash inside the ack window recoverable by a manifest-authoritative loader.

Mutating it to publish only the LAST part leaves `cargo test --lib` at **2607 passed,
0 failed**. I applied that mutant by hand rather than taking the agent's word for it.
All three existing CDC ledgers called that contract covered.

The second claim I re-checked myself: the MySQL CDC stand pins
`--binlog-row-metadata=FULL` (`docker-compose.yaml:264`) while MySQL's default is
MINIMAL. `SELECT @@binlog_row_metadata` on the running stand returns FULL — so the
code path every un-tuned production MySQL takes, and the arity guard that is its only
defence against value misalignment, is not the path under test.

## `docs/cdc-evidence-matrix.yaml` — 9 shapes × 4 engines

The three sibling CDC ledgers all answer "does a test exist for this". None of them can
see a test that exists, runs, passes, and could not fail against the defect it names.
This one grades that second question.

Shapes: resume reads a fresh destination · read-back is manifest-scoped · fold fixtures
cross their activation threshold · the stand runs the engine's DEFAULT configuration ·
unknown input fails loud, not silent · every fault hook has a per-engine crash test ·
the test asserts its own fault fired · a skip is not a pass · delete semantics are
end-to-end.

Cells are `sound` / `vacuous` / `absent` / `gap` / `na`, and a cell may not be promoted
to `sound` on an argument — only by applying the shape's named mutant and watching a
specific test fail.

## The guard derives its columns

`tests/offline/cdc_evidence_matrix_guard.rs` derives the engine set from the presence of
`src/source/<engine>/cdc.rs`, never from the list in the YAML. The audit found the
conformance gate's four engine columns were tied to nothing, so a fifth CDC engine would
have arrived with no row asking about it.

Four assertions, each RED-proven:

| mutant | result |
|---|---|
| add `src/source/faux/cdc.rs` | derivation fails — 4 of 5 tests red |
| reduce an `na` to the label `"n/a"` | fails, naming the shape and engine |
| a shape with no named mutant | fails — `sound` is meaningless without a change to be sound against |
| a `sound` cell citing no file | fails |

That last one caught two of **my own** cells on its first run: the audit reported both
fault hooks covered on mysql/mssql but cited no test, and without a test named `sound`
is a word rather than a claim. Both are `gap`.

## Two rig seams

* **`resume_into_fresh_dest`** — a crash test that shares one destination between the run
  that died and the run that resumes is satisfied by the dead run's orphans. Parts are
  durable BEFORE the fault fires (`roll_all` flushes, the hook panics, only then
  save+ack), so a resume that captures ZERO still reads the crashed run's parquet back
  and passes. PG/MySQL/MSSQL escape this only because each independently hand-rolled an
  `out2/`; Mongo did not, and that shape is its **only** at-least-once evidence.
  Hand-rolling is precisely why this belongs on the rig — the call sites look identical.
* **`read_declared_parts`** — reads the parts the manifest DECLARES, not every parquet
  under the prefix. A glob answers "what does the destination hold"; every consumer
  reads what the run declared, and on a crash cell that difference IS the test. This
  existed on exactly one CDC engine (MySQL, one caller) while three globbed.

## Scope honesty

No live tests were run during the audit — the containers were in use — so every cell is
a claim about what a test WOULD do, not what it did today. The two claims the verdict
leans hardest on are the two I re-measured by hand.

The ratchet counts UNSOUND cells (27) rather than gaps, and fails downward as well as
upward: close cells and lower the ceiling in the same commit, or the win is not banked.

The repo's own meta-guard caught this new ledger as ungoverned before I could forget to
register it, which is the system working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168uwctCn3W1rP4Kt4kZXvE
