### PR TITLE
fix(mysql/cdc): a COMMIT that is not an Xid must release the transaction

### DIFF
--- a/src/source/mysql/cdc.rs
+++ b/src/source/mysql/cdc.rs
@@ -271,6 +271,36 @@ impl MysqlChangeStream {
 
     /// Pull one binlog event and expand it into `pending`. `Ok(false)` ⇒ stream
     /// ended; `Ok(true)` ⇒ consumed an event.
+    /// Release the buffered transaction at `log_pos`, or end the stream when the
+    /// commit sits past the open-time ceiling.
+    ///
+    /// Returns `false` when the caller must stop: a commit past the bound belongs to
+    /// the NEXT run, so the transaction is dropped un-released and the checkpoint
+    /// never advances past it — the resume re-reads it in full. `past_bound` is
+    /// sticky so the sink's re-drain pass returns `None` at once rather than
+    /// consuming (and re-deferring) more past-bound events.
+    ///
+    /// Shared by the `Xid` and `Query('COMMIT')` arms: two commit markers, one
+    /// framing. Duplicating it is how the second one drifts.
+    fn close_transaction_at(&mut self, log_pos: u64) -> bool {
+        if commit_past_bound(&self.file, log_pos, self.bound.as_ref()) {
+            self.tx.clear();
+            self.tx_bytes = 0;
+            self.past_bound = true;
+            return false;
+        }
+        let commit = Position(json!({ "file": self.file, "pos": log_pos }));
+        let mut tx: Vec<ChangeEvent> = self.tx.drain(..).collect();
+        self.tx_bytes = 0;
+        // #158: the shared close — commit position on all, committed on the last
+        // only (the marker frames the whole transaction's boundary).
+        crate::source::cdc::TxnFramer::close_group(&mut tx, &commit);
+        for ev in tx {
+            self.pending.push_back(ev);
+        }
+        true
+    }
+
     fn fill(&mut self) -> Result<bool> {
         if self.past_bound {
             return Ok(false); // ended at the open-time ceiling — stay ended
@@ -358,26 +388,23 @@ impl MysqlChangeStream {
             // in the transaction and mark the last one committed, then release the
             // whole transaction atomically.
             Some(EventData::XidEvent(_)) => {
-                // A commit past the open-time ceiling belongs to the next run:
-                // end the stream WITHOUT releasing the transaction — the
-                // checkpoint never advances past it, so the resume re-reads it
-                // in full. `past_bound` is sticky so the sink's re-drain pass
-                // returns `None` at once rather than consuming (and re-deferring)
-                // more past-bound events.
-                if commit_past_bound(&self.file, log_pos, self.bound.as_ref()) {
-                    self.tx.clear();
-                    self.tx_bytes = 0;
-                    self.past_bound = true;
+                if !self.close_transaction_at(log_pos) {
                     return Ok(false);
                 }
-                let commit = Position(json!({ "file": self.file, "pos": log_pos }));
-                let mut tx: Vec<ChangeEvent> = self.tx.drain(..).collect();
-                self.tx_bytes = 0;
-                // #158: the shared close — commit position on all, committed on
-                // the last only (the XID marks the whole transaction's boundary).
-                crate::source::cdc::TxnFramer::close_group(&mut tx, &commit);
-                for ev in tx {
-                    self.pending.push_back(ev);
+            }
+            // A commit that is NOT an Xid. `Xid` is written only by a
+            // transactional storage engine's own commit; a MyISAM/MEMORY write, and
+            // every `XA COMMIT`, close the transaction with a QUERY event instead.
+            // With no arm for it those rows fell to `_ => {}` and stayed buffered
+            // FOREVER: the run captured zero, exited 0, and the checkpoint never
+            // moved — silent, total, and indistinguishable from an idle source.
+            //
+            // `XA PREPARE` deliberately does NOT release: the transaction is not
+            // committed yet, and releasing there would publish rows a later
+            // `XA ROLLBACK` erases.
+            Some(EventData::QueryEvent(qe)) if is_commit_statement(&qe.query()) => {
+                if !self.close_transaction_at(log_pos) {
+                    return Ok(false);
                 }
             }
             // #200-2: a compressed transaction. `binlog_transaction_compression`
@@ -513,6 +540,25 @@ fn connect_conn(url: &str, tls: Option<&TlsConfig>) -> Result<Conn> {
 /// (one server has one basename — rotation never changes it mid-stream). Fails
 /// open: an unparseable name is never "past" — the `BINLOG_DUMP_NON_BLOCK` EOF
 /// backstop still ends the run (delayed termination, never a dropped commit).
+/// Does this QUERY event close a transaction?
+///
+/// `COMMIT` on its own (the non-transactional-engine and binlog-format path) and
+/// `XA COMMIT <xid>`. Deliberately NOT `XA PREPARE` — prepared is not committed, and
+/// releasing there would publish rows a later `XA ROLLBACK` erases. Not `BEGIN`,
+/// `SAVEPOINT` or `ROLLBACK` either, none of which end a transaction with data to
+/// publish.
+fn is_commit_statement(sql: &str) -> bool {
+    let t = sql.trim().trim_end_matches(';').trim();
+    if t.eq_ignore_ascii_case("commit") {
+        return true;
+    }
+    let mut w = t.split_whitespace();
+    matches!(
+        (w.next(), w.next()),
+        (Some(a), Some(b)) if a.eq_ignore_ascii_case("xa") && b.eq_ignore_ascii_case("commit")
+    )
+}
+
 fn commit_past_bound(file: &str, pos: u64, bound: Option<&(String, u64)>) -> bool {
     let Some((bound_file, bound_pos)) = bound else {
         return false;
@@ -618,6 +664,48 @@ impl ChangeStream for MysqlChangeStream {
 
 #[cfg(test)]
 mod tests {
+
+    /// `Xid` is written only by a transactional engine's own commit. A MyISAM or
+    /// MEMORY write, and every `XA COMMIT`, close the transaction with a QUERY event
+    /// instead — and with no arm for those the rows stayed buffered FOREVER: the run
+    /// captured zero, exited 0, and the checkpoint never moved. Silent, total, and
+    /// indistinguishable from an idle source.
+    ///
+    /// The negative half is the load-bearing one. `XA PREPARE` must NOT release:
+    /// prepared is not committed, and publishing there hands downstream rows that a
+    /// later `XA ROLLBACK` erases — a fabrication, which is worse than the loss this
+    /// fixes.
+    #[test]
+    fn a_commit_query_closes_a_transaction_but_a_prepare_does_not() {
+        for yes in [
+            "COMMIT",
+            "commit",
+            "  COMMIT ;",
+            "XA COMMIT 'x1'",
+            "xa commit 0x01",
+        ] {
+            assert!(
+                is_commit_statement(yes),
+                "`{yes}` must close the transaction"
+            );
+        }
+        for no in [
+            "BEGIN",
+            "XA START 'x1'",
+            "XA PREPARE 'x1'",
+            "XA ROLLBACK 'x1'",
+            "ROLLBACK",
+            "SAVEPOINT s1",
+            "COMMIT_LOG_ENTRY",
+            "INSERT INTO commit VALUES (1)",
+        ] {
+            assert!(
+                !is_commit_statement(no),
+                "`{no}` must NOT release a transaction — releasing an uncommitted or \
+                 unrelated statement publishes rows that may never be committed"
+            );
+        }
+    }
     use super::*;
 
     /// The compression guard's decision, offline. Anything unrecognized — an


### PR DESCRIPTION
Only `XidEvent` released the buffered transaction. `Xid` is written by a
transactional storage engine's own commit — so a MyISAM or MEMORY write, and
every `XA COMMIT`, closed the transaction with a QUERY event that had no arm and
fell to `_ => {}`.

Those rows stayed buffered FOREVER. The run captured zero, exited 0, and the
checkpoint never moved: silent, total, and indistinguishable from an idle
source. No count, no error, nothing for an operator to see.

The fix adds the arm and extracts the release into `close_transaction_at`, shared
by both markers — two commit markers with one framing, because duplicating it is
how the second one drifts away from the first (the past-bound handling in
particular is subtle: a commit past the open-time ceiling drops the transaction
UN-released so the resume re-reads it in full).

`XA PREPARE` deliberately does not release, and that negative is the load-bearing
half of the test: prepared is not committed, and publishing there hands
downstream rows a later `XA ROLLBACK` erases — a fabrication, worse than the loss
this fixes.

RED-proven both directions: a predicate that also matches PREPARE fails, and a
predicate stubbed to false fails. 2598 lib green, clippy clean.

Found by the 44-agent CDC bughunt. NOT covered here: a live fixture on a
non-transactional engine or an XA workload — the predicate is unit-tested, the
end-to-end path is not, and the stand's MySQL runs InnoDB.

---
Found by the 44-agent CDC bughunt (29 defects survived a refuter whose default was to kill the claim). This was ranked second behind the PostgreSQL quoting defect in #279.

**Verified by hand before writing this down:** `grep EventData::` over `src/source/mysql/cdc.rs` returns arms for `Rotate`, `TableMap`, `Rows`, `Xid` and `TransactionPayload` — and nothing for `Query`. So a non-Xid commit really did fall to `_ => {}`.

**Not verified, and stated in the commit too:** there is no live fixture. The predicate is unit-tested; the end-to-end path is not, because the stand's MySQL runs InnoDB and therefore always emits `Xid`. Proving this properly needs a MEMORY/MyISAM table or an XA workload on the CDC stand — worth adding, and it is a `gap` cell in the new CDC evidence matrix (#278) rather than a silent omission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168uwctCn3W1rP4Kt4kZXvE