### PR TITLE
fix(pg/cdc): refuse an unroutable configured table at open — a partitioned parent lost every row past an acked slot

### DIFF
--- a/docs/cdc-evidence-matrix.yaml
+++ b/docs/cdc-evidence-matrix.yaml
@@ -60,6 +60,43 @@ shapes:
         at-least-once evidence and the mongo cell of crash_before_ack in the gate."
       kind: second-cause
 
+  - id: configured_identity_is_cross_checked_before_the_first_ack
+    what: >
+      The config's `table:` is a LABEL; the catalog is truth. An engine whose wire
+      identity can differ from the configured string needs that compared AT OPEN,
+      because every routing filter here is byte-exact and the commit boundary is
+      recorded BEFORE it — so a mismatch drops 100% of the events while the run
+      checkpoints and advances the source cursor over them.
+    mutant: >
+      Delete the open-time cross-check (PG `check_configured_tables_are_routable`,
+      MSSQL's `cdc.change_tables` bail). A sound cell goes RED on a 0-row `success`;
+      a missing one ships the export green. MEASURED on PostgreSQL 2026-08-24:
+      a partitioned parent took 2 committed rows to `rows: 0, status: success`,
+      slot 0/AE5F8BB8 -> 0/AE6010D8, peek EMPTY after — and re-running with the
+      config corrected recovered NOTHING while the source still held both rows.
+    postgres:
+      sound: "roast_pg_cdc_refuses_a_partitioned_parent_before_acking_the_slot
+        (live_cdc.rs) — RED against three mutants: guard removed, Never downgraded
+        to a warn, and the partition names dropped from the message. Asserts the
+        slot did NOT move, which is the whole difference between a config error and
+        two rows nobody can get back."
+    mssql:
+      sound: "mssql_cdc_capture_instance_name_must_not_decide_the_table +
+        the two-table content variant (live_cdc_mssql.rs:622, :668) — RED against
+        the split-once name heuristic that routed 6 of 8 field tables wrong."
+    mysql:
+      na: "MySQL has no relation that emits under a name other than the configured
+        one: partitioning is a storage-engine concern and the binlog's table_map
+        carries the LOGICAL table. MEASURED 2026-08-24 rather than assumed — a
+        RANGE-partitioned `mpart` captured both inserted rows through a config
+        naming the parent, on the rivet-mysql-cdc-1 stand."
+    mongo:
+      na: "A change stream's `ns` is the collection the write addressed, and Mongo
+        has no parent/child relation whose events surface under a different name —
+        there is no second identity for a cross-check to compare against. The
+        engine's routing risk is the dotted-collection-name case, already covered by
+        table_matches' full-name-first arm (sink.rs:227-234)."
+
   - id: readback_is_manifest_scoped
     what: >
       The read-back oracle must read the parts the run DECLARED, not every parquet under

--- a/docs/fail-loud-matrix.yaml
+++ b/docs/fail-loud-matrix.yaml
@@ -23,6 +23,13 @@ scenarios:
     mssql:    { test: mssql_cdc_resume_past_retention_errors_not_a_silent_gap }
     mongo:    { na: "an oplog-rolled-past resume token surfaces the driver's ChangeStreamHistoryLost directly (rivet does not swallow it — src/source/mongo/cdc.rs); forcing an oplog rollover live is impractical (documented NA in cdc_conformance_gate.rs). The adjacent corrupt-checkpoint case IS tested: roast_corrupt_checkpoint_fails_loudly_not_silent_reanchor" }
 
+  - id: cdc_unroutable_configured_table_loud
+    what: "a configured `table:` that NO change event can ever name (a PostgreSQL partitioned parent / view / matview; a SQL Server capture instance whose catalog identity differs) → loud bail AT OPEN, before any ack, never a 0-row `status: success` past an advanced cursor"
+    postgres: { test: roast_pg_cdc_refuses_a_partitioned_parent_before_acking_the_slot }
+    mssql:    { test: mssql_cdc_capture_instance_name_must_not_decide_the_table }
+    mysql:    { na: "no MySQL relation emits under a name other than the configured one — the binlog's table_map carries the LOGICAL table, partitioning included (measured 2026-08-24: a RANGE-partitioned table captured through a config naming the parent)" }
+    mongo:    { na: "a change stream's `ns` IS the collection the write addressed; Mongo has no parent/child relation surfacing events under a different name, so there is no second identity to cross-check" }
+
   - id: hostile_numeric_value_loud
     what: "a non-finite value (NaN/Inf) in a lossy fixed-point numeric → loud error, never a silent NULL / truncate-to-zero"
     postgres: { test: pg_cdc_hostile_floats_match_batch_and_nan_numeric_fails_loudly }

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -249,7 +249,14 @@ fn dispatch_cdc(a: CdcArgs) -> Result<()> {
             CdcEngine::Mysql => CdcEngineOpts::Mysql {
                 server_id: a.server_id,
             },
-            CdcEngine::Postgres => CdcEngineOpts::Postgres { slot: a.slot },
+            CdcEngine::Postgres => CdcEngineOpts::Postgres {
+                slot: a.slot,
+                // `--table` IS the routing filter on this path too, so it is
+                // exactly the set the guard must classify. Empty (`rivet cdc`
+                // with no `--table`) keeps it off: nothing named ⇒ nothing to
+                // cross-check — the same rule the SQL Server arm below states.
+                configured_tables: a.table.clone(),
+            },
             CdcEngine::Mssql => CdcEngineOpts::Mssql {
                 // `--table` IS the routing filter on this path too (the NDJSON leg
                 // passes it to `run(...)`, the `--output` leg requires exactly

--- a/src/pipeline/cdc_job.rs
+++ b/src/pipeline/cdc_job.rs
@@ -532,6 +532,8 @@ fn run_cdc_inner(
                             .slot
                             .clone()
                             .unwrap_or_else(|| crate::config::DEFAULT_PG_SLOT.to_string()),
+                        // The same strings the sink will route by — see the field's doc.
+                        configured_tables: wired.iter().map(|(t, _, _)| t.clone()).collect(),
                     },
                     crate::config::SourceType::Mssql => CdcEngineOpts::Mssql {
                         capture_instance: cdc.capture_instance.clone(),

--- a/src/source/cdc/mod.rs
+++ b/src/source/cdc/mod.rs
@@ -356,7 +356,17 @@ pub(crate) enum CdcEngineOpts {
     /// MySQL replica id (the binlog `server_id`).
     Mysql { server_id: u32 },
     /// PostgreSQL logical slot name.
-    Postgres { slot: String },
+    Postgres {
+        slot: String,
+        /// The `table:` values the CONFIG asked for — the same cross-check the
+        /// SQL Server arm carries, for a different reason.
+        ///
+        /// `test_decoding` names the relation a row PHYSICALLY landed in. A
+        /// PARTITIONED parent stores none, so every change carries a PARTITION's
+        /// name and byte-exact routing drops all of it — while the slot advances,
+        /// which on PostgreSQL makes the loss terminal rather than a delay.
+        configured_tables: Vec<String>,
+    },
     /// SQL Server capture instance (required for `sqlserver://`).
     Mssql {
         capture_instance: Option<String>,
@@ -645,6 +655,15 @@ impl CdcEngine {
                     tls,
                     PeekBound::Unbounded,
                     DrainMode::Continuous, // anchor-only open — never read, no bound to pin
+                    // No routing cross-check here, deliberately. This open exists
+                    // to CREATE the slot and is dropped without reading or
+                    // acking, so it cannot lose anything; the capture open that
+                    // follows carries the tables and bails there. Refusing before
+                    // the anchor would be actively worse for the operator —
+                    // changes written between a bad config and its fix would have
+                    // no slot holding them, whereas a slot created first keeps
+                    // every one of them until the corrected run drains it.
+                    &[],
                 )?);
                 Ok(())
             }
@@ -733,7 +752,10 @@ pub(crate) fn create_change_stream(
                 .context(MYSQL_CDC_HINT)?,
             ))
         }
-        CdcEngineOpts::Postgres { slot } => {
+        CdcEngineOpts::Postgres {
+            slot,
+            configured_tables,
+        } => {
             // A persisted checkpoint proves a prior run happened — if the slot is
             // then MISSING, it was dropped/invalidated and silently recreating it
             // at the current position would skip everything since (a silent gap).
@@ -753,6 +775,7 @@ pub(crate) fn create_change_stream(
                     tls,
                     peek,
                     cfg.drain,
+                    configured_tables,
                 )
                 .context(PG_CDC_HINT)?,
             ))

--- a/src/source/postgres/cdc.rs
+++ b/src/source/postgres/cdc.rs
@@ -91,6 +91,99 @@ pub(crate) fn slot_created_warning(slot: &str) -> String {
     )
 }
 
+/// What one CONFIGURED table can contribute to a `test_decoding` stream —
+/// the pure half of [`PgChangeStream::check_configured_tables_are_routable`].
+///
+/// `test_decoding` names the relation a row PHYSICALLY landed in, and the sink
+/// routes by byte-exact comparison against the config's `table:` string. When
+/// those two can never agree, capture is a silent 100% drop — and on PostgreSQL
+/// that is terminal, not a delay: the commit boundary is recorded BEFORE the
+/// routing filter (`cdc/sink.rs`), so the pass checkpoints and acks the slot over
+/// events it never captured, PostgreSQL frees the WAL, and the run writes
+/// `_SUCCESS` with `status: success` and zero rows.
+///
+/// Measured on a real partitioned table (2026-08-24, pg14 stand): 2 committed
+/// rows, `rows: 0`, slot `0/AE5F8BB8` → `0/AE6010D8`, peek empty afterwards, and
+/// re-running with the config corrected recovered NOTHING while the source still
+/// held both rows. That is worse than the SQL Server case this guard is modelled
+/// on (`mssql/cdc.rs`), where the change table's own retention made the same
+/// routing bug a delay.
+pub(crate) struct RelationRouting<'a> {
+    /// The `table:` string the config asked for — what the sink routes BY.
+    pub configured: &'a str,
+    /// `pg_class.relkind` of the relation that name resolves to.
+    pub relkind: char,
+    /// Relations that inherit from it — partitions, or legacy `INHERITS`
+    /// children — schema-qualified the way `test_decoding` renders them.
+    pub children: Vec<String>,
+}
+
+/// The verdict for one configured table. `Never` is a hard error (a guaranteed
+/// total, unrecoverable drop); `Partial` is a warning, because the parent's OWN
+/// rows do route and refusing would break a working config.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum RoutingVerdict {
+    Routable,
+    Never(String),
+    Partial(String),
+}
+
+/// Classify one configured relation. Pure: the catalog read that fills
+/// [`RelationRouting`] needs a live PostgreSQL, so this — every decision the
+/// guard makes — is what an offline test can hold and mutants can grade.
+pub(crate) fn classify_routing(rel: &RelationRouting<'_>) -> RoutingVerdict {
+    let cfg = rel.configured;
+    match rel.relkind {
+        // A partitioned parent stores NO rows of its own: every change carries a
+        // PARTITION's name. Byte-exact routing can never match it.
+        'p' => {
+            let named = if rel.children.is_empty() {
+                "it has no partitions yet".to_string()
+            } else {
+                format!("currently {}", rel.children.join(", "))
+            };
+            RoutingVerdict::Never(format!(
+                "pg cdc: `{cfg}` is a PARTITIONED table — it stores no rows itself, and \
+                 test_decoding names the PARTITION a row landed in, never the parent. Routing is \
+                 byte-exact, so every change would be dropped AND the slot would advance past it: \
+                 PostgreSQL frees the WAL and the changes are gone from the log and the \
+                 destination alike, while the run reports success with 0 rows. Capture the \
+                 partitions by name ({named}) — a partition added later needs its own entry — or \
+                 snapshot the parent with `mode: full`, which reads through the parent normally."
+            ))
+        }
+        // A view/matview/foreign table has no WAL of its own. Verified on the
+        // pg14 stand: a `REFRESH MATERIALIZED VIEW` emits no `table …` line at
+        // all, so this is a guaranteed zero, not a rare one.
+        'v' | 'm' | 'f' => {
+            let what = match rel.relkind {
+                'v' => "a VIEW",
+                'm' => "a MATERIALIZED VIEW",
+                _ => "a FOREIGN TABLE",
+            };
+            RoutingVerdict::Never(format!(
+                "pg cdc: `{cfg}` is {what}, which writes no WAL under its own name — no change \
+                 event can ever carry it, so capture would drop everything while advancing the \
+                 slot past it (a success with 0 rows, unrecoverable). Capture the BASE table(s) it \
+                 reads instead."
+            ))
+        }
+        // A plain table with inheritance children routes its OWN rows correctly;
+        // only rows written directly to a child are dropped. A partial gap — loud
+        // enough to see, not fatal enough to refuse a config that works today.
+        'r' | 'P' if !rel.children.is_empty() => RoutingVerdict::Partial(format!(
+            "pg cdc: `{cfg}` has {} inheritance child table(s) ({}). test_decoding names the CHILD \
+             a row landed in, so changes written directly to a child route NOWHERE while the \
+             parent's own rows capture normally — a partial, silent gap whose size depends on how \
+             the writers address the table. List the children as captured tables if their changes \
+             matter.",
+            rel.children.len(),
+            rel.children.join(", ")
+        )),
+        _ => RoutingVerdict::Routable,
+    }
+}
+
 impl PgChangeStream {
     /// Connect and ensure a `test_decoding` logical slot named `slot` exists
     /// (idempotent — reuses an existing slot, which is how a real run resumes).
@@ -198,6 +291,60 @@ impl PgChangeStream {
         }
     }
 
