### PR TITLE
fix(cdc): refuse a TRUNCATE instead of letting it vanish — PostgreSQL and MySQL both shipped a silent, permanent divergence

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -452,4 +452,23 @@ exclude_re = [
     # table must still complete), `false` fails the refusal half. Run by hand
     # 2026-08-24, mutant applied and reverted each time.
     "replace match guard truncate_target.*MysqlChangeStream::fill",
+
+    # `split_top_level_commas` (src/source/postgres/cdc.rs): dropping the
+    # `in_quotes && next == '"'` guard on the escaped-quote arm cannot change what
+    # the function RETURNS, and the reason is arithmetic rather than aesthetic.
+    #
+    # With the guard, a doubled quote is consumed as one unit: zero toggles of
+    # `in_quotes`. Without it, the pair toggles twice: also zero, net. The two
+    # states can therefore differ only at the byte BETWEEN the pair — which the
+    # guard's own condition proves is a `"`, never a comma, so nothing observes the
+    # difference before they re-converge.
+    #
+    # NOT argued into the file: proven by exhaustive search over every string up to
+    # length 7 on the alphabet `",.ax` — 97 655 inputs, ZERO differing outputs. The
+    # SIBLING mutant on the same line (`replace + with -`, the lookahead reading
+    # backward) differs on 5 580 of them, shortest witness `"",`, and is graded by
+    # `a_truncate_is_recognised_and_refused_only_for_the_captured_tables` with a
+    # name ending in an escaped quote (`"a"""`) — so this exclusion is scoped to the
+    # guard alone and does not blanket the line.
+    "replace match guard in_quotes .* in split_top_level_commas",
 ]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -411,7 +411,7 @@ exclude_re = [
     # `Ok(())` makes EVERY subcommand a silent no-op, so
     # audit_cli_dispatch::run_unknown_export_lists_available_names FAILS — the
     # run exits 0 and prints none of the message it asserts on.
-    "replace dispatch -> Result",,
+    "replace dispatch -> Result",
     # `PgChangeStream::fill` / `MysqlChangeStream::fill` are the LIVE-ONLY poll
     # bodies: each opens a replication slot or a binlog dump against a real server,
     # so `--lib --bins` never executes a line of them and the whole-function stub is

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -431,7 +431,7 @@ exclude_re = [
     # the same test also RED against the list-parse mutant and the un-addressed
     # refusal. MySQL guard disabled -> roast_mysql_cdc_refuses_a_truncate_instead_of_
     # silently_diverging FAILS, and again against the un-addressed variant.
-    "replace PgChangeStream::fill -> Result",
+"replace PgChangeStream::fill -> Result",
     "replace MysqlChangeStream::fill -> Result",
     # The match GUARD on the MySQL TRUNCATE arm sits inside that same live-only body.
     # Flipping it to `true`/`false` is the addressed/un-addressed pair that the live

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -439,6 +439,17 @@ exclude_re = [
     # refusal half) — both run by hand on the same date. Excluded here rather than
     # left MISSED, because an operator-shaped entry that IS graded live is the
     # honest form; what would be wrong is an ungraded decision hiding in glue.
-    "replace match guard with true in MysqlChangeStream::fill",
-    "replace match guard with false in MysqlChangeStream::fill",
+    # The mutant NAME embeds the guard EXPRESSION between "match guard" and
+    # "with true/false", so a pattern written as `replace match guard with true in
+    # …` matches nothing. The gate caught that as a DEAD exclusion — which is the
+    # right verdict and exactly the failure mode a hand-written regex has here
+    # (an over-escaped one earlier in this session matched nothing too, and would
+    # have left the gate red while looking handled).
+    #
+    # Anchored on the guard's own call instead. Both directions are graded LIVE by
+    # roast_mysql_cdc_refuses_a_truncate_instead_of_silently_diverging: `true`
+    # fails its bystander half (an export that does not capture the truncated
+    # table must still complete), `false` fails the refusal half. Run by hand
+    # 2026-08-24, mutant applied and reverted each time.
+    "replace match guard truncate_target.*MysqlChangeStream::fill",
 ]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -411,5 +411,34 @@ exclude_re = [
     # `Ok(())` makes EVERY subcommand a silent no-op, so
     # audit_cli_dispatch::run_unknown_export_lists_available_names FAILS — the
     # run exits 0 and prints none of the message it asserts on.
-    "replace dispatch -> Result",
+    "replace dispatch -> Result",,
+    # `PgChangeStream::fill` / `MysqlChangeStream::fill` are the LIVE-ONLY poll
+    # bodies: each opens a replication slot or a binlog dump against a real server,
+    # so `--lib --bins` never executes a line of them and the whole-function stub is
+    # unkillable HERE by construction — the CLAUDE.md "a live-only path reports 100%
+    # survival and means NOTHING" case. They entered the in-diff scope because the
+    # TRUNCATE guards were added inside them.
+    #
+    # The DECISIONS are extracted and graded offline, deliberately, so this entry
+    # excludes glue and not judgement: `truncate_targets`, `truncate_is_ours`,
+    # `truncate_refusal_message` (postgres), `truncate_target`,
+    # `undecodable_event_is_ours`, `classify_rows_event` (mysql) all have unit
+    # matrices that go RED on their own mutants.
+    #
+    # Live oracle proven by hand 2026-08-24 (mutant applied, live test run, reverted):
+    # PG guard removed -> roast_pg_cdc_refuses_a_truncate_instead_of_silently_diverging
+    # FAILS (back to the measured `status: success, rows: 2` over an EMPTY source);
+    # the same test also RED against the list-parse mutant and the un-addressed
+    # refusal. MySQL guard disabled -> roast_mysql_cdc_refuses_a_truncate_instead_of_
+    # silently_diverging FAILS, and again against the un-addressed variant.
+    "replace PgChangeStream::fill -> Result",
+    "replace MysqlChangeStream::fill -> Result",
+    # The match GUARD on the MySQL TRUNCATE arm sits inside that same live-only body.
+    # Flipping it to `true`/`false` is the addressed/un-addressed pair that the live
+    # test grades directly (`if true` fails the bystander half; disabling fails the
+    # refusal half) — both run by hand on the same date. Excluded here rather than
+    # left MISSED, because an operator-shaped entry that IS graded live is the
+    # honest form; what would be wrong is an ungraded decision hiding in glue.
+    "replace match guard with true in MysqlChangeStream::fill",
+    "replace match guard with false in MysqlChangeStream::fill",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1591,7 +1591,17 @@ jobs:
         # mongo` covers every Mongo test by substring — the live_mongo* / live_cdc_mongo
         # modules AND the Mongo cells of the engine-agnostic chunking_stand
         # (`stand_*_mongo`), which a module-prefix skip like `--skip live_mongo` misses.
-        run: cargo test -- --ignored --skip content_export --skip validates --skip edge_cases --skip via_duckdb --skip mongo
+        # Skip the warehouse cells (`tests/oracle_fixture_matrix.rs`, every test
+        # prefixed `warehouse_cell_`): they drive a REAL BigQuery/Snowflake target
+        # and need RIVET_TEST_GCS_BUCKET plus warehouse credentials, which this job
+        # does not have and no workflow supplies. They used to be SELECTED here and
+        # pass in 0.00s — the harness returned an empty oracle list on a missing
+        # env, and `assert_all_pass` walks straight through an empty list, so 20
+        # cells reported green while verifying nothing. The runners now report
+        # `Skipped`, which the strength floor treats as a failure (its own doc said
+        # so all along), so the exclusion has to be written HERE where a reader can
+        # see it rather than hidden in the harness.
+        run: cargo test -- --ignored --skip content_export --skip validates --skip edge_cases --skip via_duckdb --skip mongo --skip warehouse_cell
 
       - name: Stop services
         if: always()

--- a/.github/workflows/nightly-live.yml
+++ b/.github/workflows/nightly-live.yml
@@ -185,11 +185,22 @@ jobs:
         # mongo-less stack and panicked at require_alive — the exact latent
         # failure the matrix audit predicted. Every Mongo test (module-named or
         # stand_*) is owned by the `mongo-versions` job, same as ci.yml's e2e.
+        # Skip the warehouse cells (`tests/oracle_fixture_matrix.rs`, every test
+        # prefixed `warehouse_cell_`): they drive a REAL BigQuery/Snowflake target
+        # and need RIVET_TEST_GCS_BUCKET plus warehouse credentials, which this job
+        # does not have and no workflow supplies. They used to be SELECTED here and
+        # pass in 0.00s — the harness returned an empty oracle list on a missing
+        # env, and `assert_all_pass` walks straight through an empty list, so 20
+        # cells reported green while verifying nothing. The runners now report
+        # `Skipped`, which the strength floor treats as a failure (its own doc said
+        # so all along), so the exclusion has to be written HERE where a reader can
+        # see it rather than hidden in the harness.
         run: |
           cargo test --release -- --ignored \
             --skip full_content_export_max_pressure \
             --skip validates --skip edge_cases --skip via_duckdb \
-            --skip mongo
+            --skip mongo \
+            --skip warehouse_cell
 
       - name: Dump service logs on failure
         if: failure()

--- a/dev/cdc-oracle/README.md
+++ b/dev/cdc-oracle/README.md
@@ -95,8 +95,15 @@ catch.
     engine      crud    key-update   wide-txn      mid-stream-table
     postgres    AGREE   DIFFERS      AGREE 75/75   AGREE
     mysql       AGREE   DIFFERS      AGREE 75/75   AGREE
-    mssql       AGREE   AGREE        AGREE 75/75   AGREE
+    mssql       AGREE   AGREE        AGREE 99ev    AGREE
     mongo       AGREE*  na           AGREE 75/75   AGREE     (* delete excluded, see below)
+
+**Every cell above compares VALUES, not just (op, key)** — re-measured 2026-08-25
+after `--value` was fixed and turned on by default. The earlier version of this
+table was (op, key) only, which is blind to cell corruption: a parquet with 100%
+of a column NULLed reported AGREE. That is now RED-proven to fail, and a run
+WITHOUT `--value` says so in its own output rather than claiming a comparison it
+did not make.
 
 All sixteen cells settled: fifteen agreements, one difference, one `na`.
 
@@ -115,182 +122,50 @@ is the argument for a per-engine matrix over one representative test.
 `key-update` is **na** on MongoDB: `_id` is immutable, so the scenario cannot be
 expressed. A scenario an engine cannot express is not a passing cell.
 
-## Four artefacts the harness produced before it produced a finding
+## Seven artefacts the harness produced before it produced a finding
 
-Recorded because each one wore the costume of a defect, and three were written
-down as "undiagnosed" before being traced:
+Recorded because each one wore the costume of a defect, and most were written
+down as "undiagnosed" before being traced. The first four were found on
+2026-08-24, the last three on 2026-08-25 while closing the release-gate
+preconditions — which is the point: this list is not finished, and a gate that
+reports its own races as release blockers gets muted.
 
 1. **Shared work dir across engines** — MySQL read a PostgreSQL `offsets.dat`.
 2. **Shared work dir across scenarios** — one run's capture accumulated into the
-   next, surfacing as a `delete` in a scenario that has no delete.
-3. **A fixed flush wait** — reported a race as a shortfall; replaced by waiting
-   for the reference to quiesce.
-4. **The sink dropped batches** — HTTP/1.0 closing a connection Debezium's client
-   kept alive, plus a single thread and a 5-deep listen queue. Delivered 30/39/57
-   of 75 across identical runs and read as "the reference falls short". This one
-   cost the most, because it accused the wrong tool in our favour.
+   next, surfacing as a `delete` in a scenario that has no delete. Recorded as
+   fixed on 2026-08-24; it was not. The fix covered the cross-ENGINE leak only,
+   and the work dir was `work/engine/table` with the table name identical for
+   every scenario. Running crud then wide-txn reported wide-txn DISAGREE with
+   crud's four events listed as debezium-only.
+3. **Shared work dir across RUNS** — the dir was reused and the sink APPENDS, so
+   running one scenario twice compared the second capture against both. The dir
+   is cleared at the start of every run now.
+4. **A fixed flush wait** instead of the engine's own readiness signal.
+5. **A lossy HTTP sink** — 30, 39, 57 events of 75 across identical runs, which
+   read as "the reference falls short". HTTP/1.0 was closing the connection
+   mid-batch.
+6. **A container name without the scenario** — `srv-<table>` collided with the
+   previous scenario's leftover. Worse than the crash it caused: a container left
+   RUNNING keeps capturing into whatever it has mounted, which is how wide-txn's
+   25 updates turned up inside a crud comparison.
+7. **Column ORDER between the two views** — `EXCEPT` compares by POSITION, and the
+   two views projected the key and the values in opposite orders. With `--value`
+   on, every row of a four-row scenario reported as both-sides-only. This is the
+   one that made `--value` look broken on the delete path and kept it opt-in.
 
-The rule that came out of it: **when a differential harness says the REFERENCE
-fell short, suspect the harness first.** The reference has years of production
-use; the transport between them was written yesterday.
+Two more that were defects in the COMPARISON rather than the harness plumbing,
+listed here because they present identically:
 
-## A harness limitation, stated because it looks like a finding
-
-**MongoDB deletes carry no key in the event BODY.** Debezium puts the deleted
-document's `_id` in the message KEY, and the http sink forwards only the value —
-so `{after: null, before: null, op: "d"}` is all that arrives. The comparison
-sees a keyless delete on the reference side and a keyed one from rivet, which
-renders as a disagreement and is not one.
-
-This is the harness's own blind spot, not a difference between the tools. Fixing
-it means capturing the message key (a sink that records both, or `transforms`
-that lift `documentKey` into the value). Until then, MongoDB's `delete` is
-excluded by `--exclude-op delete` and the exclusion is recorded HERE rather than
-applied silently — an excluded op that nobody wrote down becomes an op nobody
-checks.
-
-## Known asymmetries (these are NOT findings)
-
-The two tools legitimately differ, and the comparison must account for it or it
-will report noise forever:
-
-- **Plugin.** Debezium uses `pgoutput`; rivet uses `test_decoding` (ADR-0024).
-  Debezium therefore sees a partitioned parent under its root name where rivet sees
-  the leaf — that difference is the ADR's subject, not a bug to file per-run.
-- **TRUNCATE.** Debezium skips it by default (`truncate.handling.mode=skip`);
-  rivet refuses. Compare with truncate excluded, or set `include` on both sides.
-- **Snapshot.** Debezium's `initial` emits `op=r` (read) rows for existing data;
-  rivet's `mode: cdc` alone does not snapshot. Use `snapshot.mode=no_data` for a
-  streaming-only comparison.
-- **Shape.** Debezium emits before/after envelopes with a schema; rivet writes a
-  flat row plus `__op`/`__pos`/`__seq`. Normalisation is where that is reconciled,
-  and it must be written to fail loudly on an unrecognised shape rather than
-  silently dropping a field it does not understand — a lenient normaliser would
-  reintroduce exactly the class this harness exists to catch.
-
-## Comparison runs in DuckDB, not Python
-
-`compare.py` hands BOTH captures to DuckDB — `read_json_auto` for Debezium's
-JSONL, `read_parquet` for rivet's parts — and the normalisation plus the symmetric
-difference are one SQL statement. The comparison engine is then independent of both
-tools being compared, which is the same reason every other oracle here uses DuckDB:
-a bug in a hand-rolled Python loop would be a bug in the oracle itself.
-
-rivet's side is read through the parts the MANIFEST DECLARES, never a glob.
-
-The Debezium normaliser handles the enveloped and the `transforms=unwrap` shapes,
-and an event matching NEITHER surfaces as `UNKNOWN-SHAPE` rather than being
-dropped — a lenient normaliser would reintroduce the exact class this exists to
-catch.
-
-## Status (2026-08-25)
-
-    engine      crud    key-update   wide-txn      mid-stream-table
-    postgres    AGREE   DIFFERS      AGREE 75/75   AGREE
-    mysql       AGREE   DIFFERS      AGREE 75/75   AGREE
-    mssql       AGREE   AGREE        undiagnosed   AGREE
-    mongo       AGREE*  na           AGREE 75/75   AGREE     (* delete excluded, see below)
-
-Fourteen of sixteen cells settled; all four engines run.
-
-**The key-update finding.** `UPDATE t SET id=9 WHERE id=1` gives
-`delete(1)+insert(9)` from Debezium and `update(9)` from rivet, identically on
-PostgreSQL and MySQL — so it is rivet's representation choice, not a plugin
-artefact. A consumer applying the documented latest-image MERGE keeps the old key
-in the destination forever. Counts reconcile on both sides, which is why the
-source-vs-destination oracles never saw it. SQL Server agrees because the engine
-itself splits a PK update into delete+insert in its change table, so the same
-defect is INVISIBLE on one engine of three — the argument for a per-engine matrix
-rather than one representative test.
-
-`key-update` is **na** on MongoDB: `_id` is immutable, so the scenario cannot be
-expressed. A scenario an engine cannot express is not a passing cell.
-
-**MSSQL wide-txn — measured, undiagnosed, and NOT a claim about rivet.**
-The 50-insert + 25-update scenario puts 100 rows in `cdc.dbo_<t>_CT` (SQL Server
-writes two CT rows per UPDATE). rivet captures 75 change events, which is the
-correct count. Debezium delivers 39 and then STOPS — it quiesces there across
-three consecutive checks, so this is its steady state rather than a flush race:
-an earlier fixed 8s wait gave 30, and waiting for quiescence gave 39.
-
-The 55 resulting rows all sit on the `rivet-only` side, i.e. the REFERENCE is
-short. Candidate causes not yet separated: a batch-size limit on the connector, a
-poll interval interacting with the capture job's own batching, or something about
-`snapshot.mode=no_data` on this engine. Recorded with the numbers rather than
-guessed at — a difference whose cause is unknown is not evidence about either
-tool, and calling this a rivet defect would be the harness lying in our favour.
-
-Original note follows.
-
-**MSSQL wide-txn** shows `rivet-only` rows — i.e. the REFERENCE lagged, not rivet.
-Not yet diagnosed and NOT claimed as a finding: SQL Server's capture job is
-asynchronous on both sides and the wait may still be too short for 75 changes.
-
-**MongoDB is NOT running yet.** The connector starts but never records progress
-within the readiness window. Two obstacles are already solved and worth keeping:
-the Mongo stands live in `stand_default` (not `rivet_default`), and the replica
-set advertises itself as `127.0.0.1:27017`, so a driver inside another container
-dials itself — `directConnection=true` alongside `replicaSet=rs0` gets past that.
-What remains is the readiness signal: `offsets.dat` never appears, so either the
-connector needs longer or it is failing after validation.
-
-
-## The harness compares KEYS, not values — and that was a real blind spot
-
-An adversarial pass RAN the check I had not: it took a real capture, rewrote the
-parquet with `NULL::VARCHAR AS v` — 100% of the value column destroyed — and
-`compare.py` printed a byte-identical **AGREE**. Every "15 of 16 agree" result in
-this file was therefore weaker than it read: it proves the two tools saw the same
-CHANGES, not that rivet wrote the same VALUES.
-
-`--value <col>` (repeatable) now compares cells as text on both sides, and it is
-verified to catch that mutation: the same NULLed parquet goes from AGREE to four
-differing rows.
-
-It is **not on by default yet**, deliberately. The DELETE path still compares
-unequal, because the reference carries no `after` document for a delete while the
-value extract reads only that side. Turning it on now would mean a false alarm on
-every run, and a harness that cries wolf gets muted — which is exactly how this
-blind spot survived in the first place.
-
-## The gap this harness does NOT cover: a degrading source LINK
-
-Measured 2026-08-25 while looking for negative scenarios: `toxi_` appears **zero**
-times in `live_cdc.rs`, `live_cdc_mssql.rs` and `live_cdc_mongo.rs`. Every fault
-test in the suite either kills the PROCESS (`RIVET_TEST_PANIC_AT`) or aims at the
-DESTINATION upload. A degrading source link is untested on all four engines.
-
-It is a different shape from a crash, which is why the crash coverage does not
-stand in for it: the process stays ALIVE holding a half-read stream, and that is
-where a reader can mistake "the connection ended" for "the log ended" — a bounded
-run then writes `_SUCCESS` over a short capture.
-
-Four rows belong in `cdc-evidence-matrix.yaml` when there is something to put in
-them:
-
-    cdc_source_link_drops_mid_capture              toxi_disable
-    cdc_source_link_stalls_under_a_large_txn       toxi_add_bandwidth
-    cdc_link_cut_after_flush_before_ack            toxi_disable, timed
-    cdc_latency_must_not_shorten_a_bounded_run     toxi_add_latency
-
-They are NOT in that matrix yet, deliberately. Its ratchet is shrink-only and adding
-four unproven cells would have pushed 22 past a ceiling of 23 — the ledger refuses
-to let a new gap be declared, which is the behaviour it exists for. The rows go in
-when a test goes in, and the note lives here meanwhile so the surface is not
-forgotten rather than being laundered into a ledger as "known".
-
-Per engine, the reason each is worth running:
-
-- **postgres** — the slot peek is non-consuming, so the ARGUMENT is that a lost
-  connection re-reads from the un-acked position. That argument has never been run,
-  and this engine's `until_current` bound is load-bearing for termination.
-- **mysql** — a long-lived dump connection plus a file checkpoint: a drop between
-  read and part-commit is the window the idle-first-run anchor rule was written for.
-- **mssql** — reads are ordinary SELECTs, so a drop should surface as a query error;
-  whether the run reports failure or an EMPTY SUCCESS is untested.
-- **mongo** — the stream is tailable and the driver retries internally, which is
-  precisely why a silent short read is plausible here rather than a loud one.
-
+8. **A DELETE has no `after`** — its image is in `before`, and rivet writes that
+   image into the same columns, so rivet's before-image was compared against NULL.
+   Under REPLICA IDENTITY DEFAULT both sides carry only the key and agree by
+   accident, which is why it survived.
+9. **JSON null vs the STRING "null"** — `json_extract_string` returns the same
+   4-char `'null'` for both (measured in DuckDB), so every NULL cell disagreed.
+   The lazy fix would make a cell holding the TEXT "null" indistinguishable from an
+   absent one: the degrade-to-null silent-loss class, reintroduced inside the
+   oracle meant to catch it. A `jstr` macro driven by `json_type` maps a JSON null
+   to SQL NULL and leaves the string alone.
 
 ## Wiring this into the release gate (plan item 7) — what stopped it
 
@@ -313,17 +188,20 @@ lesson it learned from a `verify_blessed_path` registered `test` on four engines
 with no caller anywhere in the tree. A row describing intent is exactly what it
 exists to reject.
 
-Three things must be true before the row belongs there, and none is yet:
+Three things must be true before the row belongs there. As of 2026-08-25 the
+second and third are done and the first is not:
 
-1. **The gate must stand up the reference.** Pull `quay.io/debezium/server`, put a
-   receiver on the stand network, wait on the engine's own readiness signal. Every
-   config trap is in this README and each presents as "started and captured
-   nothing".
-2. **`--value` must be on.** The comparison projects to (op, key) today. `--value`
-   is proven to catch a fully NULLed column, but the DELETE path still compares
-   unequal, so it is opt-in. Wiring the harness in without it wires in a check that
-   cannot see cell corruption — the exact blind spot an adversarial pass found here.
-3. **The harness must stay quiet when nothing is wrong.** It produced four false
-   findings from its own defects (shared work dirs, a fixed flush wait, a lossy
-   HTTP sink) before producing a real one. A gate that reports its own races as
-   release blockers gets bypassed.
+1. **The gate must stand up the reference.** NOT DONE. Pull
+   `quay.io/debezium/server`, put a receiver on the stand network, wait on the
+   engine's own readiness signal. Every config trap is in this README and each
+   presents as "started and captured nothing". This is the remaining work.
+2. **`--value` must be on.** DONE 2026-08-25 — on by default, RED-proven to catch
+   a fully NULLed column, and the delete path AGREES on all four engines. It was
+   never a delete-path problem: three defects in the comparison itself (artefacts
+   7, 8, 9 above) produced that symptom.
+3. **The harness must stay quiet when nothing is wrong.** DONE for the shapes
+   found so far — `postgres crud` three times in a row AGREES three times, where
+   the un-cleared work dir made run 2 disagree. Said with the caveat the artefact
+   list earns: seven plumbing defects in two days means the next one is likely,
+   and this precondition is a standing obligation rather than a box that stays
+   ticked.

--- a/dev/cdc-oracle/README.md
+++ b/dev/cdc-oracle/README.md
@@ -1,0 +1,329 @@
+# CDC oracle: Debezium as an independent reference
+
+## Why
+
+rivet's existing CDC oracles compare **the destination to the source** — DuckDB over
+the manifest-declared parts against what the database holds. That catches loss and
+duplication, and it cannot catch a case where rivet and the test agree on a wrong
+answer: the "test and code agree on a wrong spec" blind spot the mutation layer is
+also blind to (see CLAUDE.md, "Scope honesty").
+
+Debezium is a third point. It reads the same log, on the same server, at the same
+time, and it is the reference implementation every other tool is measured against.
+Where rivet and Debezium disagree about a change, one of them is wrong and the
+disagreement is the finding — no oracle in this repo can currently produce that
+signal.
+
+This is deliberately NOT a conformance suite (none exists publicly; Debezium's own
+tests are not portable). It is a differential harness.
+
+## Shape
+
+    source DB ──┬── rivet  (mode: cdc)      → parquet, read via manifest-declared parts
+                └── Debezium Server         → HTTP sink → debezium.jsonl
+
+Both read the SAME log. `compare.py` normalises each side to a set of
+`(op, table, key, after-values)` and reports the symmetric difference.
+
+Debezium Server's `http` sink is used rather than Kafka so the harness needs no
+broker; `sink.py` is a ~30-line receiver whose only job is to append raw events.
+Normalisation lives in the comparison step so the capture stays a faithful record
+of what the reference emitted.
+
+## A harness limitation, stated because it looks like a finding
+
+**MongoDB deletes cannot be compared by key — and this was PURSUED, not assumed.**
+
+The Mongo connector puts the deleted document's `_id` in the message KEY, and the
+http sink forwards only the value. Adding `ExtractNewDocumentState` (the documented
+remedy) fixed inserts and updates — those now arrive flattened with `_id` beside
+`__op`, which is why Mongo's crud cell compares three of four ops for real. A
+delete still arrives as:
+
+    {"__deleted": true, "__op": "d"}
+
+with no key at all. Three configurations were tried and MEASURED, not assumed:
+
+    add.headers=op                     -> header X-DEBEZIUM-__OP only, no key
+    delete.tombstone.handling.mode=rewrite -> `__deleted: true`, still no key
+    add.fields=op,id                   -> the field appears as `__id: null`
+
+The last one is the clearest evidence: Debezium adds the field and has nothing to
+put in it, because the key never enters the value for a Mongo delete. It lives in
+the message KEY, and the http sink transmits value plus headers only.
+
+So `delete` is excluded for MongoDB BY FLAG, with the reason here and at the call
+site. It is the harness's blind spot, not a difference between the tools, and
+closing it needs a sink that records the message key alongside the value.
+
+## Known asymmetries (these are NOT findings)
+
+The two tools legitimately differ, and the comparison must account for it or it
+will report noise forever:
+
+- **Plugin.** Debezium uses `pgoutput`; rivet uses `test_decoding` (ADR-0024).
+  Debezium therefore sees a partitioned parent under its root name where rivet sees
+  the leaf — that difference is the ADR's subject, not a bug to file per-run.
+- **TRUNCATE.** Debezium skips it by default (`truncate.handling.mode=skip`);
+  rivet refuses. Compare with truncate excluded, or set `include` on both sides.
+- **Snapshot.** Debezium's `initial` emits `op=r` (read) rows for existing data;
+  rivet's `mode: cdc` alone does not snapshot. Use `snapshot.mode=no_data` for a
+  streaming-only comparison.
+- **Shape.** Debezium emits before/after envelopes with a schema; rivet writes a
+  flat row plus `__op`/`__pos`/`__seq`. Normalisation is where that is reconciled,
+  and it must be written to fail loudly on an unrecognised shape rather than
+  silently dropping a field it does not understand — a lenient normaliser would
+  reintroduce exactly the class this harness exists to catch.
+
+## Comparison runs in DuckDB, not Python
+
+`compare.py` hands BOTH captures to DuckDB — `read_json_auto` for Debezium's
+JSONL, `read_parquet` for rivet's parts — and the normalisation plus the symmetric
+difference are one SQL statement. The comparison engine is then independent of both
+tools being compared, which is the same reason every other oracle here uses DuckDB:
+a bug in a hand-rolled Python loop would be a bug in the oracle itself.
+
+rivet's side is read through the parts the MANIFEST DECLARES, never a glob.
+
+The Debezium normaliser handles the enveloped and the `transforms=unwrap` shapes,
+and an event matching NEITHER surfaces as `UNKNOWN-SHAPE` rather than being
+dropped — a lenient normaliser would reintroduce the exact class this exists to
+catch.
+
+## Status (2026-08-25)
+
+    engine      crud    key-update   wide-txn      mid-stream-table
+    postgres    AGREE   DIFFERS      AGREE 75/75   AGREE
+    mysql       AGREE   DIFFERS      AGREE 75/75   AGREE
+    mssql       AGREE   AGREE        AGREE 75/75   AGREE
+    mongo       AGREE*  na           AGREE 75/75   AGREE     (* delete excluded, see below)
+
+All sixteen cells settled: fifteen agreements, one difference, one `na`.
+
+**The key-update finding**, and it SURVIVED the harness being fixed — which is the
+only reason to trust it. `UPDATE t SET id=9 WHERE id=1` gives `delete(1)+insert(9)`
+from Debezium and `update(9)` from rivet, identically on PostgreSQL and MySQL, so
+it is rivet's representation choice rather than a plugin artefact. A consumer
+applying the documented latest-image MERGE keeps the old key in the destination
+forever. Counts reconcile on both sides, which is why the source-vs-destination
+oracles never saw it.
+
+SQL Server agrees because the engine itself splits a PK update into delete+insert
+in its change table — the same defect is INVISIBLE on one engine of three, which
+is the argument for a per-engine matrix over one representative test.
+
+`key-update` is **na** on MongoDB: `_id` is immutable, so the scenario cannot be
+expressed. A scenario an engine cannot express is not a passing cell.
+
+## Four artefacts the harness produced before it produced a finding
+
+Recorded because each one wore the costume of a defect, and three were written
+down as "undiagnosed" before being traced:
+
+1. **Shared work dir across engines** — MySQL read a PostgreSQL `offsets.dat`.
+2. **Shared work dir across scenarios** — one run's capture accumulated into the
+   next, surfacing as a `delete` in a scenario that has no delete.
+3. **A fixed flush wait** — reported a race as a shortfall; replaced by waiting
+   for the reference to quiesce.
+4. **The sink dropped batches** — HTTP/1.0 closing a connection Debezium's client
+   kept alive, plus a single thread and a 5-deep listen queue. Delivered 30/39/57
+   of 75 across identical runs and read as "the reference falls short". This one
+   cost the most, because it accused the wrong tool in our favour.
+
+The rule that came out of it: **when a differential harness says the REFERENCE
+fell short, suspect the harness first.** The reference has years of production
+use; the transport between them was written yesterday.
+
+## A harness limitation, stated because it looks like a finding
+
+**MongoDB deletes carry no key in the event BODY.** Debezium puts the deleted
+document's `_id` in the message KEY, and the http sink forwards only the value —
+so `{after: null, before: null, op: "d"}` is all that arrives. The comparison
+sees a keyless delete on the reference side and a keyed one from rivet, which
+renders as a disagreement and is not one.
+
+This is the harness's own blind spot, not a difference between the tools. Fixing
+it means capturing the message key (a sink that records both, or `transforms`
+that lift `documentKey` into the value). Until then, MongoDB's `delete` is
+excluded by `--exclude-op delete` and the exclusion is recorded HERE rather than
+applied silently — an excluded op that nobody wrote down becomes an op nobody
+checks.
+
+## Known asymmetries (these are NOT findings)
+
+The two tools legitimately differ, and the comparison must account for it or it
+will report noise forever:
+
+- **Plugin.** Debezium uses `pgoutput`; rivet uses `test_decoding` (ADR-0024).
+  Debezium therefore sees a partitioned parent under its root name where rivet sees
+  the leaf — that difference is the ADR's subject, not a bug to file per-run.
+- **TRUNCATE.** Debezium skips it by default (`truncate.handling.mode=skip`);
+  rivet refuses. Compare with truncate excluded, or set `include` on both sides.
+- **Snapshot.** Debezium's `initial` emits `op=r` (read) rows for existing data;
+  rivet's `mode: cdc` alone does not snapshot. Use `snapshot.mode=no_data` for a
+  streaming-only comparison.
+- **Shape.** Debezium emits before/after envelopes with a schema; rivet writes a
+  flat row plus `__op`/`__pos`/`__seq`. Normalisation is where that is reconciled,
+  and it must be written to fail loudly on an unrecognised shape rather than
+  silently dropping a field it does not understand — a lenient normaliser would
+  reintroduce exactly the class this harness exists to catch.
+
+## Comparison runs in DuckDB, not Python
+
+`compare.py` hands BOTH captures to DuckDB — `read_json_auto` for Debezium's
+JSONL, `read_parquet` for rivet's parts — and the normalisation plus the symmetric
+difference are one SQL statement. The comparison engine is then independent of both
+tools being compared, which is the same reason every other oracle here uses DuckDB:
+a bug in a hand-rolled Python loop would be a bug in the oracle itself.
+
+rivet's side is read through the parts the MANIFEST DECLARES, never a glob.
+
+The Debezium normaliser handles the enveloped and the `transforms=unwrap` shapes,
+and an event matching NEITHER surfaces as `UNKNOWN-SHAPE` rather than being
+dropped — a lenient normaliser would reintroduce the exact class this exists to
+catch.
+
+## Status (2026-08-25)
+
+    engine      crud    key-update   wide-txn      mid-stream-table
+    postgres    AGREE   DIFFERS      AGREE 75/75   AGREE
+    mysql       AGREE   DIFFERS      AGREE 75/75   AGREE
+    mssql       AGREE   AGREE        undiagnosed   AGREE
+    mongo       AGREE*  na           AGREE 75/75   AGREE     (* delete excluded, see below)
+
+Fourteen of sixteen cells settled; all four engines run.
+
+**The key-update finding.** `UPDATE t SET id=9 WHERE id=1` gives
+`delete(1)+insert(9)` from Debezium and `update(9)` from rivet, identically on
+PostgreSQL and MySQL — so it is rivet's representation choice, not a plugin
+artefact. A consumer applying the documented latest-image MERGE keeps the old key
+in the destination forever. Counts reconcile on both sides, which is why the
+source-vs-destination oracles never saw it. SQL Server agrees because the engine
+itself splits a PK update into delete+insert in its change table, so the same
+defect is INVISIBLE on one engine of three — the argument for a per-engine matrix
+rather than one representative test.
+
+`key-update` is **na** on MongoDB: `_id` is immutable, so the scenario cannot be
+expressed. A scenario an engine cannot express is not a passing cell.
+
+**MSSQL wide-txn — measured, undiagnosed, and NOT a claim about rivet.**
+The 50-insert + 25-update scenario puts 100 rows in `cdc.dbo_<t>_CT` (SQL Server
+writes two CT rows per UPDATE). rivet captures 75 change events, which is the
+correct count. Debezium delivers 39 and then STOPS — it quiesces there across
+three consecutive checks, so this is its steady state rather than a flush race:
+an earlier fixed 8s wait gave 30, and waiting for quiescence gave 39.
+
+The 55 resulting rows all sit on the `rivet-only` side, i.e. the REFERENCE is
+short. Candidate causes not yet separated: a batch-size limit on the connector, a
+poll interval interacting with the capture job's own batching, or something about
+`snapshot.mode=no_data` on this engine. Recorded with the numbers rather than
+guessed at — a difference whose cause is unknown is not evidence about either
+tool, and calling this a rivet defect would be the harness lying in our favour.
+
+Original note follows.
+
+**MSSQL wide-txn** shows `rivet-only` rows — i.e. the REFERENCE lagged, not rivet.
+Not yet diagnosed and NOT claimed as a finding: SQL Server's capture job is
+asynchronous on both sides and the wait may still be too short for 75 changes.
+
+**MongoDB is NOT running yet.** The connector starts but never records progress
+within the readiness window. Two obstacles are already solved and worth keeping:
+the Mongo stands live in `stand_default` (not `rivet_default`), and the replica
+set advertises itself as `127.0.0.1:27017`, so a driver inside another container
+dials itself — `directConnection=true` alongside `replicaSet=rs0` gets past that.
+What remains is the readiness signal: `offsets.dat` never appears, so either the
+connector needs longer or it is failing after validation.
+
+
+## The harness compares KEYS, not values — and that was a real blind spot
+
+An adversarial pass RAN the check I had not: it took a real capture, rewrote the
+parquet with `NULL::VARCHAR AS v` — 100% of the value column destroyed — and
+`compare.py` printed a byte-identical **AGREE**. Every "15 of 16 agree" result in
+this file was therefore weaker than it read: it proves the two tools saw the same
+CHANGES, not that rivet wrote the same VALUES.
+
+`--value <col>` (repeatable) now compares cells as text on both sides, and it is
+verified to catch that mutation: the same NULLed parquet goes from AGREE to four
+differing rows.
+
+It is **not on by default yet**, deliberately. The DELETE path still compares
+unequal, because the reference carries no `after` document for a delete while the
+value extract reads only that side. Turning it on now would mean a false alarm on
+every run, and a harness that cries wolf gets muted — which is exactly how this
+blind spot survived in the first place.
+
+## The gap this harness does NOT cover: a degrading source LINK
+
+Measured 2026-08-25 while looking for negative scenarios: `toxi_` appears **zero**
+times in `live_cdc.rs`, `live_cdc_mssql.rs` and `live_cdc_mongo.rs`. Every fault
+test in the suite either kills the PROCESS (`RIVET_TEST_PANIC_AT`) or aims at the
+DESTINATION upload. A degrading source link is untested on all four engines.
+
+It is a different shape from a crash, which is why the crash coverage does not
+stand in for it: the process stays ALIVE holding a half-read stream, and that is
+where a reader can mistake "the connection ended" for "the log ended" — a bounded
+run then writes `_SUCCESS` over a short capture.
+
+Four rows belong in `cdc-evidence-matrix.yaml` when there is something to put in
+them:
+
+    cdc_source_link_drops_mid_capture              toxi_disable
+    cdc_source_link_stalls_under_a_large_txn       toxi_add_bandwidth
+    cdc_link_cut_after_flush_before_ack            toxi_disable, timed
+    cdc_latency_must_not_shorten_a_bounded_run     toxi_add_latency
+
+They are NOT in that matrix yet, deliberately. Its ratchet is shrink-only and adding
+four unproven cells would have pushed 22 past a ceiling of 23 — the ledger refuses
+to let a new gap be declared, which is the behaviour it exists for. The rows go in
+when a test goes in, and the note lives here meanwhile so the surface is not
+forgotten rather than being laundered into a ledger as "known".
+
+Per engine, the reason each is worth running:
+
+- **postgres** — the slot peek is non-consuming, so the ARGUMENT is that a lost
+  connection re-reads from the un-acked position. That argument has never been run,
+  and this engine's `until_current` bound is load-bearing for termination.
+- **mysql** — a long-lived dump connection plus a file checkpoint: a drop between
+  read and part-commit is the window the idle-first-run anchor rule was written for.
+- **mssql** — reads are ordinary SELECTs, so a drop should surface as a query error;
+  whether the run reports failure or an EMPTY SUCCESS is untested.
+- **mongo** — the stream is tailable and the driver retries internally, which is
+  precisely why a silent short read is plausible here rather than a loud one.
+
+
+## Wiring this into the release gate (plan item 7) — what stopped it
+
+The gate already HAS a CDC leg: `cdc.verify_cdc_e2e` compares the destination to
+the source (per-column null profile, distinct counts, over the cloud parts). It
+catches loss and degrade-to-null. It is structurally blind to rivet and its own
+oracle agreeing on a wrong SPEC, which is what this harness exists to catch.
+
+Adding a `cdc_differential_vs_debezium` row was ATTEMPTED and REVERTED, because
+`release_gate_matrix_guard` refused it twice, correctly:
+
+    gate matrix scenario `cdc_differential_vs_debezium` has no
+    sc_cdc_differential_vs_debezium() in the gate modules
+
+    release-gate-matrix has 14 gaps > ratchet 10 — you cannot ADD a gap;
+    wire the check and LOWER the ratchet
+
+Both are the right verdict. That ledger grades the CALL SITE, not the row — a
+lesson it learned from a `verify_blessed_path` registered `test` on four engines
+with no caller anywhere in the tree. A row describing intent is exactly what it
+exists to reject.
+
+Three things must be true before the row belongs there, and none is yet:
+
+1. **The gate must stand up the reference.** Pull `quay.io/debezium/server`, put a
+   receiver on the stand network, wait on the engine's own readiness signal. Every
+   config trap is in this README and each presents as "started and captured
+   nothing".
+2. **`--value` must be on.** The comparison projects to (op, key) today. `--value`
+   is proven to catch a fully NULLed column, but the DELETE path still compares
+   unequal, so it is opt-in. Wiring the harness in without it wires in a check that
+   cannot see cell corruption — the exact blind spot an adversarial pass found here.
+3. **The harness must stay quiet when nothing is wrong.** It produced four false
+   findings from its own defects (shared work dirs, a fixed flush wait, a lossy
+   HTTP sink) before producing a real one. A gate that reports its own races as
+   release blockers gets bypassed.

--- a/dev/cdc-oracle/README.md
+++ b/dev/cdc-oracle/README.md
@@ -188,20 +188,35 @@ lesson it learned from a `verify_blessed_path` registered `test` on four engines
 with no caller anywhere in the tree. A row describing intent is exactly what it
 exists to reject.
 
-Three things must be true before the row belongs there. As of 2026-08-25 the
-second and third are done and the first is not:
+Three things had to be true before the row belonged there. All three are done as
+of 2026-08-25, and the row is wired:
 
-1. **The gate must stand up the reference.** NOT DONE. Pull
-   `quay.io/debezium/server`, put a receiver on the stand network, wait on the
-   engine's own readiness signal. Every config trap is in this README and each
-   presents as "started and captured nothing". This is the remaining work.
-2. **`--value` must be on.** DONE 2026-08-25 — on by default, RED-proven to catch
-   a fully NULLed column, and the delete path AGREES on all four engines. It was
+1. **The gate must stand up the reference.** DONE — `verify_cdc_differential`
+   (dev/release_oracle/cdc.py), called from `__main__`, row `cdc_differential`
+   in docs/release-gate-matrix.yaml marked `test`. The harness already pulled
+   `quay.io/debezium/server`, put a receiver on the stand network and waited on
+   each engine's OWN readiness signal, so the gate did not have to learn any of
+   it. The gap ratchet is untouched at 10 because nothing was added to it — the
+   two earlier refusals were both correct, and the fix was to WIRE the check
+   rather than to describe it.
+2. **`--value` must be on.** DONE — on by default, RED-proven to catch a fully
+   NULLed column, AGREE on all four engines including the delete path. It was
    never a delete-path problem: three defects in the comparison itself (artefacts
    7, 8, 9 above) produced that symptom.
 3. **The harness must stay quiet when nothing is wrong.** DONE for the shapes
    found so far — `postgres crud` three times in a row AGREES three times, where
    the un-cleared work dir made run 2 disagree. Said with the caveat the artefact
-   list earns: seven plumbing defects in two days means the next one is likely,
-   and this precondition is a standing obligation rather than a box that stays
-   ticked.
+   list earns: nine defects in two days means the next one is likely, so the gate
+   grades a harness that did not complete as SKIP with the tail attached, never a
+   silent pass.
+
+Two grading decisions live at the call site rather than here, because they decide
+what the gate MEANS:
+
+- An AGREE that compared only `(op, key)` is a FAILURE, not a pass. The row claims
+  a value-level check, the comparison names its own scope in its output, and that
+  is checked rather than assumed.
+- `key-update` is excluded. rivet emits `update(new)` where Debezium emits
+  `delete(old)+insert(new)`, identically on PostgreSQL and MySQL — a representation
+  decision that belongs in an ADR. A gate cell EXPECTING a difference would go
+  green the day someone fixes it, which is the wrong direction for a ratchet.

--- a/dev/cdc-oracle/compare.py
+++ b/dev/cdc-oracle/compare.py
@@ -107,12 +107,21 @@ SELECT
   __DBZ_VALS__
 FROM (SELECT unnest(str_split(trim(content, chr(10)), chr(10))) AS j
       FROM read_text('__DBZ__'))
--- MySQL's connector also emits SCHEMA-CHANGE events (a `ddl` field, no `op`) on
--- the same sink. They are DDL, not row changes, and PostgreSQL's connector does
--- not send them — a legitimate asymmetry, so they are excluded EXPLICITLY here
--- rather than swallowed by the UNKNOWN arm. Silencing them there would have
--- disarmed the shape check for real unrecognised events too.
-WHERE j <> '' AND jstr(j, '$.ddl') IS NULL;
+-- MySQL and SQL Server also emit SCHEMA-CHANGE events on the same sink. They are
+-- DDL, not row changes, and PostgreSQL's connector does not send them — a
+-- legitimate asymmetry, so they are excluded EXPLICITLY here rather than swallowed
+-- by the UNKNOWN arm. Silencing them there would disarm the shape check for real
+-- unrecognised events too.
+--
+-- Excluded by SHAPE (`tableChanges`), not by `ddl` being non-null: SQL Server sends
+-- schema-change events with `ddl` set to JSON **null**, and once `jstr` started
+-- mapping a JSON null to SQL NULL (correctly — see the macro), a `ddl IS NULL`
+-- filter stopped recognising them. Measured: 24 of 32 events in an mssql crud
+-- capture, all surfacing as UNKNOWN-SHAPE. `tableChanges` is present on both
+-- engines' schema-change events and on no row event.
+WHERE j <> ''
+  AND json_type(j, '$.tableChanges') IS NULL
+  AND jstr(j, '$.ddl') IS NULL;
 
 CREATE OR REPLACE VIEW riv AS
 SELECT __op AS op, CAST(__KEY__ AS VARCHAR) AS k __RIV_VALS__
@@ -129,6 +138,10 @@ def main() -> int:
                     help="a VALUE column to compare as well as the key; repeatable. "
                          "Without one the comparison is blind to cell corruption — "
                          "a parquet with every value NULLed still reports AGREE.")
+    ap.add_argument("--rivet-json-column", default=None,
+                    help="on rivet's side the value columns live INSIDE this JSON "
+                         "column (MongoDB writes the whole document into `document`), "
+                         "so they are extracted from it rather than read as columns")
     ap.add_argument("--allow-empty-reference", action="store_true",
                     help="accept a zero-event Debezium capture (asserting BOTH are empty)")
     ap.add_argument("--exclude-op", action="append", default=[],
@@ -201,7 +214,19 @@ def main() -> int:
                          jstr(j, '$.{v}')) END AS v_{v}\n  """
         for v in a.value
     )
-    riv_vals = "".join(f", CAST({v} AS VARCHAR) AS v_{v}" for v in a.value)
+    # MongoDB's value columns are not columns: rivet writes the whole document into
+    # one JSON column, and Debezium's ExtractNewDocumentState flattens the same
+    # fields to the top level. Extracting `$.<v>` from both compares the same CELL —
+    # which is what a value comparison is for — where a text comparison of the two
+    # whole documents would have graded JSON key ORDER and whitespace instead. That
+    # difference is why this engine was briefly written off as `na`.
+    if a.rivet_json_column:
+        riv_vals = "".join(
+            f", jstr(CAST({a.rivet_json_column} AS VARCHAR), '$.{v}') AS v_{v}"
+            for v in a.value
+        )
+    else:
+        riv_vals = "".join(f", CAST({v} AS VARCHAR) AS v_{v}" for v in a.value)
     sql = (SQL.replace("__DBZ_VALS__", dbz_vals)
               .replace("__RIV_VALS__", riv_vals)
               .replace("__DBZ__", a.debezium_jsonl)

--- a/dev/cdc-oracle/compare.py
+++ b/dev/cdc-oracle/compare.py
@@ -43,6 +43,24 @@ def declared_parts(root: str) -> list[str]:
 
 
 SQL = """
+-- `json_extract_string` returns the 4-char STRING 'null' for a JSON null, and the
+-- same 'null' for a JSON string whose value is the text "null" — only `json_type`
+-- tells them apart (measured in DuckDB, not assumed). Two consequences, and both
+-- had to be fixed before `--value` could be trusted:
+--
+--   1. Every NULL cell disagreed: Debezium's side rendered 'null' while rivet's
+--      parquet gave SQL NULL. Any nullable column made every row containing one
+--      report DISAGREE, which is why `--value` was believed broken on deletes.
+--   2. Conflating them the lazy way (mapping the literal 'null' to SQL NULL) would
+--      make a cell holding the TEXT "null" indistinguishable from an absent one —
+--      the degrade-to-null silent-loss class, reintroduced inside the very oracle
+--      meant to catch it.
+--
+-- So the mapping is driven by json_type: a JSON null becomes SQL NULL, a string
+-- "null" stays the string.
+CREATE OR REPLACE MACRO jstr(doc, path) AS
+  CASE WHEN json_type(doc, path) = 'NULL' THEN NULL
+       ELSE json_extract_string(doc, path) END;
 -- Debezium Server's http sink with `format.value=json` and schemas disabled emits
 -- the row envelope FLAT: {after, before, op, source}. The enveloped
 -- {payload:{...}} shape appears when schemas are enabled, so both are accepted —
@@ -54,9 +72,9 @@ SELECT
   -- `__op` is the ExtractNewDocumentState shape (MongoDB): the transform flattens
   -- the document and prefixes its metadata, which is what makes a DELETE carry a
   -- key at all on that engine.
-  CASE coalesce(json_extract_string(j, '$.op'),
-                json_extract_string(j, '$.payload.op'),
-                json_extract_string(j, '$.__op'))
+  CASE coalesce(jstr(j, '$.op'),
+                jstr(j, '$.payload.op'),
+                jstr(j, '$.__op'))
     WHEN 'c' THEN 'insert' WHEN 'r' THEN 'insert'
     WHEN 'u' THEN 'update' WHEN 'd' THEN 'delete'
     WHEN 't' THEN 'truncate' ELSE 'UNKNOWN' END AS op,
@@ -70,18 +88,23 @@ SELECT
   -- nested path first, then a second parse of the string form. Without the second
   -- the key comes back NULL for every Mongo event, which looks like a total
   -- disagreement rather than a normaliser that cannot read the shape.
-  __DBZ_VALS__
   CAST(coalesce(
-    json_extract_string(j, '$.after.__KEY__'),
-    json_extract_string(j, '$.before.__KEY__'),
-    json_extract_string(j, '$.payload.after.__KEY__'),
-    json_extract_string(j, '$.payload.before.__KEY__'),
-    json_extract_string(json_extract_string(j, '$.after'), '$.__KEY__'),
-    json_extract_string(json_extract_string(j, '$.before'), '$.__KEY__'),
-    json_extract_string(json_extract_string(j, '$.payload.after'), '$.__KEY__'),
+    jstr(j, '$.after.__KEY__'),
+    jstr(j, '$.before.__KEY__'),
+    jstr(j, '$.payload.after.__KEY__'),
+    jstr(j, '$.payload.before.__KEY__'),
+    jstr(jstr(j, '$.after'), '$.__KEY__'),
+    jstr(jstr(j, '$.before'), '$.__KEY__'),
+    jstr(jstr(j, '$.payload.after'), '$.__KEY__'),
     -- flattened form: the key sits at the top level beside `__op`
-    json_extract_string(j, '$.__KEY__')
+    jstr(j, '$.__KEY__')
   ) AS VARCHAR) AS k
+  -- Value columns come AFTER the key, matching `riv` below. `EXCEPT` compares by
+  -- POSITION, not by name, so a view that put them BEFORE the key compared v
+  -- against k on every row — with `--value` on, all four rows of a four-row
+  -- scenario reported as "both sides only", which reads as total disagreement and
+  -- is why `--value` was believed to be broken on the delete path alone.
+  __DBZ_VALS__
 FROM (SELECT unnest(str_split(trim(content, chr(10)), chr(10))) AS j
       FROM read_text('__DBZ__'))
 -- MySQL's connector also emits SCHEMA-CHANGE events (a `ddl` field, no `op`) on
@@ -89,7 +112,7 @@ FROM (SELECT unnest(str_split(trim(content, chr(10)), chr(10))) AS j
 -- not send them — a legitimate asymmetry, so they are excluded EXPLICITLY here
 -- rather than swallowed by the UNKNOWN arm. Silencing them there would have
 -- disarmed the shape check for real unrecognised events too.
-WHERE j <> '' AND json_extract_string(j, '$.ddl') IS NULL;
+WHERE j <> '' AND jstr(j, '$.ddl') IS NULL;
 
 CREATE OR REPLACE VIEW riv AS
 SELECT __op AS op, CAST(__KEY__ AS VARCHAR) AS k __RIV_VALS__
@@ -158,11 +181,24 @@ def main() -> int:
     # the CELL survived, not whether two type systems render it identically — and
     # a comparison that skipped values entirely reported AGREE over a parquet with
     # 100% of a column NULLed (measured, which is why this exists).
+    # A DELETE has no `after` — its image is in `before`, and rivet writes that
+    # image into the same columns. Reading `$.after.<v>` unconditionally therefore
+    # compared rivet's before-image against NULL on every delete. Under REPLICA
+    # IDENTITY DEFAULT both sides carry only the key and agree by accident; set it
+    # to FULL and they diverge, which is the configuration a value comparison is
+    # for. Op-aware, so both are right.
     dbz_vals = "".join(
-        f"""coalesce(json_extract_string(j, '$.after.{v}'),
-                     json_extract_string(j, '$.payload.after.{v}'),
-                     json_extract_string(json_extract_string(j, '$.after'), '$.{v}'),
-                     json_extract_string(j, '$.{v}')) AS v_{v},\n  """
+        f""", CASE WHEN coalesce(jstr(j, '$.op'),
+                                 jstr(j, '$.payload.op'),
+                                 jstr(j, '$.__op')) = 'd'
+           THEN coalesce(jstr(j, '$.before.{v}'),
+                         jstr(j, '$.payload.before.{v}'),
+                         jstr(jstr(j, '$.before'), '$.{v}'),
+                         jstr(j, '$.{v}'))
+           ELSE coalesce(jstr(j, '$.after.{v}'),
+                         jstr(j, '$.payload.after.{v}'),
+                         jstr(jstr(j, '$.after'), '$.{v}'),
+                         jstr(j, '$.{v}')) END AS v_{v}\n  """
         for v in a.value
     )
     riv_vals = "".join(f", CAST({v} AS VARCHAR) AS v_{v}" for v in a.value)
@@ -171,13 +207,19 @@ def main() -> int:
               .replace("__DBZ__", a.debezium_jsonl)
               .replace("__KEY__", a.key)
               .replace("__PARTS__", "[" + ", ".join(f"'{p}'" for p in parts) + "]"))
+    # SHOW the values in the diff, not just (op, key). A row that appears on BOTH
+    # sides means the tuples differ in a column the output hides, and "everything
+    # disagrees, no reason given" is what makes a gate get bypassed (precondition 3
+    # in the README). With the values printed, a value mismatch reads as a value
+    # mismatch instead of a phantom key difference.
+    shown = "".join(f", coalesce(v_{v}, '<null>') AS v_{v}" for v in a.value)
     sql += f"""
-SELECT 'rivet-only' AS side, op, k FROM (SELECT * FROM riv{where} EXCEPT SELECT * FROM dbz{where})
+SELECT 'rivet-only' AS side, op, k{shown} FROM (SELECT * FROM riv{where} EXCEPT SELECT * FROM dbz{where})
 UNION ALL
-SELECT 'debezium-only', op, k FROM (SELECT * FROM dbz{where} EXCEPT SELECT * FROM riv{where})
+SELECT 'debezium-only', op, k{shown} FROM (SELECT * FROM dbz{where} EXCEPT SELECT * FROM riv{where})
 UNION ALL
-SELECT 'UNKNOWN-SHAPE', op, k FROM dbz WHERE op = 'UNKNOWN'
-ORDER BY 1, 2, 3;
+SELECT 'UNKNOWN-SHAPE', op, k{shown} FROM dbz WHERE op = 'UNKNOWN'
+ORDER BY 2, 3, 1;
 """
     with tempfile.NamedTemporaryFile("w", suffix=".sql", delete=False) as f:
         f.write(sql)
@@ -208,9 +250,16 @@ ORDER BY 1, 2, 3;
              "(SELECT count(*) FROM (SELECT DISTINCT * FROM dbz));"],
             capture_output=True, text=True)
         pairs = cnt.stdout.strip() or "?"
-        print(f"AGREE: rivet and Debezium produced the same (op, key) set "
+        # Name what was actually compared. An "AGREE" that says (op, key) while the
+        # caller passed --value understates the check; one that claims values when
+        # none were passed OVERSTATES it, which is the direction that matters — a
+        # gate reporting a value comparison it never ran is the blind spot this
+        # whole harness exists to close.
+        scope = (f"(op, key, {', '.join(a.value)})" if a.value
+                 else "(op, key) — VALUES NOT COMPARED, pass --value to see cell corruption")
+        print(f"AGREE: rivet and Debezium produced the same {scope} set "
               f"[{len(parts)} declared part(s) / {dbz_lines} reference event(s) "
-              f"-> {pairs} distinct (op,key) pairs compared]")
+              f"-> {pairs} distinct tuples compared]")
         return 0
     print("DISAGREE — one of the two is wrong, and which is the finding:\n")
     print(body)

--- a/dev/cdc-oracle/compare.py
+++ b/dev/cdc-oracle/compare.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Differential compare: rivet's parquet vs Debezium's JSONL — in DuckDB.
+
+DuckDB reads BOTH sides natively (`read_json_auto`, `read_parquet`), so the
+normalisation and the set difference are one SQL statement over the two captures
+rather than Python looping over parsed objects. That matters for the same reason
+the rest of this repo's oracles use DuckDB: the comparison engine is independent
+of both tools being compared, and a bug in a hand-written Python loop would be a
+bug in the oracle itself.
+
+rivet's side is read through the parts the MANIFEST DECLARES, never a directory
+glob — a crashed run leaves parts no manifest names, and counting them would
+report delivery no consumer will ever see.
+
+Exit 0 = the two agree. Exit 1 = symmetric difference, printed both ways.
+"""
+import argparse, glob, json, os, subprocess, sys, tempfile
+
+
+def declared_parts(root: str) -> list[str]:
+    """The parts the manifest declares as committed — mirrors declared_parquet_parts
+    (tests/common/parquet.rs) and _manifest_declared_parts (dev/release_oracle)."""
+    copies = sorted(glob.glob(os.path.join(root, "manifest-*.json")))
+    if not copies:
+        c = os.path.join(root, "manifest.json")
+        copies = [c] if os.path.isfile(c) else []
+    out: set[str] = set()
+    for d in copies:
+        try:
+            art = json.load(open(d))
+        except (OSError, json.JSONDecodeError):
+            continue
+        for p in art.get("parts") or []:
+            if isinstance(p, dict) and p.get("status") not in (None, "committed"):
+                continue
+            name = (p.get("path") or p.get("name")) if isinstance(p, dict) else p
+            if not name:
+                continue
+            cand = name if os.path.isabs(name) else os.path.join(os.path.dirname(d), name)
+            if os.path.isfile(cand):
+                out.add(cand)
+    return sorted(out)
+
+
+SQL = """
+-- Debezium Server's http sink with `format.value=json` and schemas disabled emits
+-- the row envelope FLAT: {after, before, op, source}. The enveloped
+-- {payload:{...}} shape appears when schemas are enabled, so both are accepted —
+-- and an event matching NEITHER surfaces as UNKNOWN rather than being dropped. A
+-- normaliser that silently skips what it does not understand would reintroduce the
+-- exact class this harness exists to catch.
+CREATE OR REPLACE VIEW dbz AS
+SELECT
+  -- `__op` is the ExtractNewDocumentState shape (MongoDB): the transform flattens
+  -- the document and prefixes its metadata, which is what makes a DELETE carry a
+  -- key at all on that engine.
+  CASE coalesce(json_extract_string(j, '$.op'),
+                json_extract_string(j, '$.payload.op'),
+                json_extract_string(j, '$.__op'))
+    WHEN 'c' THEN 'insert' WHEN 'r' THEN 'insert'
+    WHEN 'u' THEN 'update' WHEN 'd' THEN 'delete'
+    WHEN 't' THEN 'truncate' ELSE 'UNKNOWN' END AS op,
+  -- `before` is absent from an insert-only capture, and read_json_auto then does
+  -- not create the column at all — referencing it unconditionally is a BINDER
+  -- error, not a NULL. json_extract_string over the raw line is shape-agnostic:
+  -- it survives whichever fields the capture happens to contain, which is the
+  -- point. The harness must not depend on the reference having exercised every op.
+  -- MongoDB's connector serialises the document as a JSON STRING in `after`,
+  -- where the relational connectors nest it as an object. Both are tried: the
+  -- nested path first, then a second parse of the string form. Without the second
+  -- the key comes back NULL for every Mongo event, which looks like a total
+  -- disagreement rather than a normaliser that cannot read the shape.
+  __DBZ_VALS__
+  CAST(coalesce(
+    json_extract_string(j, '$.after.__KEY__'),
+    json_extract_string(j, '$.before.__KEY__'),
+    json_extract_string(j, '$.payload.after.__KEY__'),
+    json_extract_string(j, '$.payload.before.__KEY__'),
+    json_extract_string(json_extract_string(j, '$.after'), '$.__KEY__'),
+    json_extract_string(json_extract_string(j, '$.before'), '$.__KEY__'),
+    json_extract_string(json_extract_string(j, '$.payload.after'), '$.__KEY__'),
+    -- flattened form: the key sits at the top level beside `__op`
+    json_extract_string(j, '$.__KEY__')
+  ) AS VARCHAR) AS k
+FROM (SELECT unnest(str_split(trim(content, chr(10)), chr(10))) AS j
+      FROM read_text('__DBZ__'))
+-- MySQL's connector also emits SCHEMA-CHANGE events (a `ddl` field, no `op`) on
+-- the same sink. They are DDL, not row changes, and PostgreSQL's connector does
+-- not send them — a legitimate asymmetry, so they are excluded EXPLICITLY here
+-- rather than swallowed by the UNKNOWN arm. Silencing them there would have
+-- disarmed the shape check for real unrecognised events too.
+WHERE j <> '' AND json_extract_string(j, '$.ddl') IS NULL;
+
+CREATE OR REPLACE VIEW riv AS
+SELECT __op AS op, CAST(__KEY__ AS VARCHAR) AS k __RIV_VALS__
+FROM read_parquet(__PARTS__);
+"""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--rivet-dir", required=True)
+    ap.add_argument("--debezium-jsonl", required=True)
+    ap.add_argument("--key", required=True, help="the key column, on both sides")
+    ap.add_argument("--value", action="append", default=[],
+                    help="a VALUE column to compare as well as the key; repeatable. "
+                         "Without one the comparison is blind to cell corruption — "
+                         "a parquet with every value NULLed still reports AGREE.")
+    ap.add_argument("--allow-empty-reference", action="store_true",
+                    help="accept a zero-event Debezium capture (asserting BOTH are empty)")
+    ap.add_argument("--exclude-op", action="append", default=[],
+                    help="an op the two tools legitimately disagree on (see README)")
+    a = ap.parse_args()
+
+    # ── the empty-capture guard, and it runs BEFORE any comparison ──────────
+    #
+    # An empty capture and "the two agree" produce the SAME output from a set
+    # difference: nothing. So a Debezium that never started, a sink that never
+    # received, or a rivet run that wrote nothing would all read as agreement —
+    # the harness would be green exactly when it is broken. This session hit that
+    # shape three times (a CI monitor reading "no checks" as pass, a self-test
+    # grading a function it never called, a mutants config whose parse failure
+    # printed an empty list), so it is checked first and refuses rather than warns.
+    #
+    # `--allow-empty-reference` exists for the one legitimate case: asserting that
+    # NEITHER tool captured anything. It must be explicit, because the default has
+    # to be that silence is a failure.
+    parts = declared_parts(a.rivet_dir)
+    if not parts:
+        print(f"FAIL: no manifest-declared parts under {a.rivet_dir} — that is an "
+              f"outcome ('nothing was delivered'), not a reason to glob", file=sys.stderr)
+        return 1
+
+    try:
+        dbz_lines = sum(1 for _ in open(a.debezium_jsonl))
+    except OSError as e:
+        print(f"FAIL: the reference capture is unreadable ({e}). An absent file is "
+              f"NOT agreement — it means Debezium never delivered, and comparing "
+              f"against it would report 'no differences' for a harness that did "
+              f"not run.", file=sys.stderr)
+        return 1
+    if dbz_lines == 0 and not a.allow_empty_reference:
+        print(f"FAIL: the reference captured ZERO events ({a.debezium_jsonl}). "
+              f"Empty and 'agrees' are the same set difference, so this refuses "
+              f"instead of passing. Check that Debezium started (config at "
+              f"/debezium/config/, `debezium.format.value` set) and that the sink "
+              f"is reachable from its network. Pass --allow-empty-reference only "
+              f"to assert that NEITHER side captured anything.", file=sys.stderr)
+        return 1
+
+    where = ""
+    if a.exclude_op:
+        ops = ", ".join(f"'{o}'" for o in a.exclude_op)
+        where = f" WHERE op NOT IN ({ops})"
+
+    # Explicit replace, not str.format: the SQL contains DuckDB struct braces.
+    # Value columns, if any. Compared as text on both sides: the point is whether
+    # the CELL survived, not whether two type systems render it identically — and
+    # a comparison that skipped values entirely reported AGREE over a parquet with
+    # 100% of a column NULLed (measured, which is why this exists).
+    dbz_vals = "".join(
+        f"""coalesce(json_extract_string(j, '$.after.{v}'),
+                     json_extract_string(j, '$.payload.after.{v}'),
+                     json_extract_string(json_extract_string(j, '$.after'), '$.{v}'),
+                     json_extract_string(j, '$.{v}')) AS v_{v},\n  """
+        for v in a.value
+    )
+    riv_vals = "".join(f", CAST({v} AS VARCHAR) AS v_{v}" for v in a.value)
+    sql = (SQL.replace("__DBZ_VALS__", dbz_vals)
+              .replace("__RIV_VALS__", riv_vals)
+              .replace("__DBZ__", a.debezium_jsonl)
+              .replace("__KEY__", a.key)
+              .replace("__PARTS__", "[" + ", ".join(f"'{p}'" for p in parts) + "]"))
+    sql += f"""
+SELECT 'rivet-only' AS side, op, k FROM (SELECT * FROM riv{where} EXCEPT SELECT * FROM dbz{where})
+UNION ALL
+SELECT 'debezium-only', op, k FROM (SELECT * FROM dbz{where} EXCEPT SELECT * FROM riv{where})
+UNION ALL
+SELECT 'UNKNOWN-SHAPE', op, k FROM dbz WHERE op = 'UNKNOWN'
+ORDER BY 1, 2, 3;
+"""
+    with tempfile.NamedTemporaryFile("w", suffix=".sql", delete=False) as f:
+        f.write(sql)
+        path = f.name
+    try:
+        r = subprocess.run(["duckdb", "-box", "-c", f".read {path}"],
+                           capture_output=True, text=True)
+    finally:
+        os.unlink(path)
+    if r.returncode != 0:
+        print(r.stderr, file=sys.stderr)
+        return 1
+    body = r.stdout.strip()
+    # DuckDB prints an empty box when a query returns no rows; agreement is the
+    # absence of any differing row.
+    if not body or "0 rows" in body or body.count("│") == 0:
+        # Report the counts that were compared. "AGREE" over two captures whose
+        # sizes are never printed is the same silence this guard exists to remove —
+        # a reader must be able to see the comparison had something to compare.
+        # Report the size of the SET that was compared, not only the input sizes.
+        # Two captures can be non-empty and still compare a degenerate set — e.g.
+        # every event on one key — and "AGREE over 1 pair" deserves to look
+        # different from "AGREE over 40". Same reason the counts are printed at all.
+        cnt = subprocess.run(
+            ["duckdb", "-noheader", "-list", "-c",
+             sql.split("SELECT 'rivet-only'")[0] +
+             "SELECT (SELECT count(*) FROM (SELECT DISTINCT * FROM riv)) || '/' || "
+             "(SELECT count(*) FROM (SELECT DISTINCT * FROM dbz));"],
+            capture_output=True, text=True)
+        pairs = cnt.stdout.strip() or "?"
+        print(f"AGREE: rivet and Debezium produced the same (op, key) set "
+              f"[{len(parts)} declared part(s) / {dbz_lines} reference event(s) "
+              f"-> {pairs} distinct (op,key) pairs compared]")
+        return 0
+    print("DISAGREE — one of the two is wrong, and which is the finding:\n")
+    print(body)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dev/cdc-oracle/run.py
+++ b/dev/cdc-oracle/run.py
@@ -15,7 +15,7 @@ The wait matters as much as the ordering. Debezium's slot exists from the moment
 it has finished starting; applying changes before that is safe (the slot retains
 them) while applying them before the SLOT exists is not.
 """
-import argparse, json, os, re, subprocess, sys, time
+import argparse, json, os, re, shutil, subprocess, sys, time
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 # The stands do not all share one docker network: the SQL engines sit in
@@ -86,7 +86,18 @@ def _value_cols(a) -> list:
     rather than the values. The op/key comparison plus the per-column null-profile
     check in the live suite covers that engine; a value diff here would be noise.
     """
-    return [] if a.engine == "mongo" else ["v"]
+    return ["v"]
+
+
+def _rivet_json_column(a) -> list:
+    """rivet's side of a Mongo value lives inside the `document` JSON column.
+
+    Debezium's ExtractNewDocumentState flattens the document to the top level, so
+    `$.v` reads the same cell on both sides. Comparing the two whole documents as
+    text would grade JSON key ORDER and whitespace instead — which is what made
+    this look like an engine a value comparison cannot cover.
+    """
+    return ["--rivet-json-column", "document"] if a.engine == "mongo" else []
 
 
 def run_scenario(name: str, sql, t: str) -> None:
@@ -217,13 +228,30 @@ def main() -> int:
     # covered the cross-ENGINE leak (MySQL reading a PostgreSQL offsets.dat) and not
     # the cross-SCENARIO one, which reads identically at the call site.
     work = os.path.join(a.work, a.engine, a.table, a.scenario)
+    # CLEARED, not reused: the sink APPENDS to debezium.jsonl, so re-running one
+    # scenario accumulated its own previous capture and reported a disagreement
+    # against events it had already compared. Third instance of this class in the
+    # harness (cross-engine, then cross-scenario, now cross-RUN) — each one wore the
+    # costume of an engine defect. The dir is derived and owned here; anything worth
+    # keeping is behind --work.
+    shutil.rmtree(work, ignore_errors=True)
     os.makedirs(work, exist_ok=True)
     dbz_slot, riv_slot, pub = f"dbz_{t}", f"riv_{t}", f"pub_{t}"
     # Hyphens, NOT underscores: an underscore is illegal in a hostname per RFC 952,
     # and Debezium's http sink rejects the URL with `unsupported URI` — a message
     # that names the URI without saying which character offends. Cost three runs.
     safe = t.replace("_", "-")
-    sink, srv = f"sink-{safe}", f"srv-{safe}"
+    # The SCENARIO is part of the identity, same as the work dir: named from the
+    # table alone, a leftover `srv-oracle-t` from the previous scenario made the
+    # next one die on `Conflict. The container name is already in use` — a harness
+    # failure that reads as an engine problem. Slots and publications key off the
+    # table on purpose (they are server objects the scenario's own SQL manages).
+    scen = a.scenario.replace("_", "-")
+    sink, srv = f"sink-{safe}-{scen}", f"srv-{safe}-{scen}"
+    # And remove a stale pair before starting: a run killed mid-flight (Ctrl-C, a
+    # timeout) leaves them behind, and the next run must not inherit its capture.
+    for c in (sink, srv):
+        subprocess.run(["docker", "rm", "-f", c], capture_output=True)
 
     net = os.environ.get("CDC_ORACLE_NET") or NETS[a.engine]
     ckpt = os.path.join(work, "rivet.ckpt")
@@ -503,6 +531,7 @@ quarkus.log.level=WARN
                                # compared against NULL. Both fixed; PostgreSQL crud
                                # now AGREES on (op, key, v).
                                *sum((["--value", v] for v in _value_cols(a)), []),
+                               *_rivet_json_column(a),
                                ]
                               # MEASURED after adding ExtractNewDocumentState: the
                               # transform flattens inserts and updates so their `_id`

--- a/dev/cdc-oracle/run.py
+++ b/dev/cdc-oracle/run.py
@@ -77,6 +77,18 @@ def sh(*args, check=True):
     return r
 
 
+def _value_cols(a) -> list:
+    """Which non-key columns to compare, per engine.
+
+    MongoDB is the exception and it is structural, not a TODO: the document is a
+    JSON STRING in the reference and a JSON string in rivet's `document` column,
+    so a text comparison of the two would grade JSON key ORDER and whitespace
+    rather than the values. The op/key comparison plus the per-column null-profile
+    check in the live suite covers that engine; a value diff here would be noise.
+    """
+    return [] if a.engine == "mongo" else ["v"]
+
+
 def run_scenario(name: str, sql, t: str) -> None:
     """Drive one change pattern. Each is a shape the two tools could legitimately
     disagree about, which is the only reason to run it through a differential
@@ -197,7 +209,14 @@ def main() -> int:
     # scenario that has no delete. Both were harness artefacts wearing the costume
     # of a finding, and the second was only obvious because the phantom row named
     # an operation the scenario never performed.
-    work = os.path.join(a.work, a.engine, a.table)
+    # engine / table / SCENARIO. The scenario was missing until 2026-08-25 and the
+    # table name is the same for all of them, so consecutive scenarios on one engine
+    # shared a dir and Debezium's `debezium.jsonl` ACCUMULATED: running crud then
+    # wide-txn reported wide-txn DISAGREE, listing crud's four events as
+    # debezium-only. The README already recorded this artefact as fixed — the fix
+    # covered the cross-ENGINE leak (MySQL reading a PostgreSQL offsets.dat) and not
+    # the cross-SCENARIO one, which reads identically at the call site.
+    work = os.path.join(a.work, a.engine, a.table, a.scenario)
     os.makedirs(work, exist_ok=True)
     dbz_slot, riv_slot, pub = f"dbz_{t}", f"riv_{t}", f"pub_{t}"
     # Hyphens, NOT underscores: an underscore is illegal in a hostname per RFC 952,
@@ -467,18 +486,23 @@ quarkus.log.level=WARN
                                # it under that name and Debezium's after-document
                                # carries it likewise.
                                "--key", "_id" if a.engine == "mongo" else "id",
-                               # Compare the VALUE too. Without it the harness is
-                               # blind to cell corruption: a parquet with 100%% of a
-                               # column NULLed reported AGREE (measured 2026-08-25).
-                               # NOTE: --value is NOT passed by default yet. It is
-                               # proven to catch cell corruption (a parquet with 100%
-                               # of a column NULLed goes from AGREE to four
-                               # differing rows), but the DELETE path still compares
-                               # unequal because the reference carries no `after`
-                               # for a delete and the value extract only reads that
-                               # side. Shipping it on by default would mean a false
-                               # alarm every run, and a harness that cries wolf gets
-                               # muted — which is how the blind spot got here.
+                               # Compare the VALUE too — ON by default as of
+                               # 2026-08-25. Without it the harness is blind to cell
+                               # corruption: a parquet with 100% of a column NULLed
+                               # reports AGREE, measured, and says so in its own
+                               # output now.
+                               #
+                               # It was opt-in because the DELETE path "compared
+                               # unequal". Diagnosing that turned up two defects in
+                               # the COMPARISON, not in either tool: (1) the two
+                               # views projected columns in different orders and
+                               # EXCEPT compares by POSITION, so with values on, all
+                               # four rows of a four-row scenario reported as
+                               # both-sides-only; (2) a DELETE carries its image in
+                               # `before`, not `after`, so rivet's before-image was
+                               # compared against NULL. Both fixed; PostgreSQL crud
+                               # now AGREES on (op, key, v).
+                               *sum((["--value", v] for v in _value_cols(a)), []),
                                ]
                               # MEASURED after adding ExtractNewDocumentState: the
                               # transform flattens inserts and updates so their `_id`

--- a/dev/cdc-oracle/run.py
+++ b/dev/cdc-oracle/run.py
@@ -1,0 +1,500 @@
+#!/usr/bin/env python3
+"""Run one differential scenario: rivet and Debezium over the SAME window.
+
+Window alignment is the whole point of this script. The first hand-run produced
+four spurious `debezium-only` rows purely because Debezium's slot was created
+before rivet's, so the opening batch fell in one window and not the other. A
+harness that reports legitimate timing skew as a difference gets muted within a
+week, so both cursors are established BEFORE any change is applied:
+
+    create table -> create publication -> create BOTH slots -> start Debezium
+    -> wait until it is streaming -> apply changes -> run rivet -> compare
+
+The wait matters as much as the ordering. Debezium's slot exists from the moment
+`CREATE_REPLICATION_SLOT` returns, but the connector only begins consuming once
+it has finished starting; applying changes before that is safe (the slot retains
+them) while applying them before the SLOT exists is not.
+"""
+import argparse, json, os, re, subprocess, sys, time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+# The stands do not all share one docker network: the SQL engines sit in
+# `rivet_default`, the Mongo stands in `stand_default`. The sink must join the
+# SAME network as the source, or Debezium cannot resolve either of them.
+NETS = {"postgres": "rivet_default", "mysql": "rivet_default",
+        "mssql": "rivet_default", "mongo": "stand_default"}
+PG_HOST_IN_NET = os.environ.get("CDC_ORACLE_PG_HOST", "postgres-cdc")
+PG_URL = os.environ.get("POSTGRES_CDC_URL", "postgresql://rivet:rivet@127.0.0.1:5434/rivet")
+PG_EXEC = ["docker", "exec", os.environ.get("CDC_ORACLE_PG_CONTAINER", "rivet-postgres-cdc-1"),
+           "psql", "postgresql://rivet:rivet@127.0.0.1:5432/rivet", "-tAc"]
+MYSQL_HOST_IN_NET = os.environ.get("CDC_ORACLE_MYSQL_HOST", "mysql-cdc")
+MYSQL_URL = os.environ.get("MYSQL_CDC_URL", "mysql://rivet:rivet@127.0.0.1:3307/rivet")
+MYSQL_EXEC = ["docker", "exec", os.environ.get("CDC_ORACLE_MYSQL_CONTAINER", "rivet-mysql-cdc-1"),
+              "mysql", "-uroot", "-privet", "rivet", "-N", "-e"]
+MSSQL_HOST_IN_NET = os.environ.get("CDC_ORACLE_MSSQL_HOST", "mssql-cdc")
+MSSQL_URL = os.environ.get("MSSQL_CDC_URL", "sqlserver://sa:Rivet_Passw0rd!@127.0.0.1:1434/rivet")
+MSSQL_EXEC = ["docker", "exec", os.environ.get("CDC_ORACLE_MSSQL_CONTAINER", "rivet-mssql-cdc-1"),
+              "/opt/mssql-tools18/bin/sqlcmd", "-S", "localhost", "-U", "sa",
+              "-P", "Rivet_Passw0rd!", "-C", "-d", "rivet", "-h", "-1", "-W", "-Q"]
+MONGO_HOST_IN_NET = os.environ.get("CDC_ORACLE_MONGO_HOST", "mongo80-cdc")
+MONGO_URL = os.environ.get("MONGO_CDC_URL", "mongodb://127.0.0.1:27208/rivet?replicaSet=rs0&directConnection=true")
+MONGO_EXEC = ["docker", "exec", os.environ.get("CDC_ORACLE_MONGO_CONTAINER", "stand-mongo80-cdc-1"),
+              "mongosh", "--quiet", "rivet", "--eval"]
+
+
+def mongo(js: str) -> str:
+    r = subprocess.run(MONGO_EXEC + [js], capture_output=True, text=True)
+    if r.returncode != 0:
+        raise SystemExit(f"mongosh failed: {r.stderr.strip()}\n  js: {js}")
+    return r.stdout.strip()
+
+
+def mssql(sql: str) -> str:
+    r = subprocess.run(MSSQL_EXEC + [sql], capture_output=True, text=True)
+    if r.returncode != 0:
+        raise SystemExit(f"sqlcmd failed: {r.stderr.strip()}\n  sql: {sql}")
+    return r.stdout.strip()
+
+
+def mysql(sql: str) -> str:
+    r = subprocess.run(MYSQL_EXEC + [sql], capture_output=True, text=True)
+    if r.returncode != 0:
+        raise SystemExit(f"mysql failed: {r.stderr.strip()}\n  sql: {sql}")
+    return r.stdout.strip()
+
+
+def psql(sql: str) -> str:
+    r = subprocess.run(PG_EXEC + [sql], capture_output=True, text=True)
+    if r.returncode != 0:
+        raise SystemExit(f"psql failed: {r.stderr.strip()}\n  sql: {sql}")
+    return r.stdout.strip()
+
+
+def sh(*args, check=True):
+    r = subprocess.run(args, capture_output=True, text=True)
+    if check and r.returncode != 0:
+        raise SystemExit(f"failed: {' '.join(args)}\n{r.stderr[-500:]}")
+    return r
+
+
+def run_scenario(name: str, sql, t: str) -> None:
+    """Drive one change pattern. Each is a shape the two tools could legitimately
+    disagree about, which is the only reason to run it through a differential
+    harness rather than a plain assertion."""
+    if name == "crud":
+        sql(f"INSERT INTO {t} VALUES (1,'a'),(2,'b')")
+        sql(f"UPDATE {t} SET v='B' WHERE id=2")
+        sql(f"DELETE FROM {t} WHERE id=1")
+    elif name == "key-update":
+        # An UPDATE that MOVES the primary key. PostgreSQL renders it as
+        # `old-key: … new-tuple: …` on one line and rivet has a dedicated split for
+        # it (finding #42); Debezium emits before/after. Whether the two agree on
+        # which key the event belongs to is exactly the kind of question this
+        # harness answers and a self-comparison cannot.
+        sql(f"INSERT INTO {t} VALUES (1,'a')")
+        sql(f"UPDATE {t} SET id=9 WHERE id=1")
+    elif name == "wide-txn":
+        # Many rows in ONE transaction. rivet buffers a transaction whole and never
+        # splits it across parts; the reference has no such constraint. A rollover
+        # boundary landing inside the transaction is where an at-least-once break
+        # would show up as a difference rather than as a count mismatch.
+        vals = ", ".join(f"({i},'v{i}')" for i in range(1, 51))
+        sql(f"INSERT INTO {t} VALUES {vals}")
+        sql(f"UPDATE {t} SET v='x' WHERE id <= 25")
+    elif name == "mid-stream-table":
+        # A table created AFTER both cursors were pinned — Airbyte's
+        # `newTableSnapshotTest`, which this repo has no equivalent of. rivet's
+        # config names one table, so the point is not that it captures the new one:
+        # it is that traffic on a table it does NOT capture must not disturb what it
+        # does. The reference sees only its own include-list too, so agreement here
+        # means both ignored the newcomer the same way.
+        sql(f"CREATE TABLE {t}_late (id int PRIMARY KEY, v text)")
+        sql(f"INSERT INTO {t}_late VALUES (1,'late')")
+        sql(f"INSERT INTO {t} VALUES (1,'a'),(2,'b')")
+        sql(f"UPDATE {t} SET v='B' WHERE id=2")
+    else:
+        raise SystemExit(f"unknown scenario {name}")
+
+
+def run_scenario_mongo(name: str, t: str) -> None:
+    """The same change patterns in the document model.
+
+    `_id` is the key on both sides, and it is IMMUTABLE in MongoDB — so
+    `key-update` cannot be expressed as an update at all. Replacing the document
+    under a new `_id` is delete+insert by construction, which makes Mongo's answer
+    to that scenario structurally the reference's answer. Recorded as `na` rather
+    than run, because a scenario the engine cannot express is not a passing cell.
+    """
+    if name == "crud":
+        mongo(f"db.{t}.insertMany([{{_id:1,v:'a'}},{{_id:2,v:'b'}}]); "
+              f"db.{t}.updateOne({{_id:2}},{{$set:{{v:'B'}}}}); "
+              f"db.{t}.deleteOne({{_id:1}})")
+    elif name == "wide-txn":
+        docs = ", ".join(f"{{_id:{i},v:'v{i}'}}" for i in range(1, 51))
+        mongo(f"db.{t}.insertMany([{docs}]); "
+              f"db.{t}.updateMany({{_id:{{$lte:25}}}},{{$set:{{v:'x'}}}})")
+    elif name == "mid-stream-table":
+        mongo(f"db.{t}_late.insertOne({{_id:1,v:'late'}}); "
+              f"db.{t}.insertMany([{{_id:1,v:'a'}},{{_id:2,v:'b'}}]); "
+              f"db.{t}.updateOne({{_id:2}},{{$set:{{v:'B'}}}})")
+    elif name == "key-update":
+        raise SystemExit("key-update is NA on MongoDB: _id is immutable, so the "
+                         "scenario cannot be expressed — see run_scenario_mongo")
+    else:
+        raise SystemExit(f"unknown scenario {name}")
+
+
+def _write_cfg(work, a, t, ckpt, out) -> str:
+    """One rivet config writer, used for both the MySQL anchoring run and the
+    scenario run — two copies would drift and the anchor would stop anchoring the
+    thing being measured."""
+    if a.engine == "postgres":
+        src, tbl = f'{{ type: postgres, url: "{PG_URL}" }}', f"public.{t}"
+        cdc_opts = f"{{ slot: riv_{t}, until_current: true }}"
+    elif a.engine == "mongo":
+        src, tbl = f'{{ type: mongo, url: "{MONGO_URL}" }}', t
+        cdc_opts = f"{{ until_current: true, checkpoint: {ckpt} }}"
+    elif a.engine == "mssql":
+        src, tbl = f'{{ type: mssql, url: "{MSSQL_URL}" }}', f"dbo.{t}"
+        cdc_opts = f"{{ capture_instance: dbo_{t}, until_current: true, checkpoint: {ckpt} }}"
+    else:
+        src, tbl = f'{{ type: mysql, url: "{MYSQL_URL}" }}', f"rivet.{t}"
+        cdc_opts = f"{{ server_id: 9912, until_current: true, checkpoint: {ckpt} }}"
+    cfg = os.path.join(work, f"rivet_{os.path.basename(out)}.yaml")
+    with open(cfg, "w") as f:
+        f.write(f"""source: {src}
+exports:
+  - name: oracle
+    table: {tbl}
+    mode: cdc
+    format: parquet
+    cdc: {cdc_opts}
+    destination: {{ type: local, path: {out} }}
+""")
+    return cfg
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--engine", default="postgres",
+                    choices=["postgres", "mysql", "mssql", "mongo"])
+    ap.add_argument("--table", default="oracle_t")
+    ap.add_argument("--scenario", default="crud",
+                    choices=["crud", "mid-stream-table", "key-update", "wide-txn"],
+                    help="which change pattern to drive through both tools")
+    ap.add_argument("--work", default="/tmp/cdc-oracle")
+    ap.add_argument("--keep", action="store_true", help="leave the stand fixtures in place")
+    a = ap.parse_args()
+
+    # Work dir is PER ENGINE. Sharing one made the MySQL connector read the
+    # offsets.dat a PostgreSQL run had left behind and die with
+    # `Source offset 'file' parameter is missing` — a message that names neither
+    # the stale file nor the other engine. Found by running the two in sequence.
+    t = a.table
+    # Per ENGINE **and** per TABLE. Sharing across engines made MySQL read a
+    # PostgreSQL offsets.dat; sharing across scenarios let one run's
+    # debezium.jsonl accumulate into the next, which surfaced as a `delete` in a
+    # scenario that has no delete. Both were harness artefacts wearing the costume
+    # of a finding, and the second was only obvious because the phantom row named
+    # an operation the scenario never performed.
+    work = os.path.join(a.work, a.engine, a.table)
+    os.makedirs(work, exist_ok=True)
+    dbz_slot, riv_slot, pub = f"dbz_{t}", f"riv_{t}", f"pub_{t}"
+    # Hyphens, NOT underscores: an underscore is illegal in a hostname per RFC 952,
+    # and Debezium's http sink rejects the URL with `unsupported URI` — a message
+    # that names the URI without saying which character offends. Cost three runs.
+    safe = t.replace("_", "-")
+    sink, srv = f"sink-{safe}", f"srv-{safe}"
+
+    net = os.environ.get("CDC_ORACLE_NET") or NETS[a.engine]
+    ckpt = os.path.join(work, "rivet.ckpt")
+
+    def cleanup():
+        sh("docker", "rm", "-f", sink, srv, check=False)
+        if a.engine == "postgres":
+            psql(f"DROP TABLE IF EXISTS {t}, {t}_late; DROP PUBLICATION IF EXISTS {pub}")
+            psql(f"SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots "
+                 f"WHERE slot_name IN ('{dbz_slot}','{riv_slot}')")
+        elif a.engine == "mongo":
+            mongo(f"db.{t}.drop(); db.{t}_late.drop()")
+        elif a.engine == "mssql":
+            for tt in (t, f"{t}_late"):
+                mssql(f"IF EXISTS (SELECT 1 FROM cdc.change_tables WHERE capture_instance='dbo_{tt}') "
+                      f"EXEC sys.sp_cdc_disable_table @source_schema='dbo', @source_name='{tt}', "
+                      f"@capture_instance='dbo_{tt}'")
+                mssql(f"IF OBJECT_ID('dbo.{tt}') IS NOT NULL DROP TABLE dbo.{tt}")
+        else:
+            mysql(f"DROP TABLE IF EXISTS {t}, {t}_late")
+        subprocess.run(["rm", "-f", ckpt], check=False)
+
+    cleanup()
+    try:
+        # 1. fixture, and rivet's cursor, BEFORE any change.
+        #
+        # The engines pin their cursor differently and that is the whole alignment
+        # question: PostgreSQL's slot is a server-side object created here, while
+        # MySQL has NO server-side anchor — its checkpoint is a file, written by
+        # the first run. So MySQL gets an anchoring run before the scenario, which
+        # is the same guarantee reached by the other of the two documented anchor
+        # models (see CLAUDE.md on per-engine anchors).
+        if a.engine == "postgres":
+            psql(f"CREATE TABLE {t} (id int PRIMARY KEY, v text)")
+            psql(f"CREATE PUBLICATION {pub} FOR TABLE {t}")
+            psql(f"SELECT pg_create_logical_replication_slot('{riv_slot}','test_decoding')")
+        elif a.engine == "mongo":
+            # A change stream needs the collection to EXIST before it can be
+            # watched by name, so create it explicitly rather than relying on the
+            # first insert — which would land before the cursor.
+            mongo(f"db.createCollection('{t}')")
+        elif a.engine == "mssql":
+            # CDC must be enabled on the DB and the table, and the capture job needs
+            # to have populated fn_cdc_get_min_lsn before either tool can read —
+            # "enabled" is not "ready", the trap CLAUDE.md records for this engine.
+            mssql("IF (SELECT is_cdc_enabled FROM sys.databases WHERE name='rivet') = 0 "
+                  "EXEC sys.sp_cdc_enable_db")
+            mssql(f"CREATE TABLE dbo.{t} (id int PRIMARY KEY, v varchar(50))")
+            mssql(f"EXEC sys.sp_cdc_enable_table @source_schema='dbo', @source_name='{t}', "
+                  f"@role_name=NULL, @capture_instance='dbo_{t}'")
+            for _ in range(40):
+                if mssql(f"SELECT sys.fn_cdc_get_min_lsn('dbo_{t}')").strip() not in ("", "NULL"):
+                    break
+                time.sleep(2)
+            else:
+                raise SystemExit("capture instance never became readable")
+        else:
+            mysql(f"CREATE TABLE {t} (id int PRIMARY KEY, v text)")
+
+        # 3. sink inside the stand's network: host.docker.internal did not carry
+        #    the traffic, addressing the receiver by container name does.
+        subprocess.run(["cp", os.path.join(HERE, "sink.py"), work], check=True)
+        sh("docker", "run", "-d", "--name", sink, "--network", net,
+           "-v", f"{work}:/data", "-e", "DBZ_SINK_OUT=/data/debezium.jsonl", "-e", "DBZ_SINK_HEADERS=1",
+           "python:3.12-slim", "python", "/data/sink.py")
+
+        # Per-engine connector config. The two differ in more than credentials:
+        # PostgreSQL needs a publication and a slot name; MySQL needs a server id
+        # distinct from rivet's, or the two dumps evict each other.
+        if a.engine == "postgres":
+            connector_block = f"""debezium.source.connector.class=io.debezium.connector.postgresql.PostgresConnector
+debezium.source.database.hostname={PG_HOST_IN_NET}
+debezium.source.database.port=5432
+debezium.source.database.user=rivet
+debezium.source.database.password=rivet
+debezium.source.database.dbname=rivet
+debezium.source.topic.prefix=oracle
+debezium.source.plugin.name=pgoutput
+debezium.source.slot.name={dbz_slot}
+debezium.source.publication.name={pub}
+debezium.source.table.include.list=public.{t}"""
+        elif a.engine == "mongo":
+            connector_block = f"""debezium.source.connector.class=io.debezium.connector.mongodb.MongoDbConnector
+# The replica set advertises itself as 127.0.0.1:27017, so a driver that follows
+# the RS topology from inside another container dials ITSELF. directConnection
+# skips topology discovery; change streams still work because the node IS an RS
+# member — only the discovery step is bypassed.
+debezium.source.mongodb.connection.string=mongodb://{MONGO_HOST_IN_NET}:27017/?replicaSet=rs0&directConnection=true
+debezium.source.topic.prefix=oracle
+debezium.source.database.include.list=rivet
+debezium.source.collection.include.list=rivet.{t}
+debezium.source.capture.mode=change_streams_update_full
+# A Mongo DELETE carries its `_id` only in the message KEY, and the http sink
+# forwards the value alone — so the body arrives as
+# an empty envelope and the key is unrecoverable. ExtractNewDocumentState
+# lifts the key fields INTO the value (`__key.` prefixed), which is what makes the
+# delete comparable at all. Without it the harness has to exclude Mongo deletes,
+# i.e. stop checking the one operation whose loss is hardest to notice downstream.
+debezium.transforms=unwrap
+debezium.transforms.unwrap.type=io.debezium.connector.mongodb.transforms.ExtractNewDocumentState
+debezium.transforms.unwrap.add.headers=op
+debezium.transforms.unwrap.add.fields=op,id
+debezium.transforms.unwrap.delete.tombstone.handling.mode=rewrite"""
+        elif a.engine == "mssql":
+            connector_block = f"""debezium.source.connector.class=io.debezium.connector.sqlserver.SqlServerConnector
+debezium.source.database.hostname={MSSQL_HOST_IN_NET}
+debezium.source.database.port=1433
+debezium.source.database.user=sa
+debezium.source.database.password=Rivet_Passw0rd!
+debezium.source.database.names=rivet
+debezium.source.database.encrypt=false
+debezium.source.topic.prefix=oracle
+debezium.source.schema.history.internal=io.debezium.storage.file.history.FileSchemaHistory
+debezium.source.schema.history.internal.file.filename=/data/schema-history.dat
+debezium.source.table.include.list=dbo.{t}"""
+        else:
+            connector_block = f"""debezium.source.connector.class=io.debezium.connector.mysql.MySqlConnector
+debezium.source.database.hostname={MYSQL_HOST_IN_NET}
+debezium.source.database.port=3306
+debezium.source.database.user=root
+debezium.source.database.password=rivet
+debezium.source.database.server.id=9911
+debezium.source.topic.prefix=oracle
+debezium.source.schema.history.internal=io.debezium.storage.file.history.FileSchemaHistory
+debezium.source.schema.history.internal.file.filename=/data/schema-history.dat
+debezium.source.table.include.list=rivet.{t}"""
+
+        props = f"""debezium.sink.type=http
+debezium.sink.http.url=http://{sink}:8088/events
+debezium.format.value=json
+debezium.format.value.schemas.enable=false
+debezium.format.key=json
+debezium.format.key.schemas.enable=false
+{connector_block}
+debezium.source.offset.storage.file.filename=/data/offsets.dat
+debezium.source.offset.flush.interval.ms=1000
+debezium.source.snapshot.mode=no_data
+quarkus.log.level=WARN
+"""
+        # The config path is /debezium/config/ — mounting at /conf/ produces only a
+        # WARNING and a process that starts and captures nothing.
+        with open(os.path.join(work, "application.properties"), "w") as f:
+            f.write(props)
+        sh("docker", "run", "-d", "--name", srv, "--network", net,
+           "-v", f"{work}/application.properties:/debezium/config/application.properties",
+           "-v", f"{work}:/data", "quay.io/debezium/server:3.0.0.Final")
+
+        # 4. wait for the connector to be STREAMING, not merely for the container
+        #    to be up. Refuses rather than proceeding: a scenario run against a
+        #    dead reference is the silent-agreement case this harness forbids.
+        for _ in range(60):
+            time.sleep(2)
+            st = sh("docker", "ps", "-q", "--filter", f"name={srv}", check=False).stdout.strip()
+            if not st:
+                # The MESSAGE is near the start of the JSON log line and the stack
+                # frames are the tail — printing the tail shows only frames and
+                # diagnoses nothing, which cost two runs here.
+                raw = sh("docker", "logs", srv, check=False)
+                blob = (raw.stdout or "") + (raw.stderr or "")
+                msgs = re.findall(r'"message"\s*:\s*"(.*?)"', blob)
+                why = "\n".join(dict.fromkeys(m[:300] for m in msgs[-6:])) or blob[:600]
+                raise SystemExit(f"Debezium exited before streaming:\n{why}")
+            if a.engine == "postgres":
+                if psql(f"SELECT active FROM pg_replication_slots "
+                        f"WHERE slot_name='{dbz_slot}'") == "t":
+                    break
+            elif a.engine == "mongo":
+                # Ask the SERVER, not the connector. Debezium writes offsets.dat
+                # only after its FIRST event, and events come after this wait — a
+                # deadlock by construction, and the reason the first attempt hung.
+                # MongoDB reports open cursors in currentOp, and a change stream is
+                # a cursor with a $changeStream pipeline stage, so its presence IS
+                # the readiness signal.
+                cur = mongo("db.getSiblingDB('admin').aggregate(["
+                            "{$currentOp:{idleCursors:true}},"
+                            "{$match:{'cursor.originatingCommand.pipeline.0.$changeStream':"
+                            "{$exists:true}}}]).toArray().length")
+                if cur.strip().isdigit() and int(cur.strip()) > 0:
+                    break
+            elif a.engine == "mssql":
+                # No slot and no dump thread to ask about. The connector's progress
+                # IS its offsets file, so wait for it to appear rather than for the
+                # container to be up — the same distinction the other engines make
+                # with `active` and the binlog dump thread.
+                if os.path.getsize(os.path.join(work, "offsets.dat")) > 0 \
+                        if os.path.exists(os.path.join(work, "offsets.dat")) else False:
+                    break
+            else:
+                # MySQL exposes no per-connector flag, so ask the SERVER who is
+                # dumping its binlog: Debezium shows up in SHOW PROCESSLIST as a
+                # Binlog Dump thread. Waiting on the container being up instead
+                # would let the scenario start against a connector that has not
+                # begun reading — the silent-agreement case by another route.
+                if "Binlog Dump" in mysql("SHOW PROCESSLIST"):
+                    break
+        else:
+            raise SystemExit("Debezium never became active on its slot")
+
+        # 5. the scenario — applied through the engine's own client
+        binary = os.environ.get("RIVET_BIN", "./target/debug/rivet")
+        if a.engine in ("mysql", "mssql", "mongo"):
+            # MySQL has no server-side anchor: the checkpoint file IS the cursor,
+            # and it is written by a run. Anchor BEFORE the scenario so both tools
+            # start from the same point.
+            _anchor_cfg = _write_cfg(work, a, t, ckpt, os.path.join(work, "anchor_out"))
+            subprocess.run([binary, "run", "--config", _anchor_cfg],
+                           capture_output=True, text=True)
+        if a.engine == "mongo":
+            run_scenario_mongo(a.scenario, t)
+        else:
+            exec_sql = {"postgres": psql, "mysql": mysql, "mssql": mssql}[a.engine]
+            run_scenario(a.scenario, exec_sql, t)
+        # Wait for the SOURCE to have made the changes readable, then let the
+        # reference flush. A fixed sleep produced an intermittent false
+        # disagreement on SQL Server: its capture job is asynchronous, and 75
+        # changes did not always reach the change table within 8s — the second run
+        # of the identical scenario agreed. A harness that reports its own race as
+        # a finding is worse than none, so the wait is on the engine's own
+        # progress marker where it has one.
+        if a.engine == "mssql":
+            for _ in range(30):
+                if mssql(f"SELECT COUNT(*) FROM cdc.dbo_{t}_CT").strip().isdigit() and \
+                   int(mssql(f"SELECT COUNT(*) FROM cdc.dbo_{t}_CT").strip()) > 0:
+                    break
+                time.sleep(2)
+            # let the job settle past the last batch it just reported
+            time.sleep(6)
+        # Wait for the REFERENCE to stop producing, not for a clock. A fixed 8s
+        # flush let Debezium deliver 30 of 100 changes on a 75-change SQL Server
+        # scenario, and the 63 resulting `rivet-only` rows read as a finding
+        # against rivet when the truth was that the reference had not finished.
+        # Quiescence is the honest signal: stop when the capture has not grown for
+        # three consecutive checks.
+        jsonl = os.path.join(work, "debezium.jsonl")
+        stable, last = 0, -1
+        for _ in range(60):
+            time.sleep(2)
+            n = sum(1 for _ in open(jsonl)) if os.path.exists(jsonl) else 0
+            stable = stable + 1 if n == last and n > 0 else 0
+            last = n
+            if stable >= 3:
+                break
+        else:
+            print(f"warning: reference never quiesced (last count {last})", file=sys.stderr)
+
+        # 6. rivet over the same window
+        out = os.path.join(work, "rivet_out")
+        subprocess.run(["rm", "-rf", out], check=False)
+        cfg = _write_cfg(work, a, t, ckpt, out)
+        r = subprocess.run([binary, "run", "--config", cfg], capture_output=True, text=True)
+        if r.returncode != 0:
+            print(r.stdout[-800:], r.stderr[-800:], file=sys.stderr)
+            raise SystemExit("rivet run failed")
+
+        # 7. compare — the guard inside refuses a silent capture
+        return subprocess.run([sys.executable, os.path.join(HERE, "compare.py"),
+                               "--rivet-dir", out,
+                               "--debezium-jsonl", os.path.join(work, "debezium.jsonl"),
+                               # MongoDB's key is `_id` on both sides — rivet writes
+                               # it under that name and Debezium's after-document
+                               # carries it likewise.
+                               "--key", "_id" if a.engine == "mongo" else "id",
+                               # Compare the VALUE too. Without it the harness is
+                               # blind to cell corruption: a parquet with 100%% of a
+                               # column NULLed reported AGREE (measured 2026-08-25).
+                               # NOTE: --value is NOT passed by default yet. It is
+                               # proven to catch cell corruption (a parquet with 100%
+                               # of a column NULLed goes from AGREE to four
+                               # differing rows), but the DELETE path still compares
+                               # unequal because the reference carries no `after`
+                               # for a delete and the value extract only reads that
+                               # side. Shipping it on by default would mean a false
+                               # alarm every run, and a harness that cries wolf gets
+                               # muted — which is how the blind spot got here.
+                               ]
+                              # MEASURED after adding ExtractNewDocumentState: the
+                              # transform flattens inserts and updates so their `_id`
+                              # IS comparable, but a delete still arrives as
+                              # `__deleted: true, __op: d` with no key at all. The
+                              # key lives in the message KEY, which the http sink does
+                              # not forward, and no transform option tried lifts it
+                              # for the delete case. Excluded BY FLAG, with the reason
+                              # here and in the README — an excluded op nobody wrote
+                              # down is an op nobody checks.
+                              + (["--exclude-op", "delete"] if a.engine == "mongo" else [])
+                              ).returncode
+    finally:
+        if not a.keep:
+            cleanup()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dev/cdc-oracle/sink.py
+++ b/dev/cdc-oracle/sink.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""HTTP sink for Debezium Server — records every change event as JSONL.
+
+Written to be a FAITHFUL record of what the reference emitted, because everything
+downstream compares against it. Three things the first version got wrong, each of
+which silently corrupted the comparison rather than failing:
+
+1. **HTTP/1.0.** The default closes the connection after each response while
+   Debezium's Java client keeps it alive; the next POST hit a closed socket, the
+   connector logged `IOException: HTTP/1.1 header parser received no bytes` and
+   DROPPED the batch. Measured: 30, 39, 57 of 75 events across identical runs,
+   which read as the reference falling short.
+2. **Single-threaded, listen queue 5.** Connections refused under batch delivery.
+3. **Headers discarded.** Debezium carries metadata in `X-DEBEZIUM-*` headers
+   (base64-encoded Connect values) — the message key among them. Throwing them
+   away is why MongoDB deletes could not be compared by key.
+
+So: HTTP/1.1 with an explicit Content-Length, threaded with a deep queue, and the
+headers merged into each record under `__headers` rather than dropped.
+"""
+import base64, json, os, sys, threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+OUT = os.environ.get("DBZ_SINK_OUT", "/data/debezium.jsonl")
+_LOCK = threading.Lock()
+
+
+def _decode(v: str):
+    """Debezium base64-encodes header values as serialised Connect data. Decode
+    when it round-trips as JSON; otherwise keep the raw string — a lossy guess
+    would be worse than an unparsed value the comparison can still see."""
+    try:
+        raw = base64.b64decode(v, validate=True).decode("utf-8")
+    except Exception:
+        return v
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+
+
+class H(BaseHTTPRequestHandler):
+    # Load-bearing: see the module docstring. HTTP/1.0 loses batches.
+    protocol_version = "HTTP/1.1"
+
+    def do_POST(self):
+        n = int(self.headers.get("content-length", 0))
+        body = self.rfile.read(n)
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            payload = [{"_unparsed": body.decode("utf-8", "replace")}]
+        events = payload if isinstance(payload, list) else [payload]
+        hdrs = {k: _decode(v) for k, v in self.headers.items()
+                if k.upper().startswith("X-DEBEZIUM-")}
+        with _LOCK, open(OUT, "a") as f:
+            for e in events:
+                if isinstance(e, dict) and hdrs:
+                    e = {**e, "__headers": hdrs}
+                f.write(json.dumps(e, sort_keys=True) + "\n")
+        # An explicit zero-length body: under HTTP/1.1 a response with neither a
+        # Content-Length nor chunked encoding leaves the client waiting, which
+        # loses the batch by a slower route.
+        self.send_response(204)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def log_message(self, *a):
+        pass
+
+
+class Server(ThreadingHTTPServer):
+    daemon_threads = True
+    request_queue_size = 128
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("DBZ_SINK_PORT", "8088"))
+    print(f"debezium sink on :{port} -> {OUT}", flush=True)
+    Server(("0.0.0.0", port), H).serve_forever()

--- a/dev/cdc/mysql-grant.sql
+++ b/dev/cdc/mysql-grant.sql
@@ -2,4 +2,10 @@
 -- Granted on the dedicated `mysql-cdc` instance so the shared `mysql` service
 -- stays minimal. The `rivet` user itself is created by MYSQL_USER/MYSQL_DATABASE.
 GRANT REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'rivet'@'%';
+-- SYSTEM_VARIABLES_ADMIN so a live test can flip `binlog_row_metadata` to
+-- MINIMAL — MySQL's OWN default, and the only setting under which the sink's
+-- positional image mapping and its arity guard are reachable. The stack pins
+-- FULL (see docker-compose), so without this grant the engine's default
+-- configuration is the one configuration nothing tests.
+GRANT SYSTEM_VARIABLES_ADMIN ON *.* TO 'rivet'@'%';
 FLUSH PRIVILEGES;

--- a/dev/release_oracle/__main__.py
+++ b/dev/release_oracle/__main__.py
@@ -350,6 +350,7 @@ def preflight(led: Ledger, *, bless_gifs: bool = False) -> None:
     scenarios.verify_pool_e2e(led)
     scenarios.verify_pool_split(led)
     cdc.verify_cdc_e2e(led)
+    cdc.verify_cdc_differential(led)
     regression.verify_release_regression(led)
     # The two prev-release harnesses, next to the stage that shares their
     # baseline (`RIVET_PREV_RELEASE_BIN`) — and, like it, they FAIL rather than

--- a/dev/release_oracle/cdc.py
+++ b/dev/release_oracle/cdc.py
@@ -36,7 +36,10 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
 import sqlite3
+import subprocess
+import sys
 import tempfile
 import time
 import urllib.parse
@@ -1078,3 +1081,77 @@ def _cdc_state_snapshot_pg(surl: str) -> dict[str, str]:
     r = q("SELECT count(*)||' '||COALESCE(sum((status='success')::int),0) FROM run_status").split()
     snap["run_status_all_success"] = "yes" if len(r) == 2 and r[0] != "0" and r[0] == r[1] else "no"
     return snap
+
+
+# ── the differential oracle: rivet vs Debezium over the SAME window ──────────
+#
+# `verify_cdc_e2e` above compares the destination to the SOURCE, per-column null
+# profile and distinct counts included. It catches loss and degrade-to-null. It is
+# structurally blind to rivet and its own oracle agreeing on a wrong SPEC — which
+# is what an INDEPENDENT implementation of the same capture catches, and nothing
+# else in this gate does.
+#
+# The harness (`dev/cdc-oracle/run.py`) stands the reference up itself: pulls
+# quay.io/debezium/server, puts a receiver on the stand network, and waits on the
+# engine's OWN readiness signal (PG `pg_replication_slots.active`, MySQL's Binlog
+# Dump thread in SHOW PROCESSLIST, MSSQL/Mongo offsets). Every config trap it hit
+# is written down in that directory's README, and each one presents identically:
+# "started and captured nothing".
+#
+# Scenario choice, said plainly: `key-update` is EXCLUDED. rivet emits `update(new)`
+# where Debezium emits `delete(old)+insert(new)`, identically on PostgreSQL and
+# MySQL, and that is a representation decision rather than a defect — a gate cell
+# that EXPECTS a difference would go green on the day someone fixes it, which is
+# the wrong direction for a ratchet. It belongs in the ADR, not here.
+_DIFFERENTIAL_SCENARIOS = ("crud", "wide-txn", "mid-stream-table")
+
+
+def verify_cdc_differential(led: "Ledger") -> None:
+    """rivet and Debezium over one window, compared in DuckDB.
+
+    SKIPS loudly when docker or the harness is unavailable — the ledger carries an
+    explicit Skipped that is not a pass. It does NOT fail the release on a missing
+    reference image, because an unreachable quay.io is an infrastructure fact about
+    the runner rather than a statement about the build.
+    """
+    root = Path(__file__).resolve().parents[2]
+    runner = root / "dev" / "cdc-oracle" / "run.py"
+    if not runner.is_file():
+        led.skipped("-", "cdc", "differential", "-",
+                    f"differential: {runner} absent", "no harness")
+        return
+    if shutil.which("docker") is None:
+        led.skipped("-", "cdc", "differential", "-",
+                    "differential: docker unavailable on this runner", "no docker")
+        return
+
+    led.phase("CDC differential [rivet vs Debezium] (same window, compared in DuckDB)")
+    for eng in ("postgres", "mysql", "mssql", "mongo"):
+        for scen in _DIFFERENTIAL_SCENARIOS:
+            r = subprocess.run(
+                [sys.executable, str(runner), "--engine", eng, "--scenario", scen],
+                capture_output=True, text=True, timeout=900,
+            )
+            tail = (r.stdout or "")[-600:] + (r.stderr or "")[-600:]
+            if r.returncode == 0 and "AGREE" in (r.stdout or ""):
+                # The message names its own scope. A run that compared only
+                # (op, key) says so, and that is NOT the check this row claims —
+                # so it is graded as a failure rather than quietly accepted.
+                if "VALUES NOT COMPARED" in r.stdout:
+                    led.failed(eng, "cdc", f"differential:{scen}", "-",
+                               f"differential[{eng}/{scen}]: values were not compared "
+                               f"— the row claims a value-level check", "no values")
+                else:
+                    led.passed(eng, "cdc", f"differential:{scen}", "-",
+                               f"differential[{eng}/{scen}]: AGREE with values")
+            elif "DISAGREE" in (r.stdout or ""):
+                led.failed(eng, "cdc", f"differential:{scen}", "-",
+                           f"differential[{eng}/{scen}]: DISAGREE\n{tail}", "disagree")
+            else:
+                # Neither AGREE nor DISAGREE: the harness itself did not complete.
+                # Seven plumbing artefacts in two days say this happens, and a gate
+                # that reports its own races as release blockers gets muted — so it
+                # is a SKIP with the tail attached, never a silent pass.
+                led.skipped(eng, "cdc", f"differential:{scen}", "-",
+                            f"differential[{eng}/{scen}]: harness did not complete\n{tail}",
+                            "harness")

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -260,7 +260,11 @@ services:
       - "--max-connections=400"
       # FULL puts column NAMES into TABLE_MAP optional metadata (8.0.1+) —
       # the sink then maps binlog images BY NAME, closing the positional
-      # class on MySQL (doctor recommends this in production too).
+      # class on MySQL. MySQL's OWN default is MINIMAL, so this pin makes the
+      # stack UNLIKE a default deployment: two live tests flip the global back
+      # to MINIMAL under a reset guard (`RowMetadata`) precisely so the engine
+      # default is not the one configuration nothing exercises. rivet warns at
+      # run start when it sees a non-FULL value — measured swap, not folklore.
       - "--binlog-row-metadata=FULL"
     environment:
       MYSQL_ROOT_PASSWORD: rivet

--- a/docs/cdc-evidence-matrix.yaml
+++ b/docs/cdc-evidence-matrix.yaml
@@ -162,10 +162,25 @@ shapes:
     mutant: >
       Feed the boundary its unknown value and assert a warning/error is produced. A silent
       arm passes today because nothing observes the degradation.
-    postgres: { absent: "any test_decoding line that is not INSERT/UPDATE/DELETE — TRUNCATE
-        above all — is dropped with no log, no counter, no test (cdc.rs:390,576-592)" }
-    mysql:    { absent: "a transaction group with no Xid marker is buffered and never emitted
-        (mysql/cdc.rs:360-398)" }
+    postgres:
+      sound: "TRUNCATE — the one that mattered — now bails: truncate_target +
+        truncate_is_ours + truncate_refusal_message (src/source/postgres/cdc.rs),
+        graded offline by a_truncate_is_recognised_and_refused_only_for_the_captured_tables
+        and live by roast_pg_cdc_refuses_a_truncate_instead_of_silently_diverging.
+        RED against two mutants on different asserts: the guard removed (back to the
+        measured `status: success, rows: 2` over an EMPTY source) and the refusal
+        un-addressed (`if true`, which fails a bystander export on the same slot).
+        Other non-DML lines stay unhandled and that is deliberate — TRUNCATE is the
+        one that removes rows without events, so it is the one that diverges."
+    mysql:
+      sound: "the Xid-less group is closed by is_commit_statement (COMMIT / XA COMMIT,
+        #ebc9d87), and the OTHER silent QUERY-event drop — TRUNCATE — now bails:
+        truncate_target + truncate_refusal_message (src/source/mysql/cdc.rs), graded by
+        a_mysql_truncate_statement_resolves_the_table_it_names offline and
+        roast_mysql_cdc_refuses_a_truncate_instead_of_silently_diverging live. RED
+        against two mutants on different asserts: the guard disabled (back to the
+        measured `status: success, rows: 2` over an EMPTY source) and the addressing
+        removed (which fails a bystander export reading the same binlog)."
     mssql:    { absent: "a checkpoint JSON that parses but lacks its engine's key degrades to
         'no checkpoint' — MySQL uses ok_or_else here, MSSQL does not" }
     mongo:    { absent: "a `hello` without operationTime leaves the load-bearing cluster-time

--- a/docs/cdc-evidence-matrix.yaml
+++ b/docs/cdc-evidence-matrix.yaml
@@ -148,14 +148,40 @@ shapes:
       Pre-ack manifest: publish only `&s.parts[len-1..]` instead of the whole slice.
       Form B: `*e = sum` instead of `wrapping_add`. MEASURED: the manifest mutant leaves
       the lib suite at 2607 passed, 0 failed.
-    postgres: { gap: "shared sink — the MBT manifest fixture inserts 30 rows in ONE
-        autocommit statement at rollover 10, and should_roll gates on `committed`
-        (sink.rs:106-110) so it yields ONE part; the '3 parts' comments at
-        live_cdc_mbt.rs:289,386 are wrong" }
-    mysql:    { gap: "same shared fixture" }
-    mssql:    { gap: "same shared fixture" }
-    mongo:    { gap: "same shared fixture" }
-
+    postgres:
+      na: >-
+        na — the manifest fold lives in the SHARED sink (`build_manifest` over `s.parts`,
+        src/source/cdc/sink.rs), not in any engine adapter: no engine can reach a different
+        fold, so it is proven once on the fixture that drives it rather than four times. This
+        is the shared-seam/gap distinction the runner-coverage matrix draws — a feature applied
+        by construction is `na`, a feature each engine must re-apply is a `gap`. The threshold
+        rule itself is engine-agnostic for the same reason. Graded on mysql; see that cell.
+    mysql:
+      sound: >-
+        closed 2026-08-25. The fixture inserted 30 rows in ONE autocommit statement at rollover
+        10; `should_roll` gates on `committed`, which marks a TRANSACTION boundary, so it
+        yielded exactly ONE part while two comments claimed three (MEASURED parts=1). A fold
+        over one element makes every fold operator identical. Split into three statements
+        (MEASURED parts=3). Proof that the FIXTURE was the defect, not the assertion: with the
+        pre-ack manifest mutant (publish only `&s.parts[len-1..]`) applied, the OLD one-INSERT
+        fixture stays GREEN and the new three-statement one goes RED — same mutant, same
+        assertions, different fixture (tests/live/live_cdc_mbt.rs).
+    mssql:
+      na: >-
+        na — the manifest fold lives in the SHARED sink (`build_manifest` over `s.parts`,
+        src/source/cdc/sink.rs), not in any engine adapter: no engine can reach a different
+        fold, so it is proven once on the fixture that drives it rather than four times. This
+        is the shared-seam/gap distinction the runner-coverage matrix draws — a feature applied
+        by construction is `na`, a feature each engine must re-apply is a `gap`. The threshold
+        rule itself is engine-agnostic for the same reason. Graded on mysql; see that cell.
+    mongo:
+      na: >-
+        na — the manifest fold lives in the SHARED sink (`build_manifest` over `s.parts`,
+        src/source/cdc/sink.rs), not in any engine adapter: no engine can reach a different
+        fold, so it is proven once on the fixture that drives it rather than four times. This
+        is the shared-seam/gap distinction the runner-coverage matrix draws — a feature applied
+        by construction is `na`, a feature each engine must re-apply is a `gap`. The threshold
+        rule itself is engine-agnostic for the same reason. Graded on mysql; see that cell.
   - id: runs_the_engine_default_configuration
     what: >
       The stand must exercise the configuration an untuned production server has. A stand

--- a/docs/cdc-evidence-matrix.yaml
+++ b/docs/cdc-evidence-matrix.yaml
@@ -240,14 +240,40 @@ shapes:
       Each CDC fault hook must have a per-engine crash test. A hook covered on two engines
       of four is a guarantee claimed for four.
     mutant: "remove the hook's handling and see which engines notice"
-    postgres: { gap: "cdc_after_checkpoint_before_ack — no per-engine test" }
-    mysql:    { gap: "the audit reported both hooks covered but cited no test; without a
-        named test this cannot be promoted — `sound` means someone ran the mutant and
-        watched a SPECIFIC test fail" }
-    mssql:    { gap: "same — reported covered, no test named" }
-    mongo:    { gap: "cdc_after_checkpoint_before_ack — no per-engine test; and see
-        resume_reads_a_fresh_destination, which makes the other hook's cell vacuous too" }
-
+    postgres:
+      sound: >-
+        closed 2026-08-25. roast_pg_cdc_crash_between_checkpoint_and_ack_re_reads_and_releases_the_slot
+        (tests/live/live_cdc.rs). The DELIVERY half DOCUMENTS — three mutants (ack before the
+        checkpoint, ack before the flush, ack to pg_current_wal_lsn) all stay green, because
+        the crash fires before run 1's first ack and PG's resume authority is the SLOT, which
+        run 1 never moved; the checkpoint file is a boolean (`resume_expected`), never a
+        position. The RETENTION half GUARDS: the crash pins 2304 B and the resume releases to
+        0, and neutering advance_slot leaves 2480 B pinned (RED). Closes the slot-pinning
+        class from the crash side, where empty_transaction_churn covers the row-less side.
+    mysql:
+      sound: >-
+        covered by cdc_fault_point_sweep_every_phase_boundary_recovers (tests/live/live_cdc_mbt.rs),
+        which drives this hook among every phase boundary on the mysql-cdc stand. MySQL's ack
+        is the trait no-op, so the checkpoint file alone carries resume — the same structural
+        argument written out on the mongo cell, verified there against two ordering mutants.
+    mssql:
+      sound: >-
+        covered by the dedicated test at tests/live/live_cdc_mssql.rs (the 12-row single-LSN
+        transaction crashed at cdc_after_checkpoint_before_ack). This is the one engine where
+        the hook is LOAD-BEARING rather than documentary: the checkpoint IS the only resume
+        position and the ack is a no-op, so a checkpoint written mid-transaction skips the
+        tail — the bug that test was RED-proven against.
+    mongo:
+      sound: >-
+        closed 2026-08-25. mongo_cdc_crash_after_the_checkpoint_still_delivers_every_change
+        (tests/live/live_cdc_mongo.rs), sibling to the cdc_after_flush_before_ack test whose
+        vacuity this row used to cite — that one was fixed by resume_into_fresh_dest and is
+        sound now. Two ordering mutants stay green for the structural reason stated in the
+        test (the hook sits after every durability step; the resume token is per-event and
+        consume-free, see TxnFramer::single_event_commit). What it grades is its
+        preconditions: an empty resume leg fails outright, RED-proven by deleting the resume
+        run. Oracle is the UNION of both legs — crashing AFTER the checkpoint means the
+        resume legitimately starts past what leg 1 covered.
   - id: the_test_asserts_its_own_fault_fired
     what: >
       A fault-injection test must assert the injected fault ACTUALLY fired. Otherwise a

--- a/docs/cdc-evidence-matrix.yaml
+++ b/docs/cdc-evidence-matrix.yaml
@@ -390,61 +390,65 @@ shapes:
       and the test refuses to skip when the marker is present.
     mutant: "unset the precondition and observe whether the suite still reports the claim covered"
     postgres:
-      gap: >-
-        PARTIALLY closed 2026-08-25, and the honest split matters. The WORST instance of this
-        class was not in the live suite at all: all six runners in tests/harness/mod.rs
-        answered a missing warehouse env with an empty result, so 20 oracle-fixture cells
-        reported `20 passed` in 0.00s on every machine (that variable is in no workflow). Fixed
-        + guarded (tests/offline/skip_is_not_a_pass_guard.rs). What REMAINS on this engine is
-        milder and is stated rather than claimed closed: the standby refusal test (roast_pg_cdc_bounded_on_a_standby_fails_loud) and the pg18 governor catalog test return early when an opt-in
-        profile is not up, printing a SKIP line that `cargo test` still reports as `ok`. The
-        release oracle does NOT share this defect — it carries an explicit SKIP status,
-        distinct from pass, by design. The structural fix for the live suite is a marker
-        protocol the release lane can COUNT (assert N skips, not zero failures); it is named
-        here rather than half-built, because a guard that greps for early returns had ten
-        false positives out of eleven when tried on the sibling class.
+      sound: >-
+        closed 2026-08-25. The worst instance was in tests/harness/mod.rs — six runners
+        answering a missing warehouse env with an EMPTY result, so 20 oracle-fixture cells
+        reported `20 passed` in 0.00s on every machine. That half was fixed and guarded first.
+        The live half is now closed too: `cargo test` prints `ok` for a test that returned
+        early, and the 22 skip sites said `SKIP`, `skip:`, `skipping:` and `... — skipping` in
+        four different spellings, so a release lane could not grep for them. One marker now
+        (`skip_live`, tests/common/mod.rs) printing `RIVET-SKIP <test> — <why>`, verified live.
+        Guarded by a_live_test_that_skips_says_so_through_the_one_marker
+        (tests/offline/skip_is_not_a_pass_guard.rs), which is WINDOW-based rather than
+        line-based — the first cut checked one line and sailed past every multi-line macro,
+        found by RED-proving the guard rather than reading it, and the rewrite immediately
+        surfaced four more sites including this engine's own standby test. RED-proven by
+        reverting a site to its own words.
     mysql:
-      gap: >-
-        PARTIALLY closed 2026-08-25, and the honest split matters. The WORST instance of this
-        class was not in the live suite at all: all six runners in tests/harness/mod.rs
-        answered a missing warehouse env with an empty result, so 20 oracle-fixture cells
-        reported `20 passed` in 0.00s on every machine (that variable is in no workflow). Fixed
-        + guarded (tests/offline/skip_is_not_a_pass_guard.rs). What REMAINS on this engine is
-        milder and is stated rather than claimed closed: the two compressed-binlog tests (mysql_cdc_refuses_a_compressed_binlog..., mysql_cdc_compressed_payload_in_stream_refuses_not_skips) return early when an opt-in
-        profile is not up, printing a SKIP line that `cargo test` still reports as `ok`. The
-        release oracle does NOT share this defect — it carries an explicit SKIP status,
-        distinct from pass, by design. The structural fix for the live suite is a marker
-        protocol the release lane can COUNT (assert N skips, not zero failures); it is named
-        here rather than half-built, because a guard that greps for early returns had ten
-        false positives out of eleven when tried on the sibling class.
+      sound: >-
+        closed 2026-08-25. The worst instance was in tests/harness/mod.rs — six runners
+        answering a missing warehouse env with an EMPTY result, so 20 oracle-fixture cells
+        reported `20 passed` in 0.00s on every machine. That half was fixed and guarded first.
+        The live half is now closed too: `cargo test` prints `ok` for a test that returned
+        early, and the 22 skip sites said `SKIP`, `skip:`, `skipping:` and `... — skipping` in
+        four different spellings, so a release lane could not grep for them. One marker now
+        (`skip_live`, tests/common/mod.rs) printing `RIVET-SKIP <test> — <why>`, verified live.
+        Guarded by a_live_test_that_skips_says_so_through_the_one_marker
+        (tests/offline/skip_is_not_a_pass_guard.rs), which is WINDOW-based rather than
+        line-based — the first cut checked one line and sailed past every multi-line macro,
+        found by RED-proving the guard rather than reading it, and the rewrite immediately
+        surfaced four more sites including this engine's own standby test. RED-proven by
+        reverting a site to its own words.
     mssql:
-      gap: >-
-        PARTIALLY closed 2026-08-25, and the honest split matters. The WORST instance of this
-        class was not in the live suite at all: all six runners in tests/harness/mod.rs
-        answered a missing warehouse env with an empty result, so 20 oracle-fixture cells
-        reported `20 passed` in 0.00s on every machine (that variable is in no workflow). Fixed
-        + guarded (tests/offline/skip_is_not_a_pass_guard.rs). What REMAINS on this engine is
-        milder and is stated rather than claimed closed: no CDC test on this engine skips silently; the shared live sites that do (state-backend parity, validate-exit) are engine-agnostic return early when an opt-in
-        profile is not up, printing a SKIP line that `cargo test` still reports as `ok`. The
-        release oracle does NOT share this defect — it carries an explicit SKIP status,
-        distinct from pass, by design. The structural fix for the live suite is a marker
-        protocol the release lane can COUNT (assert N skips, not zero failures); it is named
-        here rather than half-built, because a guard that greps for early returns had ten
-        false positives out of eleven when tried on the sibling class.
+      sound: >-
+        closed 2026-08-25. The worst instance was in tests/harness/mod.rs — six runners
+        answering a missing warehouse env with an EMPTY result, so 20 oracle-fixture cells
+        reported `20 passed` in 0.00s on every machine. That half was fixed and guarded first.
+        The live half is now closed too: `cargo test` prints `ok` for a test that returned
+        early, and the 22 skip sites said `SKIP`, `skip:`, `skipping:` and `... — skipping` in
+        four different spellings, so a release lane could not grep for them. One marker now
+        (`skip_live`, tests/common/mod.rs) printing `RIVET-SKIP <test> — <why>`, verified live.
+        Guarded by a_live_test_that_skips_says_so_through_the_one_marker
+        (tests/offline/skip_is_not_a_pass_guard.rs), which is WINDOW-based rather than
+        line-based — the first cut checked one line and sailed past every multi-line macro,
+        found by RED-proving the guard rather than reading it, and the rewrite immediately
+        surfaced four more sites including this engine's own standby test. RED-proven by
+        reverting a site to its own words.
     mongo:
       sound: >-
-        PARTIALLY closed 2026-08-25, and the honest split matters. The WORST instance of this
-        class was not in the live suite at all: all six runners in tests/harness/mod.rs
-        answered a missing warehouse env with an empty result, so 20 oracle-fixture cells
-        reported `20 passed` in 0.00s on every machine (that variable is in no workflow). Fixed
-        + guarded (tests/offline/skip_is_not_a_pass_guard.rs). What REMAINS on this engine is
-        milder and is stated rather than claimed closed: the pre-image test added today, which self-skips below server 6.0 and says the version it saw return early when an opt-in
-        profile is not up, printing a SKIP line that `cargo test` still reports as `ok`. The
-        release oracle does NOT share this defect — it carries an explicit SKIP status,
-        distinct from pass, by design. The structural fix for the live suite is a marker
-        protocol the release lane can COUNT (assert N skips, not zero failures); it is named
-        here rather than half-built, because a guard that greps for early returns had ten
-        false positives out of eleven when tried on the sibling class.
+        closed 2026-08-25. The worst instance was in tests/harness/mod.rs — six runners
+        answering a missing warehouse env with an EMPTY result, so 20 oracle-fixture cells
+        reported `20 passed` in 0.00s on every machine. That half was fixed and guarded first.
+        The live half is now closed too: `cargo test` prints `ok` for a test that returned
+        early, and the 22 skip sites said `SKIP`, `skip:`, `skipping:` and `... — skipping` in
+        four different spellings, so a release lane could not grep for them. One marker now
+        (`skip_live`, tests/common/mod.rs) printing `RIVET-SKIP <test> — <why>`, verified live.
+        Guarded by a_live_test_that_skips_says_so_through_the_one_marker
+        (tests/offline/skip_is_not_a_pass_guard.rs), which is WINDOW-based rather than
+        line-based — the first cut checked one line and sailed past every multi-line macro,
+        found by RED-proving the guard rather than reading it, and the rewrite immediately
+        surfaced four more sites including this engine's own standby test. RED-proven by
+        reverting a site to its own words.
   - id: delete_semantics_are_end_to_end
     what: >
       Tombstones and the 'live current state is WHERE NOT __is_deleted' contract must be

--- a/docs/cdc-evidence-matrix.yaml
+++ b/docs/cdc-evidence-matrix.yaml
@@ -253,12 +253,74 @@ shapes:
       A fault-injection test must assert the injected fault ACTUALLY fired. Otherwise a
       hook that stops firing turns the test into a plain happy-path run that passes.
     mutant: "make the hook a no-op; a sound cell goes RED on 'the fault never fired'"
-    postgres: { gap: "not audited per-test; the class is proven on mysql" }
-    mysql:    { vacuous: "gremlin_cdc_sigkill_mid_drain_recovers_without_gap never asserts its
-        own fault fired (gremlin_cdc.rs)", kind: absence-only }
-    mssql:    { gap: "not audited per-test" }
-    mongo:    { gap: "not audited per-test" }
-
+    postgres:
+      sound: >-
+        audited 2026-08-25 across the whole live suite, not sampled — the sweep enumerated every test whose CODE (comments stripped — ten of eleven first-pass
+        hits were the word 'kill' in prose) injects a fault: RIVET_TEST_{PANIC,ERROR,BLOCK}_AT,
+        a real kill(1), or a toxiproxy toxic — 71 tests. Exactly ONE did not assert its own
+        fault fired: gremlin_cdc_sigkill_mid_drain_recovers_without_gap (tests/live/gremlin_cdc.rs) computed
+        killed_mid_drain and only interpolated it into the failure MESSAGE, so a run that
+        drained before the kill landed passed having verified nothing. It now asserts both
+        that the kill fired AND that it mattered (measured 3/3: 500 of 5000 rows survive, so a
+        kill at the finish line — which grades like no kill at all — is refused too). Every
+        other test proves it in the body, in a shared runner (run_pool_split_resume_with
+        asserts !crashed.status.success() plus an INCOMPLETE split), or inside the injector
+        itself: the toxi_* helpers assert the admin API answered 200, which is why eleven
+        toxiproxy tests are sound without saying so at the call site. Pinned by
+        every_toxiproxy_fault_injector_asserts_its_own_injection_landed
+        (tests/offline/skip_is_not_a_pass_guard.rs). RED-proven by
+        disabling the kill window (parts >= 99999) and by stripping one injector's assert.
+    mysql:
+      sound: >-
+        closed 2026-08-25 — the sweep enumerated every test whose CODE (comments stripped — ten of eleven first-pass
+        hits were the word 'kill' in prose) injects a fault: RIVET_TEST_{PANIC,ERROR,BLOCK}_AT,
+        a real kill(1), or a toxiproxy toxic — 71 tests. Exactly ONE did not assert its own
+        fault fired: gremlin_cdc_sigkill_mid_drain_recovers_without_gap (tests/live/gremlin_cdc.rs) computed
+        killed_mid_drain and only interpolated it into the failure MESSAGE, so a run that
+        drained before the kill landed passed having verified nothing. It now asserts both
+        that the kill fired AND that it mattered (measured 3/3: 500 of 5000 rows survive, so a
+        kill at the finish line — which grades like no kill at all — is refused too). Every
+        other test proves it in the body, in a shared runner (run_pool_split_resume_with
+        asserts !crashed.status.success() plus an INCOMPLETE split), or inside the injector
+        itself: the toxi_* helpers assert the admin API answered 200, which is why eleven
+        toxiproxy tests are sound without saying so at the call site. Pinned by
+        every_toxiproxy_fault_injector_asserts_its_own_injection_landed
+        (tests/offline/skip_is_not_a_pass_guard.rs). RED-proven by
+        disabling the kill window (parts >= 99999) and by stripping one injector's assert.
+    mssql:
+      sound: >-
+        audited 2026-08-25 across the whole live suite, not sampled — the sweep enumerated every test whose CODE (comments stripped — ten of eleven first-pass
+        hits were the word 'kill' in prose) injects a fault: RIVET_TEST_{PANIC,ERROR,BLOCK}_AT,
+        a real kill(1), or a toxiproxy toxic — 71 tests. Exactly ONE did not assert its own
+        fault fired: gremlin_cdc_sigkill_mid_drain_recovers_without_gap (tests/live/gremlin_cdc.rs) computed
+        killed_mid_drain and only interpolated it into the failure MESSAGE, so a run that
+        drained before the kill landed passed having verified nothing. It now asserts both
+        that the kill fired AND that it mattered (measured 3/3: 500 of 5000 rows survive, so a
+        kill at the finish line — which grades like no kill at all — is refused too). Every
+        other test proves it in the body, in a shared runner (run_pool_split_resume_with
+        asserts !crashed.status.success() plus an INCOMPLETE split), or inside the injector
+        itself: the toxi_* helpers assert the admin API answered 200, which is why eleven
+        toxiproxy tests are sound without saying so at the call site. Pinned by
+        every_toxiproxy_fault_injector_asserts_its_own_injection_landed
+        (tests/offline/skip_is_not_a_pass_guard.rs). RED-proven by
+        disabling the kill window (parts >= 99999) and by stripping one injector's assert.
+    mongo:
+      sound: >-
+        audited 2026-08-25 across the whole live suite, not sampled — the sweep enumerated every test whose CODE (comments stripped — ten of eleven first-pass
+        hits were the word 'kill' in prose) injects a fault: RIVET_TEST_{PANIC,ERROR,BLOCK}_AT,
+        a real kill(1), or a toxiproxy toxic — 71 tests. Exactly ONE did not assert its own
+        fault fired: gremlin_cdc_sigkill_mid_drain_recovers_without_gap (tests/live/gremlin_cdc.rs) computed
+        killed_mid_drain and only interpolated it into the failure MESSAGE, so a run that
+        drained before the kill landed passed having verified nothing. It now asserts both
+        that the kill fired AND that it mattered (measured 3/3: 500 of 5000 rows survive, so a
+        kill at the finish line — which grades like no kill at all — is refused too). Every
+        other test proves it in the body, in a shared runner (run_pool_split_resume_with
+        asserts !crashed.status.success() plus an INCOMPLETE split), or inside the injector
+        itself: the toxi_* helpers assert the admin API answered 200, which is why eleven
+        toxiproxy tests are sound without saying so at the call site. Pinned by
+        every_toxiproxy_fault_injector_asserts_its_own_injection_landed
+        (tests/offline/skip_is_not_a_pass_guard.rs). RED-proven by
+        disabling the kill window (parts >= 99999) and by stripping one injector's assert.
   - id: skip_is_not_a_pass
     what: >
       A test that SKIPS when its precondition is absent reports success. Where a CI job

--- a/docs/cdc-evidence-matrix.yaml
+++ b/docs/cdc-evidence-matrix.yaml
@@ -167,13 +167,15 @@ shapes:
         session-state class it DOES have (timezone/datestyle/bytea_output) is pinned on the
         reader's own connection and has its own non-default test" }
     mysql:
-      vacuous: "docker-compose.yaml:264 pins --binlog-row-metadata=FULL; MySQL's default is
-        MINIMAL. Under FULL the sink takes the by-NAME arm and SKIPS the arity guard
-        entirely (sink.rs:683). Every live MySQL CDC test uses MYSQL_CDC_URL -> :3307 -> the
-        named path. The nameless arm has one 2-column live test (live_cdc_replica.rs:94,
-        behind the `replica` profile) and one offline test whose fixture is a SINGLE column.
-        Verified by hand 2026-08-23: `SELECT @@binlog_row_metadata` on the stand returns FULL."
-      kind: below-threshold
+      sound: >-
+        closed 2026-08-25. docker-compose pins --binlog-row-metadata=FULL while MySQL's
+        own default is MINIMAL, so every live MySQL CDC test ran the by-NAME arm and the
+        positional arm plus its arity guard were unreachable. Two live tests now flip the
+        GLOBAL under a reset guard (`RowMetadata`, live_cdc.rs): under MINIMAL a same-arity
+        `MODIFY .. AFTER` across the resume boundary SWAPS the columns (measured a='BBB'
+        b='AAA', status success) and the run must warn; under FULL the same reorder maps
+        by name and the run must stay quiet. RED-proven both directions against
+        `row_metadata_warning` (always-None and always-Some).
     mssql:    { na: "change tables carry a fixed column set from the capture instance; there is
         no server knob that changes the image shape the reader sees" }
     mongo:    { gap: "change-stream pre/post-image settings are per-collection and unset by
@@ -206,8 +208,17 @@ shapes:
         against two mutants on different asserts: the guard disabled (back to the
         measured `status: success, rows: 2` over an EMPTY source) and the addressing
         removed (which fails a bystander export reading the same binlog)."
-    mssql:    { absent: "a checkpoint JSON that parses but lacks its engine's key degrades to
-        'no checkpoint' — MySQL uses ok_or_else here, MSSQL does not" }
+    mssql:
+      sound: "closed 2026-08-25 (src/source/mssql/cdc.rs::resume_from_checkpoint). A
+        checkpoint that PARSES but carries no 'lsn' yielded None via `.and_then`, which
+        fill_sql turns into fn_cdc_get_min_lsn — the entire retained change table re-read
+        and re-delivered under a green exit (MEASURED live: ids [1,2,3,4] where [4] was
+        owed). The decision moved out of live-only glue into a pure predicate so a mutant
+        can grade it; `pinned` stays non-strict beside it, deliberately, because absent
+        `pinned` is a supported legacy default whose value is the LOUD direction. RED
+        against the exact prior bug (key absent -> Ok(None)) offline, over 5 malformed
+        shapes, and live by
+        mssql_cdc_checkpoint_without_an_lsn_must_refuse_not_silently_reread_everything."
     mongo:
       sound: "until_current_bound (src/source/mongo/cdc.rs) replaces the `.ok()` that
         swallowed every `hello` failure: a bounded run with no cluster-time ceiling now

--- a/docs/cdc-evidence-matrix.yaml
+++ b/docs/cdc-evidence-matrix.yaml
@@ -269,9 +269,17 @@ shapes:
         profile is not up", kind: skip-as-pass }
     mysql:    { gap: "same class, not enumerated per test" }
     mssql:    { gap: "same class, not enumerated per test" }
-    mongo:    { vacuous: "run_mongo_cdc_delete returns an empty vec rather than Skipped, so
-        assert_all_pass has nothing to panic on", kind: skip-as-pass }
-
+    mongo:
+      sound: "closed 2026-08-25, and it was not one cell but SIX. Every runner in
+        tests/harness/mod.rs answered a missing RIVET_TEST_GCS_BUCKET with Ok(Vec::new());
+        assert_all_pass panics on Skipped and walks straight through an empty list, so the
+        whole oracle-fixture matrix reported `20 passed` in 0.00s on any machine without
+        credentials — which is EVERY machine, since that variable appears in no workflow.
+        Each runner now returns a Skipped outcome (SKIP_WHY), the two CI lanes that cannot
+        supply credentials exclude the cells BY NAME (--skip warehouse_cell, prefix added
+        for exactly that), and tests/offline/skip_is_not_a_pass_guard.rs derives the runner
+        set from the source so a seventh is asked the same question. RED-proven by
+        restoring one empty return." 
   - id: delete_semantics_are_end_to_end
     what: >
       Tombstones and the 'live current state is WHERE NOT __is_deleted' contract must be
@@ -280,6 +288,14 @@ shapes:
     postgres: { sound: "covered by the delete-capture cells in cdc-matrix" }
     mysql:    { sound: "covered by the delete-capture cells in cdc-matrix" }
     mssql:    { sound: "covered by the delete-capture cells in cdc-matrix" }
-    mongo:    { vacuous: "the only end-to-end assertion lives in a bespoke harness path, and
-        delete PRE-IMAGES (full_document_before_change) have no test at all while doctor
-        reports on them", kind: second-cause }
+    mongo:
+      sound: "closed 2026-08-25. The pre-existing test asserts the DEFAULT case (pre-images
+        off ⇒ document NULL) and says so, which left rivet's own
+        full_document_before_change(WhenAvailable) request — issued on every stream —
+        verified by nothing: a silent no-op and a working pre-image are indistinguishable
+        from a default collection. mongo_cdc_delete_carries_the_pre_image_when_the_collection_has_one
+        (live_cdc_mongo.rs) enables changeStreamPreAndPostImages via the rig's
+        MongoTest::enable_pre_images and asserts the delete carries the document AS OF the
+        delete (measured {_id:9,v:'doomed'}, not the earlier 'seed'). RED against
+        `ChangeOp::Delete => cse.full_document` — and the disagreement is the finding: the
+        pre-existing delete test stays GREEN against that same mutant." 

--- a/docs/cdc-evidence-matrix.yaml
+++ b/docs/cdc-evidence-matrix.yaml
@@ -204,9 +204,19 @@ shapes:
         `row_metadata_warning` (always-None and always-Some).
     mssql:    { na: "change tables carry a fixed column set from the capture instance; there is
         no server knob that changes the image shape the reader sees" }
-    mongo:    { gap: "change-stream pre/post-image settings are per-collection and unset by
-        default; delete pre-images are untested (see delete_semantics_are_end_to_end)" }
-
+    mongo:
+      sound: >-
+        closed 2026-08-25. `changeStreamPreAndPostImages` is per-COLLECTION and off by default,
+        and every Mongo CDC test ran that default — which is the right way round (unlike MySQL,
+        where the stack pinned the NON-default). What was missing was the other side:
+        rivet issues `full_document_before_change(WhenAvailable)` on every stream, and with the
+        setting off that request is a silent no-op indistinguishable from a working one.
+        mongo_cdc_delete_carries_the_pre_image_when_the_collection_has_one
+        (tests/live/live_cdc_mongo.rs) turns it on via MongoTest::enable_pre_images and asserts
+        the delete carries the document AS OF the delete (measured {_id:9,v:'doomed'}, not the
+        earlier 'seed'), and self-skips out loud below server 6.0 where there is no pre-image
+        to carry. RED against `ChangeOp::Delete => cse.full_document`; the pre-existing delete
+        test stays GREEN against that same mutant, which is what made this a gap.
   - id: unknown_input_fails_loud_not_silent
     what: >
       Every "unknown -> default" boundary must warn or bail, never degrade silently. The
@@ -379,21 +389,62 @@ shapes:
       owns the claim, the skip path must fail hard instead — the provisioner sets a marker
       and the test refuses to skip when the marker is present.
     mutant: "unset the precondition and observe whether the suite still reports the claim covered"
-    postgres: { vacuous: "the standby refusal test passes by SKIPPING whenever the opt-in
-        profile is not up", kind: skip-as-pass }
-    mysql:    { gap: "same class, not enumerated per test" }
-    mssql:    { gap: "same class, not enumerated per test" }
+    postgres:
+      gap: >-
+        PARTIALLY closed 2026-08-25, and the honest split matters. The WORST instance of this
+        class was not in the live suite at all: all six runners in tests/harness/mod.rs
+        answered a missing warehouse env with an empty result, so 20 oracle-fixture cells
+        reported `20 passed` in 0.00s on every machine (that variable is in no workflow). Fixed
+        + guarded (tests/offline/skip_is_not_a_pass_guard.rs). What REMAINS on this engine is
+        milder and is stated rather than claimed closed: the standby refusal test (roast_pg_cdc_bounded_on_a_standby_fails_loud) and the pg18 governor catalog test return early when an opt-in
+        profile is not up, printing a SKIP line that `cargo test` still reports as `ok`. The
+        release oracle does NOT share this defect — it carries an explicit SKIP status,
+        distinct from pass, by design. The structural fix for the live suite is a marker
+        protocol the release lane can COUNT (assert N skips, not zero failures); it is named
+        here rather than half-built, because a guard that greps for early returns had ten
+        false positives out of eleven when tried on the sibling class.
+    mysql:
+      gap: >-
+        PARTIALLY closed 2026-08-25, and the honest split matters. The WORST instance of this
+        class was not in the live suite at all: all six runners in tests/harness/mod.rs
+        answered a missing warehouse env with an empty result, so 20 oracle-fixture cells
+        reported `20 passed` in 0.00s on every machine (that variable is in no workflow). Fixed
+        + guarded (tests/offline/skip_is_not_a_pass_guard.rs). What REMAINS on this engine is
+        milder and is stated rather than claimed closed: the two compressed-binlog tests (mysql_cdc_refuses_a_compressed_binlog..., mysql_cdc_compressed_payload_in_stream_refuses_not_skips) return early when an opt-in
+        profile is not up, printing a SKIP line that `cargo test` still reports as `ok`. The
+        release oracle does NOT share this defect — it carries an explicit SKIP status,
+        distinct from pass, by design. The structural fix for the live suite is a marker
+        protocol the release lane can COUNT (assert N skips, not zero failures); it is named
+        here rather than half-built, because a guard that greps for early returns had ten
+        false positives out of eleven when tried on the sibling class.
+    mssql:
+      gap: >-
+        PARTIALLY closed 2026-08-25, and the honest split matters. The WORST instance of this
+        class was not in the live suite at all: all six runners in tests/harness/mod.rs
+        answered a missing warehouse env with an empty result, so 20 oracle-fixture cells
+        reported `20 passed` in 0.00s on every machine (that variable is in no workflow). Fixed
+        + guarded (tests/offline/skip_is_not_a_pass_guard.rs). What REMAINS on this engine is
+        milder and is stated rather than claimed closed: no CDC test on this engine skips silently; the shared live sites that do (state-backend parity, validate-exit) are engine-agnostic return early when an opt-in
+        profile is not up, printing a SKIP line that `cargo test` still reports as `ok`. The
+        release oracle does NOT share this defect — it carries an explicit SKIP status,
+        distinct from pass, by design. The structural fix for the live suite is a marker
+        protocol the release lane can COUNT (assert N skips, not zero failures); it is named
+        here rather than half-built, because a guard that greps for early returns had ten
+        false positives out of eleven when tried on the sibling class.
     mongo:
-      sound: "closed 2026-08-25, and it was not one cell but SIX. Every runner in
-        tests/harness/mod.rs answered a missing RIVET_TEST_GCS_BUCKET with Ok(Vec::new());
-        assert_all_pass panics on Skipped and walks straight through an empty list, so the
-        whole oracle-fixture matrix reported `20 passed` in 0.00s on any machine without
-        credentials — which is EVERY machine, since that variable appears in no workflow.
-        Each runner now returns a Skipped outcome (SKIP_WHY), the two CI lanes that cannot
-        supply credentials exclude the cells BY NAME (--skip warehouse_cell, prefix added
-        for exactly that), and tests/offline/skip_is_not_a_pass_guard.rs derives the runner
-        set from the source so a seventh is asked the same question. RED-proven by
-        restoring one empty return." 
+      sound: >-
+        PARTIALLY closed 2026-08-25, and the honest split matters. The WORST instance of this
+        class was not in the live suite at all: all six runners in tests/harness/mod.rs
+        answered a missing warehouse env with an empty result, so 20 oracle-fixture cells
+        reported `20 passed` in 0.00s on every machine (that variable is in no workflow). Fixed
+        + guarded (tests/offline/skip_is_not_a_pass_guard.rs). What REMAINS on this engine is
+        milder and is stated rather than claimed closed: the pre-image test added today, which self-skips below server 6.0 and says the version it saw return early when an opt-in
+        profile is not up, printing a SKIP line that `cargo test` still reports as `ok`. The
+        release oracle does NOT share this defect — it carries an explicit SKIP status,
+        distinct from pass, by design. The structural fix for the live suite is a marker
+        protocol the release lane can COUNT (assert N skips, not zero failures); it is named
+        here rather than half-built, because a guard that greps for early returns had ten
+        false positives out of eleven when tried on the sibling class.
   - id: delete_semantics_are_end_to_end
     what: >
       Tombstones and the 'live current state is WHERE NOT __is_deleted' contract must be

--- a/docs/fail-loud-matrix.yaml
+++ b/docs/fail-loud-matrix.yaml
@@ -30,6 +30,13 @@ scenarios:
     mysql:    { na: "no MySQL relation emits under a name other than the configured one — the binlog's table_map carries the LOGICAL table, partitioning included (measured 2026-08-24: a RANGE-partitioned table captured through a config naming the parent)" }
     mongo:    { na: "a change stream's `ns` IS the collection the write addressed; Mongo has no parent/child relation surfacing events under a different name, so there is no second identity to cross-check" }
 
+  - id: cdc_truncate_loud_not_a_silent_divergence
+    what: "a TRUNCATE on a captured table → loud bail naming the re-snapshot, never a silent drop that leaves the destination holding rows the source no longer has (no DELETE events carry them, so no later capture can reconcile it)"
+    postgres: { test: roast_pg_cdc_refuses_a_truncate_instead_of_silently_diverging }
+    mysql:    { test: roast_mysql_cdc_refuses_a_truncate_instead_of_silently_diverging }
+    mssql:    { na: "SQL Server REFUSES the truncate itself — `TRUNCATE TABLE` on a CDC-enabled table raises Msg 4711 (measured 2026-08-24 on rivet-mssql-cdc-1), so the divergence cannot be created and there is nothing for rivet to detect" }
+    mongo:    { na: "MongoDB has no TRUNCATE; a drop/collection-level delete surfaces as an invalidate event on the change stream, a separate contract" }
+
   - id: hostile_numeric_value_loud
     what: "a non-finite value (NaN/Inf) in a lossy fixed-point numeric → loud error, never a silent NULL / truncate-to-zero"
     postgres: { test: pg_cdc_hostile_floats_match_batch_and_nan_numeric_fails_loudly }

--- a/docs/load-mode-matrix.yaml
+++ b/docs/load-mode-matrix.yaml
@@ -16,8 +16,8 @@
 #      never-loaded data. Fixed: only a successful load marks runs loaded.
 #
 # Coverage note: all three modes are live-verified end-to-end on the devbox —
-# full (smoke_batch_mysql), cdc (cdc_backfill_snapshot_{mysql,pg,mongo}), and
-# incremental (incremental_dedup_mysql: no-loss + cursor dedup + never-tombstones
+# full (warehouse_cell_smoke_batch_mysql), cdc (cdc_backfill_snapshot_{mysql,pg,mongo}), and
+# incremental (warehouse_cell_incremental_dedup_mysql: no-loss + cursor dedup + never-tombstones
 # + staging wiped), backed by the dedup-view + ledger unit tests. `na` marks a
 # contract that mode does not have (full has no dedup view; incremental/cdc never
 # OVERWRITE, so never truncate).
@@ -65,7 +65,7 @@ scenarios:
     what: "a delete: cdc keeps a flagged tombstone (__is_deleted=true); incremental cannot observe deletes and never tombstones"
     full:        { na: "a full snapshot mirrors the source — a deleted row is simply absent next run" }
     incremental: { test: inc_dedup_view_orders_by_cursor_and_never_tombstones_on_every_dialect }
-    cdc:         { test: mongo_cdc_delete_flag_bigquery }
+    cdc:         { test: warehouse_cell_mongo_cdc_delete_flag_bigquery }
 
   - id: ledger_skips_already_loaded_runs
     what: "the state DB records each load and skips extraction runs already loaded into a target — the incremental step is DB-driven, not file-driven"
@@ -83,7 +83,7 @@ scenarios:
     what: "cdc.initial: snapshot backfills preexisting rows into the change log, then streams — the view keeps every backfilled row live"
     full:        { na: "full IS a snapshot — no separate backfill step" }
     incremental: { na: "incremental has no snapshot phase — the first run exports all rows above the empty cursor" }
-    cdc:         { test: cdc_backfill_snapshot_mysql }
+    cdc:         { test: warehouse_cell_cdc_backfill_snapshot_mysql }
 
   - id: snapshot_completion_survives_cleanup
     what: "snapshot completion is recorded in the state DB (not a bucket marker), so cleanup can wipe the bucket without triggering a full re-snapshot"
@@ -99,6 +99,6 @@ scenarios:
 
   - id: cleanup_source_safe_end_to_end
     what: "cleanup_source: true wipes the staged Parquet after a recorded load without losing data — proven live end to end"
-    full:        { test: smoke_batch_mysql }
-    incremental: { test: incremental_dedup_mysql }
-    cdc:         { test: cdc_backfill_snapshot_mysql }
+    full:        { test: warehouse_cell_smoke_batch_mysql }
+    incremental: { test: warehouse_cell_incremental_dedup_mysql }
+    cdc:         { test: warehouse_cell_cdc_backfill_snapshot_mysql }

--- a/docs/release-gate-matrix.yaml
+++ b/docs/release-gate-matrix.yaml
@@ -127,6 +127,19 @@ preflights:
   - id: cdc_corruption_is_detected
     what: "the same negative proof for the CDC leg, which needs its own: the CDC sink keeps a SEPARATE per-column accumulator and writes its own manifests, so a green batch cell says nothing about it. The same annihilating XOR fold lived here, and the render marker was briefly left `None` on this path — which alone would have made every CDC prefix read as corrupt. Captures to a LOCAL destination rather than the object store the e2e cell uses, because the corruption must be a byte flip IN PLACE and a download/edit/re-upload round trip rewrites the object. Positive first (a clean capture verifies), then the flip. Opt-in on RIVET_CDC_<ENGINE>_URL like the e2e cell, and SKIPs loudly without it."
     status: test        # verify_cdc_corruption_is_detected (dev/release_oracle/corruption.py)
+  - id: cdc_differential
+    what: "an INDEPENDENT implementation of the same capture. `cdc_e2e` compares the destination
+      to the SOURCE (per-column null profile, distinct counts) and catches loss and
+      degrade-to-null; it is structurally blind to rivet and its own oracle agreeing on a wrong
+      SPEC. Debezium reads the same window from the same engine and the two captures are
+      compared in DuckDB on (op, key, VALUES). The value comparison is load-bearing: without it
+      a parquet with 100% of a column NULLed reports AGREE, measured, so a run that compared only
+      (op, key) is graded a FAILURE here rather than accepted. `key-update` is excluded and the
+      reason is written at the call site: rivet emits update(new) where Debezium emits
+      delete(old)+insert(new), which is a representation decision, and a cell that EXPECTS a
+      difference goes green the day someone fixes it."
+    infra: [docker]
+    status: test        # verify_cdc_differential (dev/release_oracle/cdc.py)
   - id: row_hash
     what: "`_rivet_row_hash` recomputed by something that is NOT rivet. The in-tree auditor recomputes with rivet's own `enrich` function — `src/lib.rs` says so deliberately, to avoid a second implementation drifting from the extractor — which is sound for detecting changed DATA and structurally blind to a defect in the SPEC, because both sides share it. Render id v1 shipped non-injective in two independent ways and lived four months. So this cell holds the other side: DuckDB re-reads the exported parquet, a Python implementation rebuilds the canonical image from the spec (presence tag, u32 length, rendered bytes) and hashes it with `xxhash`, and the two are compared. TWO checks, neither implying the other: DIGEST PARITY (catches a drift in rendering or framing) and INJECTIVITY (two rows differing only in where a field boundary falls must hash differently). The probe is exported TWICE because injectivity needs the primary key OUT of the coverage — measured: under v1's rendering the same probe scores 4/4 distinct with the key covered and 3/4 without it, so `row_hash: true` alone would pass against a length-less join. RED-proven on postgres against a v1-shape mutant: both checks fire, the second naming the colliding row pair. SKIPs loudly without the `xxhash` package rather than comparing rivet against itself."
     status: test        # verify_row_hash (dev/release_oracle/rowhash.py)

--- a/src/preflight/cdc_health.rs
+++ b/src/preflight/cdc_health.rs
@@ -858,6 +858,24 @@ mod slot_retention_warning_tests {
              operators to ignore the message"
         );
 
+        // EXACTLY at the bar, both directions. The sibling test above covers this
+        // boundary for `pg_retained_wal_warning` and this one did not — it fed
+        // `bar + 1` and nothing else, so `< bar` and `<= bar` behaved identically
+        // and the mutant survived CI (`replace < with <=`, 2026-08-25). Testing one
+        // function's boundary and not its twin's is exactly the asymmetry mutation
+        // testing exists to find; reading the two tests side by side does not show it.
+        assert!(
+            pg_foreign_slots_warning(&[("at_the_bar".into(), PG_RETAINED_WAL_FAIL_BYTES)])
+                .is_some(),
+            "a slot sitting exactly ON the bar must be reported — `<=` here would let \
+             the single most common boundary value through in silence"
+        );
+        assert_eq!(
+            pg_foreign_slots_warning(&[("under".into(), PG_RETAINED_WAL_FAIL_BYTES - 1)]),
+            None,
+            "...and one byte under it must not be"
+        );
+
         let big = PG_RETAINED_WAL_FAIL_BYTES + 1;
         let w = pg_foreign_slots_warning(&[
             ("small".into(), 4096),

--- a/src/preflight/cdc_health.rs
+++ b/src/preflight/cdc_health.rs
@@ -26,6 +26,23 @@ use super::doctor::DoctorCheck;
 /// consumer stopped and the disk is filling.
 const PG_RETAINED_WAL_FAIL_BYTES: i64 = 1 << 30; // 1 GiB
 
+/// The bar, with a test seam.
+///
+/// Crossing 1 GiB of real WAL takes minutes of writes, so a live test that wanted
+/// to prove the run REACHES this check had to either burn that time or assert
+/// nothing — and the version that asserted nothing is the one that would have
+/// shipped. `RIVET_TEST_SLOT_WAL_BAR` lets a test cross the bar with a KiB.
+///
+/// Deliberately not a config knob: an operator lowering this would get a warning on
+/// every ordinary backlog and learn to ignore it, which costs more than the warning
+/// is worth. Same reasoning as the fault hooks — a seam for tests, not a feature.
+fn retained_wal_bar() -> i64 {
+    std::env::var("RIVET_TEST_SLOT_WAL_BAR")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(PG_RETAINED_WAL_FAIL_BYTES)
+}
+
 fn mib(bytes: i64) -> String {
     format!("{:.1} MiB", bytes as f64 / (1024.0 * 1024.0))
 }
@@ -85,6 +102,54 @@ struct PgSlot {
 
 /// Verdict for the export's own slot. Absent is healthy (created on first
 /// run); present is healthy while the retained WAL stays small.
+/// Does this slot's retained WAL warrant telling the operator? Shared by `doctor`
+/// (which FAILS on it) and by every `run` (which WARNS) so the threshold and the
+/// wording have ONE definition. Two would drift on the first change, and the
+/// run-time one is the copy nobody would notice going stale.
+///
+/// `None` below the threshold: a slot legitimately holds everything since the last
+/// run, and a warning on every ordinary backlog is a warning that stops being read.
+pub(crate) fn pg_retained_wal_warning(
+    slot: &str,
+    retained_bytes: i64,
+    active: bool,
+) -> Option<String> {
+    if retained_bytes < retained_wal_bar() {
+        return None;
+    }
+    Some(format!(
+        "slot '{slot}' is pinning {} of WAL (active={active}) — the source disk is filling. \
+         This run will drain it, but a drain that far behind takes time and the WAL keeps \
+         growing meanwhile. If capture here is retired instead: \
+         SELECT pg_drop_replication_slot('{slot}'); consider max_slot_wal_keep_size as a \
+         blast-radius bound",
+        mib(retained_bytes)
+    ))
+}
+
+/// The same question for slots this config does NOT own. These are the dangerous
+/// ones: nobody is draining them, so the WAL they pin is pinned forever — measured
+/// live at 9 abandoned slots holding 1.5 GiB each on a dev stand.
+pub(crate) fn pg_foreign_slots_warning(foreign: &[(String, i64)]) -> Option<String> {
+    let worst = foreign.iter().max_by_key(|(_, b)| *b)?;
+    let bar = retained_wal_bar();
+    if worst.1 < bar {
+        return None;
+    }
+    let listing = foreign
+        .iter()
+        .filter(|(_, b)| *b >= bar)
+        .map(|(n, b)| format!("{n} ({})", mib(*b)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    Some(format!(
+        "inactive slot(s) NOT owned by this config are pinning WAL: {listing} — nothing is \
+         draining them, so this WAL is pinned until someone acts. If the consumer is gone \
+         for good: SELECT pg_drop_replication_slot('{}')",
+        worst.0
+    ))
+}
+
 fn pg_slot_verdict(export: &str, slot: &str, state: Option<PgSlot>) -> DoctorCheck {
     let name = format!("CDC slot '{slot}' (export '{export}')");
     match state {
@@ -104,14 +169,12 @@ fn pg_slot_verdict(export: &str, slot: &str, state: Option<PgSlot>) -> DoctorChe
             )),
             None,
         ),
+        // The threshold and the wording come from the shared warning so `doctor` and
+        // `run` cannot disagree about when a slot is too far behind.
         Some(s) => check(
             name,
             false,
-            Some(format!(
-                "slot is pinning {} of WAL (active={}) — the source disk is filling",
-                mib(s.retained_bytes),
-                s.active
-            )),
+            pg_retained_wal_warning(slot, s.retained_bytes, s.active),
             Some(
                 "run the CDC export to drain it (advancing the slot releases WAL), or drop it \
                  if capture is retired: SELECT pg_drop_replication_slot('<slot>'); consider \
@@ -746,5 +809,80 @@ mod tests {
     fn norm_lsn_compares_across_prefix_and_case() {
         assert!(norm_lsn("0x0000001000000001") < norm_lsn("00000028000009f0"));
         assert_eq!(norm_lsn("0xABC"), norm_lsn("abc"));
+    }
+}
+
+#[cfg(test)]
+mod slot_retention_warning_tests {
+    use super::*;
+
+    /// The threshold has ONE definition, and both callers must sit on the same side
+    /// of it: `doctor` fails, every `run` warns. A second threshold in the run path
+    /// is the copy that goes stale unnoticed.
+    #[test]
+    fn an_ordinary_backlog_is_silent_and_a_pinned_slot_names_its_escape() {
+        // Below the bar: a slot legitimately holds everything since the last run, and
+        // a warning on every ordinary backlog is one that stops being read.
+        assert_eq!(pg_retained_wal_warning("s", 0, true), None);
+        assert_eq!(
+            pg_retained_wal_warning("s", PG_RETAINED_WAL_FAIL_BYTES - 1, false),
+            None,
+            "one byte under the bar must stay silent — the boundary is the whole \
+             contract, and an off-by-one here makes the warning fire on every run"
+        );
+
+        let w = pg_retained_wal_warning("mine", PG_RETAINED_WAL_FAIL_BYTES, true)
+            .expect("at the bar the operator must be told");
+        assert!(w.contains("mine"), "name the slot: {w}");
+        assert!(
+            w.contains("pg_drop_replication_slot") && w.contains("max_slot_wal_keep_size"),
+            "name what to DO — a warning without an escape is noise: {w}"
+        );
+        assert!(
+            w.contains("This run will drain it"),
+            "and be honest that the run itself fixes this case, or an operator drops a \
+             slot that was about to be drained: {w}"
+        );
+    }
+
+    /// The foreign slots are the dangerous half: nobody is draining them, so their
+    /// WAL is pinned until a human acts. Measured live at 9 abandoned slots holding
+    /// 1.5 GiB each on a dev stand.
+    #[test]
+    fn foreign_slots_warn_only_past_the_bar_and_list_only_the_offenders() {
+        assert_eq!(pg_foreign_slots_warning(&[]), None);
+        assert_eq!(
+            pg_foreign_slots_warning(&[("small".into(), 1024)]),
+            None,
+            "an inactive slot holding a KiB is not a hazard; warning about it teaches \
+             operators to ignore the message"
+        );
+
+        let big = PG_RETAINED_WAL_FAIL_BYTES + 1;
+        let w = pg_foreign_slots_warning(&[
+            ("small".into(), 4096),
+            ("orphan_a".into(), big),
+            ("orphan_b".into(), big * 2),
+        ])
+        .expect("two slots past the bar must be reported");
+        assert!(
+            w.contains("orphan_a") && w.contains("orphan_b"),
+            "list every offender, not just the worst — an operator fixing one and \
+             re-running should not have to discover the rest one at a time: {w}"
+        );
+        assert!(
+            !w.contains("small"),
+            "and NOT the ones under the bar, or the list is unreadable at the scale \
+             where it matters: {w}"
+        );
+        assert!(
+            w.contains("pg_drop_replication_slot('orphan_b')"),
+            "the ready-to-paste command should name the WORST one: {w}"
+        );
+        assert!(
+            w.contains("nothing is draining them"),
+            "say why this differs from our own backlog — that distinction is the \
+             reason there are two warnings: {w}"
+        );
     }
 }

--- a/src/preflight/mod.rs
+++ b/src/preflight/mod.rs
@@ -6,7 +6,7 @@ mod analysis;
 #[cfg(test)]
 pub(crate) use analysis::diagnose_mode_str;
 pub(crate) use analysis::overlay_measured_rows;
-mod cdc_health;
+pub(crate) mod cdc_health;
 pub(crate) mod cursor_expr;
 mod doctor;
 mod mongo;

--- a/src/source/cdc/mod.rs
+++ b/src/source/cdc/mod.rs
@@ -609,6 +609,26 @@ impl CdcEngine {
         }
     }
 
+    /// Does this engine's CURRENT configuration map change images by position
+    /// rather than by name, and what does that cost?
+    ///
+    /// MySQL is the only engine that can answer yes: its binlog carries column
+    /// names only at `binlog_row_metadata=FULL`, and the default is MINIMAL. The
+    /// other three name their columns unconditionally — PostgreSQL's
+    /// `test_decoding` prints `name[type]:value`, SQL Server's change table IS a
+    /// table, Mongo's events are documents — so there is no positional mapping to
+    /// warn about, and a `None` here is structural rather than unimplemented.
+    pub(crate) fn positional_mapping_warning(
+        &self,
+        url: &str,
+        tls: Option<&TlsConfig>,
+    ) -> Option<String> {
+        match self {
+            Self::Mysql => crate::source::mysql::cdc::MysqlChangeStream::row_metadata(url, tls),
+            Self::Postgres | Self::Mssql | Self::Mongo => None,
+        }
+    }
+
     pub(crate) fn from_url(url: &str) -> Result<Self> {
         if url.starts_with("mysql://") {
             Ok(Self::Mysql)
@@ -1105,6 +1125,13 @@ pub(crate) fn run_capture(
                 )),
             );
         }
+    }
+    // `warn`, at run start, before a single event is read: an operator whose
+    // capture is about to map by position must learn it from the run rather than
+    // from a swapped column months later. `info` would be functionally silent at
+    // the default log level — the same rule the sparse-chunk warning follows.
+    if let Some(why) = engine.positional_mapping_warning(&url, tls.as_ref()) {
+        log::warn!("{} cdc: {why}.", engine.label());
     }
     let mut resolver = match CdcSchemaResolver::connect(&url, tls.as_ref()) {
         Ok(r) => r,

--- a/src/source/cdc/mod.rs
+++ b/src/source/cdc/mod.rs
@@ -817,38 +817,23 @@ pub(crate) fn create_change_stream(
             let ci = capture_instance.as_deref().ok_or_else(|| {
                 anyhow::anyhow!("sqlserver cdc requires --capture-instance (e.g. dbo_orders)")
             })?;
-            // Resume from the checkpoint's LSN if one was persisted (SQL Server has no
-            // server-side cursor — the from-LSN is what makes it at-least-once instead
-            // of re-reading the whole change table each run).
-            let from_lsn = match cfg.checkpoint.as_deref() {
-                // A corrupt checkpoint must fail loud (#99), not silently drop to
-                // None (a full change-table over-read that re-loads everything).
-                Some(p) => Position::load(p)?.and_then(|pos| {
-                    pos.0
-                        .get("lsn")
-                        .and_then(|v| v.as_str())
-                        .map(str::to_string)
-                }),
-                None => None,
-            };
-            // Was that position an ANCHOR or a resume? Only an anchor may be
-            // floored up to the instance's start; a resume position below the
-            // change table's min LSN is retention loss and must THROW. Absent on
-            // a legacy checkpoint ⇒ treated as a resume, the loud direction.
-            let from_is_pin = match cfg.checkpoint.as_deref() {
-                Some(p) => Position::load(p)?
-                    .and_then(|pos| pos.0.get("pinned").and_then(|v| v.as_bool()))
-                    .unwrap_or(false),
-                None => false,
+            // Resume from the checkpoint's position if one was persisted (SQL Server
+            // has no server-side cursor — the from-LSN is what makes it at-least-once
+            // instead of re-reading the whole change table each run). One load, and
+            // the DECISION — including what an `lsn`-less file means — lives in
+            // `resume_from_checkpoint` where a unit test can grade it.
+            let resume = match cfg.checkpoint.as_deref() {
+                Some(p) => crate::source::mssql::cdc::resume_from_checkpoint(
+                    Position::load(p)?.as_ref(),
+                    &p.display().to_string(),
+                )?,
+                None => crate::source::mssql::cdc::resume_from_checkpoint(None, "")?,
             };
             Ok(Box::new(
                 crate::source::mssql::cdc::MssqlChangeStream::from_url(
                     url,
                     ci,
-                    crate::source::mssql::cdc::Resume {
-                        from_lsn,
-                        from_is_pin,
-                    },
+                    resume,
                     tls,
                     peek,
                     cfg.drain,

--- a/src/source/cdc/mod.rs
+++ b/src/source/cdc/mod.rs
@@ -629,6 +629,67 @@ impl CdcEngine {
         }
     }
 
+    /// WAL this source is holding that an operator should know about before the run
+    /// starts, not after the disk fills.
+    ///
+    /// PostgreSQL only, and structurally so: a replication slot is the one CDC
+    /// anchor that makes the SERVER retain log on the reader's behalf. MySQL's
+    /// binlog and SQL Server's change tables expire on their own schedule whatever
+    /// rivet does (which is why they can lose data to retention and PG cannot), and
+    /// Mongo's oplog is a capped collection. There is nothing to pin, so nothing to
+    /// warn about — a `None` here is a fact about those engines, not a TODO.
+    ///
+    /// Two questions, and the second is the dangerous one. This export's OWN slot
+    /// being far behind is worth saying (the drain will be long and WAL grows
+    /// meanwhile) but the run does fix it. A slot NOBODY owns is pinned until a
+    /// human acts — measured live at 9 abandoned slots holding 1.5 GiB each.
+    ///
+    /// Best-effort like `row_image`: a catalog the reader cannot query answers with
+    /// nothing. This exists to surface a CONFIGURATION hazard, not to police access,
+    /// and a run that refuses because it could not read `pg_replication_slots` would
+    /// trade a warning for an outage.
+    pub(crate) fn retention_warnings(
+        &self,
+        url: &str,
+        tls: Option<&TlsConfig>,
+        opts: &CdcEngineOpts,
+    ) -> Vec<String> {
+        let Self::Postgres = self else {
+            return Vec::new();
+        };
+        let CdcEngineOpts::Postgres { slot, .. } = opts else {
+            return Vec::new();
+        };
+        let slot = slot.clone();
+        let Ok(mut client) = crate::source::postgres::connect_client(url, tls) else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        if let Ok(Some(row)) = client.query_opt(
+            "SELECT active, COALESCE(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn), 0)::bigint \
+             FROM pg_replication_slots WHERE slot_name = $1",
+            &[&slot],
+        ) && let Some(w) = crate::preflight::cdc_health::pg_retained_wal_warning(
+            &slot,
+            row.get(1),
+            row.get(0),
+        ) {
+            out.push(w);
+        }
+        let ours = vec![slot];
+        if let Ok(rows) = client.query(
+            "SELECT slot_name, COALESCE(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn), 0)::bigint \
+             FROM pg_replication_slots WHERE NOT active AND slot_name <> ALL($1)",
+            &[&ours],
+        ) {
+            let foreign: Vec<(String, i64)> = rows.iter().map(|r| (r.get(0), r.get(1))).collect();
+            if let Some(w) = crate::preflight::cdc_health::pg_foreign_slots_warning(&foreign) {
+                out.push(w);
+            }
+        }
+        out
+    }
+
     pub(crate) fn from_url(url: &str) -> Result<Self> {
         if url.starts_with("mysql://") {
             Ok(Self::Mysql)
@@ -1131,6 +1192,9 @@ pub(crate) fn run_capture(
     // from a swapped column months later. `info` would be functionally silent at
     // the default log level — the same rule the sparse-chunk warning follows.
     if let Some(why) = engine.positional_mapping_warning(&url, tls.as_ref()) {
+        log::warn!("{} cdc: {why}.", engine.label());
+    }
+    for why in engine.retention_warnings(&url, tls.as_ref(), &cap.cdc_cfg.engine) {
         log::warn!("{} cdc: {why}.", engine.label());
     }
     let mut resolver = match CdcSchemaResolver::connect(&url, tls.as_ref()) {

--- a/src/source/mssql/cdc.rs
+++ b/src/source/mssql/cdc.rs
@@ -308,12 +308,74 @@ CDC change-table retention (the cleanup job removed it). Resuming would silently
 /// `String` and a `bool` whose meaning is invisible at the call site — and the
 /// bool decides whether a position the cleanup job purged past is REFUSED or
 /// silently skipped.
+#[derive(Debug)]
 pub(crate) struct Resume {
     /// Hex LSN to read after, or `None` for "from the change table's min".
     pub from_lsn: Option<String>,
     /// True when that LSN is an ANCHOR (nothing was captured from it) rather
     /// than a flushed resume position.
     pub from_is_pin: bool,
+}
+
+/// Read a resume position out of a checkpoint that has already PARSED.
+///
+/// `Position::load` refuses a file that is not valid JSON, and says why: treating
+/// it as absent "would permanently skip every change since the last checkpoint".
+/// This is the other half of that guard — a file that parses and yet carries no
+/// `lsn`. The call site used to reach for it with `.and_then(...)`, so the key's
+/// absence became `None`, and `fill_sql` turns `None` into
+/// `fn_cdc_get_min_lsn(ci)`: the whole retained change table, re-read and
+/// re-delivered under a green exit.
+///
+/// MEASURED (2026-08-25, live SQL Server): a checkpoint whose `lsn` key was
+/// renamed delivered ids `[1, 2, 3, 4]` on the resume leg where `[4]` was owed —
+/// silently, with `status: success`. The direction of harm is over-read, so
+/// at-least-once holds; the resume CONTRACT does not, and the comment at the call
+/// site already claimed this case was closed (#99).
+///
+/// `pinned` is deliberately NOT strict: a checkpoint written before that field
+/// existed is a real and supported input, and its documented default (`false` ⇒
+/// treat the position as a resume) is the loud direction. `lsn` is different in
+/// kind — it IS the position, and a checkpoint without one says nothing at all.
+///
+/// A named function rather than an expression at the call site because it DECIDES
+/// something: live-only glue may sequence and wrap, but the branch that separates
+/// "resume here" from "re-read everything" is graded by a mutant only if a unit
+/// test can call it.
+pub(crate) fn resume_from_checkpoint(
+    pos: Option<&crate::source::cdc::Position>,
+    path: &str,
+) -> Result<Resume> {
+    let Some(pos) = pos else {
+        return Ok(Resume {
+            from_lsn: None,
+            from_is_pin: false,
+        });
+    };
+    let from_lsn = pos
+        .0
+        .get("lsn")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "checkpoint '{path}' parses as JSON but carries no 'lsn' — refusing to treat \
+                 it as absent, which would re-read and re-deliver the ENTIRE retained change \
+                 table from fn_cdc_get_min_lsn under a successful exit. Restore the file, or \
+                 delete it to accept a fresh anchor."
+            )
+        })?
+        .to_string();
+    Ok(Resume {
+        from_lsn: Some(from_lsn),
+        // Absent on a checkpoint written before the field existed ⇒ treated as a
+        // resume position, which is the direction that THROWS on retention loss
+        // rather than silently flooring past it.
+        from_is_pin: pos
+            .0
+            .get("pinned")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+    })
 }
 
 pub(crate) struct MssqlCdcConfig {
@@ -912,6 +974,61 @@ fn probe_max_lsn(probe: &crate::source::mssql::MssqlCdcProbe) -> Option<String> 
 
 #[cfg(test)]
 mod tests {
+
+    fn ckpt(j: serde_json::Value) -> crate::source::cdc::Position {
+        crate::source::cdc::Position(j)
+    }
+
+    /// The whole point: absence of `lsn` is an ERROR, absence of `pinned` is a
+    /// documented default. Conflating them re-reads the entire change table.
+    #[test]
+    fn a_checkpoint_without_an_lsn_is_refused_not_read_as_absent() {
+        // No file at all — a genuine first run.
+        let fresh = resume_from_checkpoint(None, "/x").expect("no checkpoint is not an error");
+        assert_eq!(fresh.from_lsn, None);
+        assert!(!fresh.from_is_pin);
+
+        // The ordinary resume, and the pin.
+        let r = resume_from_checkpoint(Some(&ckpt(serde_json::json!({"lsn": "0a0b"}))), "/x")
+            .expect("an lsn without `pinned` is a legacy checkpoint, still valid");
+        assert_eq!(r.from_lsn.as_deref(), Some("0a0b"));
+        assert!(
+            !r.from_is_pin,
+            "a checkpoint written before `pinned` existed must default to RESUME — the \
+             direction that throws on retention loss rather than flooring past it"
+        );
+        let pinned = resume_from_checkpoint(
+            Some(&ckpt(serde_json::json!({"lsn": "0a0b", "pinned": true}))),
+            "/x",
+        )
+        .unwrap();
+        assert!(pinned.from_is_pin);
+
+        // And the defect this function exists for. Each of these parses as JSON.
+        for missing in [
+            serde_json::json!({}),
+            serde_json::json!({"pinned": false}),
+            serde_json::json!({"lsn_renamed_by_a_future_version": "0a0b"}),
+            // Present but not a string: `as_str` yields None, and a position that
+            // cannot be read is no position at all.
+            serde_json::json!({"lsn": 2571}),
+            serde_json::json!({"lsn": null}),
+        ] {
+            let err = resume_from_checkpoint(Some(&ckpt(missing.clone())), "/tmp/c.ckpt")
+                .expect_err(&format!(
+                    "{missing} carries no readable position — treating it as absent re-reads \
+                     the ENTIRE retained change table under a green exit (measured: ids \
+                     [1,2,3,4] delivered where [4] was owed)"
+                ))
+                .to_string();
+            assert!(
+                err.contains("lsn") && err.contains("/tmp/c.ckpt"),
+                "the refusal must name the key AND the file, or an operator cannot act on \
+                 it: {err}"
+            );
+        }
+    }
+
     use super::*;
 
     /// Every data-only `ColumnData` arm, with an INDEPENDENT expectation.

--- a/src/source/mysql/cdc.rs
+++ b/src/source/mysql/cdc.rs
@@ -447,6 +447,20 @@ impl MysqlChangeStream {
             // `XA PREPARE` deliberately does NOT release: the transaction is not
             // committed yet, and releasing there would publish rows a later
             // `XA ROLLBACK` erases.
+            // A TRUNCATE is a QUERY event, never rows — so the rows path below
+            // never sees it and the `_ => {}` arm dropped it silently, leaving the
+            // destination holding rows the source no longer has. Table-addressed
+            // for the reason #281 measured: the binlog carries every table on the
+            // server, so refusing without asking whose relation it is would make
+            // one truncated table an outage for exports that never read it.
+            Some(EventData::QueryEvent(qe))
+                if truncate_target(&qe.query(), &qe.schema()).is_some_and(|(sc, tb)| {
+                    undecodable_event_is_ours(Some((&sc, &tb)), &self.configured_tables)
+                }) =>
+            {
+                let (sc, tb) = truncate_target(&qe.query(), &qe.schema()).expect("just matched");
+                anyhow::bail!(truncate_refusal_message(&sc, &tb));
+            }
             Some(EventData::QueryEvent(qe)) if is_commit_statement(&qe.query()) => {
                 if !self.close_transaction_at(log_pos) {
                     return Ok(false);
@@ -676,6 +690,61 @@ fn connect_conn(url: &str, tls: Option<&TlsConfig>) -> Result<Conn> {
     Ok(conn)
 }
 
+/// The table a `TRUNCATE` QUERY event names, as `(schema, table)` — schema from
+/// the statement's qualifier when it has one, else the event's own database.
+///
+/// A TRUNCATE is logged as a QUERY event, never as rows, so the rows-event path
+/// never sees it and the `_ => {}` arm dropped it in silence. Measured 2026-08-24
+/// on the rivet-mysql-cdc-1 stand: 2 inserts then a TRUNCATE left the source table
+/// EMPTY while the run reported `status: success, rows: 2` — the identical
+/// divergence PostgreSQL had, by a different route.
+///
+/// Parses `TRUNCATE [TABLE] [`db`.]`tbl`` with optional backticks. Deliberately
+/// permissive about whitespace and case (MySQL logs the statement as written) and
+/// deliberately NOT a general SQL parser: anything it cannot read confidently
+/// returns `None` and falls through to the old behaviour, which is what it was
+/// before this existed.
+pub(crate) fn truncate_target(sql: &str, event_db: &str) -> Option<(String, String)> {
+    let t = sql.trim().trim_end_matches(';').trim();
+    let mut w = t.split_whitespace();
+    if !w.next()?.eq_ignore_ascii_case("truncate") {
+        return None;
+    }
+    let mut name = w.next()?;
+    if name.eq_ignore_ascii_case("table") {
+        name = w.next()?;
+    }
+    if w.next().is_some() {
+        return None; // trailing tokens — not a shape this reader claims to understand
+    }
+    let unq = |s: &str| s.trim_matches('`').to_string();
+    match name.split_once('.') {
+        Some((db, tbl)) => Some((unq(db), unq(tbl))),
+        None => Some((event_db.to_string(), unq(name))),
+    }
+}
+
+/// Refuse a TRUNCATE on a captured table. Same contract as the PostgreSQL arm —
+/// see `postgres::cdc::truncate_refusal_message` for why this bails rather than
+/// warns: the rows leave the source with no DELETE events to carry them, so the
+/// destination disagrees with its source permanently and no later capture can
+/// reconcile it.
+pub(crate) fn truncate_refusal_message(schema: &str, table: &str) -> String {
+    let qualified = if schema.is_empty() {
+        table.to_string()
+    } else {
+        format!("{schema}.{table}")
+    };
+    format!(
+        "mysql cdc: `{qualified}` was TRUNCATEd, and this reader cannot represent that as a \
+         change. Skipping it would leave every row the truncate removed sitting in the \
+         destination with no DELETE to retract it — the source empty, the destination \
+         not, permanently, because those rows left the source without events and no \
+         later capture can reconcile them. Re-snapshot the table (`mode: full`) to \
+         re-establish the baseline, then resume CDC from a fresh checkpoint."
+    )
+}
+
 /// Is the commit at `(file, pos)` PAST the open-time bound? — the pure heart of
 /// the bounded run's termination contract (see [`MysqlChangeStream::bound`]).
 /// Binlog files order by their numeric suffix (`binlog.000042`); a lexicographic
@@ -807,6 +876,63 @@ impl ChangeStream for MysqlChangeStream {
 
 #[cfg(test)]
 mod tests {
+    /// The MySQL TRUNCATE recogniser, graded offline.
+    ///
+    /// MySQL logs the statement AS WRITTEN, so the parser must survive the forms a
+    /// human or an ORM actually emits — with and without `TABLE`, with and without
+    /// backticks, qualified and bare — and must refuse to guess at anything else
+    /// rather than fire on a statement it half-understood.
+    #[test]
+    fn a_mysql_truncate_statement_resolves_the_table_it_names() {
+        let t = |sql: &str| truncate_target(sql, "appdb");
+        for form in [
+            "TRUNCATE TABLE orders",
+            "truncate table orders",
+            "TRUNCATE orders",
+            "TRUNCATE TABLE `orders`",
+            "TRUNCATE TABLE orders;",
+            "  TRUNCATE   TABLE   orders  ",
+        ] {
+            assert_eq!(
+                t(form),
+                Some(("appdb".to_string(), "orders".to_string())),
+                "a bare name takes the EVENT's database: {form}"
+            );
+        }
+        assert_eq!(
+            t("TRUNCATE TABLE `other`.`orders`"),
+            Some(("other".to_string(), "orders".to_string())),
+            "a qualified name carries its OWN schema — a cross-database truncate \
+             must not be attributed to the event's database"
+        );
+        assert_eq!(
+            t("TRUNCATE other.orders"),
+            Some(("other".to_string(), "orders".to_string()))
+        );
+
+        // Not a truncate, and — just as important — not a shape this reader claims
+        // to understand. Guessing would fail runs on statements it misread.
+        for other in [
+            "COMMIT",
+            "BEGIN",
+            "DELETE FROM orders",
+            "DROP TABLE orders",
+            "TRUNCATE TABLE orders PARTITION (p0)",
+        ] {
+            assert_eq!(t(other), None, "must not fire on: {other}");
+        }
+
+        let msg = truncate_refusal_message("appdb", "orders");
+        assert!(
+            msg.contains("appdb.orders") && msg.contains("mode: full"),
+            "the refusal must name the table AND the re-snapshot that recovers: {msg}"
+        );
+        assert!(
+            truncate_refusal_message("", "orders").contains("`orders`"),
+            "a schema-less identity must not render a leading dot"
+        );
+    }
+
     /// The refusal message IS the remediation — an operator has nothing else to go
     /// on, because the alternative to this error was a green run with missing rows.
     /// The refusal must be TABLE-ADDRESSED. Every arm here was a live failure

--- a/src/source/mysql/cdc.rs
+++ b/src/source/mysql/cdc.rs
@@ -134,6 +134,60 @@ impl MysqlChangeStream {
         }
     }
 
+    /// Pure verdict on `binlog_row_metadata` — the engine setting that decides
+    /// whether the sink maps binlog images by NAME or by POSITION.
+    ///
+    /// A WARNING and not a refusal, unlike its sibling [`Self::row_image_verdict`],
+    /// and the asymmetry is the whole point: `binlog_row_image` defaults to FULL, so
+    /// refusing a non-FULL value refuses a setting somebody CHOSE.
+    /// `binlog_row_metadata` defaults to MINIMAL — refusing it would refuse every
+    /// MySQL nobody has touched.
+    ///
+    /// What MINIMAL costs, MEASURED (2026-08-25, MySQL 8.0.46) rather than argued:
+    /// a table `(id, a, b)` holding `(1, 'AAA', 'BBB')`, then
+    /// `ALTER TABLE .. MODIFY b VARCHAR(9) AFTER id`, then a resume across that
+    /// boundary — the schema is resolved at OPEN (new order) while the event
+    /// replays from the CHECKPOINT (old order), so the parquet came back
+    /// `a = 'BBB', b = 'AAA'`. Swapped, `status: success`, nothing in the log.
+    ///
+    /// The sink's arity guard cannot see it: a reorder does not change arity, and
+    /// under FULL the guard is skipped outright (`image_names.is_some()` ⇒ mapped by
+    /// name, which is reorder-proof). So FULL is not a tuning preference here — it
+    /// is what makes a mid-stream DDL safe.
+    ///
+    /// `None` (a server too old to have the variable — it is 8.0.1+) is NOT
+    /// evidence of a bad setting: MySQL 5.7 has no way to carry names, the sink
+    /// maps positionally there by construction, and a warning naming a variable
+    /// that does not exist is one an operator cannot act on.
+    pub(crate) fn row_metadata_warning(metadata: Option<&str>) -> Option<String> {
+        let m = metadata?;
+        if m.eq_ignore_ascii_case("FULL") {
+            return None;
+        }
+        Some(format!(
+            "the server has binlog_row_metadata = {m} (MySQL's default), so binlog row events \
+             carry no column NAMES and the sink maps values by POSITION. A same-arity DDL that \
+             reorders columns across a resume boundary then silently SWAPS them (measured: a \
+             MODIFY .. AFTER moved 'BBB' into column `a` and 'AAA' into `b`, with status \
+             success), and any arity-changing DDL mid-window aborts the flush instead. Set \
+             `binlog_row_metadata = FULL` (8.0.1+) — rivet then maps by name and both cases \
+             become safe"
+        ))
+    }
+
+    /// Live half of [`Self::row_metadata_warning`]: one query at open, on a
+    /// connection that is about to dump. A connect/permission failure answers
+    /// "nothing to say" — this exists to catch a CONFIGURATION, not to police
+    /// access, the same contract as [`Self::row_image`].
+    pub(crate) fn row_metadata(url: &str, tls: Option<&TlsConfig>) -> Option<String> {
+        use mysql::prelude::Queryable;
+        let mut conn = connect_conn(url, tls).ok()?;
+        let m: Option<String> = conn
+            .query_first("SELECT @@global.binlog_row_metadata")
+            .unwrap_or(None);
+        Self::row_metadata_warning(m.as_deref())
+    }
+
     pub(crate) fn row_image(url: &str, tls: Option<&TlsConfig>) -> super::super::cdc::RowImage {
         use super::super::cdc::RowImage;
         use mysql::prelude::Queryable;
@@ -1021,6 +1075,46 @@ impl ChangeStream for MysqlChangeStream {
 
 #[cfg(test)]
 mod tests {
+
+    /// The asymmetry with `row_image_verdict` is deliberate and this pins it: a
+    /// non-FULL `binlog_row_image` is REFUSED (somebody chose it, the default is
+    /// FULL); a non-FULL `binlog_row_metadata` is WARNED (the default IS non-FULL,
+    /// so refusing would refuse every untouched MySQL).
+    #[test]
+    fn minimal_row_metadata_warns_and_names_the_escape_while_full_stays_quiet() {
+        assert_eq!(
+            MysqlChangeStream::row_metadata_warning(Some("FULL")),
+            None,
+            "a correctly-configured server must stay quiet, or the warning fires on \
+             every run and stops being read"
+        );
+        assert_eq!(
+            MysqlChangeStream::row_metadata_warning(Some("full")),
+            None,
+            "the server renders this variable uppercase, but a proxy or a older \
+             build need not — compare case-insensitively like row_image_verdict"
+        );
+        assert_eq!(
+            MysqlChangeStream::row_metadata_warning(None),
+            None,
+            "a server too old to HAVE the variable (pre-8.0.1) maps positionally by \
+             construction; naming a variable that does not exist is a warning nobody \
+             can act on"
+        );
+        for m in ["MINIMAL", "minimal", "SOMETHING_NEW"] {
+            let w = MysqlChangeStream::row_metadata_warning(Some(m))
+                .unwrap_or_else(|| panic!("{m} is not FULL — the sink maps by POSITION"));
+            assert!(
+                w.contains("binlog_row_metadata = FULL"),
+                "the warning must name the ESCAPE, not just the risk: {w}"
+            );
+            assert!(
+                w.contains("POSITION") && w.contains("SWAP"),
+                "and must say what it costs — measured, not hedged: {w}"
+            );
+        }
+    }
+
     /// The MySQL routing guard's decision surface.
     ///
     /// `None` (the catalog has no row) must stay ROUTABLE, deliberately: the schema

--- a/src/source/mysql/cdc.rs
+++ b/src/source/mysql/cdc.rs
@@ -515,6 +515,20 @@ impl MysqlChangeStream {
             // `XA PREPARE` deliberately does NOT release: the transaction is not
             // committed yet, and releasing there would publish rows a later
             // `XA ROLLBACK` erases.
+            // A TRUNCATE is a QUERY event, never rows — so the rows path below
+            // never sees it and the `_ => {}` arm dropped it silently, leaving the
+            // destination holding rows the source no longer has. Table-addressed
+            // for the reason #281 measured: the binlog carries every table on the
+            // server, so refusing without asking whose relation it is would make
+            // one truncated table an outage for exports that never read it.
+            Some(EventData::QueryEvent(qe))
+                if truncate_target(&qe.query(), &qe.schema()).is_some_and(|(sc, tb)| {
+                    undecodable_event_is_ours(Some((&sc, &tb)), &self.configured_tables)
+                }) =>
+            {
+                let (sc, tb) = truncate_target(&qe.query(), &qe.schema()).expect("just matched");
+                anyhow::bail!(truncate_refusal_message(&sc, &tb));
+            }
             Some(EventData::QueryEvent(qe)) if is_commit_statement(&qe.query()) => {
                 if !self.close_transaction_at(log_pos) {
                     return Ok(false);

--- a/src/source/mysql/cdc.rs
+++ b/src/source/mysql/cdc.rs
@@ -690,6 +690,27 @@ fn connect_conn(url: &str, tls: Option<&TlsConfig>) -> Result<Conn> {
     Ok(conn)
 }
 
+/// Remove `/* … */` comment spans, leaving a space so tokens never fuse.
+///
+/// Not a general SQL lexer: a `/*` inside a string literal is not something a
+/// TRUNCATE statement can contain (it takes only identifiers), so the simple scan
+/// is exact for this one shape and the parser refuses anything it cannot read
+/// confidently anyway.
+fn strip_sql_comments(sql: &str) -> String {
+    let mut out = String::with_capacity(sql.len());
+    let mut rest = sql;
+    while let Some(start) = rest.find("/*") {
+        out.push_str(&rest[..start]);
+        out.push(' ');
+        match rest[start + 2..].find("*/") {
+            Some(end) => rest = &rest[start + 2 + end + 2..],
+            None => return out, // unterminated — everything after is comment
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
 /// The table a `TRUNCATE` QUERY event names, as `(schema, table)` — schema from
 /// the statement's qualifier when it has one, else the event's own database.
 ///
@@ -705,7 +726,17 @@ fn connect_conn(url: &str, tls: Option<&TlsConfig>) -> Result<Conn> {
 /// returns `None` and falls through to the old behaviour, which is what it was
 /// before this existed.
 pub(crate) fn truncate_target(sql: &str, event_db: &str) -> Option<(String, String)> {
-    let t = sql.trim().trim_end_matches(';').trim();
+    // Strip `/* … */` comments before tokenising. An adversarial pass predicted a
+    // hole here (sqlcommenter / Flyway / Rails append one to every statement) and
+    // MEASURING it did NOT reproduce: `SHOW BINLOG EVENTS` renders a trailing
+    // `/* xid=N */` that the QUERY event's own `query()` does not carry, and four
+    // live forms — trailing comment, leading comment, backticked, db-qualified —
+    // all refuse correctly on the 8.0 stand. Handled anyway because the cost is a
+    // few lines and the failure mode is a SILENT divergence: if any server version
+    // or client setting does deliver the text, this is the difference between a
+    // refusal and rows quietly left behind.
+    let stripped = strip_sql_comments(sql);
+    let t = stripped.trim().trim_end_matches(';').trim();
     let mut w = t.split_whitespace();
     if !w.next()?.eq_ignore_ascii_case("truncate") {
         return None;
@@ -908,6 +939,30 @@ mod tests {
         assert_eq!(
             t("TRUNCATE other.orders"),
             Some(("other".to_string(), "orders".to_string()))
+        );
+
+        // Comment forms. The prediction that these were a live hole did NOT
+        // reproduce (the QUERY event's `query()` does not carry the `/* xid=N */`
+        // that SHOW BINLOG EVENTS renders, and four live forms all refused
+        // correctly), so this is insurance rather than a fix — but it is the kind
+        // of insurance worth having, because the failure mode is a silent
+        // divergence rather than an error.
+        for form in [
+            "TRUNCATE TABLE orders /* xid=892514 */",
+            "TRUNCATE TABLE orders /*controller='orders',action='purge'*/",
+            "/*route=purge*/ TRUNCATE TABLE orders",
+            "TRUNCATE /*odd*/ TABLE orders",
+        ] {
+            assert_eq!(
+                t(form),
+                Some(("appdb".to_string(), "orders".to_string())),
+                "a comment must not hide a truncate: {form}"
+            );
+        }
+        // An UNTERMINATED comment must not resurrect the tail as a table name.
+        assert_eq!(
+            t("TRUNCATE TABLE orders /* never closed"),
+            Some(("appdb".to_string(), "orders".to_string()))
         );
 
         // Not a truncate, and — just as important — not a shape this reader claims

--- a/src/source/postgres/cdc.rs
+++ b/src/source/postgres/cdc.rs
@@ -1592,6 +1592,29 @@ mod tests {
             vec![("public".to_string(), "odd,name".to_string())],
             "splitting on a quoted comma would invent two relations that do not exist"
         );
+        // A DOUBLED quote is an escaped quote INSIDE the name, not the end of it.
+        // Mutation testing found this: five mutants in `split_top_level_commas`'
+        // escape branch survived, because every quoted fixture above closes its
+        // quote immediately and the escape path was never taken. A name like
+        // `od"d` re-opens the quoted span if the doubling is mishandled, and the
+        // following comma is then read as part of the name — one relation instead
+        // of two, and OUR table silently not among them.
+        assert_eq!(
+            one("table public.\"od\"\"d\", public.b: TRUNCATE: (no-flags)"),
+            vec![
+                ("public".to_string(), "od\"d".to_string()),
+                ("public".to_string(), "b".to_string())
+            ],
+            "a doubled quote is an ESCAPE; mishandling it swallows the separator and \
+             loses every relation after it — including possibly ours"
+        );
+        // …and the same escape inside a name that also carries a comma, which is
+        // where the two rules interact.
+        assert_eq!(
+            one("table public.\"a\"\",b\": TRUNCATE: (no-flags)"),
+            vec![("public".to_string(), "a\",b".to_string())],
+            "escape then comma: still ONE relation"
+        );
 
         assert!(
             one("table public.orders: INSERT: id[integer]:1").is_empty(),

--- a/src/source/postgres/cdc.rs
+++ b/src/source/postgres/cdc.rs
@@ -1657,6 +1657,23 @@ mod tests {
             "escape then comma: still ONE relation"
         );
 
+        // A name ENDING in the escaped quote — `a"` renders as `"a"""`, three quotes
+        // in a row. The fixtures above all have text after the doubling, so the
+        // lookahead `b.get(i + 1)` was never asked about a position where reading
+        // BACKWARD would answer differently: `replace + with -` survived CI
+        // (2026-08-25) against every case here. Proven to be the discriminator by
+        // exhaustive search over 97 655 strings on the alphabet `",.ax` — the
+        // shortest witness is `"",`, and this is its realistic form.
+        assert_eq!(
+            one("table public.\"a\"\"\", public.b: TRUNCATE: (no-flags)"),
+            vec![
+                ("public".to_string(), "a\"".to_string()),
+                ("public".to_string(), "b".to_string())
+            ],
+            "a name ending in an escaped quote must still close, or the following \
+             comma is read as part of it and every later relation disappears"
+        );
+
         assert!(
             one("table public.orders: INSERT: id[integer]:1").is_empty(),
             "an ordinary change must not be mistaken for a truncate"

--- a/src/source/postgres/cdc.rs
+++ b/src/source/postgres/cdc.rs
@@ -70,6 +70,9 @@ pub(crate) struct PgChangeStream {
     /// Rendered LSN of the last frontier advance — the zero-yield release
     /// target. `take()`n once at exhaust.
     frontier_text: Option<String>,
+    /// The `table:` values this run captures — what a TRUNCATE is checked against
+    /// before it is allowed to fail the run. See [`truncate_is_ours`].
+    configured_tables: Vec<String>,
 }
 
 /// The run-start warning emitted when a logical replication slot has to be
@@ -468,6 +471,7 @@ impl PgChangeStream {
             bound,
             yielded_data: false,
             frontier_text: None,
+            configured_tables: configured_tables.to_vec(),
         })
     }
 
@@ -540,6 +544,18 @@ impl PgChangeStream {
             } else if data.starts_with("BEGIN") {
                 tx.clear();
                 tx_bytes = 0;
+            } else if let Some((schema, table)) = truncate_target(&data) {
+                // A TRUNCATE carries no rows, so the parser below has nothing to
+                // build and dropped it silently — leaving the destination holding
+                // rows the source no longer has, with no DELETE to retract them
+                // and no later capture able to reconcile it.
+                if truncate_is_ours(&schema, &table, &self.configured_tables) {
+                    anyhow::bail!(truncate_refusal_message(&schema, &table));
+                }
+                // Another table's truncate: the routing filter would drop its rows
+                // anyway, so failing here would make one truncated table an outage
+                // for every export on this server — the MySQL undecodable-rows
+                // guard's measured lesson, applied before it could bite again.
             } else if let Some(ev) = parse_test_decoding(&lsn, &data)? {
                 tx_bytes = tx_bytes.saturating_add(ev.estimated_bytes());
                 tx.push(ev);
@@ -783,6 +799,65 @@ fn split_qualified_ident(qual: &str) -> (String, String) {
         Some(i) => (unquote_ident(&qual[..i]), unquote_ident(&qual[i + 1..])),
         None => (String::new(), unquote_ident(qual)),
     }
+}
+
+/// The relation a `test_decoding` TRUNCATE line names, or `None` if the line is
+/// not a TRUNCATE.
+///
+/// `TRUNCATE` is decoded (PostgreSQL 11+) and rendered as
+/// `table public.t: TRUNCATE: (no-flags)`, but it carries NO rows — so
+/// [`parse_test_decoding`], which builds a change out of the column list, has
+/// nothing to return and dropped the line into its catch-all `None`. Measured
+/// 2026-08-24 on the pg14 stand: 2 inserts then a TRUNCATE left the source table
+/// EMPTY while the run reported `status: success, rows: 2` and wrote both inserts
+/// to the destination. Not one line about it at `RUST_LOG=trace` either — zero
+/// occurrences of the word.
+///
+/// That divergence is permanent. The rows left the source with no DELETE events
+/// to carry them, so no later capture can reconcile the destination back: the
+/// stream is now describing a table state that never existed.
+pub(crate) fn truncate_target(data: &str) -> Option<(String, String)> {
+    let (qual, tail) = data
+        .strip_prefix("table ")
+        .and_then(|s| s.split_once(": "))?;
+    tail.starts_with("TRUNCATE")
+        .then(|| split_qualified_ident(qual))
+}
+
+/// Refuse a TRUNCATE on a captured table, naming why re-running cannot fix it.
+///
+/// Loud, not a warning: this is an UNRECOVERABLE divergence, and the repo's rule
+/// is that those fail rather than degrade. A warning would leave a destination
+/// that silently disagrees with the source forever, which is the outcome the
+/// `unknown -> default` shape exists to prevent.
+pub(crate) fn truncate_refusal_message(schema: &str, table: &str) -> String {
+    let qualified = if schema.is_empty() {
+        table.to_string()
+    } else {
+        format!("{schema}.{table}")
+    };
+    format!(
+        "pg cdc: `{qualified}` was TRUNCATEd, and this reader cannot represent that as a \
+         change. Skipping it would leave every row the truncate removed sitting in the \
+         destination with no DELETE to retract it — the source empty, the destination \
+         not, permanently, because those rows left the source without events and no \
+         later capture can reconcile them. Re-snapshot the table (`mode: full`) to \
+         re-establish the baseline, then resume CDC from a fresh checkpoint."
+    )
+}
+
+/// Is a TRUNCATE this run's problem? Same asymmetry as the MySQL undecodable-rows
+/// guard, and for the same measured reason: one server's stream carries every
+/// table's changes, so refusing without asking whose relation it is makes one
+/// truncated table an outage for exports that never read it.
+///
+/// Empty `configured` means "capture whatever the stream emits", which makes every
+/// truncate ours.
+pub(crate) fn truncate_is_ours(schema: &str, table: &str, configured: &[String]) -> bool {
+    configured.is_empty()
+        || configured
+            .iter()
+            .any(|c| crate::source::cdc::sink::table_matches(c, schema, table))
 }
 
 /// Parse one `test_decoding` line into a canonical change, or `None` for the
@@ -1317,6 +1392,75 @@ fn parse_pg_timestamp(val: &str) -> RivetValue {
 mod tests {
 
     use super::*;
+
+    /// The TRUNCATE recogniser and its addressing, graded offline.
+    ///
+    /// The live test proves the seam; this proves the branches, including the two
+    /// that a live fixture cannot reach cheaply — a bare (schema-less) config name,
+    /// and the empty-config case `rivet cdc` without `--table` takes.
+    #[test]
+    fn a_truncate_is_recognised_and_refused_only_for_the_captured_tables() {
+        assert_eq!(
+            truncate_target("table public.orders: TRUNCATE: (no-flags)"),
+            Some(("public".to_string(), "orders".to_string())),
+            "the exact line test_decoding emits (measured on pg14) must be recognised"
+        );
+        assert_eq!(
+            truncate_target("table \"My Schema\".\"Odd.Name\": TRUNCATE: (no-flags)"),
+            Some(("My Schema".to_string(), "Odd.Name".to_string())),
+            "a quoted identifier must unquote like every other wire identity (#279) — \
+             a dot INSIDE quotes is part of the name, not the qualifier split"
+        );
+        assert_eq!(
+            truncate_target("table public.orders: INSERT: id[integer]:1"),
+            None,
+            "an ordinary change must NOT be mistaken for a truncate"
+        );
+        assert_eq!(
+            truncate_target("COMMIT 123"),
+            None,
+            "markers are not truncates"
+        );
+        // `TRUNCATED` would be a different word; the guard must not fire on a
+        // table whose row happens to start with the prefix in another position.
+        assert_eq!(
+            truncate_target("table public.t: DELETE: id[integer]:1"),
+            None,
+            "DELETE stays a change — the guard is for the op with NO rows"
+        );
+
+        let cfg = vec!["public.orders".to_string()];
+        assert!(
+            truncate_is_ours("public", "orders", &cfg),
+            "our own table must fail the run — the divergence it leaves is permanent"
+        );
+        assert!(
+            !truncate_is_ours("public", "audit", &cfg),
+            "another table's truncate must NOT fail this run: the slot decodes the \
+             whole database, so refusing would make one truncated table an outage \
+             for every export on it (the MySQL undecodable-rows lesson, #281)"
+        );
+        assert!(
+            truncate_is_ours("public", "audit", &[]),
+            "`rivet cdc` with no --table captures whatever the stream emits"
+        );
+        assert!(
+            truncate_is_ours("otherschema", "orders", &["orders".to_string()]),
+            "a bare config name matches any schema, exactly as sink::table_matches \
+             routes it — a guard asking a different question protects the wrong set"
+        );
+
+        let msg = truncate_refusal_message("public", "orders");
+        assert!(
+            msg.contains("public.orders") && msg.contains("mode: full"),
+            "the refusal must name the table AND the re-snapshot that recovers from \
+             it; a bail with no way forward just moves the operator's problem: {msg}"
+        );
+        assert!(
+            truncate_refusal_message("", "orders").contains("`orders`"),
+            "a schema-less identity must not render a leading dot"
+        );
+    }
 
     /// The guard's whole decision surface, one case per relkind that behaves
     /// differently. Every arm was MEASURED on the pg14 stand (2026-08-24) rather

--- a/src/source/postgres/cdc.rs
+++ b/src/source/postgres/cdc.rs
@@ -429,6 +429,36 @@ impl PgChangeStream {
             else {
                 continue; // unresolvable here — the schema probe reports it, loudly
             };
+            // A BARE (unqualified) name matches ANY schema in the router: `cfg == table`
+            // in sink::table_matches, which exists because a MongoDB collection has no
+            // schema qualifier and may itself contain dots. On PostgreSQL that makes an
+            // unqualified `table: orders` capture EVERY schema's `orders` into one
+            // export, silently interleaved.
+            //
+            // MEASURED 2026-08-25: `table: bare` with `public.bare` and `s2.bare` both
+            // present captured 2 rows — one from each schema — into a single part, with
+            // nothing in the output distinguishing them.
+            //
+            // A warning, not a refusal: capturing one table under a bare name is the
+            // common and correct case, and `to_regclass` resolves it through search_path
+            // exactly as the schema probe does. What the operator cannot see is that a
+            // SECOND relation of that name will ride along.
+            if !cfg.contains('.') {
+                let others: Vec<String> = client
+                    .query(
+                        "SELECT n.nspname || '.' || c.relname                          FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace                          WHERE c.relname = $1 AND c.relkind IN ('r','p')                            AND n.nspname NOT IN ('pg_catalog','information_schema')",
+                        &[&cfg.as_str()],
+                    )
+                    .map(|rows| rows.iter().map(|r| r.get::<_, String>(0)).collect())
+                    .unwrap_or_default();
+                if others.len() > 1 {
+                    log::warn!(
+                        "pg cdc: `{cfg}` is unqualified and {} relations share that name                          ({}). Routing matches a bare name in ANY schema, so changes from                          ALL of them land in this one export, interleaved and                          indistinguishable in the output. Qualify it (`schema.{cfg}`) to                          capture the one you mean.",
+                        others.len(),
+                        others.join(", ")
+                    );
+                }
+            }
             let relkind: String = row.get(0);
             let relpersistence: String = row.get(1);
             let resolved_schema: String = row.get(2);

--- a/src/source/postgres/cdc.rs
+++ b/src/source/postgres/cdc.rs
@@ -544,18 +544,23 @@ impl PgChangeStream {
             } else if data.starts_with("BEGIN") {
                 tx.clear();
                 tx_bytes = 0;
-            } else if let Some((schema, table)) = truncate_target(&data) {
+            } else if let Some((schema, table)) = truncate_targets(&data)
+                .into_iter()
+                .find(|(sc, tb)| truncate_is_ours(sc, tb, &self.configured_tables))
+            {
                 // A TRUNCATE carries no rows, so the parser below has nothing to
                 // build and dropped it silently — leaving the destination holding
                 // rows the source no longer has, with no DELETE to retract them
                 // and no later capture able to reconcile it.
-                if truncate_is_ours(&schema, &table, &self.configured_tables) {
-                    anyhow::bail!(truncate_refusal_message(&schema, &table));
-                }
-                // Another table's truncate: the routing filter would drop its rows
-                // anyway, so failing here would make one truncated table an outage
-                // for every export on this server — the MySQL undecodable-rows
-                // guard's measured lesson, applied before it could bite again.
+                //
+                // ONE line can name MANY relations (`TRUNCATE a, b`, and every
+                // CASCADE that pulls in referencing tables), so this searches the
+                // whole list for one of OURS rather than testing the first. A
+                // truncate naming only other tables falls through — the routing
+                // filter would drop their rows anyway, and failing on them would
+                // make one truncated table an outage for every export on this
+                // server (the MySQL undecodable-rows guard's measured lesson).
+                anyhow::bail!(truncate_refusal_message(&schema, &table));
             } else if let Some(ev) = parse_test_decoding(&lsn, &data)? {
                 tx_bytes = tx_bytes.saturating_add(ev.estimated_bytes());
                 tx.push(ev);
@@ -816,12 +821,61 @@ fn split_qualified_ident(qual: &str) -> (String, String) {
 /// That divergence is permanent. The rows left the source with no DELETE events
 /// to carry them, so no later capture can reconcile the destination back: the
 /// stream is now describing a table state that never existed.
-pub(crate) fn truncate_target(data: &str) -> Option<(String, String)> {
-    let (qual, tail) = data
-        .strip_prefix("table ")
-        .and_then(|s| s.split_once(": "))?;
-    tail.starts_with("TRUNCATE")
-        .then(|| split_qualified_ident(qual))
+pub(crate) fn truncate_targets(data: &str) -> Vec<(String, String)> {
+    // The op keyword sits AFTER the (possibly multi-relation) name list, so find the
+    // LAST top-level `": "` rather than the first: a quoted identifier may legally
+    // contain `": "` and splitting at the first occurrence cuts a name in half.
+    let Some(rest) = data.strip_prefix("table ") else {
+        return Vec::new();
+    };
+    // Anchor on the OPERATION marker, not on a bare `": "`. The line holds two of
+    // those — one after the name list, one after the keyword
+    // (`table a, b: TRUNCATE: (no-flags)`) — so "the last `": "`" lands after
+    // TRUNCATE and yields an empty match. Caught by re-measuring the fix rather
+    // than by re-reading it.
+    const MARK: &str = ": TRUNCATE:";
+    let Some(sep) = find_outside_quotes(rest, MARK) else {
+        return Vec::new();
+    };
+    let quals = &rest[..sep];
+    // ONE line can name MANY relations — `TRUNCATE a, b` decodes as
+    // `table public.a, public.b: TRUNCATE: (no-flags)`, and every CASCADE that
+    // pulls in referencing tables does the same. Treating that as a single name
+    // made the guard miss the whole statement: MEASURED with `public.tmulti_a`
+    // configured, `TRUNCATE tmulti_a, tmulti_b` left the source EMPTY while the
+    // run reported `status: success, rows: 1`. Found by an adversarial pass over
+    // the first version of this guard.
+    split_top_level_commas(quals)
+        .into_iter()
+        .map(|q| split_qualified_ident(q.trim()))
+        .collect()
+}
+
+/// Split a relation LIST on top-level commas — a comma inside a quoted identifier
+/// (`"odd,name"`) is part of the name, not a separator.
+fn split_top_level_commas(list: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let mut in_quotes = false;
+    let mut escaped = false;
+    let mut start = 0usize;
+    let b = list.as_bytes();
+    for i in 0..b.len() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match b[i] {
+            b'"' if in_quotes && b.get(i + 1) == Some(&b'"') => escaped = true,
+            b'"' => in_quotes = !in_quotes,
+            b',' if !in_quotes => {
+                out.push(&list[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    out.push(&list[start..]);
+    out
 }
 
 /// Refuse a TRUNCATE on a captured table, naming why re-running cannot fix it.
@@ -1395,37 +1449,51 @@ mod tests {
 
     /// The TRUNCATE recogniser and its addressing, graded offline.
     ///
-    /// The live test proves the seam; this proves the branches, including the two
-    /// that a live fixture cannot reach cheaply — a bare (schema-less) config name,
-    /// and the empty-config case `rivet cdc` without `--table` takes.
+    /// The multi-relation case is here because the FIRST version of this guard
+    /// shipped without it and an adversarial pass measured the consequence: with
+    /// `public.tmulti_a` configured, `TRUNCATE tmulti_a, tmulti_b` left the source
+    /// EMPTY while the run reported `status: success, rows: 1`. One line names
+    /// every relation, and every CASCADE that pulls in referencing tables produces
+    /// the same shape.
     #[test]
-    fn a_truncate_is_recognised_and_refused_only_for_the_captured_tables() {
+    fn a_truncate_is_recognised_across_a_relation_list_and_refused_only_for_ours() {
+        let one = |d: &str| truncate_targets(d);
+
         assert_eq!(
-            truncate_target("table public.orders: TRUNCATE: (no-flags)"),
-            Some(("public".to_string(), "orders".to_string())),
-            "the exact line test_decoding emits (measured on pg14) must be recognised"
+            one("table public.orders: TRUNCATE: (no-flags)"),
+            vec![("public".to_string(), "orders".to_string())],
+            "the exact line test_decoding emits for a single relation (measured on pg14)"
+        );
+        // MEASURED wire text for `TRUNCATE tmulti_a, tmulti_b`.
+        assert_eq!(
+            one("table public.a, public.b: TRUNCATE: (no-flags)"),
+            vec![
+                ("public".to_string(), "a".to_string()),
+                ("public".to_string(), "b".to_string())
+            ],
+            "a multi-relation TRUNCATE must yield EVERY relation — missing the list \
+             is how the first version of this guard let the statement through"
         );
         assert_eq!(
-            truncate_target("table \"My Schema\".\"Odd.Name\": TRUNCATE: (no-flags)"),
-            Some(("My Schema".to_string(), "Odd.Name".to_string())),
-            "a quoted identifier must unquote like every other wire identity (#279) — \
-             a dot INSIDE quotes is part of the name, not the qualifier split"
+            one("table \"My Schema\".\"Odd.Name\": TRUNCATE: (no-flags)"),
+            vec![("My Schema".to_string(), "Odd.Name".to_string())],
+            "a quoted identifier unquotes like every other wire identity (#279) — a \
+             dot INSIDE quotes belongs to the name"
         );
+        // A comma inside a quoted name is part of the name, not a list separator.
         assert_eq!(
-            truncate_target("table public.orders: INSERT: id[integer]:1"),
-            None,
-            "an ordinary change must NOT be mistaken for a truncate"
+            one("table public.\"odd,name\": TRUNCATE: (no-flags)"),
+            vec![("public".to_string(), "odd,name".to_string())],
+            "splitting on a quoted comma would invent two relations that do not exist"
         );
-        assert_eq!(
-            truncate_target("COMMIT 123"),
-            None,
-            "markers are not truncates"
+
+        assert!(
+            one("table public.orders: INSERT: id[integer]:1").is_empty(),
+            "an ordinary change must not be mistaken for a truncate"
         );
-        // `TRUNCATED` would be a different word; the guard must not fire on a
-        // table whose row happens to start with the prefix in another position.
-        assert_eq!(
-            truncate_target("table public.t: DELETE: id[integer]:1"),
-            None,
+        assert!(one("COMMIT 123").is_empty(), "markers are not truncates");
+        assert!(
+            one("table public.t: DELETE: id[integer]:1").is_empty(),
             "DELETE stays a change — the guard is for the op with NO rows"
         );
 
@@ -1449,6 +1517,18 @@ mod tests {
             "a bare config name matches any schema, exactly as sink::table_matches \
              routes it — a guard asking a different question protects the wrong set"
         );
+        // The whole point of parsing the LIST: ours can be anywhere in it.
+        let multi = one("table public.other, public.orders: TRUNCATE: (no-flags)");
+        assert!(
+            multi.iter().any(|(s, t)| truncate_is_ours(s, t, &cfg)),
+            "a truncate naming ours SECOND must still be found: {multi:?}"
+        );
+        assert!(
+            !one("table public.x, public.y: TRUNCATE: (no-flags)")
+                .iter()
+                .any(|(s, t)| truncate_is_ours(s, t, &cfg)),
+            "a list naming only OTHER tables must not fail this run"
+        );
 
         let msg = truncate_refusal_message("public", "orders");
         assert!(
@@ -1462,11 +1542,6 @@ mod tests {
         );
     }
 
-    /// The guard's whole decision surface, one case per relkind that behaves
-    /// differently. Every arm was MEASURED on the pg14 stand (2026-08-24) rather
-    /// than read off the docs — `REFRESH MATERIALIZED VIEW` in particular emits
-    /// no `table …` line at all, which is why 'm' sits with the never-routable
-    /// kinds instead of being assumed routable.
     #[test]
     fn classify_routing_refuses_only_the_relations_no_event_can_ever_name() {
         let rel = |kind: char, children: &[&str]| RelationRouting {

--- a/src/source/postgres/cdc.rs
+++ b/src/source/postgres/cdc.rs
@@ -1001,8 +1001,19 @@ pub(crate) fn truncate_refusal_message(schema: &str, table: &str) -> String {
          change. Skipping it would leave every row the truncate removed sitting in the \
          destination with no DELETE to retract it — the source empty, the destination \
          not, permanently, because those rows left the source without events and no \
-         later capture can reconcile them. Re-snapshot the table (`mode: full`) to \
-         re-establish the baseline, then resume CDC from a fresh checkpoint."
+         later capture can reconcile them. \
+         \
+         AND THIS RUN WILL NOT MOVE ON ITS OWN. The peek is non-consuming, so the \
+         slot still sits on this commit: every later run meets it first and clean \
+         changes queued BEHIND it are blocked too, while the un-acked slot pins WAL. \
+         MEASURED — a truncate followed by an ordinary INSERT leaves the second run \
+         failing identically. \
+         \
+         Re-snapshot the table (`mode: full`) to re-establish the baseline, and then \
+         get the stream past this commit: \
+         SELECT pg_replication_slot_advance('<slot>', '<lsn past the truncate>'); \
+         Re-snapshotting ALONE leaves the capture wedged, because the slot has not \
+         moved."
     )
 }
 

--- a/tests/cdc_conformance_gate.rs
+++ b/tests/cdc_conformance_gate.rs
@@ -384,6 +384,7 @@ fn derived_capture_marker_set_is_pinned() {
         "run_args_env(",
         "run_expect_fail(",
         "run_ok(",
+        "run_ok_capture(",
         "run_rivet(",
         "run_rivet_args_bounded(",
         "run_rivet_args_bounded_env(",

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -86,6 +86,29 @@ static NAME_COUNTER: AtomicU64 = AtomicU64::new(0);
 /// Build a globally-unique identifier safe to use as a SQL table name or an
 /// export name.  Combines process id and an atomic counter so parallel
 /// `cargo test --test-threads=N` runs do not collide.
+/// Announce that a live test did NOT run, in a form a release lane can COUNT.
+///
+/// `cargo test` prints `ok` for a test that returned early, so a skip and a pass
+/// are indistinguishable in the output — the same shape that let 20 warehouse
+/// cells report `20 passed` in 0.00s. The harness half of that was fixed by giving
+/// its runners an explicit `Skipped` outcome; the live suite has no such channel,
+/// so the marker IS the channel.
+///
+/// One token, `RIVET-SKIP`, and the test's own name, because the messages it
+/// replaces said `SKIP`, `skip:`, and `skipping` in three different shapes and a
+/// lane cannot grep for all of them. What a lane does with the count is its
+/// business: assert a ceiling, diff against a previous run, or just print it —
+/// none of which is possible while the skips are invisible.
+///
+/// Returns `()` so a call site reads `return skip_live("...")`.
+pub fn skip_live(why: &str) {
+    let who = std::thread::current()
+        .name()
+        .unwrap_or("<unnamed test>")
+        .to_string();
+    eprintln!("RIVET-SKIP {who} — {why}");
+}
+
 pub fn unique_name(prefix: &str) -> String {
     let c = NAME_COUNTER.fetch_add(1, Ordering::SeqCst);
     let pid = std::process::id();

--- a/tests/common/mongo.rs
+++ b/tests/common/mongo.rs
@@ -58,6 +58,33 @@ impl MongoTest {
         })
     }
 
+    /// Turn on `changeStreamPreAndPostImages` for one collection (6.0+).
+    ///
+    /// Off by DEFAULT and per-COLLECTION, which is why it needs saying in a test
+    /// rather than in the stack: rivet asks for
+    /// `full_document_before_change(WhenAvailable)`, so on a default collection a
+    /// delete's `document` is legitimately NULL and the request is a silent no-op.
+    /// Whether the pre-image actually arrives when the collection HAS it enabled is
+    /// a different question, and it is the one nothing asked.
+    ///
+    /// Returns false when the server is too old to honour it, so a caller on 4.4/5.0
+    /// can say "not applicable here" out loud instead of asserting a null.
+    pub fn enable_pre_images(&self, name: &str) -> bool {
+        if self.server_major() < 6 {
+            return false;
+        }
+        self.rt.block_on(async {
+            self.client
+                .database(&self.db)
+                .run_command(doc! {
+                    "collMod": name,
+                    "changeStreamPreAndPostImages": { "enabled": true },
+                })
+                .await
+                .is_ok()
+        })
+    }
+
     fn coll(&self, name: &str) -> Collection<Document> {
         self.client.database(&self.db).collection(name)
     }

--- a/tests/common/rig/invoke.rs
+++ b/tests/common/rig/invoke.rs
@@ -229,6 +229,28 @@ impl Rig {
         );
     }
 
+    /// Run rivet; panic unless it succeeds, and return what it SAID.
+    ///
+    /// The oracle for a WARNING: a warning by definition rides on a successful run,
+    /// so `run_ok` (which throws the output away) and `run_expect_fail` (which
+    /// demands a non-zero exit) both grade the wrong thing. Tests that hand-rolled
+    /// `Command::new(RIVET_BIN)` to read stderr off a green run are what this
+    /// replaces.
+    pub fn run_ok_capture(&self) -> String {
+        let out = self.run_args(&[]);
+        let said = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(
+            out.status.success(),
+            "rig run failed for '{}':\n{said}",
+            self.name
+        );
+        said
+    }
+
     /// Run rivet expecting a loud failure; returns combined output.
     pub fn run_expect_fail(&self) -> String {
         let out = self.run_args(&[]);

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -377,6 +377,11 @@ pub enum OracleOutcome {
     Skipped { why: String },
 }
 
+/// Why a runner reports `Skipped` rather than an empty result. `assert_all_pass`
+/// panics on Skipped and walks straight through an empty vec — so an empty return
+/// is a cell that verified nothing and said it passed.
+const SKIP_WHY: &str = "RIVET_TEST_GCS_BUCKET unset — no live warehouse env. This cell verified NOTHING; a green run without it is absence, not success";
+
 impl Verification {
     pub fn new(engine: Engine, mode: Mode, fixture: Fixture) -> Self {
         Verification {
@@ -407,12 +412,29 @@ impl Verification {
         &self,
         oracles: &[WarehouseOracle],
     ) -> Result<Vec<(WarehouseOracle, OracleOutcome)>> {
-        if no_live_warehouse_env() {
-            eprintln!("SKIP run: RIVET_TEST_GCS_BUCKET unset — no live warehouse env");
-            return Ok(Vec::new());
-        }
+        // Order matters: an empty oracle list is a CONFIG error whatever the
+        // environment, so it is answered before the env check — otherwise a machine
+        // without credentials cannot tell a mis-declared cell from a skipped one.
         if oracles.is_empty() {
             bail!("strength-floor: a `test:` case must declare ≥1 oracle (ADR-0001)");
+        }
+        if no_live_warehouse_env() {
+            // A `Skipped` per requested oracle, NOT an empty vec: `assert_all_pass`
+            // panics on Skipped and walks straight through an empty list, so the
+            // empty return made every cell in the matrix pass vacuously on a machine
+            // with no credentials — while this function's own doc called that a
+            // strength-floor failure.
+            return Ok(oracles
+                .iter()
+                .map(|o| {
+                    (
+                        *o,
+                        OracleOutcome::Skipped {
+                            why: SKIP_WHY.to_string(),
+                        },
+                    )
+                })
+                .collect());
         }
         let env = HarnessEnv::load()?;
         let work = TempWork::new("rivet-pro-matrix")?;
@@ -447,8 +469,12 @@ impl Verification {
         soak: &[SoakOracle],
     ) -> Result<Vec<(String, OracleOutcome)>> {
         if no_live_warehouse_env() {
-            eprintln!("SKIP run_soak: RIVET_TEST_GCS_BUCKET unset — no live warehouse env");
-            return Ok(Vec::new());
+            return Ok(vec![(
+                "run_soak".to_string(),
+                OracleOutcome::Skipped {
+                    why: SKIP_WHY.to_string(),
+                },
+            )]);
         }
         if self.mode != Mode::Cdc {
             bail!("run_soak requires Mode::Cdc");
@@ -512,8 +538,12 @@ impl Verification {
     /// `_id:1` live and `_id:2` as a tombstone (`__is_deleted = true`).
     pub fn run_mongo_cdc_delete(&self) -> Result<Vec<(String, OracleOutcome)>> {
         if no_live_warehouse_env() {
-            eprintln!("SKIP run_mongo_cdc_delete: RIVET_TEST_GCS_BUCKET unset");
-            return Ok(Vec::new());
+            return Ok(vec![(
+                "run_mongo_cdc_delete".to_string(),
+                OracleOutcome::Skipped {
+                    why: SKIP_WHY.to_string(),
+                },
+            )]);
         }
         if self.engine != Engine::Mongo || self.mode != Mode::Cdc {
             bail!("run_mongo_cdc_delete is Mongo+Cdc only");
@@ -591,8 +621,12 @@ impl Verification {
     /// source + an `id` column — neither holds for Mongo's `_id`/JSON-blob model).
     pub fn run_mongo_batch(&self) -> Result<Vec<(String, OracleOutcome)>> {
         if no_live_warehouse_env() {
-            eprintln!("SKIP run_mongo_batch: RIVET_TEST_GCS_BUCKET unset");
-            return Ok(Vec::new());
+            return Ok(vec![(
+                "run_mongo_batch".to_string(),
+                OracleOutcome::Skipped {
+                    why: SKIP_WHY.to_string(),
+                },
+            )]);
         }
         if self.engine != Engine::Mongo || self.mode != Mode::Batch {
             bail!("run_mongo_batch is Mongo+Batch only");
@@ -663,8 +697,12 @@ impl Verification {
     /// insert), tombstoned 1, and an untouched mid-backfill row live.
     pub fn run_cdc_backfill(&self) -> Result<Vec<(String, OracleOutcome)>> {
         if no_live_warehouse_env() {
-            eprintln!("SKIP run_cdc_backfill: RIVET_TEST_GCS_BUCKET unset");
-            return Ok(Vec::new());
+            return Ok(vec![(
+                "run_cdc_backfill".to_string(),
+                OracleOutcome::Skipped {
+                    why: SKIP_WHY.to_string(),
+                },
+            )]);
         }
         if self.mode != Mode::Cdc || !self.initial_snapshot {
             bail!("run_cdc_backfill needs Mode::Cdc + .initial_snapshot()");
@@ -775,8 +813,12 @@ impl Verification {
     /// bucket.
     pub fn run_incremental(&self) -> Result<Vec<(String, OracleOutcome)>> {
         if no_live_warehouse_env() {
-            eprintln!("SKIP run_incremental: RIVET_TEST_GCS_BUCKET unset");
-            return Ok(Vec::new());
+            return Ok(vec![(
+                "run_incremental".to_string(),
+                OracleOutcome::Skipped {
+                    why: SKIP_WHY.to_string(),
+                },
+            )]);
         }
         let env = HarnessEnv::load()?;
         let work = TempWork::new("rivet-incremental")?;

--- a/tests/live/gremlin_cdc.rs
+++ b/tests/live/gremlin_cdc.rs
@@ -138,11 +138,33 @@ fn gremlin_cdc_sigkill_mid_drain_recovers_without_gap() {
             break;
         }
         if let Some(_status) = child.try_wait().unwrap() {
-            break; // drained before we could kill — too fast; still assert below
+            break; // drained before the kill landed — asserted against below
         }
         std::thread::sleep(std::time::Duration::from_millis(10));
     }
     let _ = child.wait();
+
+    // The fault must have FIRED. `killed_mid_drain` used to be computed and only
+    // interpolated into the failure message, so a run that drained before the kill
+    // landed passed having verified nothing about crash recovery — the test's own
+    // comment said "too fast; still assert below", and what it asserted below was
+    // an ordinary complete export.
+    assert!(
+        killed_mid_drain,
+        "the SIGKILL never landed — this run drained to completion, so nothing here \
+         says anything about recovery. Not a pass: a fault-injection test whose fault \
+         did not fire has no subject"
+    );
+    // ...and it must have MATTERED. A kill that lands at the finish line fires the
+    // flag while leaving a complete export behind, which grades the same as no kill
+    // at all. MEASURED 3/3: exactly 500 of 5000 rows survive, the first rollover.
+    let after_kill = distinct_ids(&out).len();
+    assert!(
+        after_kill < 5_000,
+        "the kill landed but left a COMPLETE export ({after_kill} of 5000) — the \
+         recovery legs below then have nothing to recover and would pass over a \
+         resume that captured zero"
+    );
 
     // Recovery run(s): drain whatever the killed run left behind.
     for _ in 0..3 {

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -6305,3 +6305,160 @@ fn mysql_cdc_refuses_a_partial_json_binlog_instead_of_dropping_the_update() {
          and the routing filter would have dropped it anyway"
     );
 }
+
+/// A guard that returns `binlog_row_metadata` to whatever the stack pinned.
+///
+/// The variable is GLOBAL-only in MySQL 8 — there is no session scope to flip —
+/// so a test that leaves it MINIMAL silently changes every later test's engine.
+struct RowMetadata(String);
+
+impl RowMetadata {
+    fn set(to: &str) -> Self {
+        let mut c = conn();
+        let was: String = c
+            .query_first("SELECT @@GLOBAL.binlog_row_metadata")
+            .expect("read binlog_row_metadata")
+            .expect("a value");
+        c.query_drop(format!("SET GLOBAL binlog_row_metadata={to}"))
+            .expect(
+                "SET GLOBAL binlog_row_metadata needs SYSTEM_VARIABLES_ADMIN — see \
+                 dev/cdc/mysql-grant.sql; without it MySQL's own default configuration is \
+                 the one configuration nothing tests",
+            );
+        Self(was)
+    }
+}
+
+impl Drop for RowMetadata {
+    fn drop(&mut self) {
+        if let Ok(mut c) = mysql::Pool::new(MYSQL_CDC_URL).and_then(|p| p.get_conn()) {
+            let _ = c.query_drop(format!("SET GLOBAL binlog_row_metadata={}", self.0));
+        }
+    }
+}
+
+/// MySQL's DEFAULT `binlog_row_metadata=MINIMAL` maps binlog images POSITIONALLY,
+/// and a same-arity column reorder across the resume boundary silently swaps them.
+///
+/// The stack pins `--binlog-row-metadata=FULL` (docker-compose), which puts column
+/// NAMES into TABLE_MAP — so the sink takes the by-name arm and `continue`s past
+/// the arity guard entirely (`sink.rs`, `if ev.image_names.is_some()`). MySQL's own
+/// default is MINIMAL. Every live MySQL CDC test therefore runs the ONE
+/// configuration a user does not have, and the positional path plus the guard that
+/// protects it are reachable only from the default nobody exercises.
+///
+/// This is the measurement that decides how loud rivet should be about it. Under
+/// MINIMAL: the schema is resolved at OPEN, the events replay from the CHECKPOINT
+/// — so an `ALTER TABLE ... MODIFY b AFTER id` between the two puts a row written
+/// as `(id, a, b)` into columns resolved as `(id, b, a)`.
+#[test]
+#[ignore = "live: requires docker compose mysql-cdc (SYSTEM_VARIABLES_ADMIN)"]
+fn mysql_cdc_minimal_row_metadata_is_the_engine_default_and_reorders_silently() {
+    let _serial = cross_process_serial("mysql_cdc_row_metadata");
+    let _meta = RowMetadata::set("MINIMAL");
+    let table = unique_name("rivet_cdc_min");
+    let mut c = conn();
+    c.query_drop(format!("DROP TABLE IF EXISTS {table}"))
+        .unwrap();
+    c.query_drop(format!(
+        "CREATE TABLE {table}(id INT PRIMARY KEY, a VARCHAR(9), b VARCHAR(9))"
+    ))
+    .unwrap();
+    let _t = Table(table.clone());
+
+    let d = tempfile::tempdir().unwrap();
+    let ckpt = d.path().join("cdc.ckpt");
+    write_checkpoint(&mut c, &ckpt);
+    let rig = Rig::mysql_cdc(&table).checkpoint_path(ckpt.clone());
+
+    // Written under the OLD column order, read back under the new one.
+    c.query_drop(format!("INSERT INTO {table} VALUES (1,'AAA','BBB')"))
+        .unwrap();
+    c.query_drop(format!(
+        "ALTER TABLE {table} MODIFY COLUMN b VARCHAR(9) AFTER id"
+    ))
+    .unwrap();
+
+    let out = rig.out_dir();
+    let said = rig.run_ok_capture();
+
+    // The corruption is REAL and this test does not pretend otherwise: rivet cannot
+    // undo it after the fact, because under MINIMAL the wire carries no names to
+    // detect the reorder from. What it CAN do — and now does — is say so before a
+    // single event is read.
+    assert_eq!(
+        duckdb_dir_parquet_distinct_strings(&out, "a"),
+        ["BBB".to_string()].into_iter().collect(),
+        "MEASURED: positional mapping puts the OLD order's `b` into `a`. If this ever \
+         reads AAA the engine learned to map by name under MINIMAL and the warning \
+         below should go with it"
+    );
+    assert_eq!(
+        duckdb_dir_parquet_distinct_strings(&out, "b"),
+        ["AAA".to_string()].into_iter().collect(),
+        "...and symmetrically the OLD order's `a` into `b`"
+    );
+
+    // The load-bearing half: the operator is TOLD, at warn level, at run start.
+    assert!(
+        said.contains("binlog_row_metadata") && said.contains("POSITION"),
+        "a run that maps by position must say so — an operator who learns it from a \
+         swapped column months later cannot act on it. Got:\n{said}"
+    );
+    assert!(
+        said.contains("binlog_row_metadata = FULL"),
+        "the warning must name the ESCAPE, not just the risk. Got:\n{said}"
+    );
+}
+
+/// ...and under the FULL the stack pins, the same reorder is mapped BY NAME and
+/// comes back correct, with no warning.
+///
+/// Without this half the test above proves only that a swap happens, not that the
+/// setting is what causes it — and the warning would be free to fire on every run,
+/// which is how a warning gets ignored.
+#[test]
+#[ignore = "live: requires docker compose mysql-cdc (SYSTEM_VARIABLES_ADMIN)"]
+fn mysql_cdc_full_row_metadata_maps_the_same_reorder_by_name_and_stays_quiet() {
+    let _serial = cross_process_serial("mysql_cdc_row_metadata");
+    let _meta = RowMetadata::set("FULL");
+    let table = unique_name("rivet_cdc_full");
+    let mut c = conn();
+    c.query_drop(format!("DROP TABLE IF EXISTS {table}"))
+        .unwrap();
+    c.query_drop(format!(
+        "CREATE TABLE {table}(id INT PRIMARY KEY, a VARCHAR(9), b VARCHAR(9))"
+    ))
+    .unwrap();
+    let _t = Table(table.clone());
+
+    let d = tempfile::tempdir().unwrap();
+    let ckpt = d.path().join("cdc.ckpt");
+    write_checkpoint(&mut c, &ckpt);
+    let rig = Rig::mysql_cdc(&table).checkpoint_path(ckpt.clone());
+
+    c.query_drop(format!("INSERT INTO {table} VALUES (1,'AAA','BBB')"))
+        .unwrap();
+    c.query_drop(format!(
+        "ALTER TABLE {table} MODIFY COLUMN b VARCHAR(9) AFTER id"
+    ))
+    .unwrap();
+
+    let out = rig.out_dir();
+    let said = rig.run_ok_capture();
+    assert_eq!(
+        duckdb_dir_parquet_distinct_strings(&out, "a"),
+        ["AAA".to_string()].into_iter().collect(),
+        "under FULL the image carries names, so the reorder maps correctly — this is \
+         the assertion that makes FULL the documented escape rather than folklore"
+    );
+    assert_eq!(
+        duckdb_dir_parquet_distinct_strings(&out, "b"),
+        ["BBB".to_string()].into_iter().collect()
+    );
+    assert!(
+        !said.contains("binlog_row_metadata"),
+        "a correctly-configured server must stay quiet, or the warning becomes noise \
+         on every run and stops being read. Got:\n{said}"
+    );
+}

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -6608,3 +6608,85 @@ fn roast_pg_cdc_crash_between_checkpoint_and_ack_re_reads_and_releases_the_slot(
          cell proves nothing about the boundary it exists for"
     );
 }
+
+/// A slot nobody is draining pins WAL forever, and `run` used to say nothing.
+///
+/// `rivet doctor` has caught this since it was written — it FAILS past 1 GiB and
+/// names every offender. But doctor is a thing an operator runs when they already
+/// suspect something; the scheduler runs `rivet run` every cycle and it was silent.
+/// Measured on a dev stand: nine abandoned slots holding 1.5 GiB each, 1552 MiB of
+/// WAL on disk, and every CDC run over that instance exited 0 without a word.
+///
+/// Two warnings, and the split is the point. Our OWN slot being far behind is worth
+/// saying but the run does fix it — so the message says so, or an operator drops a
+/// slot that was about to be drained. A FOREIGN inactive slot is pinned until a
+/// human acts, which is the one that fills disks.
+///
+/// The threshold and the wording live in `preflight::cdc_health` and are shared with
+/// doctor, so the two cannot drift; this test is about the WIRING — that a run
+/// reaches them at all, and stays quiet when there is nothing to say.
+#[test]
+#[ignore = "live: requires docker compose --profile cdc postgres-cdc"]
+fn roast_pg_cdc_run_warns_about_an_abandoned_slot_pinning_wal() {
+    use postgres::NoTls;
+    let tbl = unique_name("rivet_cdc_slotwarn");
+    let slot = unique_name("rivet_slotwarn").to_lowercase();
+    let orphan = unique_name("rivet_orphan").to_lowercase();
+    let mut c = postgres::Client::connect(POSTGRES_CDC_URL, NoTls).expect("connect postgres");
+    c.batch_execute(&format!(
+        "DROP TABLE IF EXISTS {tbl}; CREATE TABLE {tbl} (id BIGINT PRIMARY KEY)"
+    ))
+    .unwrap();
+    let _tbl = PgTable::adopt_on(POSTGRES_CDC_URL, tbl.clone());
+    for s in [&slot, &orphan] {
+        c.execute(
+            "SELECT pg_create_logical_replication_slot($1, 'test_decoding')",
+            &[s],
+        )
+        .unwrap();
+    }
+    let _slot = Slot(slot.clone());
+    let _orphan_guard = Slot(orphan.clone());
+    c.execute(&format!("INSERT INTO {tbl} VALUES (1)"), &[])
+        .unwrap();
+
+    // Healthy first: two small slots, nothing to report. Asserted BEFORE the noisy
+    // case because a warning that fires unconditionally would satisfy the positive
+    // assertion below while being useless — and this is the half that catches it.
+    let quiet = Rig::pg_cdc(&tbl, &slot).run_ok_capture();
+    assert!(
+        !quiet.to_lowercase().contains("pinning"),
+        "a healthy instance must stay silent, or the message is noise on every \
+         scheduler cycle and stops being read. Got:\n{quiet}"
+    );
+
+    // Now the loud case. Crossing a real GiB takes minutes of writes, so the bar
+    // moves instead (`RIVET_TEST_SLOT_WAL_BAR`, a test seam beside the threshold —
+    // deliberately not a config knob, since an operator lowering it would get a
+    // warning on every ordinary backlog and learn to ignore it).
+    let loud = Rig::pg_cdc(&tbl, &slot).run_with_env("RIVET_TEST_SLOT_WAL_BAR", "1");
+    let said = format!(
+        "{}{}",
+        String::from_utf8_lossy(&loud.stdout),
+        String::from_utf8_lossy(&loud.stderr)
+    );
+    assert!(
+        loud.status.success(),
+        "a retention WARNING must never fail the run — the export is the thing that \
+         drains the slot, so refusing here would make the problem permanent:\n{said}"
+    );
+    assert!(
+        said.contains(&orphan),
+        "the run must name the ABANDONED slot — it is the one nothing is draining, \
+         and an operator cannot drop what they were not told about. Got:\n{said}"
+    );
+    assert!(
+        said.contains("pg_drop_replication_slot"),
+        "and hand over the command, not just the diagnosis. Got:\n{said}"
+    );
+    assert!(
+        said.contains(&slot) && said.contains("This run will drain it"),
+        "our OWN slot gets the other message — saying it will be drained, so nobody \
+         drops a slot that was about to recover. Got:\n{said}"
+    );
+}

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -6462,3 +6462,149 @@ fn mysql_cdc_full_row_metadata_maps_the_same_reorder_by_name_and_stays_quiet() {
          on every run and stops being read. Got:\n{said}"
     );
 }
+
+/// PostgreSQL crash between the checkpoint write and the slot ack — DOCUMENTED,
+/// not guarded, and the difference is the point.
+///
+/// This is the one CDC fault point with no PostgreSQL test, and the reason it had
+/// none turns out to be structural rather than an oversight. Three mutants were
+/// applied and this test stayed GREEN against all three:
+///
+///   1. `stream.ack` moved BEFORE the checkpoint write  — green
+///   2. `stream.ack` moved BEFORE the parts are flushed — green
+///   3. `ack` advancing the slot to `pg_current_wal_lsn()` instead of the last
+///      commit                                          — green
+///
+/// Why: the crash fires BEFORE run 1's first ack, so every ack-side mutant is
+/// unreachable in this fixture; and PostgreSQL's resume authority is the SLOT,
+/// which run 1 therefore never moved. The checkpoint file is consulted only as a
+/// boolean ("a prior run happened", `resume_expected` in cdc/mod.rs) and never as
+/// a position, so the file racing ahead of the slot has nothing to act on.
+/// Contrast SQL Server, where the checkpoint IS the only position and its ack is a
+/// no-op — which is why that engine's test of this hook is load-bearing and this
+/// one is not.
+///
+/// So the DELIVERY half of this test documents rather than guards — no reordering
+/// of the sink's steps can make it red, and that is a fact about PostgreSQL's
+/// design, not a weakness to paper over.
+///
+/// The RETENTION half is a real guard, and it is the half an operator cares about.
+/// A crash here PINS WAL on the slot — it must, or the un-acked span is lost — and
+/// the question is whether that is a transient or a leak. MEASURED: 2304 B pinned
+/// by the crash, 0 after the resume. Neutering `ack` (`advance_slot` -> `Ok(())`)
+/// leaves 2480 B pinned and this test goes RED, which is the mutant it grades.
+///
+/// That closes the crash-side of the slot-pinning class from the direction
+/// `roast_pg_cdc_empty_transaction_churn_must_not_pin_the_slot` does not cover:
+/// that one is about row-less spans starving the ack, this one is about a crash
+/// leaving the ack unrun. Both end at the same place — `confirmed_flush_lsn`
+/// frozen while WAL accumulates on an idle database.
+#[test]
+#[ignore = "live: requires docker compose --profile cdc postgres-cdc"]
+fn roast_pg_cdc_crash_between_checkpoint_and_ack_re_reads_and_releases_the_slot() {
+    use postgres::NoTls;
+    let d = tempfile::tempdir().unwrap();
+    let tbl = unique_name("rivet_cdc_pgckpt");
+    let slot = unique_name("rivet_ckpt_slot");
+    let mut c = postgres::Client::connect(POSTGRES_CDC_URL, NoTls).expect("connect postgres");
+    c.batch_execute(&format!(
+        "DROP TABLE IF EXISTS {tbl}; CREATE TABLE {tbl} (id BIGINT PRIMARY KEY, v INT)"
+    ))
+    .unwrap();
+    let _tbl = PgTable::adopt_on(POSTGRES_CDC_URL, tbl.clone());
+    c.execute(
+        "SELECT pg_create_logical_replication_slot($1, 'test_decoding')",
+        &[&slot],
+    )
+    .unwrap();
+    let _slot = Slot(slot.clone());
+    // Separate transactions so several parts roll: the crash must land in the
+    // window, and a single transaction would give it only one chance.
+    for g in 0..12 {
+        c.execute(&format!("INSERT INTO {tbl} VALUES ({g}, {g})"), &[])
+            .unwrap();
+    }
+
+    let ckpt = d.path().join("cdc.ckpt");
+    let out = d.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let rig = Rig::pg_cdc(&tbl, &slot)
+        .cdc("rollover: 3")
+        .checkpoint_path(ckpt.clone())
+        .dest_path(out.clone());
+    let crashed = rig.run_args_env(
+        &[],
+        &[("RIVET_TEST_PANIC_AT", "cdc_after_checkpoint_before_ack")],
+    );
+    assert!(
+        !crashed.status.success(),
+        "the injected crash must fail run 1 — a fault that did not fire leaves this \
+         test asserting an ordinary two-run export"
+    );
+
+    let retained_after_crash: i64 = c
+        .query_one(
+            "SELECT pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)::bigint \
+             FROM pg_replication_slots WHERE slot_name = $1",
+            &[&slot],
+        )
+        .map(|r| r.get(0))
+        .unwrap_or(-1);
+    eprintln!("RIVET_MEASURE retained_after_crash={retained_after_crash}");
+
+    // Run 2 into a FRESH destination, so what it delivers is its own doing: a
+    // shared dir would let run 1's durable parts satisfy the oracle even if the
+    // resume captured nothing (the CDC audit's headline finding).
+    let out2 = d.path().join("out2");
+    std::fs::create_dir_all(&out2).unwrap();
+    let rig2 = Rig::pg_cdc(&tbl, &slot)
+        .checkpoint_path(ckpt.clone())
+        .dest_path(out2.clone());
+    run_rivet_ok(&rig2.config_path());
+
+    // The union is what at-least-once promises. Overlap between the legs is fine
+    // and expected — the un-acked span is re-read by construction.
+    let mut got: std::collections::BTreeSet<i64> =
+        duckdb_dir_parquet_i64(&out, "id").into_iter().collect();
+    got.extend(duckdb_dir_parquet_i64(&out2, "id"));
+    let want: std::collections::BTreeSet<i64> = (0..12).collect();
+    assert_eq!(
+        got, want,
+        "every row must survive a crash between the checkpoint write and the slot \
+         ack. A missing id means resume trusted the checkpoint FILE over the slot \
+         and started past changes the slot had never released."
+    );
+    let retained: i64 = c
+        .query_one(
+            "SELECT pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)::bigint \
+             FROM pg_replication_slots WHERE slot_name = $1",
+            &[&slot],
+        )
+        .map(|r| r.get(0))
+        .unwrap_or(-1);
+    // MEASURED: 2304 B retained by the crash (exactly the un-acked span — the data
+    // that must not be lost), and 0 after the resume. The crash PINS WAL, which is
+    // correct; what this asserts is that it is a transient, not a leak. A resume
+    // that captured the rows but never acked would leave the slot exactly where the
+    // crash left it, and PostgreSQL would retain WAL forever on an idle database —
+    // the slot-pinning class `roast_pg_cdc_empty_transaction_churn_must_not_pin_the_slot`
+    // covers from the other side (row-less spans).
+    assert!(
+        retained_after_crash > 0,
+        "the crash must PIN the un-acked span (measured 2304 B) — a zero here means \
+         the fixture never left anything un-acked and the release below is vacuous"
+    );
+    assert!(
+        retained >= 0 && retained < retained_after_crash,
+        "the resume must RELEASE the WAL the crash pinned (measured: 2304 B -> 0). \
+         Still {retained} B means the slot never advanced past what was re-read, and \
+         an operator who crash-loops fills the disk"
+    );
+    // And the second leg must really have done work — otherwise the assertion above
+    // is satisfied by leg 1 alone and would pass against a resume that captured zero.
+    assert!(
+        !duckdb_dir_parquet_i64(&out2, "id").is_empty(),
+        "the resume leg delivered NOTHING: the un-acked span was not re-read, so this \
+         cell proves nothing about the boundary it exists for"
+    );
+}

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -3685,6 +3685,183 @@ fn roast_pg_cdc_refuses_a_partitioned_parent_before_acking_the_slot() {
     );
 }
 
+/// A TRUNCATE on a captured table must FAIL the run, not vanish.
+///
+/// `test_decoding` renders it as `table public.t: TRUNCATE: (no-flags)` — a line
+/// with no columns, so the parser that builds a change out of the column list had
+/// nothing to return and dropped it into its catch-all `None`. The
+/// `unknown -> default` shape the CDC evidence audit found on all four engines.
+///
+/// Measured before the guard (2026-08-24, pg14 stand — this test's RED):
+/// 2 inserts then a TRUNCATE left the source table EMPTY while the run reported
+/// `status: success, rows: 2` and wrote both inserts to the destination. Zero
+/// occurrences of the word at `RUST_LOG=trace` — not a quiet log, no log.
+///
+/// The divergence is PERMANENT, which is why this bails rather than warns: the
+/// rows left the source with no DELETE events to carry them, so no later capture
+/// can reconcile the destination back. A warning would leave a destination that
+/// disagrees with its source forever and call the run a success.
+///
+/// Isolated in its OWN database (see `CdcDb`): the slot decodes the whole DB, so
+/// a parallel test's TRUNCATE on the shared one would fail this run instead.
+#[test]
+#[ignore = "live: requires docker compose postgres (wal_level=logical)"]
+fn roast_pg_cdc_refuses_a_truncate_instead_of_silently_diverging() {
+    let cdc_db = CdcDb::new("cdc_trunc");
+    let tbl = unique_name("rivet_cdc_tr").to_lowercase();
+    let other = unique_name("rivet_cdc_trother").to_lowercase();
+    let slot = unique_name("rivet_trunc_slot").to_lowercase();
+    let mut c = cdc_db.connect();
+    c.batch_execute(&format!(
+        "CREATE TABLE {tbl} (id BIGINT PRIMARY KEY, v INT); \
+         CREATE TABLE {other} (id BIGINT PRIMARY KEY, v INT)"
+    ))
+    .unwrap();
+    c.execute(
+        "SELECT pg_create_logical_replication_slot($1, 'test_decoding')",
+        &[&slot],
+    )
+    .unwrap();
+    c.execute(&format!("INSERT INTO {tbl} VALUES (1,10),(2,20)"), &[])
+        .unwrap();
+    c.execute(&format!("TRUNCATE {tbl}"), &[]).unwrap();
+    // The SOURCE oracle, asked of PostgreSQL: the truncate really emptied it, so
+    // any row in the destination is a row that does not exist.
+    let source_rows: i64 = c
+        .query_one(&format!("SELECT count(*) FROM {tbl}"), &[])
+        .unwrap()
+        .get(0);
+    assert_eq!(
+        source_rows, 0,
+        "the fixture's TRUNCATE must have emptied it"
+    );
+
+    let rig = Rig::pg_cdc(&format!("public.{tbl}"), &slot).source_url(cdc_db.url());
+    let out = run_rivet(&["run", "--config", rig.config_path().to_str().unwrap()]);
+    let said = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !out.status.success(),
+        "a TRUNCATE on a captured table must fail the run — shipping the 2 inserts \
+         as a success leaves them in the destination with nothing to retract them. \
+         Output:\n{said}"
+    );
+    assert!(
+        said.contains("TRUNCATE") && said.contains("mode: full"),
+        "the refusal must name what happened AND the re-snapshot that recovers \
+         from it — a bail with no way forward just moves the operator's problem. \
+         Output:\n{said}"
+    );
+
+    // ── and it must be TABLE-ADDRESSED ────────────────────────────────────────
+    //
+    // The slot decodes the whole DATABASE, so this TRUNCATE is in the stream every
+    // other export on it reads. Failing without asking whose relation it is makes
+    // one truncated table an outage for exports that never touch it — the MySQL
+    // undecodable-rows guard's measured lesson (#281), pinned here before it could
+    // bite again. This export is anchored on the SAME slot span that holds the
+    // truncate, so the event is inside its window by construction.
+    let other_slot = unique_name("rivet_trunc_slot_b").to_lowercase();
+    c.execute(
+        "SELECT pg_create_logical_replication_slot($1, 'test_decoding')",
+        &[&other_slot],
+    )
+    .unwrap();
+    c.execute(&format!("INSERT INTO {other} VALUES (7,70)"), &[])
+        .unwrap();
+    c.execute(&format!("TRUNCATE {tbl}"), &[]).unwrap();
+    let bystander = Rig::pg_cdc(&format!("public.{other}"), &other_slot).source_url(cdc_db.url());
+    let rows: usize = bystander.run_and_read().iter().map(|b| b.num_rows()).sum();
+    assert_eq!(
+        rows, 1,
+        "an export that does not capture the truncated table must complete and \
+         capture its own change"
+    );
+}
+
+/// MySQL peer of `roast_pg_cdc_refuses_a_truncate_instead_of_silently_diverging`,
+/// and the same divergence by a DIFFERENT route: a TRUNCATE is logged as a QUERY
+/// event, never as rows, so the rows path never sees it and the `_ => {}` arm
+/// dropped it silently.
+///
+/// Measured before the guard (2026-08-24, rivet-mysql-cdc-1): 2 inserts then a
+/// TRUNCATE left the source table EMPTY while the run reported
+/// `status: success, rows: 2`.
+///
+/// The engines differ in the mechanism and agree on the outcome, which is why
+/// both cells are `test` in the fail-loud ledger rather than one being inferred
+/// from the other. SQL Server needs neither: it REFUSES the truncate itself
+/// (Msg 4711 on a CDC-enabled table), so the divergence cannot be created.
+#[test]
+#[ignore = "live: requires docker compose --profile cdc mysql-cdc"]
+fn roast_mysql_cdc_refuses_a_truncate_instead_of_silently_diverging() {
+    let d = tempfile::tempdir().unwrap();
+    let tbl = unique_name("cdc_mtr");
+    let other = unique_name("cdc_mtrother");
+    let mut c = conn();
+    for t in [&tbl, &other] {
+        c.query_drop(format!("DROP TABLE IF EXISTS {t}")).unwrap();
+        c.query_drop(format!("CREATE TABLE {t} (id INT PRIMARY KEY, v INT)"))
+            .unwrap();
+    }
+    let _g1 = Table(tbl.clone());
+    let _g2 = Table(other.clone());
+
+    let ck = d.path().join("tr.ckpt");
+    let rig = || {
+        Rig::mysql_cdc(&tbl)
+            .checkpoint_path(ck.to_path_buf())
+            .dest_path(d.path().join("out"))
+    };
+    rig().run_ok(); // anchor before the truncate lands
+
+    c.query_drop(format!("INSERT INTO {tbl} VALUES (1,10),(2,20)"))
+        .unwrap();
+    c.query_drop(format!("TRUNCATE {tbl}")).unwrap();
+    // The SOURCE oracle: the truncate really emptied it, so any row the run ships
+    // is a row that does not exist.
+    let left: Option<i64> = c
+        .query_first(format!("SELECT count(*) FROM {tbl}"))
+        .unwrap();
+    assert_eq!(left, Some(0), "the fixture's TRUNCATE must have emptied it");
+
+    let msg = rig().run_expect_fail();
+    assert!(
+        msg.contains("TRUNCATE") && msg.contains("mode: full"),
+        "the run must refuse and name both what happened and the re-snapshot that \
+         recovers from it — shipping the 2 inserts as a success leaves them in the \
+         destination with nothing to retract them. Got: {msg}"
+    );
+
+    // Table-addressed, same as the undecodable-rows guard beside it (#281): the
+    // binlog carries every table on the server, so an export that does not capture
+    // the truncated table must still complete. Anchored BEFORE the truncate, so
+    // the event is inside its window by construction rather than by timing.
+    let other_ck = d.path().join("tr_other.ckpt");
+    let other_rig = || {
+        Rig::mysql_cdc(&other)
+            .checkpoint_path(other_ck.to_path_buf())
+            .dest_path(d.path().join("out_other"))
+    };
+    other_rig().run_ok();
+    c.query_drop(format!("INSERT INTO {other} VALUES (7,70)"))
+        .unwrap();
+    c.query_drop(format!("TRUNCATE {tbl}")).unwrap();
+    let rows: usize = other_rig()
+        .run_and_read()
+        .iter()
+        .map(|b| b.num_rows())
+        .sum();
+    assert_eq!(
+        rows, 1,
+        "an export that does not capture the truncated table must complete and \
+         capture its own change"
+    );
+}
+
 struct CdcDb {
     name: String,
     url: String,

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -4925,9 +4925,9 @@ fn roast_pg_cdc_bounded_on_a_standby_fails_loud() {
     )
     .is_err()
     {
-        eprintln!(
-            "SKIP roast_pg_cdc_bounded_on_a_standby_fails_loud: cdc-standby not up on :5436 \
-             (bring it up with `python3 -m dev.pytools.cdc_stand standby`)"
+        skip_live(
+            "roast_pg_cdc_bounded_on_a_standby_fails_loud: cdc-standby not up on :5436 \
+             (bring it up with `python3 -m dev.pytools.cdc_stand standby`)",
         );
         return;
     }
@@ -5527,7 +5527,7 @@ fn mysql_cdc_refuses_a_compressed_binlog_instead_of_capturing_nothing() {
         .ok()
         .flatten();
     if supported.is_none() {
-        eprintln!("skip: server has no binlog_transaction_compression (pre-8.0.20)");
+        skip_live("server has no binlog_transaction_compression (pre-8.0.20)");
         return;
     }
 
@@ -5655,7 +5655,7 @@ fn mysql_cdc_compressed_payload_in_stream_refuses_not_skips() {
         .ok()
         .flatten();
     if supported.is_none() {
-        eprintln!("skip: server has no binlog_transaction_compression (pre-8.0.20)");
+        skip_live("server has no binlog_transaction_compression (pre-8.0.20)");
         return;
     }
 

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -3780,6 +3780,40 @@ fn roast_pg_cdc_refuses_a_truncate_instead_of_silently_diverging() {
         "an export that does not capture the truncated table must complete and \
          capture its own change"
     );
+
+    // ── and a MULTI-relation truncate must be caught wherever ours sits ───────
+    //
+    // `TRUNCATE a, b` decodes as ONE line naming both
+    // (`table public.a, public.b: TRUNCATE: (no-flags)`), and so does every
+    // CASCADE that pulls in referencing tables. The FIRST version of this guard
+    // read that list as a single name and let the statement through: MEASURED,
+    // with the captured table configured, the source ended EMPTY while the run
+    // reported `status: success, rows: 1`. An adversarial pass found it; re-reading
+    // the code had not.
+    //
+    // Ours goes SECOND on purpose — a first-position-only fixture would pass
+    // against the very defect this exists to catch.
+    let third_slot = unique_name("rivet_trunc_slot_c").to_lowercase();
+    c.execute(
+        "SELECT pg_create_logical_replication_slot($1, 'test_decoding')",
+        &[&third_slot],
+    )
+    .unwrap();
+    c.execute(&format!("INSERT INTO {tbl} VALUES (9,90)"), &[])
+        .unwrap();
+    c.execute(&format!("TRUNCATE {other}, {tbl}"), &[]).unwrap();
+    let multi = Rig::pg_cdc(&format!("public.{tbl}"), &third_slot).source_url(cdc_db.url());
+    let out2 = run_rivet(&["run", "--config", multi.config_path().to_str().unwrap()]);
+    let said2 = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out2.stdout),
+        String::from_utf8_lossy(&out2.stderr)
+    );
+    assert!(
+        !out2.status.success() && said2.contains(&tbl),
+        "a TRUNCATE naming our table SECOND in a list must still refuse, and name \
+         OUR table rather than whichever came first. Output:\n{said2}"
+    );
 }
 
 /// MySQL peer of `roast_pg_cdc_refuses_a_truncate_instead_of_silently_diverging`,

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -4100,6 +4100,51 @@ fn roast_pg_cdc_refuses_a_truncate_instead_of_silently_diverging() {
         "a TRUNCATE naming our table SECOND in a list must still refuse, and name \
          OUR table rather than whichever came first. Output:\n{said2}"
     );
+    // ── and the refusal must not WEDGE the capture ────────────────────────────
+    //
+    // The peek is non-consuming, so the slot still sits on the truncate commit:
+    // every later run meets it first and clean changes queued BEHIND it are
+    // blocked, while the un-acked slot pins WAL. MEASURED: an ordinary INSERT
+    // after the truncate leaves the second run failing identically.
+    //
+    // The message's first version said only "re-snapshot (mode: full)" — which on
+    // PostgreSQL does not move the SLOT and therefore does not recover. This is
+    // the same defect the unchanged-TOAST refusal had, found the same day by an
+    // adversarial pass, in a guard I wrote after fixing that one.
+    c.execute(&format!("INSERT INTO {tbl} VALUES (77,770)"), &[])
+        .unwrap();
+    let again = run_rivet(&["run", "--config", rig.config_path().to_str().unwrap()]);
+    assert!(
+        !again.status.success(),
+        "a clean change queued behind the truncate must still be blocked — if this \
+         ever passes the wedge is gone and the message should be softened"
+    );
+    assert!(
+        said.contains("pg_replication_slot_advance"),
+        "the refusal must name the way OUT of the wedge, not only the re-snapshot: \
+         re-snapshotting alone leaves the slot where it is. Got:\n{said}"
+    );
+    // The route the message names must actually work.
+    let past: String = c
+        .query_one(
+            &format!(
+                "SELECT max(lsn)::text FROM pg_logical_slot_peek_changes('{slot}', NULL, NULL) \
+                 WHERE data LIKE '%COMMIT%'"
+            ),
+            &[],
+        )
+        .unwrap()
+        .get(0);
+    c.execute(
+        &format!("SELECT pg_replication_slot_advance('{slot}', '{past}')"),
+        &[],
+    )
+    .unwrap();
+    c.execute(&format!("INSERT INTO {tbl} VALUES (88,880)"), &[])
+        .unwrap();
+    Rig::pg_cdc(&format!("public.{tbl}"), &slot)
+        .source_url(cdc_db.url())
+        .run_ok();
 }
 
 /// MySQL peer of `roast_pg_cdc_refuses_a_truncate_instead_of_silently_diverging`,

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -4220,6 +4220,71 @@ fn roast_mysql_cdc_refuses_a_truncate_instead_of_silently_diverging() {
     );
 }
 
+/// An unqualified `table:` captures EVERY schema's relation of that name.
+///
+/// `sink::table_matches` matches a bare config name against any schema — it has to,
+/// because a MongoDB collection has no schema qualifier and may itself contain dots.
+/// On PostgreSQL that means `table: orders` silently captures `public.orders` AND
+/// `archive.orders` into one export.
+///
+/// MEASURED before the warning (2026-08-25): `table: bare` with `public.bare` and
+/// `s2.bare` both present captured 2 rows — one from each schema — into a single
+/// part, with nothing in the output distinguishing them. Counts reconcile against
+/// neither table alone, and a reader of the parquet cannot tell which row came from
+/// where.
+///
+/// A WARNING, not a refusal: capturing one table under a bare name is the common and
+/// correct case. What the operator cannot see is the second relation riding along.
+#[test]
+#[ignore = "live: requires docker compose postgres (wal_level=logical)"]
+fn roast_pg_cdc_warns_when_a_bare_table_name_matches_two_schemas() {
+    let cdc_db = CdcDb::new("cdc_bare");
+    let tbl = unique_name("rivet_cdc_bare").to_lowercase();
+    let slot = unique_name("rivet_bare_slot").to_lowercase();
+    let mut c = cdc_db.connect();
+    c.batch_execute(&format!(
+        "CREATE TABLE {tbl} (id int PRIMARY KEY, v text); \
+         CREATE SCHEMA other; \
+         CREATE TABLE other.{tbl} (id int PRIMARY KEY, v text)"
+    ))
+    .unwrap();
+    c.execute(
+        "SELECT pg_create_logical_replication_slot($1, 'test_decoding')",
+        &[&slot],
+    )
+    .unwrap();
+    c.batch_execute(&format!(
+        "INSERT INTO {tbl} VALUES (1,'public'); INSERT INTO other.{tbl} VALUES (2,'other')"
+    ))
+    .unwrap();
+
+    let rig = Rig::pg_cdc(&tbl, &slot).source_url(cdc_db.url());
+    let said = rig.run_ok_capture();
+    assert!(
+        said.contains("unqualified") && said.contains(&format!("other.{tbl}")),
+        "the run must WARN and name the other relation — the operator cannot see it \
+         in the output otherwise. Got:\n{said}"
+    );
+
+    let rows: usize = rig.read_declared_parts().iter().map(|b| b.num_rows()).sum();
+    assert_eq!(
+        rows, 2,
+        "both schemas' rows land in ONE export — that is the behaviour being warned \
+         about, and if it ever changes the warning should change with it"
+    );
+
+    // Not too WIDE: one matching relation is the ordinary case and must stay silent,
+    // or the warning becomes noise and gets ignored.
+    c.batch_execute("DROP SCHEMA other CASCADE").unwrap();
+    c.execute(&format!("INSERT INTO {tbl} VALUES (3,'only')"), &[])
+        .unwrap();
+    let quiet = Rig::pg_cdc(&tbl, &slot).source_url(cdc_db.url());
+    assert!(
+        !quiet.run_ok_capture().contains("unqualified"),
+        "a bare name with ONE matching relation must not warn"
+    );
+}
+
 struct CdcDb {
     name: String,
     url: String,

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -6653,7 +6653,17 @@ fn roast_pg_cdc_run_warns_about_an_abandoned_slot_pinning_wal() {
     // Healthy first: two small slots, nothing to report. Asserted BEFORE the noisy
     // case because a warning that fires unconditionally would satisfy the positive
     // assertion below while being useless — and this is the half that catches it.
-    let quiet = Rig::pg_cdc(&tbl, &slot).run_ok_capture();
+    let rig = Rig::pg_cdc(&tbl, &slot);
+    let quiet = rig.run_ok_capture();
+    // The capture itself must have worked. A diagnostic test that never checks its
+    // run delivered anything would pass over a 0-row success — the conformance gate
+    // asks this of every live CDC test, and it caught this one.
+    assert_eq!(
+        duckdb_dir_parquet_i64(&rig.out_dir(), "id"),
+        vec![1],
+        "the run must still CAPTURE while it warns — a warning path that broke the \
+         export would be worse than the silence it replaced"
+    );
     assert!(
         !quiet.to_lowercase().contains("pinning"),
         "a healthy instance must stay silent, or the message is noise on every \

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -6542,15 +6542,22 @@ fn roast_pg_cdc_crash_between_checkpoint_and_ack_re_reads_and_releases_the_slot(
          test asserting an ordinary two-run export"
     );
 
-    let retained_after_crash: i64 = c
-        .query_one(
-            "SELECT pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)::bigint \
-             FROM pg_replication_slots WHERE slot_name = $1",
+    // The slot's OWN anchor, not its distance from `pg_current_wal_lsn()`. The first
+    // version measured that distance and failed in CI at 13 243 536 B where it read
+    // 0 locally: the E2E runner drives the whole live suite against one PostgreSQL,
+    // so unrelated WAL moves the reference point between the two reads and the
+    // "distance" grows for reasons that have nothing to do with this slot. Comparing
+    // the anchor to ITSELF is immune to that — the same unscoped-measurement class
+    // as counting rows without scoping to the run.
+    let confirmed = |c: &mut postgres::Client| -> String {
+        c.query_one(
+            "SELECT confirmed_flush_lsn::text FROM pg_replication_slots WHERE slot_name = $1",
             &[&slot],
         )
         .map(|r| r.get(0))
-        .unwrap_or(-1);
-    eprintln!("RIVET_MEASURE retained_after_crash={retained_after_crash}");
+        .expect("the slot must exist after the crashed run")
+    };
+    let after_crash = confirmed(&mut c);
 
     // Run 2 into a FRESH destination, so what it delivers is its own doing: a
     // shared dir would let run 1's durable parts satisfy the oracle even if the
@@ -6574,31 +6581,28 @@ fn roast_pg_cdc_crash_between_checkpoint_and_ack_re_reads_and_releases_the_slot(
          ack. A missing id means resume trusted the checkpoint FILE over the slot \
          and started past changes the slot had never released."
     );
-    let retained: i64 = c
+    let after_resume = confirmed(&mut c);
+    let advanced: i64 = c
         .query_one(
-            "SELECT pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)::bigint \
-             FROM pg_replication_slots WHERE slot_name = $1",
-            &[&slot],
+            &format!(
+                "SELECT pg_wal_lsn_diff('{after_resume}'::pg_lsn, '{after_crash}'::pg_lsn)::bigint"
+            ),
+            &[],
         )
         .map(|r| r.get(0))
-        .unwrap_or(-1);
-    // MEASURED: 2304 B retained by the crash (exactly the un-acked span — the data
-    // that must not be lost), and 0 after the resume. The crash PINS WAL, which is
-    // correct; what this asserts is that it is a transient, not a leak. A resume
-    // that captured the rows but never acked would leave the slot exactly where the
-    // crash left it, and PostgreSQL would retain WAL forever on an idle database —
-    // the slot-pinning class `roast_pg_cdc_empty_transaction_churn_must_not_pin_the_slot`
-    // covers from the other side (row-less spans).
+        .expect("compare the two anchor positions");
+
+    // A crash here PINS WAL — it must, or the un-acked span is lost — so the
+    // question is transient or leak. What proves it is the slot MOVING, measured
+    // against where the crash left it: MEASURED 2304 B of WAL pinned by the crash
+    // and released on resume, and neutering `advance_slot` to `Ok(())` leaves the
+    // anchor exactly where it was (advanced = 0) and this goes RED.
     assert!(
-        retained_after_crash > 0,
-        "the crash must PIN the un-acked span (measured 2304 B) — a zero here means \
-         the fixture never left anything un-acked and the release below is vacuous"
-    );
-    assert!(
-        retained >= 0 && retained < retained_after_crash,
-        "the resume must RELEASE the WAL the crash pinned (measured: 2304 B -> 0). \
-         Still {retained} B means the slot never advanced past what was re-read, and \
-         an operator who crash-loops fills the disk"
+        advanced > 0,
+        "the resume must ADVANCE the slot past what it re-read: confirmed_flush_lsn \
+         went {after_crash} -> {after_resume} ({advanced} B). Standing still means \
+         the WAL the crash pinned is pinned for good, and an operator who \
+         crash-loops fills the disk"
     );
     // And the second leg must really have done work — otherwise the assertion above
     // is satisfied by leg 1 alone and would pass against a resume that captured zero.

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -4023,14 +4023,14 @@ fn roast_pg_cdc_refuses_a_truncate_instead_of_silently_diverging() {
     );
 
     let rig = Rig::pg_cdc(&format!("public.{tbl}"), &slot).source_url(cdc_db.url());
-    let out = run_rivet(&["run", "--config", rig.config_path().to_str().unwrap()]);
-    let said = format!(
-        "{}{}",
-        String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr)
-    );
+    // Through the rig, like every other live test here: `run_expect_fail` asserts
+    // the non-zero exit AND returns stdout+stderr, so the hand-rolled
+    // `run_rivet(&["run", "--config", …])` this used to call was a second way of
+    // doing what the rig already does — the per-file command wrapper the rig exists
+    // to have replaced.
+    let said = rig.run_expect_fail();
     assert!(
-        !out.status.success(),
+        said.contains("TRUNCATE"),
         "a TRUNCATE on a captured table must fail the run — shipping the 2 inserts \
          as a success leaves them in the destination with nothing to retract them. \
          Output:\n{said}"
@@ -4089,14 +4089,9 @@ fn roast_pg_cdc_refuses_a_truncate_instead_of_silently_diverging() {
         .unwrap();
     c.execute(&format!("TRUNCATE {other}, {tbl}"), &[]).unwrap();
     let multi = Rig::pg_cdc(&format!("public.{tbl}"), &third_slot).source_url(cdc_db.url());
-    let out2 = run_rivet(&["run", "--config", multi.config_path().to_str().unwrap()]);
-    let said2 = format!(
-        "{}{}",
-        String::from_utf8_lossy(&out2.stdout),
-        String::from_utf8_lossy(&out2.stderr)
-    );
+    let said2 = multi.run_expect_fail();
     assert!(
-        !out2.status.success() && said2.contains(&tbl),
+        said2.contains(&tbl),
         "a TRUNCATE naming our table SECOND in a list must still refuse, and name \
          OUR table rather than whichever came first. Output:\n{said2}"
     );
@@ -4113,12 +4108,10 @@ fn roast_pg_cdc_refuses_a_truncate_instead_of_silently_diverging() {
     // adversarial pass, in a guard I wrote after fixing that one.
     c.execute(&format!("INSERT INTO {tbl} VALUES (77,770)"), &[])
         .unwrap();
-    let again = run_rivet(&["run", "--config", rig.config_path().to_str().unwrap()]);
-    assert!(
-        !again.status.success(),
-        "a clean change queued behind the truncate must still be blocked — if this \
-         ever passes the wedge is gone and the message should be softened"
-    );
+    // `run_expect_fail` panics if the run SUCCEEDS, which is exactly the assertion:
+    // a clean change queued behind the truncate must still be blocked. If this ever
+    // stops panicking the wedge is gone and the message should be softened.
+    let _still_wedged = rig.run_expect_fail();
     assert!(
         said.contains("pg_replication_slot_advance"),
         "the refusal must name the way OUT of the wedge, not only the re-snapshot: \

--- a/tests/live/live_cdc_mbt.rs
+++ b/tests/live/live_cdc_mbt.rs
@@ -288,9 +288,23 @@ fn cdc_fault_point_sweep_every_phase_boundary_recovers() {
         let out = rig.out_dir();
         // Pin cleanly, then a 30-row backlog (3 parts at rollover 10).
         rig.run_ok();
-        let vals: Vec<String> = (1..=30).map(|i| format!("({i}, {i})")).collect();
-        c.query_drop(format!("INSERT INTO {tbl} VALUES {}", vals.join(",")))
-            .unwrap();
+        // THREE statements, not one: `should_roll` gates on `committed`, which marks a
+        // TRANSACTION boundary, so 30 rows in a single autocommit INSERT is one
+        // transaction and yields exactly ONE part (MEASURED: parts=1, while the comment
+        // above claimed three). A fold over one element makes every fold operator
+        // identical — `^=`, `|=` and `+=` all agree — so the cross-part manifest fold
+        // this test exists to cover was never exercised. Three statements cross the
+        // threshold.
+        for chunk in 0..3 {
+            let vals: Vec<String> = (1..=10)
+                .map(|i| {
+                    let id = chunk * 10 + i;
+                    format!("({id}, {id})")
+                })
+                .collect();
+            c.query_drop(format!("INSERT INTO {tbl} VALUES {}", vals.join(",")))
+                .unwrap();
+        }
 
         // Faulted run: must crash (loudly), never report success.
         let res = rig.run_with_env("RIVET_TEST_PANIC_AT", point);
@@ -379,9 +393,19 @@ fn cdc_crash_before_manifest_loses_nothing_on_a_manifest_driven_read() {
     let rig = Rig::mysql_cdc(&tbl).cdc("rollover: 10");
     let out = rig.out_dir();
     rig.run_ok(); // pin cleanly
-    let vals: Vec<String> = (1..=30).map(|i| format!("({i}, {i})")).collect();
-    c.query_drop(format!("INSERT INTO {tbl} VALUES {}", vals.join(",")))
-        .unwrap();
+    // Three statements so three parts really roll — see the note on the sibling
+    // fixture above: one autocommit INSERT is one transaction and one part, and a
+    // one-part fold cannot tell `^=` from `|=`.
+    for chunk in 0..3 {
+        let vals: Vec<String> = (1..=10)
+            .map(|i| {
+                let id = chunk * 10 + i;
+                format!("({id}, {id})")
+            })
+            .collect();
+        c.query_drop(format!("INSERT INTO {tbl} VALUES {}", vals.join(",")))
+            .unwrap();
+    }
 
     // Crash in the ack→terminal-manifest window: the 3 parts are flushed and the
     // slot acked past them, but the terminal manifest is not yet written.

--- a/tests/live/live_cdc_mbt.rs
+++ b/tests/live/live_cdc_mbt.rs
@@ -1057,7 +1057,7 @@ fn cdc_replication_grant_revoked_mid_life_fails_loud_and_resumes_after_regrant()
 #[ignore = "live: requires mysql-cdc + RIVET_TINYFS_DIR pointing at a ~2MB filesystem"]
 fn cdc_destination_disk_full_is_loud_and_lossless() {
     let Some(tiny) = std::env::var_os("RIVET_TINYFS_DIR") else {
-        eprintln!("RIVET_TINYFS_DIR not set — skipping (see the test doc for mounting)");
+        skip_live("RIVET_TINYFS_DIR not set — skipping (see the test doc for mounting)");
         return;
     };
     let tiny = std::path::PathBuf::from(tiny);

--- a/tests/live/live_cdc_mongo.rs
+++ b/tests/live/live_cdc_mongo.rs
@@ -760,10 +760,10 @@ fn mongo_cdc_delete_carries_the_pre_image_when_the_collection_has_one() {
     if !m.enable_pre_images("t") {
         // Said out loud rather than passed quietly: on a pre-6.0 server there is no
         // pre-image to carry and this cell is genuinely not applicable.
-        eprintln!(
-            "SKIP: server major {} has no changeStreamPreAndPostImages",
+        skip_live(&format!(
+            "server major {} has no changeStreamPreAndPostImages",
             m.server_major()
-        );
+        ));
         return;
     }
 

--- a/tests/live/live_cdc_mongo.rs
+++ b/tests/live/live_cdc_mongo.rs
@@ -803,3 +803,86 @@ fn mongo_cdc_delete_carries_the_pre_image_when_the_collection_has_one() {
         del.document
     );
 }
+
+/// The OTHER side of the same window: a crash after the checkpoint is persisted.
+///
+/// Mongo's `ack` is the trait's default no-op — only PostgreSQL consumes on read —
+/// so its resume position is the checkpoint FILE alone. That makes
+/// `cdc_after_checkpoint_before_ack` and `cdc_after_ack` the same instant for this
+/// engine, and what protects it is not the ack but the ORDER: parts flushed, then
+/// manifested, then the checkpoint saved. A crash anywhere in that sequence either
+/// leaves the checkpoint behind the data (re-read, a duplicate) or everything
+/// durable together.
+///
+/// Two ordering mutants were applied and this stayed GREEN against both —
+/// `p.save(ck)` moved above the flush, and the ack moved above the checkpoint —
+/// for a structural reason worth writing down rather than hiding: the fault hook
+/// sits AFTER every durability step, so anything the crash could have skipped was
+/// already written before it fired. Mongo's own model closes the rest (see
+/// `TxnFramer::single_event_commit`): the resume token is per-event and
+/// consume-free, so a checkpoint landing mid-transaction re-reads the tail rather
+/// than skipping it the way a PG slot or an MSSQL from-LSN would.
+///
+/// What the body DOES grade is its two preconditions, and they are not decoration:
+/// `leg1 < 6` fails if the crash left nothing behind, and a resume that delivers
+/// NOTHING fails outright — which is what a checkpoint jumping past unread changes
+/// would produce.
+///
+/// The sibling above (`cdc_after_flush_before_ack`) proves the duplicate side; this
+/// proves there is no gap side. Both resume into a FRESH destination, because a
+/// shared one is satisfied by the crashed run's own durable parts — Mongo's
+/// at-least-once evidence used to be exactly that shape.
+#[test]
+#[ignore = "live: requires docker compose up -d mongo-rs"]
+fn mongo_cdc_crash_after_the_checkpoint_still_delivers_every_change() {
+    require_alive(LiveService::MongoRs);
+    require_alive(LiveService::DuckDb);
+    let db = unique_name("cdc_ckcrash");
+    let m = MongoTest::connect(PORT, &db);
+    m.drop_collection("t");
+
+    let mut rig = cdc(&db, "t").cdc("rollover: 2");
+    rig.run_ok(); // pin the anchor
+    for i in 1..=6 {
+        m.upsert_set("t", i, "v", &format!("x{i}"));
+    }
+
+    let crashed = rig.run_with_env("RIVET_TEST_PANIC_AT", "cdc_after_checkpoint_before_ack");
+    assert!(
+        !crashed.status.success(),
+        "the fault hook must crash the run — a fault that did not fire leaves this \
+         asserting an ordinary two-run export"
+    );
+    // The crash must have left work behind, or the resume below has nothing to
+    // prove: with rollover 2 and six changes, run 1 checkpoints after the first
+    // part and dies with four changes unread.
+    let leg1 = duckdb_declared_rows(rig.oracle_dir());
+    assert!(
+        leg1 < 6,
+        "run 1 delivered {leg1} of 6 before the crash — nothing was left for the \
+         resume, so the union below would pass over a resume that captured zero"
+    );
+
+    // Leg 1's ids, read BEFORE the destination moves: unlike the sibling above, the
+    // resume here legitimately starts PAST what the checkpoint already covered, so
+    // the oracle is the union — and the union is exactly what at-least-once promises.
+    let leg1_ids = duckdb_declared_distinct_set(rig.oracle_dir(), "_id");
+
+    rig.resume_into_fresh_dest();
+    rig.run_ok();
+    let resumed = duckdb_declared_distinct_set(rig.oracle_dir(), "_id");
+    assert!(
+        !resumed.is_empty(),
+        "the resume leg delivered NOTHING — with four changes left unread after the \
+         crash, an empty leg means the checkpoint jumped past them"
+    );
+    let mut union = leg1_ids.clone();
+    union.extend(resumed.iter().cloned());
+    for i in 1..=6 {
+        assert!(
+            union.contains(&i.to_string()),
+            "id {i} was never delivered by EITHER leg — the checkpoint advanced past a \
+             change whose part was not durable. leg1={leg1_ids:?} resume={resumed:?}"
+        );
+    }
+}

--- a/tests/live/live_cdc_mongo.rs
+++ b/tests/live/live_cdc_mongo.rs
@@ -734,3 +734,72 @@ fn mongo_cdc_per_field_presence_matches_the_source() {
         );
     }
 }
+
+/// A DELETE carries the PRE-IMAGE when the collection has one — the half of Mongo's
+/// delete semantics that nothing asked about.
+///
+/// `mongo_cdc_update_and_delete_carry_document` asserts the opposite case and says
+/// so: with pre-images off, a delete's `document` is NULL and the schema must allow
+/// it. That is the DEFAULT, and it left the whole `full_document_before_change`
+/// request — which rivet issues on every stream — verified by nothing. A silent
+/// no-op and a working pre-image look identical from the default collection.
+///
+/// The distinction matters to a consumer: with a pre-image the delete tombstone
+/// carries what the row WAS, so a loader can reconcile it against the destination;
+/// without one it carries only `_id`.
+#[test]
+#[ignore = "live: requires docker compose up -d mongo-rs (6.0+ for pre-images)"]
+fn mongo_cdc_delete_carries_the_pre_image_when_the_collection_has_one() {
+    require_alive(LiveService::MongoRs);
+    require_alive(LiveService::DuckDb);
+    let db = unique_name("cdc_preimg");
+    let m = MongoTest::connect(PORT, &db);
+    m.drop_collection("t");
+    // The collection must EXIST before collMod can change it.
+    m.upsert_set("t", 9, "v", "seed");
+    if !m.enable_pre_images("t") {
+        // Said out loud rather than passed quietly: on a pre-6.0 server there is no
+        // pre-image to carry and this cell is genuinely not applicable.
+        eprintln!(
+            "SKIP: server major {} has no changeStreamPreAndPostImages",
+            m.server_major()
+        );
+        return;
+    }
+
+    let rig = cdc(&db, "t");
+    rig.run_ok(); // pin the anchor past the seed
+
+    m.upsert_set("t", 9, "v", "doomed");
+    m.delete_one("t", 9);
+    rig.run_ok();
+
+    let changes = read_mongo_cdc_changes(&rig.out_dir());
+    let del = changes
+        .iter()
+        .find(|c| c.op == "delete")
+        .unwrap_or_else(|| {
+            panic!(
+                "no delete captured — the fixture is inert ({} changes)",
+                changes.len()
+            )
+        });
+    assert_eq!(del.id, "9", "the delete must carry its _id");
+
+    // MEASURED 2026-08-25 (MongoDB 7.0.37): {"_id":9,"v":"doomed"} — the pre-image
+    // is the document as it was at the instant of the delete, not the seed value it
+    // held two writes earlier. Both halves are asserted, because a `document` that
+    // merely parses proves nothing about WHICH image arrived.
+    assert!(
+        del.document.contains("\"v\":\"doomed\""),
+        "the delete must carry the PRE-IMAGE — the value the document held when it \
+         was deleted. Got: {}",
+        del.document
+    );
+    assert!(
+        !del.document.contains("seed"),
+        "...and the pre-image is the state at DELETE time, not an earlier one. \
+         Got: {}",
+        del.document
+    );
+}

--- a/tests/live/live_cdc_mssql.rs
+++ b/tests/live/live_cdc_mssql.rs
@@ -1812,3 +1812,101 @@ fn mssql_cdc_cli_path_case_only_table_mismatch_must_not_silently_drop_events() {
          event was dropped while the checkpoint advanced past it."
     );
 }
+
+/// A checkpoint that PARSES but has no `lsn` silently re-reads the whole change
+/// table — the guard at the parse site claims it doesn't.
+///
+/// `Position::load` refuses a checkpoint that is not valid JSON, and its message
+/// says why: treating it as absent "would permanently skip every change since the
+/// last checkpoint". The MSSQL call site then reads the position with
+/// `.and_then(|pos| pos.0.get("lsn")...)` — so a file that IS valid JSON yet
+/// carries no `lsn` (a key renamed by a future version, a hand-edit, a half-written
+/// migration) yields `None`, which `fill_sql` turns into
+/// `from_expr = fn_cdc_get_min_lsn(ci)`: the entire retained change table, re-read
+/// and re-delivered, with a green exit and nothing in the log.
+///
+/// MySQL refuses exactly this (`ok_or_else`, "checkpoint missing 'file'/'pos'");
+/// Mongo refuses it (`decode_resume_token`); PostgreSQL cannot hit it at all
+/// because its anchor is the slot, server-side. SQL Server is the one engine whose
+/// resume position lives ONLY in that file, and it was the one that shrugged.
+///
+/// The direction of harm is over-read, not loss — at-least-once still holds. It
+/// is still a silent breach of the resume contract, and the comment above the code
+/// already claimed it was closed (#99).
+///
+/// NOT the `pinned` key beside it: absent `pinned` is a documented legacy default
+/// (`unwrap_or(false)` = treat as a resume, the loud direction). Only `lsn` — the
+/// position itself — makes the checkpoint meaningless by its absence.
+#[test]
+#[ignore = "live: requires docker compose mssql with SQL Server Agent + CDC"]
+fn mssql_cdc_checkpoint_without_an_lsn_must_refuse_not_silently_reread_everything() {
+    let _serial = cross_process_serial("mssql_cdc");
+    let d = tempfile::tempdir().unwrap();
+    let table = unique_name("rivet_cdc_nolsn");
+    let ci = format!("dbo_{table}");
+    mssql_cdc_drop_table(&format!("dbo.{table}"));
+    mssql_cdc_exec(&format!(
+        "CREATE TABLE dbo.{table}(id INT PRIMARY KEY, v INT)"
+    ));
+    enable_cdc(&table, &ci);
+    let _guard = MssqlCdcTable {
+        table: table.clone(),
+        ci: ci.clone(),
+    };
+
+    let ckpt = d.path().join("cdc.ckpt");
+    mssql_cdc_exec(&format!(
+        "INSERT INTO dbo.{table} VALUES (1,10),(2,20),(3,30)"
+    ));
+    wait_for_capture(&ci, 3);
+
+    // Leg 1: an ordinary run, which writes a real checkpoint.
+    let r1 = mssql_cdc_rig(&table, &ci, &ckpt, &d.path().join("out1"));
+    r1.run_ok();
+    assert_eq!(
+        duckdb_dir_parquet_id_set(&r1.out_dir())
+            .into_iter()
+            .collect::<Vec<i64>>(),
+        vec![1, 2, 3],
+        "leg 1 must really capture — a leg that captured nothing would make every \
+         assertion below vacuous"
+    );
+
+    // The degradation: the file still parses, the position is gone. Keep `pinned`
+    // so the test isolates the `lsn` key rather than two changes at once.
+    let before: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&ckpt).unwrap()).unwrap();
+    assert!(
+        before.get("lsn").and_then(|v| v.as_str()).is_some(),
+        "the fixture is inert: leg 1 wrote no `lsn` to key off. Got {before}"
+    );
+    std::fs::write(
+        &ckpt,
+        serde_json::to_string(&serde_json::json!({
+            "lsn_renamed_by_a_future_version": before.get("lsn").unwrap(),
+            "pinned": false,
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    mssql_cdc_exec(&format!("INSERT INTO dbo.{table} VALUES (4,40)"));
+    wait_for_capture(&ci, 4);
+
+    // Leg 2 into a FRESH destination, so what it delivers is its own doing and not
+    // leg 1's parts read a second time.
+    let r2 = mssql_cdc_rig(&table, &ci, &ckpt, &d.path().join("out2"));
+    let said = r2.run_expect_fail();
+    assert!(
+        said.contains("lsn") && said.to_lowercase().contains("checkpoint"),
+        "the refusal must name the key and the file, or an operator cannot act on \
+         it. Got:\n{said}"
+    );
+
+    // And the refusal must be the LOUD direction: nothing delivered, checkpoint
+    // untouched, so a restored file resumes exactly where leg 1 stopped.
+    assert!(
+        !r2.out_dir().join("manifest.json").is_file(),
+        "a refused run must deliver nothing"
+    );
+}

--- a/tests/live/live_cdc_oracle.rs
+++ b/tests/live/live_cdc_oracle.rs
@@ -129,9 +129,12 @@ fn cdc_types_round_trip_via_duckdb_and_clickhouse() {
                 .expect("clickhouse meta is JSON");
         assert_eq!(cmeta["k"], 1, "clickhouse: json column round-trips");
     } else {
-        eprintln!(
-            "NOTE: ClickHouse unreachable (:8123) — skipping the ClickHouse oracle. \
-             DuckDB validated above; ClickHouse runs on nightly's Linux runner."
+        // A PARTIAL skip — DuckDB already validated above, so the test is not
+        // vacuous. Still marked, because a lane counting coverage should see that
+        // one of the two independent readers did not run.
+        skip_live(
+            "ClickHouse unreachable (:8123) — the ClickHouse half of the oracle did \
+             not run. DuckDB validated above; ClickHouse runs on nightly's Linux runner.",
         );
     }
 

--- a/tests/live/live_governor.rs
+++ b/tests/live/live_governor.rs
@@ -1018,9 +1018,9 @@ fn the_idle_canary_refuses_the_229_walk_and_allows_the_documented_dip() {
 #[ignore = "live: requires the optional dev/stand pg18-batch (:5518)"]
 fn pg18_governor_samples_the_modern_checkpointer_catalog() {
     if !pg_modern_alive() {
-        eprintln!(
-            "SKIP pg18_governor_samples_the_modern_checkpointer_catalog: the optional \
-             dev/stand pg18-batch (:5518) is not up"
+        skip_live(
+            "pg18_governor_samples_the_modern_checkpointer_catalog: the optional \
+             dev/stand pg18-batch (:5518) is not up",
         );
         return;
     }

--- a/tests/live/live_keyset_parallel.rs
+++ b/tests/live/live_keyset_parallel.rs
@@ -655,7 +655,7 @@ fn parallel_keyset_incremental_survives_no_backslash_escapes_mysql() {
     if c.query_drop("SET GLOBAL sql_mode = CONCAT(@@global.sql_mode, ',NO_BACKSLASH_ESCAPES')")
         .is_err()
     {
-        eprintln!("skip: setting @@global.sql_mode needs SUPER (unavailable for the test user)");
+        skip_live("setting @@global.sql_mode needs SUPER (unavailable for the test user)");
         return;
     }
     c.query_drop(format!("DROP TABLE IF EXISTS {table}"))

--- a/tests/live/live_mongo.rs
+++ b/tests/live/live_mongo.rs
@@ -388,7 +388,7 @@ fn mongo_batch_read_concern_snapshot_empty_first_run_then_populated() {
     // `read_concern: snapshot` for a find requires MongoDB 5.0+; on 4.4 it is
     // unsupported, so self-skip rather than fail the version matrix.
     if m.server_major() < 5 {
-        eprintln!("skipping: read_concern: snapshot needs MongoDB 5.0+ (server is 4.x)");
+        skip_live("ping: read_concern: snapshot needs MongoDB 5.0+ (server is 4.x)");
         return;
     }
     m.drop_collection("t");

--- a/tests/live/live_source_parity_sweep.rs
+++ b/tests/live/live_source_parity_sweep.rs
@@ -33,7 +33,9 @@ fn run_sweep(module: &str) {
     // this test is inert in jobs that don't provide the sweep's deps (e.g. the E2E
     // matrix has no host `duckdb` CLI). Corruption is exit 1; a clean run is exit 0.
     if out.status.code() == Some(2) {
-        eprintln!("SKIP {module}: sweep dependencies unavailable in this environment:\n{stdout}");
+        crate::common::skip_live(&format!(
+            "{module}: sweep dependencies unavailable in this environment:\n{stdout}"
+        ));
         return;
     }
     assert!(

--- a/tests/live/live_state_backend_parity.rs
+++ b/tests/live/live_state_backend_parity.rs
@@ -124,7 +124,7 @@ fn parallel_checkpoint(rig: Rig) -> Rig {
 fn state_parity_parallel_keyset_checkpoint() {
     require_alive(LiveService::Postgres);
     let Some(pg) = pg_state_url() else {
-        eprintln!("skip: RIVET_TEST_STATE_URL not set");
+        skip_live("RIVET_TEST_STATE_URL not set");
         return;
     };
     let table = unique_name("sp_ckpt");
@@ -152,7 +152,7 @@ fn incremental(rig: Rig) -> Rig {
 fn state_parity_incremental_cursor() {
     require_alive(LiveService::Postgres);
     let Some(pg) = pg_state_url() else {
-        eprintln!("skip: RIVET_TEST_STATE_URL not set");
+        skip_live("RIVET_TEST_STATE_URL not set");
         return;
     };
     let table = unique_name("sp_incr");
@@ -210,7 +210,7 @@ fn state_parity_incremental_cursor() {
 fn state_parity_parallel_keyset_crash_resume() {
     require_alive(LiveService::Postgres);
     let Some(pg) = pg_state_url() else {
-        eprintln!("skip: RIVET_TEST_STATE_URL not set");
+        skip_live("RIVET_TEST_STATE_URL not set");
         return;
     };
     let table = unique_name("sp_crash");

--- a/tests/live/roast_validate_exit.rs
+++ b/tests/live/roast_validate_exit.rs
@@ -96,9 +96,9 @@ fn roast_validate_exits_nonzero_when_manifest_unreadable() {
     if std::fs::read(&manifest_path).is_ok() {
         // Running as root: mode 000 does not block reads, so the degraded
         // state cannot be staged.  Skip rather than report a false verdict.
-        eprintln!(
+        skip_live(
             "skipping roast_validate_exits_nonzero_when_manifest_unreadable: \
-             euid 0 ignores file modes"
+             euid 0 ignores file modes",
         );
         return;
     }

--- a/tests/offline/cdc_evidence_matrix_guard.rs
+++ b/tests/offline/cdc_evidence_matrix_guard.rs
@@ -177,7 +177,7 @@ fn a_sound_cell_cites_where_the_evidence_lives() {
 /// or the win is not banked and drifts back.
 #[test]
 fn unsound_cells_only_ever_shrink() {
-    const CEILING: usize = 26;
+    const CEILING: usize = 24;
     let engines = cdc_engines();
     let m = matrix();
     let mut unsound: BTreeMap<String, Vec<String>> = BTreeMap::new();

--- a/tests/offline/cdc_evidence_matrix_guard.rs
+++ b/tests/offline/cdc_evidence_matrix_guard.rs
@@ -177,7 +177,7 @@ fn a_sound_cell_cites_where_the_evidence_lives() {
 /// or the win is not banked and drifts back.
 #[test]
 fn unsound_cells_only_ever_shrink() {
-    const CEILING: usize = 12;
+    const CEILING: usize = 8;
     let engines = cdc_engines();
     let m = matrix();
     let mut unsound: BTreeMap<String, Vec<String>> = BTreeMap::new();

--- a/tests/offline/cdc_evidence_matrix_guard.rs
+++ b/tests/offline/cdc_evidence_matrix_guard.rs
@@ -177,7 +177,7 @@ fn a_sound_cell_cites_where_the_evidence_lives() {
 /// or the win is not banked and drifts back.
 #[test]
 fn unsound_cells_only_ever_shrink() {
-    const CEILING: usize = 4;
+    const CEILING: usize = 3;
     let engines = cdc_engines();
     let m = matrix();
     let mut unsound: BTreeMap<String, Vec<String>> = BTreeMap::new();

--- a/tests/offline/cdc_evidence_matrix_guard.rs
+++ b/tests/offline/cdc_evidence_matrix_guard.rs
@@ -177,7 +177,7 @@ fn a_sound_cell_cites_where_the_evidence_lives() {
 /// or the win is not banked and drifts back.
 #[test]
 fn unsound_cells_only_ever_shrink() {
-    const CEILING: usize = 8;
+    const CEILING: usize = 4;
     let engines = cdc_engines();
     let m = matrix();
     let mut unsound: BTreeMap<String, Vec<String>> = BTreeMap::new();

--- a/tests/offline/cdc_evidence_matrix_guard.rs
+++ b/tests/offline/cdc_evidence_matrix_guard.rs
@@ -177,7 +177,7 @@ fn a_sound_cell_cites_where_the_evidence_lives() {
 /// or the win is not banked and drifts back.
 #[test]
 fn unsound_cells_only_ever_shrink() {
-    const CEILING: usize = 20;
+    const CEILING: usize = 16;
     let engines = cdc_engines();
     let m = matrix();
     let mut unsound: BTreeMap<String, Vec<String>> = BTreeMap::new();

--- a/tests/offline/cdc_evidence_matrix_guard.rs
+++ b/tests/offline/cdc_evidence_matrix_guard.rs
@@ -171,13 +171,23 @@ fn a_sound_cell_cites_where_the_evidence_lives() {
     }
 }
 
-/// Shrink-only ratchet. Not a pass/fail bar on today's state — a floor under it, so the
-/// audit that produced this file does not have to be repeated to discover the same
-/// numbers. It fails DOWNWARD too: close cells and lower the ceiling in the same commit,
-/// or the win is not banked and drifts back.
+/// ZERO unsound cells — and at zero this stopped being a ratchet.
+///
+/// It was one: a floor under the audit's findings so the same numbers would not have
+/// to be rediscovered, failing DOWNWARD too so a closed cell had to be banked in the
+/// same commit. It counted 20 when it was written and was lowered to 16, 12, 8, 3 and
+/// now 0 as the cells closed.
+///
+/// At zero the contract changes shape, so the assertion does too: this ledger now has
+/// the same admission policy as `cdc-matrix` — every cell is `sound` (someone ran the
+/// mutant and watched a specific test fail) or a justified `na` (structurally
+/// inapplicable, with the reason written out and length-checked above). There is no
+/// budget left to spend, which means a NEW CDC shape arrives closed or does not arrive.
+///
+/// Restoring a budget is a decision someone has to argue for in a commit message, not
+/// a number they can nudge.
 #[test]
-fn unsound_cells_only_ever_shrink() {
-    const CEILING: usize = 3;
+fn every_cell_is_sound_or_a_justified_na() {
     let engines = cdc_engines();
     let m = matrix();
     let mut unsound: BTreeMap<String, Vec<String>> = BTreeMap::new();
@@ -189,17 +199,13 @@ fn unsound_cells_only_ever_shrink() {
             }
         }
     }
-    let total: usize = unsound.values().map(|v| v.len()).sum();
     assert!(
-        total <= CEILING,
-        "{total} cells are neither `sound` nor a justified `na`, over the ceiling of \
-         {CEILING}: {unsound:?}. Adding CDC surface without evidence is what this ledger \
-         records; raising the ceiling to accommodate it is not an option."
-    );
-    assert!(
-        total >= CEILING.saturating_sub(4),
-        "only {total} unsound cells remain against a ceiling of {CEILING} — lower CEILING \
-         to {total} in the same commit that closed them. A ratchet that is not tightened \
-         is a ratchet that lets the next regression back in for free."
+        unsound.is_empty(),
+        "{} cell(s) are neither `sound` nor a justified `na`: {unsound:?}. This ledger \
+         reached zero on 2026-08-25 and holds there — a cell is promoted by someone \
+         running its mutant, so a new shape lands closed or it does not land. If a gap \
+         genuinely has to be admitted, say why in the commit that admits it rather than \
+         raising a number.",
+        unsound.values().map(Vec::len).sum::<usize>()
     );
 }

--- a/tests/offline/cdc_evidence_matrix_guard.rs
+++ b/tests/offline/cdc_evidence_matrix_guard.rs
@@ -177,7 +177,7 @@ fn a_sound_cell_cites_where_the_evidence_lives() {
 /// or the win is not banked and drifts back.
 #[test]
 fn unsound_cells_only_ever_shrink() {
-    const CEILING: usize = 16;
+    const CEILING: usize = 12;
     let engines = cdc_engines();
     let m = matrix();
     let mut unsound: BTreeMap<String, Vec<String>> = BTreeMap::new();

--- a/tests/offline/skip_is_not_a_pass_guard.rs
+++ b/tests/offline/skip_is_not_a_pass_guard.rs
@@ -103,3 +103,56 @@ fn the_guard_can_actually_see_a_runner_body() {
          here) or the parse is not reading bodies at all (not fine)"
     );
 }
+
+/// Every fault INJECTOR must verify its own injection landed.
+///
+/// A sibling of the class above, and the reason the toxiproxy tests survived the
+/// 2026-08-25 audit: `toxi_add_latency` asserts the admin API answered 200, so a
+/// toxic that fails to install panics the test instead of letting an ordinary,
+/// un-degraded export pass as "survived the fault". Move that assertion into the
+/// caller and eleven tests become vacuous at once; leave it in the helper and no
+/// caller can get it wrong.
+///
+/// Injectors only. `toxi_reset_toxics` is TEARDOWN — asserting there would fail
+/// tests during cleanup, reporting a fixture problem as a product one.
+#[test]
+fn every_toxiproxy_fault_injector_asserts_its_own_injection_landed() {
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/common/toxi.rs");
+    let src = std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()));
+
+    let mut injectors = 0;
+    let mut silent = Vec::new();
+    let mut rest = src.as_str();
+    while let Some(i) = rest.find("pub fn toxi_") {
+        let name: String = rest[i + "pub fn ".len()..]
+            .chars()
+            .take_while(|c| c.is_alphanumeric() || *c == '_')
+            .collect();
+        let end = rest[i + 5..]
+            .find("\npub fn ")
+            .map(|j| i + 5 + j)
+            .unwrap_or(rest.len());
+        let body = &rest[i..end];
+        rest = &rest[end..];
+        // An injector CHANGES the link; reset/teardown restores it.
+        if name.contains("reset") {
+            continue;
+        }
+        injectors += 1;
+        if !(body.contains("assert") && (body.contains("code") || body.contains("status"))) {
+            silent.push(name);
+        }
+    }
+    assert!(
+        injectors >= 5,
+        "derived only {injectors} injectors from tests/common/toxi.rs — a broken \
+         derivation grades nothing while looking green"
+    );
+    assert!(
+        silent.is_empty(),
+        "these fault injectors do not check that the fault was actually installed: \
+         {silent:?}. A toxic that fails to install leaves the export running over a \
+         healthy link, and the test then reports that rivet survived a fault that \
+         never happened."
+    );
+}

--- a/tests/offline/skip_is_not_a_pass_guard.rs
+++ b/tests/offline/skip_is_not_a_pass_guard.rs
@@ -156,3 +156,97 @@ fn every_toxiproxy_fault_injector_asserts_its_own_injection_landed() {
          never happened."
     );
 }
+
+/// A live test that does not run must say so in ONE countable form.
+///
+/// `cargo test` prints `ok` for a test that returned early, so a skip and a pass
+/// are indistinguishable in the output — the same shape that let 20 warehouse
+/// cells report `20 passed` in 0.00s. The harness half got an explicit `Skipped`
+/// outcome; the live suite has no such channel, so the marker IS the channel.
+///
+/// Before this, the thirteen skip sites said `SKIP`, `skip:`, `skipping:` and
+/// `RIVET_TINYFS_DIR not set — skipping` in four different shapes. A release lane
+/// cannot grep for all of them, which is why the skips were invisible rather than
+/// merely inconvenient.
+///
+/// Narrow ON PURPOSE. The obvious guard — find every early return and ask whether
+/// it announced itself — was tried on the sibling class today and produced ten
+/// false positives out of eleven (the word "kill" in a comment, assertions living
+/// in a shared runner). This one looks for a specific string in a specific macro,
+/// which is exactly the drift it exists to catch and nothing else.
+#[test]
+fn a_live_test_that_skips_says_so_through_the_one_marker() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
+    let mut offenders = Vec::new();
+    let mut marked = 0usize;
+    let mut stack: Vec<PathBuf> = vec![root.clone()];
+    while let Some(dir) = stack.pop() {
+        for e in std::fs::read_dir(&dir).expect("read tests dir") {
+            let p = e.expect("dir entry").path();
+            if p.is_dir() {
+                stack.push(p);
+                continue;
+            }
+            if p.extension().and_then(|x| x.to_str()) != Some("rs") {
+                continue;
+            }
+            // The helper's own definition and this guard both mention the token.
+            if p.ends_with("common/mod.rs") || p.ends_with("skip_is_not_a_pass_guard.rs") {
+                continue;
+            }
+            let src = std::fs::read_to_string(&p).expect("read a test file");
+            marked += src.matches("skip_live(").count();
+            // WINDOW-based, not line-based. The first cut checked `is_print &&
+            // says_skip` on ONE line and sailed past a multi-line macro — where
+            // `eprintln!(` sits on its own line and the message on the next, which
+            // is how rustfmt writes any message long enough to matter. Found by
+            // RED-proving the guard rather than by reading it: reverting a site to
+            // `eprintln!(\n  "SKIP: ...` left it green.
+            let bytes = src.as_bytes();
+            for m in ["println!(", "eprintln!("] {
+                let mut from = 0usize;
+                while let Some(rel) = src[from..].find(m) {
+                    let at = from + rel;
+                    from = at + m.len();
+                    // `eprintln!(` also matches inside `println!(` — skip the inner hit.
+                    if m == "println!(" && at > 0 && bytes[at - 1] == b'e' {
+                        continue;
+                    }
+                    let line_start = src[..at].rfind('\n').map(|i| i + 1).unwrap_or(0);
+                    if src[line_start..at].trim_start().starts_with("//") {
+                        continue;
+                    }
+                    // The macro's arguments, bounded so a later unrelated "skip"
+                    // cannot be attributed to this call.
+                    let end = (at + 300).min(src.len());
+                    let win = &src[at..src[at..end].find(");").map(|i| at + i).unwrap_or(end)];
+                    if !win.to_lowercase().contains("skip") {
+                        continue;
+                    }
+                    if win.contains("skip_live") || win.contains("RIVET-SKIP {who}") {
+                        continue;
+                    }
+                    let line_no = src[..at].matches('\n').count() + 1;
+                    offenders.push(format!(
+                        "{}:{}  {}",
+                        p.strip_prefix(&root).unwrap_or(&p).display(),
+                        line_no,
+                        win.replace('\n', " ").chars().take(90).collect::<String>()
+                    ));
+                }
+            }
+        }
+    }
+    assert!(
+        marked >= 9,
+        "found only {marked} `skip_live(` call sites — the sweep that introduced the \
+         marker converted nine, so a number below that means they were reverted or \
+         this guard is reading the wrong tree, and it would pass over anything"
+    );
+    assert!(
+        offenders.is_empty(),
+        "these announce a skip in their own words instead of through `skip_live`, so \
+         a release lane cannot count them:\n  {}",
+        offenders.join("\n  ")
+    );
+}

--- a/tests/offline/skip_is_not_a_pass_guard.rs
+++ b/tests/offline/skip_is_not_a_pass_guard.rs
@@ -1,0 +1,105 @@
+//! A runner that cannot run must report `Skipped`, never an empty result.
+//!
+//! `assert_all_pass` (tests/oracle_fixture_matrix.rs) panics on a `Skipped`
+//! outcome — the strength floor — and walks straight through an EMPTY list,
+//! because a `for` over nothing executes nothing. So a runner that answers a
+//! missing environment with `Ok(Vec::new())` makes every cell that calls it
+//! report green while verifying nothing.
+//!
+//! MEASURED 2026-08-25: all six runners in `tests/harness/mod.rs` did exactly
+//! that, and `cargo test --test oracle_fixture_matrix -- --ignored` reported
+//! `20 passed` in **0.00s** on a machine with no warehouse credentials — which
+//! is every machine, since `RIVET_TEST_GCS_BUCKET` appears in no workflow. The
+//! doc comment on `run` had called an empty oracle list a strength-floor failure
+//! since it was written.
+//!
+//! This guard is source-shaped rather than behavioural on purpose: the runners
+//! read process environment, and a test that mutates env to observe them races
+//! every other test in the binary. What it checks is exactly the shape that
+//! failed — an early return of an empty vec from a runner whose result feeds the
+//! floor.
+
+use std::path::PathBuf;
+
+fn harness_source() -> String {
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/harness/mod.rs");
+    std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()))
+}
+
+/// The runners are DERIVED from the source, never listed here: a seventh added
+/// tomorrow is asked the same question without anyone remembering to add a row.
+fn runner_bodies(src: &str) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    let mut rest = src;
+    while let Some(i) = rest.find("    pub fn run") {
+        let after = &rest[i + 4..];
+        let name: String = after["pub fn ".len()..]
+            .chars()
+            .take_while(|c| c.is_alphanumeric() || *c == '_')
+            .collect();
+        // Body = up to the next `    pub fn ` (or end): enough to see an early
+        // return, which is all this guard is about.
+        let body_start = i + 4;
+        let body_end = after[4..]
+            .find("\n    pub fn ")
+            .map(|j| body_start + 4 + j)
+            .unwrap_or(rest.len());
+        out.push((name, rest[body_start..body_end].to_string()));
+        rest = &rest[body_end..];
+    }
+    assert!(
+        out.len() >= 6,
+        "derived only {} runners from tests/harness/mod.rs — the derivation is broken, \
+         and a broken derivation grades nothing while looking green",
+        out.len()
+    );
+    out
+}
+
+#[test]
+fn no_harness_runner_answers_a_missing_environment_with_an_empty_result() {
+    let src = harness_source();
+    let mut offenders = Vec::new();
+    for (name, body) in runner_bodies(&src) {
+        // Only runners whose result feeds the strength floor: the ones returning a
+        // list of outcomes. A helper returning something else is not this class.
+        if !body.contains("OracleOutcome") {
+            continue;
+        }
+        if body.contains("Ok(Vec::new())") {
+            offenders.push(name);
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "these runners return an EMPTY result instead of a `Skipped` outcome: {offenders:?}. \
+         `assert_all_pass` panics on Skipped and walks straight through an empty list, so \
+         every cell calling one of these reports green while verifying nothing — measured \
+         at `20 passed in 0.00s` before this was closed. Return \
+         `Ok(vec![(name, OracleOutcome::Skipped {{ why: SKIP_WHY.to_string() }})])`."
+    );
+}
+
+/// The positive control: the thing this guard looks for must be findable. A grep
+/// that matches nothing reads identically to a grep that found no problem — which
+/// is the same defect one layer up.
+#[test]
+fn the_guard_can_actually_see_a_runner_body() {
+    let src = harness_source();
+    let bodies = runner_bodies(&src);
+    let with_outcomes = bodies
+        .iter()
+        .filter(|(_, b)| b.contains("OracleOutcome"))
+        .count();
+    assert!(
+        with_outcomes >= 6,
+        "only {with_outcomes} of {} derived runners mention OracleOutcome — the parse is \
+         reading the wrong thing, and the guard above would pass over any input",
+        bodies.len()
+    );
+    assert!(
+        bodies.iter().any(|(_, b)| b.contains("SKIP_WHY")),
+        "no runner references SKIP_WHY — either the skip path was removed (fine, say so \
+         here) or the parse is not reading bodies at all (not fine)"
+    );
+}

--- a/tests/offline/trust_artifacts_integration.rs
+++ b/tests/offline/trust_artifacts_integration.rs
@@ -19,6 +19,20 @@
 
 use std::path::{Path, PathBuf};
 
+/// The same `RIVET-SKIP` marker the live suite uses, defined locally because this
+/// suite is deliberately self-contained (no shared `mod common` — see the module
+/// doc on tests/offline_suite.rs).
+///
+/// These skips fire when the binary is not built, which is exactly the vacuous
+/// pass this marker exists to make visible: `cargo test` prints `ok` either way.
+fn skip_live(why: &str) {
+    let who = std::thread::current()
+        .name()
+        .unwrap_or("<unnamed test>")
+        .to_string();
+    eprintln!("RIVET-SKIP {who} — {why}");
+}
+
 use rivet::config::{DestinationConfig, DestinationType};
 use rivet::journal::PlanSnapshot;
 use rivet::manifest::{
@@ -2030,7 +2044,7 @@ fn rivet_run_subcommand_has_exactly_the_adr_0013_flag_set() {
         })
         .unwrap_or_else(|| "target/debug/rivet".into());
     if !std::path::Path::new(&bin).exists() {
-        eprintln!("skipping flag-count test: binary not built at {bin}");
+        skip_live(&format!("flag-count test: binary not built at {bin}"));
         return;
     }
     let output = std::process::Command::new(&bin)
@@ -2106,7 +2120,7 @@ fn rivet_validate_subcommand_drives_existing_m5_semantics_passing_path() {
     // a `summary.json[validation][manifest]` consumer already parses.
     let bin = locate_rivet_bin();
     let Some(bin) = bin else {
-        eprintln!("skipping rivet_validate_subcommand test: binary not built");
+        skip_live("rivet_validate_subcommand test: binary not built");
         return;
     };
 
@@ -2182,7 +2196,7 @@ fn rivet_validate_subcommand_exits_nonzero_on_missing_part() {
     // branch on the exit code without parsing JSON.
     let bin = locate_rivet_bin();
     let Some(bin) = bin else {
-        eprintln!("skipping rivet_validate_subcommand failure test: binary not built");
+        skip_live("rivet_validate_subcommand failure test: binary not built");
         return;
     };
 
@@ -2239,7 +2253,7 @@ fn rivet_validate_subcommand_legacy_run_exits_zero() {
     // failures), JSON carries `legacy_run: true`, parts_verified = 0.
     let bin = locate_rivet_bin();
     let Some(bin) = bin else {
-        eprintln!("skipping rivet_validate_subcommand legacy test: binary not built");
+        skip_live("rivet_validate_subcommand legacy test: binary not built");
         return;
     };
 
@@ -2297,7 +2311,7 @@ fn rivet_run_resume_refuses_when_success_marker_present_without_force() {
     // `--force` is given.  This test pins the refusal end-to-end.
     let bin = locate_rivet_bin();
     let Some(bin) = bin else {
-        eprintln!("skipping success-gate test: binary not built");
+        skip_live("success-gate test: binary not built");
         return;
     };
 
@@ -2388,7 +2402,7 @@ fn rivet_run_resume_proceeds_when_no_success_marker() {
     // protect.
     let bin = locate_rivet_bin();
     let Some(bin) = bin else {
-        eprintln!("skipping success-gate-absent test: binary not built");
+        skip_live("success-gate-absent test: binary not built");
         return;
     };
 

--- a/tests/offline_suite.rs
+++ b/tests/offline_suite.rs
@@ -20,6 +20,9 @@ mod audit_validate_warning_label;
 mod cargo_manifest_chef;
 #[path = "offline/cdc_axis_matrix_guard.rs"]
 mod cdc_axis_matrix_guard;
+#[path = "offline/skip_is_not_a_pass_guard.rs"]
+mod skip_is_not_a_pass_guard;
+
 #[path = "offline/cdc_evidence_matrix_guard.rs"]
 mod cdc_evidence_matrix_guard;
 #[path = "offline/chunking_matrix_guard.rs"]

--- a/tests/oracle_fixture_matrix.rs
+++ b/tests/oracle_fixture_matrix.rs
@@ -30,7 +30,7 @@ fn assert_all_pass<O: std::fmt::Debug>(results: Vec<(O, OracleOutcome)>) {
 // ── tracer cell: heavy content_items under Postgres batch → BigQuery ─────────
 #[test]
 #[ignore = "live: needs devbox seeded stack + BigQuery creds"]
-fn heavy_content_batch_pg() {
+fn warehouse_cell_heavy_content_batch_pg() {
     let v = Verification::new(
         Engine::Postgres,
         Mode::Batch,
@@ -50,7 +50,7 @@ fn heavy_content_batch_pg() {
 // ── the white space: heavy content_items under Postgres CDC → BigQuery ───────
 #[test]
 #[ignore = "live: needs devbox cdc stack + BigQuery creds"]
-fn heavy_content_cdc_pg() {
+fn warehouse_cell_heavy_content_cdc_pg() {
     let v = Verification::new(
         Engine::Postgres,
         Mode::Cdc,
@@ -69,7 +69,7 @@ fn heavy_content_cdc_pg() {
 // ── MySQL parity: heavy content_items under CDC (binlog) → BigQuery ───────────
 #[test]
 #[ignore = "live: needs devbox mysql-cdc stack + BigQuery creds"]
-fn heavy_content_cdc_mysql() {
+fn warehouse_cell_heavy_content_cdc_mysql() {
     let v = Verification::new(
         Engine::Mysql,
         Mode::Cdc,
@@ -88,7 +88,7 @@ fn heavy_content_cdc_mysql() {
 // ── live smokes: fast end-to-end validation on MySQL → BigQuery ───────────────
 #[test]
 #[ignore = "live smoke: mysql batch → BigQuery"]
-fn smoke_batch_mysql() {
+fn warehouse_cell_smoke_batch_mysql() {
     let v = Verification::new(Engine::Mysql, Mode::Batch, Fixture::smoke("content_items"));
     assert_all_pass(
         v.run(&[
@@ -109,7 +109,7 @@ fn smoke_batch_mysql() {
 // never-tombstones, staging wiped). MySQL batch source (no binlog needed).
 #[test]
 #[ignore = "live: needs devbox mysql stack + BigQuery creds"]
-fn incremental_dedup_mysql() {
+fn warehouse_cell_incremental_dedup_mysql() {
     // Mode::Batch is a placeholder — run_incremental builds its own incremental
     // config (like run_mongo_cdc_delete); it does not route through the Mode enum.
     let v = Verification::new(Engine::Mysql, Mode::Batch, Fixture::smoke("inc_matrix"));
@@ -118,7 +118,7 @@ fn incremental_dedup_mysql() {
 
 #[test]
 #[ignore = "live smoke: mysql cdc soak → BigQuery"]
-fn smoke_cdc_mysql() {
+fn warehouse_cell_smoke_cdc_mysql() {
     let v = Verification::new(Engine::Mysql, Mode::Cdc, Fixture::smoke("content_items"));
     assert_all_pass(
         v.run_soak(
@@ -132,7 +132,7 @@ fn smoke_cdc_mysql() {
 
 #[test]
 #[ignore = "live smoke: postgres cdc soak → BigQuery"]
-fn smoke_cdc_pg() {
+fn warehouse_cell_smoke_cdc_pg() {
     let v = Verification::new(Engine::Postgres, Mode::Cdc, Fixture::smoke("content_items"));
     assert_all_pass(
         v.run_soak(
@@ -146,7 +146,7 @@ fn smoke_cdc_pg() {
 
 #[test]
 #[ignore = "live smoke: postgres cdc soak → Snowflake"]
-fn smoke_cdc_pg_snowflake() {
+fn warehouse_cell_smoke_cdc_pg_snowflake() {
     let v = Verification::new(Engine::Postgres, Mode::Cdc, Fixture::smoke("content_items"))
         .warehouse(Warehouse::Snowflake);
     assert_all_pass(
@@ -161,7 +161,7 @@ fn smoke_cdc_pg_snowflake() {
 
 #[test]
 #[ignore = "live smoke: mysql cdc soak → Snowflake"]
-fn smoke_cdc_mysql_snowflake() {
+fn warehouse_cell_smoke_cdc_mysql_snowflake() {
     let v = Verification::new(Engine::Mysql, Mode::Cdc, Fixture::smoke("content_items"))
         .warehouse(Warehouse::Snowflake);
     assert_all_pass(
@@ -177,7 +177,7 @@ fn smoke_cdc_mysql_snowflake() {
 // ── Snowflake parity: the same batch pipeline into a second warehouse ─────────
 #[test]
 #[ignore = "live smoke: postgres batch → Snowflake"]
-fn smoke_batch_pg_snowflake() {
+fn warehouse_cell_smoke_batch_pg_snowflake() {
     let v = Verification::new(
         Engine::Postgres,
         Mode::Batch,
@@ -202,7 +202,7 @@ fn smoke_batch_pg_snowflake() {
 // FILES materialize path + type fidelity for a MySQL-sourced snapshot.
 #[test]
 #[ignore = "live smoke: mysql batch → Snowflake"]
-fn smoke_batch_mysql_snowflake() {
+fn warehouse_cell_smoke_batch_mysql_snowflake() {
     let v = Verification::new(Engine::Mysql, Mode::Batch, Fixture::smoke("content_items"))
         .warehouse(Warehouse::Snowflake);
     assert_all_pass(
@@ -219,7 +219,7 @@ fn smoke_batch_mysql_snowflake() {
 // ── Mongo CDC: soft-delete tombstone in the current-state view ────────────────
 #[test]
 #[ignore = "live: needs the mongo replica-set devbox (rivet-mongo-rs-1) + Snowflake"]
-fn mongo_cdc_delete_flag_snowflake() {
+fn warehouse_cell_mongo_cdc_delete_flag_snowflake() {
     let v = Verification::new(Engine::Mongo, Mode::Cdc, Fixture::smoke("cdc_del"))
         .warehouse(Warehouse::Snowflake);
     assert_all_pass(v.run_mongo_cdc_delete().expect("mongo cdc delete"));
@@ -227,7 +227,7 @@ fn mongo_cdc_delete_flag_snowflake() {
 
 #[test]
 #[ignore = "live: needs the mongo replica-set devbox (rivet-mongo-rs-1) + BigQuery"]
-fn mongo_cdc_delete_flag_bigquery() {
+fn warehouse_cell_mongo_cdc_delete_flag_bigquery() {
     let v = Verification::new(Engine::Mongo, Mode::Cdc, Fixture::smoke("cdc_del"))
         .warehouse(Warehouse::BigQuery);
     assert_all_pass(v.run_mongo_cdc_delete().expect("mongo cdc delete"));
@@ -239,14 +239,14 @@ fn mongo_cdc_delete_flag_bigquery() {
 // Uses the standalone `rivet-mongo-1` (no replica set needed for a full scan).
 #[test]
 #[ignore = "live: needs the mongo devbox (rivet-mongo-1) + BigQuery"]
-fn smoke_batch_mongo_bigquery() {
+fn warehouse_cell_smoke_batch_mongo_bigquery() {
     let v = Verification::new(Engine::Mongo, Mode::Batch, Fixture::smoke("mongo_full"));
     assert_all_pass(v.run_mongo_batch().expect("mongo batch"));
 }
 
 #[test]
 #[ignore = "live: needs the mongo devbox (rivet-mongo-1) + Snowflake"]
-fn smoke_batch_mongo_snowflake() {
+fn warehouse_cell_smoke_batch_mongo_snowflake() {
     let v = Verification::new(Engine::Mongo, Mode::Batch, Fixture::smoke("mongo_full"))
         .warehouse(Warehouse::Snowflake);
     assert_all_pass(v.run_mongo_batch().expect("mongo batch"));
@@ -256,7 +256,7 @@ fn smoke_batch_mongo_snowflake() {
 // every backfilled row live (the snapshot/stream seam — NULL __op/__pos rows).
 #[test]
 #[ignore = "live: needs devbox mysql-cdc stack + BigQuery creds"]
-fn cdc_backfill_snapshot_mysql() {
+fn warehouse_cell_cdc_backfill_snapshot_mysql() {
     // Engine-distinct table: CDC names the target from `table:`, so every engine's
     // backfill cell must own a table or they collide on `rivet_matrix.<t>__changes`
     // (an `id` vs `_id` schema clash, or silent cross-engine row contamination).
@@ -269,7 +269,7 @@ fn cdc_backfill_snapshot_mysql() {
 // PG lane, not `server_id:`) backfills the same way — anchor = slot creation.
 #[test]
 #[ignore = "live: needs devbox postgres-cdc stack + BigQuery creds"]
-fn cdc_backfill_snapshot_pg() {
+fn warehouse_cell_cdc_backfill_snapshot_pg() {
     let v = Verification::new(Engine::Postgres, Mode::Cdc, Fixture::smoke("cdc_bf_pg"))
         .initial_snapshot();
     assert_all_pass(v.run_cdc_backfill().expect("cdc backfill"));
@@ -279,7 +279,7 @@ fn cdc_backfill_snapshot_pg() {
 // dedup PK, and `initial: snapshot` covers the pre-existing documents.
 #[test]
 #[ignore = "live: needs the mongo replica-set devbox (rivet-mongo-rs-1) + BigQuery"]
-fn cdc_backfill_snapshot_mongo() {
+fn warehouse_cell_cdc_backfill_snapshot_mongo() {
     let v = Verification::new(Engine::Mongo, Mode::Cdc, Fixture::smoke("cdc_bf_mongo"))
         .initial_snapshot();
     assert_all_pass(v.run_cdc_backfill().expect("cdc backfill"));
@@ -289,7 +289,7 @@ fn cdc_backfill_snapshot_mongo() {
 // the `COALESCE(__op='delete',FALSE)` guard must keep the backfill live there too.
 #[test]
 #[ignore = "live: needs devbox mysql-cdc stack + Snowflake (RIVET_SF_* + snow CLI)"]
-fn cdc_backfill_snapshot_mysql_snowflake() {
+fn warehouse_cell_cdc_backfill_snapshot_mysql_snowflake() {
     // Shares the MySQL source table with the BigQuery cell (different warehouse ⇒
     // no target collision); run one at a time.
     let v = Verification::new(Engine::Mysql, Mode::Cdc, Fixture::smoke("cdc_bf_mysql"))
@@ -305,7 +305,7 @@ fn cdc_backfill_snapshot_mysql_snowflake() {
 // rather than a silent skip; unignore once the MSSQL CDC lane is built out.
 #[test]
 #[ignore = "blocked: MSSQL CDC lane not wired in the harness (empty Lane client)"]
-fn cdc_backfill_snapshot_mssql() {
+fn warehouse_cell_cdc_backfill_snapshot_mssql() {
     let v = Verification::new(Engine::Mssql, Mode::Cdc, Fixture::smoke("cdc_backfill"))
         .initial_snapshot();
     // Negative test: MSSQL's CDC lane isn't wired, so a live-env run bails with a

--- a/tests/type_roundtrip/bigquery_load.rs
+++ b/tests/type_roundtrip/bigquery_load.rs
@@ -44,11 +44,21 @@ struct BqConfig {
 
 /// Read BigQuery configuration from env. Returns `None` if any required piece
 /// is missing — tests skip in that case rather than fail.
+/// The `RIVET-SKIP` marker, local to this suite (see tests/common/mod.rs for why
+/// one token: a lane cannot grep for four different spellings).
+fn skip_live(why: &str) {
+    let who = std::thread::current()
+        .name()
+        .unwrap_or("<unnamed test>")
+        .to_string();
+    eprintln!("RIVET-SKIP {who} — {why}");
+}
+
 fn bq_config() -> Option<BqConfig> {
     let project = std::env::var("BIGQUERY_TEST_PROJECT").ok()?;
     // `bq --version` is the cheapest reachable probe.
     if Command::new("bq").arg("--version").output().is_err() {
-        eprintln!("bigquery_load: skipping — `bq` CLI not on PATH");
+        skip_live("`bq` CLI not on PATH");
         return None;
     }
     Some(BqConfig {
@@ -159,7 +169,7 @@ impl BqConfig {
 fn bigquery_validates_postgres_type_matrix_parquet() {
     require_alive(LiveService::Postgres);
     let Some(cfg) = bq_config() else {
-        eprintln!("bigquery_load: skipping (BIGQUERY_TEST_PROJECT not set)");
+        skip_live("BIGQUERY_TEST_PROJECT not set");
         return;
     };
 
@@ -302,7 +312,7 @@ fn bigquery_validates_postgres_type_matrix_parquet() {
 fn bigquery_validates_mysql_type_matrix_parquet() {
     require_alive(LiveService::Mysql);
     let Some(cfg) = bq_config() else {
-        eprintln!("bigquery_load: skipping (BIGQUERY_TEST_PROJECT not set)");
+        skip_live("BIGQUERY_TEST_PROJECT not set");
         return;
     };
 
@@ -461,7 +471,7 @@ exports:
 fn bigquery_validates_mssql_type_matrix_parquet() {
     require_alive(LiveService::Mssql);
     let Some(cfg) = bq_config() else {
-        eprintln!("bigquery_load: skipping (BIGQUERY_TEST_PROJECT not set)");
+        skip_live("BIGQUERY_TEST_PROJECT not set");
         return;
     };
 

--- a/tests/type_roundtrip/snowflake_load.rs
+++ b/tests/type_roundtrip/snowflake_load.rs
@@ -47,10 +47,20 @@ struct SfConfig {
 
 /// Read Snowflake configuration from env. Returns `None` if the connection name
 /// is missing or `snow` is not on PATH — tests skip rather than fail.
+/// The `RIVET-SKIP` marker, local to this suite (see tests/common/mod.rs for why
+/// one token: a lane cannot grep for four different spellings).
+fn skip_live(why: &str) {
+    let who = std::thread::current()
+        .name()
+        .unwrap_or("<unnamed test>")
+        .to_string();
+    eprintln!("RIVET-SKIP {who} — {why}");
+}
+
 fn sf_config() -> Option<SfConfig> {
     let connection = std::env::var("SNOWFLAKE_TEST_CONNECTION").ok()?;
     if Command::new("snow").arg("--version").output().is_err() {
-        eprintln!("snowflake_load: skipping — `snow` CLI not on PATH");
+        skip_live("`snow` CLI not on PATH");
         return None;
     }
     Some(SfConfig {
@@ -173,7 +183,7 @@ fn infer_type<'a>(rows: &'a serde_json::Value, col: &str) -> &'a str {
 fn snowflake_validates_postgres_type_matrix_parquet() {
     require_alive(LiveService::Postgres);
     let Some(cfg) = sf_config() else {
-        eprintln!("snowflake_load: skipping (SNOWFLAKE_TEST_CONNECTION not set)");
+        skip_live("SNOWFLAKE_TEST_CONNECTION not set");
         return;
     };
 
@@ -294,7 +304,7 @@ fn snowflake_validates_mysql_uint64_overflow_survives_via_decimal_override() {
     use mysql::prelude::Queryable;
     require_alive(LiveService::Mysql);
     let Some(cfg) = sf_config() else {
-        eprintln!("snowflake_load: skipping (SNOWFLAKE_TEST_CONNECTION not set)");
+        skip_live("SNOWFLAKE_TEST_CONNECTION not set");
         return;
     };
 


### PR DESCRIPTION
The CDC evidence audit graded `unknown_input_fails_loud_not_silent` as **`absent` on all four engines**, naming TRUNCATE as the PostgreSQL instance. It is real, it is worse than "unknown input", and it is on **two** engines by two different routes.

## Measured before any fix (2026-08-24, both stands)

| | source after TRUNCATE | rivet reported |
|---|---|---|
| PostgreSQL | **0 rows** | `status: success, rows: 2` |
| MySQL | **0 rows** | `status: success, rows: 2` |

Zero occurrences of the word at `RUST_LOG=trace`. Not a quiet log — **no log**.

## Why it bails rather than warns

The rows leave the source with **no DELETE events to carry them**, so the destination holds rows that no longer exist and *no later capture can reconcile it* — there is nothing left to read. A warning would leave a destination permanently disagreeing with its source and still call the run a success.

## Two engines, two hiding places

- **PostgreSQL** — `table public.t: TRUNCATE: (no-flags)`, a line with no columns, so `parse_test_decoding` had nothing to build and dropped it into its catch-all `None`.
- **MySQL** — a QUERY event, never rows, so the rows path never sees it and the `_ => {}` arm dropped it.

**SQL Server** needs neither: it *refuses the truncate itself* (Msg 4711 on a CDC-enabled table, measured), so the divergence cannot be created. **MongoDB** has no TRUNCATE. Both cells are `na` on measurement, not assumption — the fail-loud ratchet admits zero gaps, and that is what forced the measurement instead of a "not investigated" note.

## Table-addressed on both, in advance

#281 measured what happens when a refusal fires before asking *whose* relation it is: one PARTIAL_JSON table failed every concurrent export on the server. A PostgreSQL slot decodes the whole database and a binlog carries every table, so the same trap was one line away here.

Each live test therefore has a second half — a **bystander export**, anchored *before* the truncate so the event is inside its window by construction rather than by timing, which must still complete and capture its own change.

## Evidence

Four mutants, each caught on a different assert: PG guard removed → back to the measured 0-row-source success; PG refusal un-addressed → bystander fails; same two for MySQL.

Offline tests grade the branches a live fixture cannot reach cheaply — a quoted identity, a bare schema-less config name, the empty-config case, and the statement forms MySQL logs as written. The MySQL parser returns `None` on anything it cannot read confidently (`TRUNCATE … PARTITION` included) rather than guessing and failing a run it misread.

Also checked the guard is not too **wide**: a TRUNCATE *before* the slot exists does not affect capture (measured), because the guard only ever sees events the slot carries.

Whole CDC live suite: **160/160**. Ratchet 26 → 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168uwctCn3W1rP4Kt4kZXvE