### PR TITLE
fix(test/rig): scope the Mongo crash oracle to the resume leg

### DIFF
--- a/docs/cdc-evidence-matrix.yaml
+++ b/docs/cdc-evidence-matrix.yaml
@@ -53,12 +53,13 @@ shapes:
     postgres: { sound: "resumes into a fresh out2/ — live_cdc.rs:2849-2863" }
     mysql:    { sound: "resumes into a fresh out2/ — live_cdc.rs:474-486" }
     mssql:    { sound: "resumes into a fresh out2/ — live_cdc_mssql.rs:782-795" }
-    mongo:
-      vacuous: "one Rig at live_cdc_mongo.rs:83 drives both the crash (:91) and the resume
-        (:100); Rig::out_dir is fixed at construction (tests/common/rig/oracle.rs:9-13) and
-        the oracle is a **/*.parquet glob (tests/common/duckdb.rs:257). This is Mongo's ONLY
-        at-least-once evidence and the mongo cell of crash_before_ack in the gate."
-      kind: second-cause
+    mongo: { sound: "the resume leg takes its own destination via Rig::resume_into_fresh_dest
+        (live_cdc_mongo.rs, mongo_cdc_crash_after_flush_before_ack_re_reads_on_resume).
+        RED-proven by deleting the resume run: `id 1 lost across the crash`, where the
+        shared-destination version stayed green because the crashed run's orphans satisfied
+        it. That seam also had to set the CONTAINER-visible path, not only the host one —
+        the DuckDB oracle reads from inside a container and a resume destination it cannot
+        see reads zero, which looks like data loss and is a harness bug." }
 
   - id: readback_is_manifest_scoped
     what: >

--- a/tests/common/rig/oracle.rs
+++ b/tests/common/rig/oracle.rs
@@ -63,14 +63,18 @@ impl Rig {
         // The leg number is derived from what is on disk rather than carried as
         // state: two calls in one test must not collide, and a rig that never
         // resumed must still get `out2`.
-        let mut n = 2;
-        while self.dir.path().join(format!("out{n}")).exists() {
-            n += 1;
-        }
-        let fresh = self.dir.path().join(format!("out{n}"));
-        std::fs::create_dir_all(&fresh).expect("create the resume leg's destination");
-        self.dest_override = Some(fresh.clone());
-        fresh
+        // A shared-workdir pair, not a tempdir path: the DuckDB oracle reads from
+        // INSIDE a container, so a resume destination it cannot see would make every
+        // assertion downstream read zero — the failure mode that looks like data loss
+        // and is a harness bug. `duckdb_oracle` sets both halves for the same reason;
+        // the first cut of this seam set only the host half and the oracle came back
+        // empty, which is how this comment exists.
+        let (host, container) = super::super::env::live_shared_workdir(&super::super::unique_name(
+            &format!("rig_{}_resume", self.name),
+        ));
+        self.dest_override = Some(host.clone());
+        self.oracle_container_dir = Some(container);
+        host
     }
 
     /// Read back ONLY the parts the manifest DECLARES, not every parquet under the dir.

--- a/tests/live/live_cdc_mongo.rs
+++ b/tests/live/live_cdc_mongo.rs
@@ -80,7 +80,7 @@ fn mongo_cdc_crash_after_flush_before_ack_re_reads_on_resume() {
     let m = MongoTest::connect(PORT, &db);
     m.drop_collection("t");
 
-    let rig = cdc(&db, "t");
+    let mut rig = cdc(&db, "t");
     rig.run_ok(); // pin
     for i in 1..=5 {
         m.upsert_set("t", i, "v", &format!("x{i}"));
@@ -94,9 +94,17 @@ fn mongo_cdc_crash_after_flush_before_ack_re_reads_on_resume() {
         "the fault hook must crash the run"
     );
 
-    // Resume: the un-acked changes are RE-READ. The destination is a complete
-    // superset of the 5 source changes — no silent loss, at-least-once the only
-    // allowed surplus.
+    // Resume into its OWN destination. Sharing one with the crashed run made this
+    // assertion satisfiable by that run's ORPHANS: parts are durable BEFORE the hook
+    // fires (roll_all flushes, then panics, then saves and acks), so a resume that
+    // re-read NOTHING still found five ids under a `**/*.parquet` glob. This was
+    // Mongo's only at-least-once evidence, and it could not fail — the CDC audit's
+    // first finding, and the reason `resume_into_fresh_dest` exists on the rig.
+    //
+    // Scoped this way the assertion means what it says: every id below was captured
+    // by the RESUME. RED-proven by deleting the resume run — "id 1 lost across the
+    // crash", where the shared-destination version stayed green.
+    rig.resume_into_fresh_dest();
     rig.run_ok();
     let ids = duckdb_distinct_set(rig.oracle_dir(), "_id");
     for i in 1..=5 {

--- a/tests/offline/cdc_evidence_matrix_guard.rs
+++ b/tests/offline/cdc_evidence_matrix_guard.rs
@@ -177,7 +177,7 @@ fn a_sound_cell_cites_where_the_evidence_lives() {
 /// or the win is not banked and drifts back.
 #[test]
 fn unsound_cells_only_ever_shrink() {
-    const CEILING: usize = 27;
+    const CEILING: usize = 26;
     let engines = cdc_engines();
     let m = matrix();
     let mut unsound: BTreeMap<String, Vec<String>> = BTreeMap::new();


### PR DESCRIPTION
The CDC audit's first finding, closed. One Rig drove both the crash and the
resume, so `duckdb_distinct_set(rig.oracle_dir(), "_id")` was satisfied by the
CRASHED run's orphans: parts are durable BEFORE the hook fires — roll_all
flushes, then panics, then saves and acks — so a resume that re-read NOTHING
still found five ids under a glob. That was Mongo's only at-least-once evidence
and it could not fail.

RED-proven by deleting the resume run: `id 1 lost across the crash`. The
shared-destination version stays green against the same deletion.

The seam needed fixing too, and this is the part I got wrong in #278:
`resume_into_fresh_dest` set only `dest_override` and not
`oracle_container_dir`. The DuckDB oracle reads from INSIDE a container, so the
resume destination was invisible to it and every assertion read zero — a failure
that looks exactly like data loss and is a harness bug. `duckdb_oracle` sets
both halves for the same reason; now so does this.

Evidence-matrix cell mongo/resume_reads_a_fresh_destination goes vacuous ->
sound, and the ratchet drops 27 -> 26 in the same commit, which is the rule the
guard enforces downward as well as upward.

---
This is finding #1 of the CDC audit (#278's matrix, cell `mongo / resume_reads_a_fresh_destination`), and the one the audit put first: until crash oracles are scoped, no other result from the CDC suite means what it says.

**RED-proven live**, not argued: deleting the resume run makes the test fail with `id 1 lost across the crash`, while the shared-destination version stays green against the same deletion.

The seam fix is a correction to my own #278: `resume_into_fresh_dest` set only the host path and not the container-visible one, so the DuckDB oracle — which reads from inside a container — saw an empty directory and every assertion read zero. That failure looks exactly like data loss and is a harness bug; `duckdb_oracle` sets both halves for the same reason.

Ratchet drops 27 → 26 in the same commit, which the guard enforces downward as well as upward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168uwctCn3W1rP4Kt4kZXvE