+    /// Live half of the routing guard: ask the CATALOG what each configured
+    /// table actually is, and refuse a capture that could only ever drop
+    /// everything. Decisions live in [`classify_routing`]; this is glue.
+    ///
+    /// Runs on the stream's OWN connection, before the slot is created and long
+    /// before any ack — which is the whole point. A guard that fires after the
+    /// first roll has already let PostgreSQL free the WAL.
+    ///
+    /// `to_regclass` (not `::regclass`) so a name that resolves to nothing
+    /// returns NULL instead of raising: an absent table is the schema probe's
+    /// error to report (`SELECT * FROM {table}`, `cdc/mod.rs`), with a message
+    /// that already names it. Resolution follows the same SQL rules that probe
+    /// does, so the two agree about which relation a config string means.
+    fn check_configured_tables_are_routable(
+        client: &mut Client,
+        configured: &[String],
+    ) -> Result<()> {
+        use anyhow::Context as _;
+        for cfg in configured {
+            let Some(row) = client
+                .query_opt(
+                    "SELECT c.relkind::text, \
+                            coalesce(array_agg(n2.nspname || '.' || c2.relname) \
+                                     FILTER (WHERE c2.oid IS NOT NULL), '{}') \
+                     FROM pg_class c \
+                     LEFT JOIN pg_inherits i ON i.inhparent = c.oid \
+                     LEFT JOIN pg_class c2 ON c2.oid = i.inhrelid \
+                     LEFT JOIN pg_namespace n2 ON n2.oid = c2.relnamespace \
+                     WHERE c.oid = to_regclass($1) \
+                     GROUP BY c.relkind",
+                    &[&cfg.as_str()],
+                )
+                .with_context(|| {
+                    format!("pg cdc: reading pg_class to check that `{cfg}` is routable")
+                })?
+            else {
+                continue; // unresolvable here — the schema probe reports it, loudly
+            };
+            let relkind: String = row.get(0);
+            let children: Vec<String> = row.get(1);
+            let rel = RelationRouting {
+                configured: cfg,
+                relkind: relkind.chars().next().unwrap_or('?'),
+                children,
+            };
+            match classify_routing(&rel) {
+                RoutingVerdict::Routable => {}
+                RoutingVerdict::Partial(why) => log::warn!("{why}"),
+                RoutingVerdict::Never(why) => anyhow::bail!("{why}"),
+            }
+        }
+        Ok(())
+    }
+
     pub(crate) fn open(
         conn_str: &str,
         slot: &str,
@@ -205,6 +352,7 @@ impl PgChangeStream {
         tls: Option<&TlsConfig>,
         peek: crate::source::cdc::PeekBound,
         mode: DrainMode,
+        configured_tables: &[String],
     ) -> Result<Self> {
         // Same gate the batch path uses: refuse remote plaintext (CWE-319), and
         // use a verifying TLS connector when a TlsConfig is enforced.
@@ -238,6 +386,11 @@ impl PgChangeStream {
             "SET datestyle = 'ISO, MDY'; SET bytea_output = 'hex'; \
              SET intervalstyle = 'postgres'; SET extra_float_digits = 3;",
         )?;
+        // BEFORE the slot exists and long before any ack: a configured table that
+        // no change event can ever name is a total, unrecoverable drop, and the
+        // slot advancing is what makes it unrecoverable.
+        Self::check_configured_tables_are_routable(&mut client, configured_tables)?;
+
         // A bounded run cannot work on a STANDBY: it pins its ceiling with
         // pg_current_wal_lsn() (unavailable during recovery) and a fresh run
         // creates the logical slot (also refused in recovery). Detect recovery
@@ -1165,6 +1318,65 @@ mod tests {
 
     use super::*;
 
+    /// The guard's whole decision surface, one case per relkind that behaves
+    /// differently. Every arm was MEASURED on the pg14 stand (2026-08-24) rather
+    /// than read off the docs — `REFRESH MATERIALIZED VIEW` in particular emits
+    /// no `table …` line at all, which is why 'm' sits with the never-routable
+    /// kinds instead of being assumed routable.
+    #[test]
+    fn classify_routing_refuses_only_the_relations_no_event_can_ever_name() {
+        let rel = |kind: char, children: &[&str]| RelationRouting {
+            configured: "public.t",
+            relkind: kind,
+            children: children.iter().map(|c| c.to_string()).collect(),
+        };
+
+        // A partitioned parent stores no rows: 100% drop, and the slot advances
+        // past it. This is the case measured live (2 rows in, 0 captured,
+        // unrecoverable).
+        let RoutingVerdict::Never(why) = classify_routing(&rel('p', &["public.t_2026_01"])) else {
+            panic!("a partitioned parent can never be routed — it must be refused");
+        };
+        assert!(
+            why.contains("public.t_2026_01"),
+            "the refusal must name the partitions, because listing them IS the \
+             remediation: {why}"
+        );
+
+        // …and with no partitions yet, it is still unroutable — the message just
+        // cannot name one. A guard that only fired when children exist would miss
+        // the empty-parent config entirely.
+        let RoutingVerdict::Never(why) = classify_routing(&rel('p', &[])) else {
+            panic!("a partitioned parent with no partitions yet is still unroutable");
+        };
+        assert!(why.contains("no partitions yet"), "{why}");
+
+        for (kind, word) in [
+            ('v', "VIEW"),
+            ('m', "MATERIALIZED VIEW"),
+            ('f', "FOREIGN TABLE"),
+        ] {
+            let RoutingVerdict::Never(why) = classify_routing(&rel(kind, &[])) else {
+                panic!("{kind} writes no WAL under its own name — it must be refused");
+            };
+            assert!(why.contains(word), "the refusal must say what it is: {why}");
+        }
+
+        // A plain table is routable, and stays routable — refusing it would break
+        // every working config.
+        assert_eq!(classify_routing(&rel('r', &[])), RoutingVerdict::Routable);
+
+        // Inheritance children are a PARTIAL gap: the parent's own rows route
+        // fine, so this warns rather than refusing.
+        let RoutingVerdict::Partial(why) = classify_routing(&rel('r', &["public.t_child"])) else {
+            panic!("an inheritance parent routes its OWN rows — warn, never refuse");
+        };
+        assert!(
+            why.contains("public.t_child") && why.contains('1'),
+            "the warning must name the children and how many: {why}"
+        );
+    }
+
     #[test]
     fn parse_pg_array_backslash_before_multibyte_does_not_panic() {
         // Round-6: a quoted array element with a backslash BEFORE a multi-byte UTF-8
@@ -1695,6 +1907,7 @@ mod tests {
             None,
             crate::source::cdc::PeekBound::Sized(10_000),
             DrainMode::Continuous,
+            &[], // this test routes nothing — it reads the stream directly
         )
         .unwrap();
         admin

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -3567,6 +3567,124 @@ fn roast_mysql_until_current_open_bound_two_runs_lose_nothing() {
 /// own database makes the slot see only this test's WAL — parallel-safe by
 /// construction, no `--test-threads=1` needed. Dropped (backends terminated) on
 /// teardown; the table + slot live inside it, so no separate guards are needed.
+/// A PARTITIONED parent must be refused at OPEN — before the slot is acked past
+/// changes no event could ever route.
+///
+/// The second half of #279. That fix taught the reader to UNQUOTE the wire
+/// identity; this one compares that identity to what the CONFIG asked for, the
+/// cross-check the SQL Server arm has carried since the capture-instance find
+/// (`mssql/cdc.rs`). The reachable shape is not a mixed-case name — the schema
+/// probe (`SELECT * FROM {table}`) already fails loudly on those — it is a
+/// partitioned table, where the probe succeeds PERFECTLY (the parent has a full,
+/// correct column list) and `test_decoding` then names the PARTITION every row
+/// physically landed in.
+///
+/// Measured before the guard (2026-08-24, pg14 stand — this test's RED):
+/// 2 committed rows → `status: success`, `rows: 0`, `files: 0`, slot
+/// `0/AE5F8BB8` → `0/AE6010D8`, and `pg_logical_slot_peek_changes` EMPTY
+/// afterwards. Re-running with the config corrected to the partition recovered
+/// NOTHING while the source still held both rows. Worse than the SQL Server
+/// case this is modelled on, where the change table's own retention made the
+/// same routing bug a delay: here PostgreSQL frees the WAL and it is gone.
+///
+/// Isolated in its OWN database (see `CdcDb`): the guard reads `pg_class`, and
+/// the assertion is about a slot position a parallel test's WAL would perturb.
+#[test]
+#[ignore = "live: requires docker compose postgres (wal_level=logical)"]
+fn roast_pg_cdc_refuses_a_partitioned_parent_before_acking_the_slot() {
+    let cdc_db = CdcDb::new("cdc_part");
+    let slot = unique_name("rivet_part_slot");
+    let parent = unique_name("rivet_cdc_par").to_lowercase();
+    let part = format!("{parent}_2026_01");
+    let mut c = cdc_db.connect();
+    c.batch_execute(&format!(
+        "CREATE TABLE {parent} (id BIGINT NOT NULL, ts DATE NOT NULL, v INT) \
+         PARTITION BY RANGE (ts); \
+         CREATE TABLE {part} PARTITION OF {parent} \
+         FOR VALUES FROM ('2026-01-01') TO ('2026-02-01')"
+    ))
+    .unwrap();
+    c.execute(
+        "SELECT pg_create_logical_replication_slot($1, 'test_decoding')",
+        &[&slot],
+    )
+    .unwrap();
+    c.execute(
+        &format!("INSERT INTO {parent} VALUES (1,'2026-01-05',10),(2,'2026-01-06',20)"),
+        &[],
+    )
+    .unwrap();
+    // The SOURCE oracle, asked of PostgreSQL itself — never rivet's counters.
+    let source_rows: i64 = c
+        .query_one(&format!("SELECT count(*) FROM {parent}"), &[])
+        .unwrap()
+        .get(0);
+    assert_eq!(source_rows, 2, "fixture seeded 2 rows through the parent");
+    let before: String = c
+        .query_one(
+            "SELECT confirmed_flush_lsn::text FROM pg_replication_slots WHERE slot_name = $1",
+            &[&slot],
+        )
+        .unwrap()
+        .get(0);
+
+    // The config a user writes: the LOGICAL table. Its schema probe succeeds —
+    // which is exactly why this was silent.
+    let wrong = Rig::pg_cdc(&format!("public.{parent}"), &slot).source_url(cdc_db.url());
+    let out = run_rivet(&["run", "--config", wrong.config_path().to_str().unwrap()]);
+    let said = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !out.status.success(),
+        "capturing a partitioned parent must fail at open, not ship a 0-row \
+         success — output:\n{said}"
+    );
+    assert!(
+        said.contains(&part),
+        "the refusal must name the PARTITION `{part}` — listing the partitions is \
+         the remediation, and a user who could guess that would not have hit this. \
+         Output:\n{said}"
+    );
+
+    // The slot must NOT have moved. Failing at open only buys anything if it
+    // happens BEFORE the ack: this assert is the whole difference between a
+    // config error and two rows nobody can get back.
+    let moved: bool = c
+        .query_one(
+            &format!(
+                "SELECT confirmed_flush_lsn <> '{before}'::pg_lsn \
+                 FROM pg_replication_slots WHERE slot_name = $1"
+            ),
+            &[&slot],
+        )
+        .unwrap()
+        .get(0);
+    assert!(
+        !moved,
+        "the refused run acked the slot anyway — the 2 changes are unreachable \
+         now and the guard bought nothing"
+    );
+
+    // Defer-not-drop: with the partition named, the same slot still holds every
+    // change. Oracle: the parts the MANIFEST declares, re-read — never the
+    // manifest's own `row_count`, and compared to the source count above.
+    let right = Rig::pg_cdc(&format!("public.{part}"), &slot).source_url(cdc_db.url());
+    run_rivet_ok(&right.config_path());
+    let captured: usize = right
+        .read_declared_parts()
+        .iter()
+        .map(|b| b.num_rows())
+        .sum();
+    assert_eq!(
+        captured, source_rows as usize,
+        "the corrected run must recover all {source_rows} changes from the \
+         un-acked slot — that is what makes the refusal a delay, not a loss"
+    );
+}
+
 struct CdcDb {
     name: String,
     url: String,


### PR DESCRIPTION
The second half of #279. That fix taught the `test_decoding` reader to UNQUOTE the wire identity; nothing then compared that identity to what the **config** asked for — the cross-check the SQL Server arm has carried since the capture-instance find.

## The reachable shape is not what the report assumed

A mixed-case name already fails loudly: the schema probe interpolates the config string into `SELECT * FROM {table}` **unquoted**, so PostgreSQL folds it and reports `relation does not exist` at any spelling. I measured that first, and it ruled the assumed shape out.

The shape that is **silent** is a **partitioned table** — where the probe succeeds *perfectly* (the parent has a full, correct column list) and `test_decoding` then names the **partition** every row physically landed in.

## Measured, not inferred (pg14 stand, 2026-08-24)

```
slot before   0/AE5F8BB8
2 rows committed through the parent
rivet run     status: success, rows: 0, files: 0
slot after    0/AE6010D8      <- advanced
peek          EMPTY           <- PostgreSQL freed the WAL
```

Re-running with the config **corrected** to the partition recovered **nothing**, while the source still held both rows. Worse than the SQL Server case this is modelled on, where the change table's retention made the same routing bug a delay: here the changes are gone from the log and the destination alike, and the run reported success.

Cause is the class CLAUDE.md already names — *names are labels, catalogs are truth* — with PostgreSQL's twist that the commit boundary is recorded **before** the routing filter, so a pass that captures nothing still checkpoints and acks.

## The guard

Classifies each configured table against `pg_class` on the stream's own connection, **before the slot exists and long before any ack**:

| relkind | verdict | why |
|---|---|---|
| `p` | **refuse** | stores no rows; only partitions ever emit |
| `v` / `m` / `f` | **refuse** | no WAL under its own name — `REFRESH MATERIALIZED VIEW` emits no `table …` line at all (measured) |
| `r` + children | **warn** | an `INHERITS` parent routes its *own* rows; refusing would break a config that works today |

Decisions live in `classify_routing`, a pure function, per the live-only purity rule: the catalog read is glue, every branch is offline-testable and its mutants are graded. `to_regclass` (not `::regclass`) so an unresolvable name returns NULL and stays the schema probe's error to report.

The anchor-only open deliberately passes no tables — it creates the slot and is dropped without reading or acking, so it cannot lose anything, and refusing before the anchor would be actively *worse*: changes written between a bad config and its fix would have no slot holding them.

## Evidence

`roast_pg_cdc_refuses_a_partitioned_parent_before_acking_the_slot` is RED against three mutants — guard removed (`status: success`, `rows: 0`), `Never` downgraded to a warn, partition names dropped from the message — **each caught on a different assert**. It asserts the slot did **not** move (the whole difference between a config error and two rows nobody can get back), then proves defer-not-drop by re-reading the manifest-**declared** parts of the corrected run against the source count.

Ledgers: new `configured_identity_is_cross_checked_before_the_first_ack` shape in the CDC evidence matrix, `cdc_unroutable_configured_table_loud` in fail-loud. Both MySQL cells are `na` on a **measured** basis — a RANGE-partitioned table captured both rows through a config naming the parent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168uwctCn3W1rP4Kt4kZXvE