### PR TITLE
fix(mysql/cdc): refuse an undecodable rows event instead of dropping it silently

### DIFF
--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -248,6 +248,9 @@ fn dispatch_cdc(a: CdcArgs) -> Result<()> {
         engine: match CdcEngine::from_url(&url)? {
             CdcEngine::Mysql => CdcEngineOpts::Mysql {
                 server_id: a.server_id,
+                // `--table` IS the routing filter on this path; empty means capture
+                // whatever the stream emits, which makes every event ours.
+                configured_tables: a.table.clone(),
             },
             CdcEngine::Postgres => CdcEngineOpts::Postgres { slot: a.slot },
             CdcEngine::Mssql => CdcEngineOpts::Mssql {

--- a/src/pipeline/cdc_job.rs
+++ b/src/pipeline/cdc_job.rs
@@ -526,6 +526,8 @@ fn run_cdc_inner(
                         server_id: cdc
                             .server_id
                             .unwrap_or(crate::config::DEFAULT_MYSQL_SERVER_ID),
+                        // The same strings the sink will route by — see the field's doc.
+                        configured_tables: wired.iter().map(|(t, _, _)| t.clone()).collect(),
                     },
                     crate::config::SourceType::Postgres => CdcEngineOpts::Postgres {
                         slot: cdc

--- a/src/source/cdc/mod.rs
+++ b/src/source/cdc/mod.rs
@@ -354,7 +354,16 @@ pub(crate) fn run(
 #[derive(Debug, Clone)]
 pub(crate) enum CdcEngineOpts {
     /// MySQL replica id (the binlog `server_id`).
-    Mysql { server_id: u32 },
+    Mysql {
+        server_id: u32,
+        /// The `table:` values the CONFIG asked for.
+        ///
+        /// The binlog is ONE stream per server, so it carries every table's
+        /// changes. An UNDECODABLE rows event is checked against this set before
+        /// it is allowed to fail the run — otherwise one PARTIAL_JSON table is a
+        /// server-wide outage for exports that never read it.
+        configured_tables: Vec<String>,
+    },
     /// PostgreSQL logical slot name.
     Postgres { slot: String },
     /// SQL Server capture instance (required for `sqlserver://`).
@@ -712,7 +721,10 @@ pub(crate) fn create_change_stream(
     let tls = cfg.tls.as_ref();
     // The engine identity IS the opts variant — no re-resolution from the URL.
     match &cfg.engine {
-        CdcEngineOpts::Mysql { server_id } => {
+        CdcEngineOpts::Mysql {
+            server_id,
+            configured_tables,
+        } => {
             // Validate the checkpoint BEFORE open_or_resume so a corrupt/truncated
             // checkpoint (or a directory path) surfaces cleanly, not blanketed by
             // the MYSQL_CDC_HINT binlog-grants message — the same hoist PG/MSSQL
@@ -729,6 +741,7 @@ pub(crate) fn create_change_stream(
                     cfg.checkpoint.as_deref(),
                     cfg.drain,
                     tls,
+                    configured_tables.clone(),
                 )
                 .context(MYSQL_CDC_HINT)?,
             ))
@@ -1275,7 +1288,10 @@ mod tests {
             checkpoint: Some(ckpt),
             drain: DrainMode::BoundedAtOpen,
             tls: None,
-            engine: CdcEngineOpts::Mysql { server_id: 4321 },
+            engine: CdcEngineOpts::Mysql {
+                server_id: 4321,
+                configured_tables: Vec::new(),
+            },
         };
         let err = match create_change_stream(&cfg, PeekBound::Unbounded) {
             Ok(_) => panic!("a corrupt checkpoint must error, not open a stream"),

--- a/src/source/mysql/cdc.rs
+++ b/src/source/mysql/cdc.rs
@@ -308,7 +308,24 @@ impl MysqlChangeStream {
                     RowsEventData::WriteRowsEvent(_) => ChangeOp::Insert,
                     RowsEventData::UpdateRowsEvent(_) => ChangeOp::Update,
                     RowsEventData::DeleteRowsEvent(_) => ChangeOp::Delete,
-                    _ => return Ok(true),
+                    // Anything else is a rows event this reader cannot decode, and the
+                    // old `return Ok(true)` DISCARDED it silently — the surrounding
+                    // transaction still committed, so the checkpoint advanced past
+                    // changes that never reached the destination. Unrecoverable, and
+                    // reported as success.
+                    //
+                    // Two real sources, neither exotic: MariaDB emits only the v1
+                    // rows events, so on MariaDB EVERY insert, update and delete was
+                    // dropped while the pipeline stayed green at zero rows; and MySQL
+                    // 8 with `binlog_row_value_options=PARTIAL_JSON` emits
+                    // `PartialUpdateRowsEvent` for JSON column updates, where the
+                    // surrounding transactions ARE captured — so the loss is a subset,
+                    // which is the shape no count check can see.
+                    //
+                    // Refuse loudly instead, exactly as the compressed-payload arm
+                    // below does: the un-acked span is re-read once the source is
+                    // configured for a reader that can decode it.
+                    other => return Err(undecodable_rows_event_refusal(other)),
                 };
                 let Some((tme, image_names)) = self.tables.get(&re.table_id()).cloned() else {
                     return Ok(true); // started mid-stream, no TABLE_MAP yet — skip
@@ -406,6 +423,70 @@ impl MysqlChangeStream {
 /// message and the fact that it IS an error are testable offline — deleting the
 /// match arm that calls it (falling through to `_ => {}`) is exactly the silent-skip
 /// bug, which only a live compressed server would otherwise flip.
+/// Refuse a rows event this reader cannot decode, naming WHICH one and what to do.
+///
+/// Silence here is worse than on most refusal paths: the transaction around the
+/// dropped rows still commits, so the checkpoint advances and the changes are gone
+/// from both the binlog window and the destination while the run reports success.
+/// Which undecodable shape a rows event is. Separated from the message so the
+/// message — the ONLY thing an operator sees, since the alternative was a green run
+/// with missing rows — is testable without constructing binlog events the crate does
+/// not let a test build.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UndecodableRows {
+    /// Pre-5.6 row format. MariaDB emits only these.
+    V1,
+    /// `binlog_row_value_options=PARTIAL_JSON` logs a JSON diff, not a row image.
+    PartialJson,
+    Other,
+}
+
+fn classify_rows_event(ev: &RowsEventData<'_>) -> UndecodableRows {
+    match ev {
+        RowsEventData::WriteRowsEventV1(_)
+        | RowsEventData::UpdateRowsEventV1(_)
+        | RowsEventData::DeleteRowsEventV1(_) => UndecodableRows::V1,
+        RowsEventData::PartialUpdateRowsEvent(_) => UndecodableRows::PartialJson,
+        _ => UndecodableRows::Other,
+    }
+}
+
+/// Refuse a rows event this reader cannot decode, naming WHICH one and what to do.
+///
+/// Silence here is worse than on most refusal paths: the transaction around the
+/// dropped rows still commits, so the checkpoint advances and the changes are gone
+/// from both the binlog window and the destination while the run reports success.
+pub(crate) fn undecodable_rows_refusal_message(kind: UndecodableRows) -> String {
+    let (what, cause) = match kind {
+        UndecodableRows::V1 => (
+            "a v1 rows event",
+            "the source writes the pre-5.6 row format — MariaDB emits only v1 rows events. \
+             Point rivet at a MySQL replica, or use a MariaDB-native CDC reader",
+        ),
+        UndecodableRows::PartialJson => (
+            "a partial-JSON update",
+            "the source has binlog_row_value_options=PARTIAL_JSON, which logs a JSON diff \
+             rather than the row image. Set binlog_row_value_options='' on the replica \
+             rivet reads, then re-run",
+        ),
+        UndecodableRows::Other => (
+            "an unrecognised rows event",
+            "this reader decodes only the v2 write/update/delete rows events",
+        ),
+    };
+    format!(
+        "mysql cdc: encountered {what} in the binlog and this reader cannot decode it. \
+         Skipping it would capture NOTHING for those rows while the surrounding \
+         transaction commits and the checkpoint advances past them — a silent, \
+         unrecoverable loss reported as success. {cause}: the un-acked span is re-read \
+         from the checkpoint."
+    )
+}
+
+fn undecodable_rows_event_refusal(ev: &RowsEventData<'_>) -> anyhow::Error {
+    anyhow::anyhow!(undecodable_rows_refusal_message(classify_rows_event(ev)))
+}
+
 fn compressed_payload_refusal() -> anyhow::Error {
     anyhow::anyhow!(
         "mysql cdc: encountered a Transaction_payload_event in the binlog — the source has \
@@ -618,6 +699,34 @@ impl ChangeStream for MysqlChangeStream {
 
 #[cfg(test)]
 mod tests {
+
+    /// The refusal message IS the remediation — an operator has nothing else to go
+    /// on, because the alternative to this error was a green run with missing rows.
+    #[test]
+    fn an_undecodable_rows_event_refusal_names_the_cause_and_the_way_out() {
+        let v1 = undecodable_rows_refusal_message(UndecodableRows::V1);
+        assert!(v1.contains("v1 rows event"), "must name the variant: {v1}");
+        assert!(v1.contains("MariaDB"), "must name who emits it: {v1}");
+
+        let partial = undecodable_rows_refusal_message(UndecodableRows::PartialJson);
+        assert!(
+            partial.contains("binlog_row_value_options"),
+            "must name the SETTING to change, not just the symptom: {partial}"
+        );
+
+        for msg in [&v1, &partial] {
+            assert!(
+                msg.contains("re-read"),
+                "must say the un-acked span is re-read — an operator who believes the data \
+                 is already gone has no reason to fix the source and re-run: {msg}"
+            );
+            assert!(
+                msg.contains("checkpoint advances"),
+                "must say WHY silence was unacceptable: the surrounding transaction \
+                 commits and the checkpoint moves past the dropped rows: {msg}"
+            );
+        }
+    }
     use super::*;
 
     /// The compression guard's decision, offline. Anything unrecognized — an

--- a/src/source/mysql/cdc.rs
+++ b/src/source/mysql/cdc.rs
@@ -65,6 +65,11 @@ pub(crate) struct MysqlChangeStream {
     /// indefinitely); `None` (daemon) streams forever. The contract lives on
     /// [`DrainMode`].
     bound: Option<(String, u64)>,
+    /// The `table:` values this run captures — the set an UNDECODABLE rows event is
+    /// checked against before it is allowed to fail the run. Empty means "capture
+    /// whatever the stream emits" (`rivet cdc` with no `--table`), which makes every
+    /// event ours. See [`undecodable_event_is_ours`].
+    configured_tables: Vec<String>,
     /// Bound tripped — the stream ended at the open-time ceiling. Sticky, so the
     /// sink's re-drain pass (which re-calls `next_change` after acking) returns
     /// `None` at once instead of consuming — and re-deferring — the past-bound
@@ -149,6 +154,7 @@ impl MysqlChangeStream {
         pos: u64,
         mode: DrainMode,
         tls: Option<&TlsConfig>,
+        configured_tables: Vec<String>,
     ) -> Result<Self> {
         // Snapshot the ceiling BEFORE the dump starts: every commit already in
         // the log is ≤ it, and anything racing in after is the next run's work.
@@ -169,6 +175,7 @@ impl MysqlChangeStream {
         let stream = conn.get_binlog_stream(req)?;
         Ok(Self {
             stream,
+            configured_tables,
             tables: HashMap::new(),
             pending: VecDeque::new(),
             tx: Vec::new(),
@@ -225,7 +232,10 @@ impl MysqlChangeStream {
         tls: Option<&TlsConfig>,
     ) -> Result<Self> {
         let (file, pos) = Self::current_coordinates(url, tls)?;
-        Self::open(url, server_id, file, pos, mode, tls)
+        // No table filter: these tests read the stream directly rather than routing
+        // it, so every event is theirs — the same `configured.is_empty()` arm
+        // `rivet cdc` without `--table` takes.
+        Self::open(url, server_id, file, pos, mode, tls, Vec::new())
     }
 
     /// Resume from a persisted [`Position`] checkpoint, or start from the current
@@ -239,6 +249,7 @@ impl MysqlChangeStream {
         ckpt: Option<&Path>,
         mode: DrainMode,
         tls: Option<&TlsConfig>,
+        configured_tables: Vec<String>,
     ) -> Result<Self> {
         if let Some(path) = ckpt
             && let Some(pos) = Position::load(path)?
@@ -254,7 +265,7 @@ impl MysqlChangeStream {
                 .get("pos")
                 .and_then(Json::as_u64)
                 .ok_or_else(|| anyhow::anyhow!("mysql cdc checkpoint missing 'pos'"))?;
-            return Self::open(url, server_id, file, p, mode, tls);
+            return Self::open(url, server_id, file, p, mode, tls, configured_tables);
         }
         // First run (no checkpoint yet): anchor at the current position and persist
         // it IMMEDIATELY. PostgreSQL pins its anchor server-side at open (slot
@@ -266,7 +277,7 @@ impl MysqlChangeStream {
         if let Some(path) = ckpt {
             Position(serde_json::json!({ "file": file, "pos": pos })).save(path)?;
         }
-        Self::open(url, server_id, file, pos, mode, tls)
+        Self::open(url, server_id, file, pos, mode, tls, configured_tables)
     }
 
     /// Pull one binlog event and expand it into `pending`. `Ok(false)` ⇒ stream
@@ -355,7 +366,24 @@ impl MysqlChangeStream {
                     // Refuse loudly instead, exactly as the compressed-payload arm
                     // below does: the un-acked span is re-read once the source is
                     // configured for a reader that can decode it.
-                    other => return Err(undecodable_rows_event_refusal(other)),
+                    other => {
+                        // WHOSE event is it? The binlog carries every table on the
+                        // server, so refusing without asking turns one PARTIAL_JSON
+                        // table into a server-wide outage — measured: this refusal
+                        // failed a concurrent export on a table it does not capture.
+                        // The resolve is the same TABLE_MAP lookup the decode path
+                        // does below; `None` (no TABLE_MAP yet) deliberately counts
+                        // as OURS, because a silent skip is the one outcome this
+                        // path exists to prevent.
+                        let resolved = self.tables.get(&other.table_id());
+                        let named =
+                            resolved.map(|(tme, _)| (tme.database_name(), tme.table_name()));
+                        let named = named.as_ref().map(|(d, t)| (d.as_ref(), t.as_ref()));
+                        if undecodable_event_is_ours(named, &self.configured_tables) {
+                            return Err(undecodable_rows_event_refusal(other));
+                        }
+                        return Ok(true); // another table's — the routing filter would drop it anyway
+                    }
                 };
                 let Some((tme, image_names)) = self.tables.get(&re.table_id()).cloned() else {
                     return Ok(true); // started mid-stream, no TABLE_MAP yet — skip
@@ -463,6 +491,43 @@ pub(crate) enum UndecodableRows {
     Other,
 }
 
+/// Does an UNDECODABLE rows event belong to a table this run captures?
+///
+/// The binlog is ONE stream per server, so it carries every table's changes,
+/// including tables nobody configured. Refusing on an undecodable event without
+/// asking whose it is turns one PARTIAL_JSON table into a server-wide outage:
+/// every other export refuses too, on data it was never going to read. Measured
+/// 2026-08-24 — the live PARTIAL_JSON fixture failed a concurrent, unrelated
+/// MySQL CDC test with this exact error, on a table it does not capture.
+///
+/// The asymmetry is deliberate and it is the whole safety argument:
+/// - a **captured** table: REFUSE. Skipping loses the change while the surrounding
+///   transaction commits and the checkpoint advances past it.
+/// - **another** table: skip. The run would have dropped it at the routing filter
+///   anyway, so skipping loses nothing.
+/// - table **unknown**: REFUSE. No TABLE_MAP means the stream started
+///   mid-transaction; guessing "not mine" there would be a silent drop of exactly
+///   the kind this path exists to prevent. Over-refusing is recoverable; a skip is
+///   not.
+/// - **nothing configured**: REFUSE. `rivet cdc` with no `--table` captures
+///   whatever the stream emits, so every event is "mine".
+///
+/// Pure so every branch is graded offline; the caller resolves the name.
+pub(crate) fn undecodable_event_is_ours(
+    resolved: Option<(&str, &str)>,
+    configured: &[String],
+) -> bool {
+    if configured.is_empty() {
+        return true;
+    }
+    match resolved {
+        None => true,
+        Some((schema, table)) => configured
+            .iter()
+            .any(|c| crate::source::cdc::sink::table_matches(c, schema, table)),
+    }
+}
+
 fn classify_rows_event(ev: &RowsEventData<'_>) -> UndecodableRows {
     match ev {
         RowsEventData::WriteRowsEventV1(_)
@@ -487,9 +552,11 @@ pub(crate) fn undecodable_rows_refusal_message(kind: UndecodableRows) -> String 
         ),
         UndecodableRows::PartialJson => (
             "a partial-JSON update",
-            "the source has binlog_row_value_options=PARTIAL_JSON, which logs a JSON diff \
-             rather than the row image. Set binlog_row_value_options='' on the replica \
-             rivet reads, then re-run",
+            "the WRITING session had binlog_row_value_options=PARTIAL_JSON, which logs a \
+             JSON diff rather than the row image. That is usually the server global, but \
+             it is a SESSION variable too — so check `SELECT @@GLOBAL.binlog_row_value_options` \
+             first and, if it is already empty, the writer set it per-session. Clear it on \
+             the replica rivet reads (and on whatever writes to it), then re-run",
         ),
         UndecodableRows::Other => (
             "an unrecognised rows event",
@@ -742,6 +809,45 @@ impl ChangeStream for MysqlChangeStream {
 mod tests {
     /// The refusal message IS the remediation — an operator has nothing else to go
     /// on, because the alternative to this error was a green run with missing rows.
+    /// The refusal must be TABLE-ADDRESSED. Every arm here was a live failure
+    /// first: the un-filtered refusal failed a concurrent, unrelated MySQL CDC
+    /// export on a table it does not capture (measured 2026-08-24 on #281 — the
+    /// PARTIAL_JSON fixture and `mysql_cdc_cli_stream_with_a_cap…` in one run,
+    /// which is how the over-refusal was found at all).
+    #[test]
+    fn an_undecodable_event_fails_only_the_runs_that_capture_that_table() {
+        let cfg = vec!["rivet.orders".to_string()];
+
+        assert!(
+            undecodable_event_is_ours(Some(("rivet", "orders")), &cfg),
+            "our own table must refuse — skipping loses the change while the \
+             transaction commits and the checkpoint advances past it"
+        );
+        assert!(
+            !undecodable_event_is_ours(Some(("rivet", "audit")), &cfg),
+            "another table must NOT fail this run: the routing filter would have \
+             dropped it anyway, so refusing turns one PARTIAL_JSON table into a \
+             server-wide outage"
+        );
+        assert!(
+            undecodable_event_is_ours(None, &cfg),
+            "an UNRESOLVED table must refuse — guessing 'not mine' with no TABLE_MAP \
+             is the silent drop this path exists to prevent"
+        );
+        assert!(
+            undecodable_event_is_ours(Some(("rivet", "audit")), &[]),
+            "`rivet cdc` with no --table captures whatever the stream emits, so \
+             every event is ours"
+        );
+        // A bare (schema-less) config entry matches any schema, exactly as the sink
+        // routes it — the guard must ask the SAME question the router does, or it
+        // protects a set the run does not actually capture.
+        assert!(
+            undecodable_event_is_ours(Some(("otherdb", "orders")), &["orders".to_string()]),
+            "a bare config name matches any schema, like sink::table_matches"
+        );
+    }
+
     #[test]
     fn an_undecodable_rows_event_refusal_names_the_cause_and_the_way_out() {
         let v1 = undecodable_rows_refusal_message(UndecodableRows::V1);
@@ -991,6 +1097,7 @@ mod tests {
             Some(&ckpt),
             DrainMode::BoundedAtOpen,
             None,
+            Vec::new(),
         )
         .unwrap();
         assert!(
@@ -1017,6 +1124,7 @@ mod tests {
             Some(&ckpt),
             DrainMode::BoundedAtOpen,
             None,
+            Vec::new(),
         )
         .unwrap();
         let got = s2
@@ -1062,9 +1170,15 @@ mod tests {
             .unwrap();
 
         // Resuming from the checkpoint must yield B (id=2), never re-read A.
-        let mut s2 =
-            MysqlChangeStream::open_or_resume(URL, 4244, Some(&ckpt), DrainMode::Continuous, None)
-                .unwrap();
+        let mut s2 = MysqlChangeStream::open_or_resume(
+            URL,
+            4244,
+            Some(&ckpt),
+            DrainMode::Continuous,
+            None,
+            Vec::new(),
+        )
+        .unwrap();
         let b = s2
             .by_ref()
             .map(|e| e.unwrap())

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -5464,54 +5464,44 @@ fn mysql_cdc_cli_resolves_the_source_from_env_and_file_alike() {
 #[test]
 #[ignore = "live: requires docker compose --profile cdc mysql-cdc"]
 fn mysql_cdc_refuses_a_partial_json_binlog_instead_of_dropping_the_update() {
-    // Serialize with every other test that flips a GLOBAL on this shared server.
-    // Without it this test'''s PARTIAL_JSON window is visible to concurrent MySQL CDC
-    // tests, and rivet — correctly — refuses their runs too: measured on #281, where
-    // mysql_cdc_cli_stream_with_a_cap_terminates_and_accepts_a_server_id failed while
-    // 634 others passed. A static Mutex would serialize NOTHING here (nextest runs
-    // each test in its own process — an r3 bughunt find recorded above).
-    let _serial = quiet_window_guard();
+    // PARTIAL_JSON is set on the WRITING SESSION, never the server global — the
+    // binlog record's shape is decided by whoever wrote it. An earlier version of
+    // this test flipped `SET GLOBAL` and took `quiet_window_guard()` to serialize;
+    // that was the wrong shape twice over. The guard only excludes tests that TAKE
+    // it, and `mysql_cdc_cli_stream_with_a_cap_terminates_and_accepts_a_server_id`
+    // does not — so the global window was still visible to it and rivet, correctly,
+    // refused its run too (measured on #281: it failed while 633 others passed,
+    // both before and after the guard was added). Session scope removes the shared
+    // state entirely: nothing to serialize, nothing to restore, no window for a
+    // parallel test to fall into. Verified on the stand — the UPDATE below reaches
+    // the partial arm while `@@GLOBAL.binlog_row_value_options` stays empty.
     let d = tempfile::tempdir().unwrap();
     let tbl = unique_name("cdc_pj");
+    // `SET SESSION binlog_row_value_options` needs SESSION_VARIABLES_ADMIN, which
+    // the `rivet` test user does not hold — hence root for the WRITER only. The
+    // capture itself still runs as `rivet`, exactly like every other test here.
     let root_url = MYSQL_CDC_URL.replace("rivet:rivet@", "root:rivet@");
-    let mut admin = mysql::Conn::new(mysql::Opts::from_url(&root_url).unwrap()).unwrap();
+    let mut writer = mysql::Conn::new(mysql::Opts::from_url(&root_url).unwrap()).unwrap();
     use mysql::prelude::Queryable as _;
-    let old: String = admin
-        .query_first("SELECT @@global.binlog_row_value_options")
-        .unwrap()
-        .unwrap_or_default();
-    admin
-        .query_drop("SET GLOBAL binlog_row_value_options = 'PARTIAL_JSON'")
-        .expect("set partial json");
-    struct OptGuard(String, String);
-    impl Drop for OptGuard {
-        fn drop(&mut self) {
-            // Restoring matters beyond tidiness: a stand left pinned to a non-default
-            // makes the DEFAULT path unreachable by every other test — the exact defect
-            // the CDC audit found in `binlog_row_metadata`.
-            if let Ok(mut c) = mysql::Conn::new(mysql::Opts::from_url(&self.1).unwrap()) {
-                use mysql::prelude::Queryable as _;
-                let _ = c.query_drop(format!(
-                    "SET GLOBAL binlog_row_value_options = '{}'",
-                    self.0
-                ));
-            }
-        }
-    }
-    let _opt = OptGuard(old, root_url);
+    writer
+        .query_drop("SET SESSION binlog_row_value_options = 'PARTIAL_JSON'")
+        .expect("set partial json on this session only");
 
-    let mut c = conn();
-    c.query_drop(format!("DROP TABLE IF EXISTS {tbl}")).unwrap();
-    c.query_drop(format!("CREATE TABLE {tbl} (id INT PRIMARY KEY, doc JSON)"))
+    writer
+        .query_drop(format!("DROP TABLE IF EXISTS {tbl}"))
+        .unwrap();
+    writer
+        .query_drop(format!("CREATE TABLE {tbl} (id INT PRIMARY KEY, doc JSON)"))
         .unwrap();
     let _guard = Table(tbl.clone());
     // The document must be big enough that MySQL logs a DIFF rather than falling back
     // to a full image — a short JSON value is rewritten whole and never reaches the
     // partial arm, which would make this test pass for the wrong reason.
-    c.query_drop(format!(
-        "INSERT INTO {tbl} VALUES (1, JSON_OBJECT('a', 1, 'pad', REPEAT('x', 400)))"
-    ))
-    .unwrap();
+    writer
+        .query_drop(format!(
+            "INSERT INTO {tbl} VALUES (1, JSON_OBJECT('a', 1, 'pad', REPEAT('x', 400)))"
+        ))
+        .unwrap();
 
     let ck = d.path().join("pj.ckpt");
     let rig = || {
@@ -5522,10 +5512,12 @@ fn mysql_cdc_refuses_a_partial_json_binlog_instead_of_dropping_the_update() {
     // Anchor the stream before provoking the diff, so the update is inside the window.
     rig().run_ok();
 
-    c.query_drop(format!(
-        "UPDATE {tbl} SET doc = JSON_SET(doc, '$.a', 2) WHERE id = 1"
-    ))
-    .unwrap();
+    // The diff-logging session writes the UPDATE — this is the whole fixture.
+    writer
+        .query_drop(format!(
+            "UPDATE {tbl} SET doc = JSON_SET(doc, '$.a', 2) WHERE id = 1"
+        ))
+        .unwrap();
 
     let msg = rig().run_expect_fail();
     assert!(
@@ -5543,5 +5535,55 @@ fn mysql_cdc_refuses_a_partial_json_binlog_instead_of_dropping_the_update() {
         msg.contains("re-read"),
         "the message must say the un-acked span is re-read; an operator who believes \
          the data is already gone has no reason to fix the source and re-run: {msg}"
+    );
+
+    // ── and the refusal must be TABLE-ADDRESSED ────────────────────────────────
+    //
+    // The binlog is ONE stream per server, so the undecodable event above sits in
+    // the log every OTHER export reads too. Refusing without asking whose event it
+    // is turns one PARTIAL_JSON table into a server-wide outage — measured on #281,
+    // where this fixture failed `mysql_cdc_cli_stream_with_a_cap_terminates_and_
+    // accepts_a_server_id` with this exact error, on a table it does not capture.
+    //
+    // That failure was a RACE (the neighbour only sees it when its window covers
+    // the event), which is why it is pinned HERE instead: this export is anchored
+    // BEFORE the partial update, so the event is inside its window by construction
+    // and the assertion cannot pass by timing. RED against `if true` in place of
+    // the `undecodable_event_is_ours` call.
+    let other = unique_name("cdc_pj_other");
+    writer
+        .query_drop(format!("DROP TABLE IF EXISTS {other}"))
+        .unwrap();
+    writer
+        .query_drop(format!("CREATE TABLE {other} (id INT PRIMARY KEY, v INT)"))
+        .unwrap();
+    let _other_guard = Table(other.clone());
+    let other_ck = d.path().join("other.ckpt");
+    let other_rig = || {
+        Rig::mysql_cdc(&other)
+            .checkpoint_path(other_ck.to_path_buf())
+            .dest_path(d.path().join("out_other"))
+    };
+    other_rig().run_ok(); // anchor BEFORE the partial update lands
+
+    writer
+        .query_drop(format!(
+            "UPDATE {tbl} SET doc = JSON_SET(doc, '$.a', 3) WHERE id = 1"
+        ))
+        .unwrap();
+    writer
+        .query_drop(format!("INSERT INTO {other} VALUES (7, 70)"))
+        .unwrap();
+
+    let rows: usize = other_rig()
+        .run_and_read()
+        .iter()
+        .map(|b| b.num_rows())
+        .sum();
+    assert_eq!(
+        rows, 1,
+        "an export that does NOT capture the partial-JSON table must complete and \
+         capture its own change — the undecodable event belongs to another table, \
+         and the routing filter would have dropped it anyway"
     );
 }

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -5447,3 +5447,94 @@ fn mysql_cdc_cli_resolves_the_source_from_env_and_file_alike() {
         "passing two source forms must be REFUSED, not silently resolved to one of them"
     );
 }
+
+/// A PARTIAL_JSON binlog must be REFUSED, not silently skipped.
+///
+/// `binlog_row_value_options=PARTIAL_JSON` is a legal MySQL 8 setting that logs a JSON
+/// diff instead of the row image. The reader cannot decode that, and the arm that met
+/// it was `_ => return Ok(true)` — the rows vanished while the surrounding transaction
+/// committed and the checkpoint advanced past them. Unrecoverable, and reported as
+/// `status: success`.
+///
+/// The loss is a SUBSET, which is what makes it the dangerous half: transactions that
+/// touch no JSON column are captured normally, so counts and sums keep reconciling.
+///
+/// Non-default-state test (CLAUDE.md): the default is exactly where the bug hides, so
+/// the setting is flipped and restored by a guard rather than assumed.
+#[test]
+#[ignore = "live: requires docker compose --profile cdc mysql-cdc"]
+fn mysql_cdc_refuses_a_partial_json_binlog_instead_of_dropping_the_update() {
+    let d = tempfile::tempdir().unwrap();
+    let tbl = unique_name("cdc_pj");
+    let root_url = MYSQL_CDC_URL.replace("rivet:rivet@", "root:rivet@");
+    let mut admin = mysql::Conn::new(mysql::Opts::from_url(&root_url).unwrap()).unwrap();
+    use mysql::prelude::Queryable as _;
+    let old: String = admin
+        .query_first("SELECT @@global.binlog_row_value_options")
+        .unwrap()
+        .unwrap_or_default();
+    admin
+        .query_drop("SET GLOBAL binlog_row_value_options = 'PARTIAL_JSON'")
+        .expect("set partial json");
+    struct OptGuard(String, String);
+    impl Drop for OptGuard {
+        fn drop(&mut self) {
+            // Restoring matters beyond tidiness: a stand left pinned to a non-default
+            // makes the DEFAULT path unreachable by every other test — the exact defect
+            // the CDC audit found in `binlog_row_metadata`.
+            if let Ok(mut c) = mysql::Conn::new(mysql::Opts::from_url(&self.1).unwrap()) {
+                use mysql::prelude::Queryable as _;
+                let _ = c.query_drop(format!(
+                    "SET GLOBAL binlog_row_value_options = '{}'",
+                    self.0
+                ));
+            }
+        }
+    }
+    let _opt = OptGuard(old, root_url);
+
+    let mut c = conn();
+    c.query_drop(format!("DROP TABLE IF EXISTS {tbl}")).unwrap();
+    c.query_drop(format!("CREATE TABLE {tbl} (id INT PRIMARY KEY, doc JSON)"))
+        .unwrap();
+    let _guard = Table(tbl.clone());
+    // The document must be big enough that MySQL logs a DIFF rather than falling back
+    // to a full image — a short JSON value is rewritten whole and never reaches the
+    // partial arm, which would make this test pass for the wrong reason.
+    c.query_drop(format!(
+        "INSERT INTO {tbl} VALUES (1, JSON_OBJECT('a', 1, 'pad', REPEAT('x', 400)))"
+    ))
+    .unwrap();
+
+    let ck = d.path().join("pj.ckpt");
+    let rig = || {
+        Rig::mysql_cdc(&tbl)
+            .checkpoint_path(ck.to_path_buf())
+            .dest_path(d.path().join("out"))
+    };
+    // Anchor the stream before provoking the diff, so the update is inside the window.
+    rig().run_ok();
+
+    c.query_drop(format!(
+        "UPDATE {tbl} SET doc = JSON_SET(doc, '$.a', 2) WHERE id = 1"
+    ))
+    .unwrap();
+
+    let msg = rig().run_expect_fail();
+    assert!(
+        msg.contains("partial-JSON"),
+        "the run must REFUSE and name the shape it met. Silently skipping the diff \
+         loses the update while the checkpoint advances past it — a subset loss no \
+         count check can see. Got: {msg}"
+    );
+    assert!(
+        msg.contains("binlog_row_value_options"),
+        "the message must name the SETTING to change — it is the only remediation an \
+         operator gets: {msg}"
+    );
+    assert!(
+        msg.contains("re-read"),
+        "the message must say the un-acked span is re-read; an operator who believes \
+         the data is already gone has no reason to fix the source and re-run: {msg}"
+    );
+}

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -5464,6 +5464,13 @@ fn mysql_cdc_cli_resolves_the_source_from_env_and_file_alike() {
 #[test]
 #[ignore = "live: requires docker compose --profile cdc mysql-cdc"]
 fn mysql_cdc_refuses_a_partial_json_binlog_instead_of_dropping_the_update() {
+    // Serialize with every other test that flips a GLOBAL on this shared server.
+    // Without it this test'''s PARTIAL_JSON window is visible to concurrent MySQL CDC
+    // tests, and rivet — correctly — refuses their runs too: measured on #281, where
+    // mysql_cdc_cli_stream_with_a_cap_terminates_and_accepts_a_server_id failed while
+    // 634 others passed. A static Mutex would serialize NOTHING here (nextest runs
+    // each test in its own process — an r3 bughunt find recorded above).
+    let _serial = quiet_window_guard();
     let d = tempfile::tempdir().unwrap();
     let tbl = unique_name("cdc_pj");
     let root_url = MYSQL_CDC_URL.replace("rivet:rivet@", "root:rivet@");


### PR DESCRIPTION
`_ => return Ok(true)` in the rows arm discarded every rows event this reader cannot decode. The surrounding transaction still committed, so the checkpoint advanced past changes that never reached the destination: unrecoverable, and reported as `status: success`.

## Proven live, on a SUPPORTED source

MySQL 8 on the stand with `binlog_row_value_options=PARTIAL_JSON` — a legal setting that logs a JSON diff instead of the row image — and a `JSON_SET` update on a padded document:

```
status: failed, rows: 0
mysql cdc: encountered a partial-JSON update in the binlog and this reader cannot
decode it. Skipping it would capture NOTHING for those rows while the surrounding
transaction commits and the checkpoint advances past them — a silent, unrecoverable
loss reported as success. Set binlog_row_value_options='' on the replica rivet reads,
then re-run: the un-acked span is re-read from the checkpoint.
```

This is the case that matters, and it is the **worse** of the two the arm covers: the surrounding transactions ARE captured, so the loss is a **subset** while the checkpoint advances — the shape no count or sum check can see.

## A correction to the finding that produced this

The bughunt led with MariaDB, and so did my first two attempts. That was wrong twice over: MariaDB is not a source rivet claims (it is not in `SourceType`, not documented, not reachable by any user), and its events are lost **above** this arm anyway. Measured, with the fix built in: `status: success, rows: 0` against MariaDB 11.4 with rows sitting in the source. I stood up a container for it, learned that, and removed it again.

So the MariaDB half of the original claim is **not** what this fixes, and the PR should not be read as claiming MariaDB support or a MariaDB fix.

## Shape

Classification is split from message assembly (`classify_rows_event` → `UndecodableRows` → `undecodable_rows_refusal_message`) because the crate does not let a test construct binlog events, and the message is the only thing an operator ever sees — so it is the part that must be gradeable. The message names the variant, the setting responsible, and says the span is re-read: an operator who believes the data is already gone has no reason to fix the source and re-run.

## What is still NOT graded, measured rather than assumed

* Restoring the old `_ => return Ok(true)` and running the suite: **2598 passed, 0 failed**. Nothing in the offline suite observes that the refusal fires — the live probe above is the only evidence, and it is not in CI.
* Deleting the `PartialJson` arm from `classify_rows_event` leaves the unit test green, because it calls the message builder directly. I tested the helper through its own front door and not the decision.

Closing both needs a live test that flips `binlog_row_value_options`, provokes the refusal and resets the setting — the non-default-state shape CLAUDE.md already requires. Until it exists this is a `gap` cell in the CDC evidence matrix, not a silent omission.

The stand was restored to `binlog_row_value_options=''` after the probe; leaving it pinned would reproduce exactly the defect the CDC audit found in `binlog_row_metadata`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168uwctCn3W1rP4Kt4kZXvE