### PR TITLE
fix(cdc): three silent-loss shapes an adversarial pass found in guards I wrote today

### DIFF
--- a/docs/adr/0024-pg-cdc-pgoutput-migration.md
+++ b/docs/adr/0024-pg-cdc-pgoutput-migration.md
@@ -69,3 +69,59 @@ anchor-model contract is unchanged — PG still pins server-side at slot creatio
 - The non-UTC session test (`pg_cdc_non_utc_database_timezone_matches_batch`)
   is the canary for this ADR — it fails first if a new session-shaped
   rendering appears.
+
+## Amendment 2026-08-24: a SECOND text class — identity, not values
+
+The six defects above are all about the rendering of a *value*. A hostile
+verification pass found a distinct class the pin set never covered: the rendering
+of an **identity**. `test_decoding` names relations as TEXT, and every routing
+decision compares that text byte-exact, so the same hop corrupts *which table a
+change belongs to* rather than what it contains.
+
+Four measured this session, each a silent loss past an advancing slot:
+
+1. **Partitioned parent.** `test_decoding` names the PARTITION a row landed in.
+   A config naming the logical parent captured 0 of 2 rows, reported
+   `status: success`, advanced the slot, and the corrected re-run recovered
+   nothing (the WAL was already freed).
+2. **A folded twin.** The schema probe interpolates the config into
+   `SELECT * FROM {table}` (PostgreSQL FOLDS it); the router compares byte-exact.
+   With `"MixedCase"` and `mixedcase` both present, rows were written under the
+   WRONG table's schema — the real column absent entirely, exit 0.
+3. **A 3-part name.** `to_regclass` accepts `db.schema.table`; `table_matches`
+   splits on the first dot. Resolves, never routes.
+4. **TRUNCATE.** Arrives as a line of prose naming a comma-separated LIST of
+   relations, which had to be re-parsed (twice — the first fix anchored on the
+   wrong separator and matched nothing).
+
+`pgoutput` makes all four unrepresentable for the same structural reason the
+value class disappears: it carries a **relation OID plus a Relation message**,
+not a name to parse, and TRUNCATE is a typed message carrying an ARRAY of
+relation OIDs rather than text. Partition identity is a publication-level
+setting — `publish_via_partition_root`, which Debezium 3.2 exposes as
+`publish.via.partition.root` — and it does not exist for `test_decoding` at all,
+because publications are a pgoutput concept.
+
+External corroboration worth recording: **Debezium supports only `decoderbufs`
+and `pgoutput`** — `test_decoding` is not a supported plugin, and PostgreSQL's
+own docs call it "meant for testing that replication works rather than for
+building robust production apps". The guards this session added are the correct
+minimum FOR `test_decoding` (they turn each silent loss into a loud refusal),
+but each is a parser standing in for a mechanism the protocol would provide.
+
+### Effect on the decision
+
+Trigger 1 is widened: it now fires on a seventh text-rendering defect class **or
+a text-IDENTITY defect class**. The identity class has now fired — four
+instances in one day — so by the ADR's own terms this is no longer "not
+scheduled" but a candidate whose gate has been met. The blockers in "Why not
+now" (the sync `postgres` crate does not speak streaming replication; a
+PUBLICATION is a new server-side resource with its own lifecycle) are unchanged
+and still real; what has changed is the cost of NOT migrating, which is now
+measured rather than projected.
+
+Recommended next step, and deliberately scoped smaller than the migration: a
+spike that answers (a) which streaming-replication crate is audit-clean today,
+and (b) whether a PUBLICATION can be made optional — capture without DDL rights
+was the original reason for this plugin, and if `pgoutput` cannot preserve it,
+the migration is a dual-mode adapter rather than a replacement.

--- a/docs/adr/0024-pg-cdc-pgoutput-migration.md
+++ b/docs/adr/0024-pg-cdc-pgoutput-migration.md
@@ -125,3 +125,34 @@ spike that answers (a) which streaming-replication crate is audit-clean today,
 and (b) whether a PUBLICATION can be made optional — capture without DDL rights
 was the original reason for this plugin, and if `pgoutput` cannot preserve it,
 the migration is a dual-mode adapter rather than a replacement.
+
+### What the rest of the ecosystem does (surveyed 2026-08-24)
+
+Checked because "are we reinventing the wheel" is the right question to ask
+before building the seventh parser. Answer: on the plugin choice, yes.
+
+- **Debezium** supports `decoderbufs` and `pgoutput` only. `test_decoding` is not
+  a supported plugin at all.
+- **PeerDB** takes the parent table name and nothing else — "you don't need to
+  specify the names of each partition" — via a publication with
+  `publish_via_partition_root` (PG 13-16; on PG 12, a publication FOR ALL TABLES).
+- **Sequin's** plugin guide states test_decoding's "output format is not designed
+  for production parsing" and calls it "mainly useful for understanding how
+  logical decoding works or for quick debugging".
+- PostgreSQL's own docs: "meant for testing that replication works rather than
+  for building robust production apps".
+
+Two design answers worth stealing regardless of which way this ADR goes:
+
+1. **TRUNCATE is a MODE, not a verdict.** Debezium's `truncate.handling.mode`
+   defaults to `skip` and can be set to `include`. rivet now REFUSES, which is
+   right for a file/warehouse sink (there is no consumer to interpret a truncate
+   event, and the divergence is permanent) — but it is a stricter answer than the
+   ecosystem's, and the difference should be a documented choice rather than an
+   accident of what we happened to implement.
+2. **Partition drop is documented, not detected.** PeerDB explicitly does NOT
+   propagate a dropped partition: "we don't delete data matching that partition."
+   That is the same class as the `SWITCH PARTITION` finding this session left
+   open on SQL Server — rows leaving the source with no events. The mature answer
+   is a stated contract, not a detector, and our ledger should record it that way
+   rather than carrying it as an unfilled gap forever.

--- a/docs/fail-loud-matrix.yaml
+++ b/docs/fail-loud-matrix.yaml
@@ -24,10 +24,10 @@ scenarios:
     mongo:    { na: "an oplog-rolled-past resume token surfaces the driver's ChangeStreamHistoryLost directly (rivet does not swallow it — src/source/mongo/cdc.rs); forcing an oplog rollover live is impractical (documented NA in cdc_conformance_gate.rs). The adjacent corrupt-checkpoint case IS tested: roast_corrupt_checkpoint_fails_loudly_not_silent_reanchor" }
 
   - id: cdc_unroutable_configured_table_loud
-    what: "a configured `table:` that NO change event can ever name (a PostgreSQL partitioned parent / view / matview; a SQL Server capture instance whose catalog identity differs) → loud bail AT OPEN, before any ack, never a 0-row `status: success` past an advanced cursor"
+    what: "a configured `table:` that NO change event can ever name (a PostgreSQL partitioned parent / view / matview; a MySQL VIEW, whose binlog Table_map names the BASE table; a SQL Server capture instance whose catalog identity differs) → loud bail AT OPEN, before any ack, never a 0-row `status: success` past an advanced cursor"
     postgres: { test: roast_pg_cdc_refuses_a_partitioned_parent_before_acking_the_slot }
     mssql:    { test: mssql_cdc_capture_instance_name_must_not_decide_the_table }
-    mysql:    { na: "no MySQL relation emits under a name other than the configured one — the binlog's table_map carries the LOGICAL table, partitioning included (measured 2026-08-24: a RANGE-partitioned table captured through a config naming the parent)" }
+    mysql:    { test: roast_mysql_cdc_refuses_a_view_whose_binlog_identity_is_the_base_table }
     mongo:    { na: "a change stream's `ns` IS the collection the write addressed; Mongo has no parent/child relation surfacing events under a different name, so there is no second identity to cross-check" }
 
   - id: hostile_numeric_value_loud

--- a/src/source/cdc/mod.rs
+++ b/src/source/cdc/mod.rs
@@ -788,6 +788,15 @@ pub(crate) fn create_change_stream(
                 Some(p) => Position::load(p)?.is_some(),
                 None => false,
             };
+            // Hoisted out of the PG_CDC_HINT wrap below: a configured name the
+            // stream can never route is a CONFIG problem, and raising it inside
+            // open prefixes it with a wal_level/REPLICATION hint that sends the
+            // operator to fix permissions they never had a problem with.
+            crate::source::postgres::cdc::PgChangeStream::precheck_configured_tables(
+                url,
+                tls,
+                configured_tables,
+            )?;
             Ok(Box::new(
                 crate::source::postgres::cdc::PgChangeStream::open(
                     url,

--- a/src/source/cdc/mod.rs
+++ b/src/source/cdc/mod.rs
@@ -753,6 +753,14 @@ pub(crate) fn create_change_stream(
             if let Some(p) = cfg.checkpoint.as_deref() {
                 Position::load(std::path::Path::new(p))?;
             }
+            // Same hoist, same reason: a configured name the binlog can never carry
+            // (a VIEW, whose Table_map names the BASE table) is a CONFIG problem, and
+            // raising it inside open would prefix it with the binlog-grants hint.
+            crate::source::mysql::cdc::MysqlChangeStream::precheck_configured_tables(
+                url,
+                tls,
+                configured_tables,
+            )?;
             Ok(Box::new(
                 crate::source::mysql::cdc::MysqlChangeStream::open_or_resume(
                     url,

--- a/src/source/mysql/cdc.rs
+++ b/src/source/mysql/cdc.rs
@@ -147,6 +147,74 @@ impl MysqlChangeStream {
         Self::row_image_verdict(image.as_deref())
     }
 
+    /// [`Self::check_configured_tables_are_routable`] on its own connection, for the
+    /// caller to run BEFORE `open_or_resume`.
+    ///
+    /// The hoist matters: `create_change_stream` wraps that call in
+    /// `MYSQL_CDC_HINT` (binlog grants / binlog_format), so a routing refusal raised
+    /// inside `open` reaches the operator prefixed with "if this is a
+    /// permissions/setup error" — for a config problem that has nothing to do with
+    /// permissions. Same reason the checkpoint is validated before the call, and the
+    /// same defect that hoist was added for.
+    ///
+    /// A connect failure here is swallowed deliberately: `open_or_resume` is about to
+    /// dial the same server and its error — WITH the grants hint — is the right one
+    /// for that case.
+    pub(crate) fn precheck_configured_tables(
+        url: &str,
+        tls: Option<&TlsConfig>,
+        configured: &[String],
+    ) -> Result<()> {
+        if configured.is_empty() {
+            return Ok(());
+        }
+        let Ok(mut conn) = connect_conn(url, tls) else {
+            return Ok(());
+        };
+        Self::check_configured_tables_are_routable(&mut conn, configured)
+    }
+
+    /// Live half: ask `information_schema` what each configured name IS, before
+    /// the stream is read and long before any checkpoint advance. Decisions live
+    /// in [`classify_mysql_routing`]; this is glue.
+    ///
+    /// Best-effort on the QUERY itself — a catalog permission error must not fail
+    /// a capture that is otherwise fine, the same posture `row_image` takes. What
+    /// is NOT best-effort is the verdict: once the catalog answers, a non-base
+    /// relation bails.
+    pub(crate) fn check_configured_tables_are_routable(
+        conn: &mut mysql::Conn,
+        configured: &[String],
+    ) -> Result<()> {
+        use mysql::prelude::Queryable as _;
+        for cfg in configured {
+            let (schema, table) = match cfg.split_once('.') {
+                Some((s, t)) => (Some(s.to_string()), t.to_string()),
+                None => (None, cfg.clone()),
+            };
+            let row: Option<String> = match &schema {
+                Some(s) => conn
+                    .exec_first(
+                        "SELECT TABLE_TYPE FROM information_schema.TABLES \
+                         WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?",
+                        (s, &table),
+                    )
+                    .unwrap_or(None),
+                None => conn
+                    .exec_first(
+                        "SELECT TABLE_TYPE FROM information_schema.TABLES \
+                         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?",
+                        (&table,),
+                    )
+                    .unwrap_or(None),
+            };
+            if let MysqlRoutingVerdict::Never(why) = classify_mysql_routing(cfg, row.as_deref()) {
+                anyhow::bail!("{why}");
+            }
+        }
+        Ok(())
+    }
+
     pub(crate) fn open(
         url: &str,
         server_id: u32,
@@ -676,6 +744,52 @@ fn connect_conn(url: &str, tls: Option<&TlsConfig>) -> Result<Conn> {
     Ok(conn)
 }
 
+/// What a configured MySQL `table:` actually IS, and whether the binlog can ever
+/// name it — the MySQL half of the PostgreSQL routing guard (#283).
+///
+/// A binlog `Table_map` names the relation the rows PHYSICALLY landed in. For a
+/// RANGE-partitioned table that is the logical table (measured — partitioning is
+/// fine here, unlike PostgreSQL). For an updatable VIEW it is the BASE table, and
+/// the sink routes byte-exact, so every change is dropped.
+///
+/// MEASURED 2026-08-24 by an adversarial re-check of a matrix cell that claimed
+/// MySQL had no such relation: 3 rows committed through a view gave
+/// `rows: 0, files: 0, status: success, exit 0` with the checkpoint advanced past
+/// the commit (54945184 -> 54945514), and fixing the config recovered NOTHING
+/// from that checkpoint.
+///
+/// Severity differs from PostgreSQL and the message says so: MySQL binlog
+/// retention is reader-independent, so the events are still in the log and
+/// deleting the checkpoint re-reads them. On PostgreSQL the slot had already
+/// freed the WAL, which is why that one is unrecoverable.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum MysqlRoutingVerdict {
+    Routable,
+    Never(String),
+}
+
+/// Pure half of the guard. `table_type` is `information_schema.TABLES.TABLE_TYPE`
+/// for the configured name, or `None` when the catalog has no row for it — which
+/// the schema probe reports on its own, loudly, so this stays quiet about it
+/// rather than producing a second, competing error for one cause.
+pub(crate) fn classify_mysql_routing(
+    configured: &str,
+    table_type: Option<&str>,
+) -> MysqlRoutingVerdict {
+    match table_type {
+        None => MysqlRoutingVerdict::Routable,
+        Some(t) if t.eq_ignore_ascii_case("BASE TABLE") => MysqlRoutingVerdict::Routable,
+        Some(t) => MysqlRoutingVerdict::Never(format!(
+            "mysql cdc: `{configured}` is a {t}, not a base table. The binlog names the relation \
+             rows physically landed in — for a view that is the BASE table — and routing is \
+             byte-exact, so every change would be dropped while the checkpoint advanced past it: \
+             a run reporting success with 0 rows. Capture the base table(s) the view reads \
+             instead. If a run already did this, the changes are NOT lost — MySQL binlog \
+             retention does not depend on the reader, so deleting the checkpoint re-reads them."
+        )),
+    }
+}
+
 /// Is the commit at `(file, pos)` PAST the open-time bound? — the pure heart of
 /// the bounded run's termination contract (see [`MysqlChangeStream::bound`]).
 /// Binlog files order by their numeric suffix (`binlog.000042`); a lexicographic
@@ -807,6 +921,57 @@ impl ChangeStream for MysqlChangeStream {
 
 #[cfg(test)]
 mod tests {
+    /// The MySQL routing guard's decision surface.
+    ///
+    /// `None` (the catalog has no row) must stay ROUTABLE, deliberately: the schema
+    /// probe reports a missing table with a message that already names it, and a
+    /// second competing error for one cause is worse than none.
+    #[test]
+    fn a_non_base_relation_is_refused_and_a_base_table_is_not() {
+        assert_eq!(
+            classify_mysql_routing("rivet.orders", Some("BASE TABLE")),
+            MysqlRoutingVerdict::Routable,
+            "an ordinary table must stay routable — refusing it would break every config"
+        );
+        assert_eq!(
+            classify_mysql_routing("rivet.orders", Some("base table")),
+            MysqlRoutingVerdict::Routable,
+            "TABLE_TYPE casing is not something to depend on"
+        );
+        assert_eq!(
+            classify_mysql_routing("rivet.orders", None),
+            MysqlRoutingVerdict::Routable,
+            "an absent catalog row is the schema probe's error to report, not this \
+             guard's — two errors for one cause is worse than one"
+        );
+
+        let MysqlRoutingVerdict::Never(why) =
+            classify_mysql_routing("rivet.orders_v", Some("VIEW"))
+        else {
+            panic!("a VIEW can never be routed — the binlog names its BASE table");
+        };
+        assert!(
+            why.contains("rivet.orders_v") && why.contains("VIEW"),
+            "the refusal must name the relation and what it is: {why}"
+        );
+        assert!(
+            why.contains("base table(s)"),
+            "it must say what to capture instead: {why}"
+        );
+        assert!(
+            why.contains("NOT lost"),
+            "MySQL binlog retention is reader-independent, so this IS recoverable by \
+             deleting the checkpoint — saying so is the difference between a config \
+             fix and a re-snapshot the operator does not need: {why}"
+        );
+        // SYSTEM VIEW is the other type information_schema reports; it must refuse
+        // for the same reason rather than fall through to Routable.
+        assert!(matches!(
+            classify_mysql_routing("x", Some("SYSTEM VIEW")),
+            MysqlRoutingVerdict::Never(_)
+        ));
+    }
+
     /// The refusal message IS the remediation — an operator has nothing else to go
     /// on, because the alternative to this error was a green run with missing rows.
     /// The refusal must be TABLE-ADDRESSED. Every arm here was a live failure

--- a/src/source/postgres/cdc.rs
+++ b/src/source/postgres/cdc.rs
@@ -113,6 +113,14 @@ pub(crate) struct RelationRouting<'a> {
     pub configured: &'a str,
     /// `pg_class.relkind` of the relation that name resolves to.
     pub relkind: char,
+    /// `pg_class.relpersistence` — `u` for UNLOGGED. An unlogged table writes no
+    /// WAL, so logical decoding never emits a single event for it.
+    pub relpersistence: char,
+    /// The CATALOG's spelling of the relation the config string resolved to, as
+    /// `(schema, table)`. The probe resolves through SQL rules (which FOLD an
+    /// unquoted name); the router compares BYTE-EXACT. When those two disagree the
+    /// config means one relation to the probe and another to routing.
+    pub resolved: (String, String),
     /// Relations that inherit from it — partitions, or legacy `INHERITS`
     /// children — schema-qualified the way `test_decoding` renders them.
     pub children: Vec<String>,
@@ -133,6 +141,42 @@ pub(crate) enum RoutingVerdict {
 /// guard makes — is what an offline test can hold and mutants can grade.
 pub(crate) fn classify_routing(rel: &RelationRouting<'_>) -> RoutingVerdict {
     let cfg = rel.configured;
+    let (rs, rt) = (&rel.resolved.0, &rel.resolved.1);
+
+    // FIRST, because it is the case where the schema is resolved from one relation
+    // and the events come from another. The config string is read by two resolvers
+    // with different case rules: the schema probe interpolates it into
+    // `SELECT * FROM {table}` and lets PostgreSQL FOLD it, while the sink routes
+    // byte-exact against the unquoted wire identity. They agree for an ordinary
+    // lowercase name and diverge the moment a folded twin exists.
+    //
+    // MEASURED (adversarial pass, 2026-08-24) with BOTH `"MixedCase"(id,v)` and
+    // `mixedcase(id,other_col,extra)` present and `table: MixedCase` configured:
+    // exit 0 and `status: success` throughout, while (a) writes to `mixedcase` —
+    // the relation the probe actually resolved — captured `rows: 0` with no
+    // warning, and (b) writes to `"MixedCase"` were written under the WRONG
+    // table's schema: columns `id, other_col, extra`, the real `v` values absent
+    // entirely and no `v` column in the output. Silent column loss on top of
+    // silent event loss.
+    //
+    // This also catches the 3-part `db.schema.table` form: PostgreSQL's
+    // `to_regclass` accepts it when `db` is the current database, so the probe
+    // resolves happily while `table_matches` splits on the FIRST dot and compares
+    // `db` against the schema — never matching.
+    if !crate::source::cdc::sink::table_matches(cfg, rs, rt) {
+        return RoutingVerdict::Never(format!(
+            "pg cdc: `{cfg}` resolves to the relation `{rs}.{rt}`, but routing compares the              config string BYTE-EXACT against the name test_decoding emits — and those two              disagree here. The schema probe would read `{rs}.{rt}`'s columns while events              carrying a different spelling route nowhere, so the run would either capture              NOTHING or write rows under the wrong table's schema, silently, past an              advancing slot. Set `table:` to `{rs}.{rt}` exactly as the catalog spells it."
+        ));
+    }
+
+    // An UNLOGGED table writes no WAL at all, so no logical-decoding event can ever
+    // exist for it — the same total, silent drop as a view, by a different route.
+    if rel.relpersistence == 'u' {
+        return RoutingVerdict::Never(format!(
+            "pg cdc: `{cfg}` is an UNLOGGED table. Unlogged tables write no WAL, so logical              decoding never produces a single event for them and the capture would report              success with zero rows forever while the slot advanced past other traffic.              `ALTER TABLE {rs}.{rt} SET LOGGED` to capture it, or drop it from the config."
+        ));
+    }
+
     match rel.relkind {
         // A partitioned parent stores NO rows of its own: every change carries a
         // PARTITION's name. Byte-exact routing can never match it.
@@ -291,6 +335,43 @@ impl PgChangeStream {
         }
     }
 
+    /// [`Self::check_configured_tables_are_routable`] on its own connection, for the
+    /// caller to run BEFORE the stream is opened.
+    ///
+    /// `create_change_stream` wraps the open call in `PG_CDC_HINT` (wal_level and
+    /// the REPLICATION attribute), so a routing refusal raised inside `open` reaches
+    /// the operator prefixed with "if this is a permissions/setup error" — for a
+    /// CONFIG problem with nothing to do with permissions. MEASURED on this branch,
+    /// and the same defect the MySQL side was just fixed for, which is why both now
+    /// run their check outside the wrap.
+    ///
+    /// A connect failure is swallowed on purpose: `open` is about to dial the same
+    /// server, and its error — WITH the hint — is the right one for that case.
+    pub(crate) fn precheck_configured_tables(
+        conn_str: &str,
+        tls: Option<&TlsConfig>,
+        configured: &[String],
+    ) -> Result<()> {
+        if configured.is_empty() {
+            return Ok(());
+        }
+        if require_tls_or_loopback(conn_str, tls).is_err() {
+            return Ok(()); // open() bails on the same posture, with the right message
+        }
+        let Ok(mut client) = (match tls {
+            Some(cfg) if cfg.mode.is_enforced() => crate::source::tls::build_native_tls(cfg)
+                .and_then(|c| {
+                    super::pg_config_ssl_forced(conn_str)?
+                        .connect(postgres_native_tls::MakeTlsConnector::new(c))
+                        .map_err(Into::into)
+                }),
+            _ => Client::connect(conn_str, NoTls).map_err(Into::into),
+        }) else {
+            return Ok(());
+        };
+        Self::check_configured_tables_are_routable(&mut client, configured)
+    }
+
     /// Live half of the routing guard: ask the CATALOG what each configured
     /// table actually is, and refuse a capture that could only ever drop
     /// everything. Decisions live in [`classify_routing`]; this is glue.
@@ -304,7 +385,7 @@ impl PgChangeStream {
     /// error to report (`SELECT * FROM {table}`, `cdc/mod.rs`), with a message
     /// that already names it. Resolution follows the same SQL rules that probe
     /// does, so the two agree about which relation a config string means.
-    fn check_configured_tables_are_routable(
+    pub(crate) fn check_configured_tables_are_routable(
         client: &mut Client,
         configured: &[String],
     ) -> Result<()> {
@@ -312,15 +393,17 @@ impl PgChangeStream {
         for cfg in configured {
             let Some(row) = client
                 .query_opt(
-                    "SELECT c.relkind::text, \
+                    "SELECT c.relkind::text, c.relpersistence::text, \
+                            n.nspname::text, c.relname::text, \
                             coalesce(array_agg(n2.nspname || '.' || c2.relname) \
                                      FILTER (WHERE c2.oid IS NOT NULL), '{}') \
                      FROM pg_class c \
+                     JOIN pg_namespace n ON n.oid = c.relnamespace \
                      LEFT JOIN pg_inherits i ON i.inhparent = c.oid \
                      LEFT JOIN pg_class c2 ON c2.oid = i.inhrelid \
                      LEFT JOIN pg_namespace n2 ON n2.oid = c2.relnamespace \
                      WHERE c.oid = to_regclass($1) \
-                     GROUP BY c.relkind",
+                     GROUP BY c.relkind, c.relpersistence, n.nspname, c.relname",
                     &[&cfg.as_str()],
                 )
                 .with_context(|| {
@@ -330,10 +413,15 @@ impl PgChangeStream {
                 continue; // unresolvable here — the schema probe reports it, loudly
             };
             let relkind: String = row.get(0);
-            let children: Vec<String> = row.get(1);
+            let relpersistence: String = row.get(1);
+            let resolved_schema: String = row.get(2);
+            let resolved_table: String = row.get(3);
+            let children: Vec<String> = row.get(4);
             let rel = RelationRouting {
                 configured: cfg,
                 relkind: relkind.chars().next().unwrap_or('?'),
+                relpersistence: relpersistence.chars().next().unwrap_or('p'),
+                resolved: (resolved_schema, resolved_table),
                 children,
             };
             match classify_routing(&rel) {
@@ -386,9 +474,11 @@ impl PgChangeStream {
             "SET datestyle = 'ISO, MDY'; SET bytea_output = 'hex'; \
              SET intervalstyle = 'postgres'; SET extra_float_digits = 3;",
         )?;
-        // BEFORE the slot exists and long before any ack: a configured table that
-        // no change event can ever name is a total, unrecoverable drop, and the
-        // slot advancing is what makes it unrecoverable.
+        // Also here, not only in the caller's precheck. The precheck exists so the
+        // refusal reaches the operator WITHOUT the wal_level/REPLICATION hint
+        // wrapped around it; this one keeps the guarantee for any path that opens a
+        // stream directly. The duplicate catalog read costs one round-trip on a
+        // config that is about to fail anyway.
         Self::check_configured_tables_are_routable(&mut client, configured_tables)?;
 
         // A bounded run cannot work on a STANDBY: it pins its ceiling with
@@ -1328,6 +1418,10 @@ mod tests {
         let rel = |kind: char, children: &[&str]| RelationRouting {
             configured: "public.t",
             relkind: kind,
+            relpersistence: 'p',
+            // The catalog agrees with the config here, so these cases exercise the
+            // relkind arms rather than the identity check above them.
+            resolved: ("public".to_string(), "t".to_string()),
             children: children.iter().map(|c| c.to_string()).collect(),
         };
 
@@ -1364,6 +1458,67 @@ mod tests {
 
         // A plain table is routable, and stays routable — refusing it would break
         // every working config.
+        assert_eq!(classify_routing(&rel('r', &[])), RoutingVerdict::Routable);
+
+        // ── the identity check, which runs BEFORE any relkind arm ──────────────
+        //
+        // Both cases below were MEASURED by an adversarial pass over the first
+        // version of this guard, which read only relkind and passed them through.
+        let mismatched = RelationRouting {
+            configured: "MixedCase",
+            relkind: 'r',
+            relpersistence: 'p',
+            // What `SELECT * FROM MixedCase` actually resolves to: PostgreSQL folds
+            // the unquoted name, so the probe reads THIS relation's columns while
+            // events spelled `MixedCase` route nowhere.
+            resolved: ("public".to_string(), "mixedcase".to_string()),
+            children: vec![],
+        };
+        let RoutingVerdict::Never(why) = classify_routing(&mismatched) else {
+            panic!(
+                "a config whose resolved identity differs from what routing compares \
+                 must be refused — measured, it wrote rows under the WRONG table's \
+                 schema with the real column absent entirely, exit 0"
+            );
+        };
+        assert!(
+            why.contains("public.mixedcase"),
+            "the refusal must name the CATALOG's spelling — that spelling is the \
+             remediation: {why}"
+        );
+
+        // The 3-part `db.schema.table` form: to_regclass accepts it when db is the
+        // current database, so the probe resolves while table_matches splits on the
+        // FIRST dot and compares `db` against the schema.
+        let three_part = RelationRouting {
+            configured: "rivet.public.orders",
+            relkind: 'r',
+            relpersistence: 'p',
+            resolved: ("public".to_string(), "orders".to_string()),
+            children: vec![],
+        };
+        assert!(
+            matches!(classify_routing(&three_part), RoutingVerdict::Never(_)),
+            "a 3-part name resolves for the probe and never matches the router"
+        );
+
+        // UNLOGGED: writes no WAL, so no event can ever exist for it.
+        let unlogged = RelationRouting {
+            configured: "public.t",
+            relkind: 'r',
+            relpersistence: 'u',
+            resolved: ("public".to_string(), "t".to_string()),
+            children: vec![],
+        };
+        let RoutingVerdict::Never(why) = classify_routing(&unlogged) else {
+            panic!("an UNLOGGED table writes no WAL — capture is a guaranteed zero");
+        };
+        assert!(
+            why.contains("SET LOGGED"),
+            "the refusal must name the one-line fix: {why}"
+        );
+        // …and a plain permanent table with a matching identity stays routable, or
+        // the guard would refuse every working config.
         assert_eq!(classify_routing(&rel('r', &[])), RoutingVerdict::Routable);
 
         // Inheritance children are a PARTIAL gap: the parent's own rows route

--- a/src/source/postgres/cdc.rs
+++ b/src/source/postgres/cdc.rs
@@ -124,6 +124,13 @@ pub(crate) struct RelationRouting<'a> {
     /// Relations that inherit from it — partitions, or legacy `INHERITS`
     /// children — schema-qualified the way `test_decoding` renders them.
     pub children: Vec<String>,
+    /// For a partitioned parent: the LEAF partitions, from `pg_partition_tree`.
+    ///
+    /// Not the same as `children` on a sub-partitioned table, and the difference is
+    /// a dead-end remediation: `children` there is the intermediate PARTITIONED
+    /// table, which stores no rows either and is refused by this same guard on the
+    /// next run. Only a leaf ever appears in the WAL.
+    pub leaves: Vec<String>,
 }
 
 /// The verdict for one configured table. `Never` is a hard error (a guaranteed
@@ -181,10 +188,13 @@ pub(crate) fn classify_routing(rel: &RelationRouting<'_>) -> RoutingVerdict {
         // A partitioned parent stores NO rows of its own: every change carries a
         // PARTITION's name. Byte-exact routing can never match it.
         'p' => {
-            let named = if rel.children.is_empty() {
+            // LEAVES, not children. On a sub-partitioned table the immediate child
+            // is another partitioned table that stores no rows, so naming it sends
+            // the operator to a config this same guard refuses on the next run.
+            let named = if rel.leaves.is_empty() {
                 "it has no partitions yet".to_string()
             } else {
-                format!("currently {}", rel.children.join(", "))
+                format!("currently {}", rel.leaves.join(", "))
             };
             RoutingVerdict::Never(format!(
                 "pg cdc: `{cfg}` is a PARTITIONED table — it stores no rows itself, and \
@@ -396,14 +406,18 @@ impl PgChangeStream {
                     "SELECT c.relkind::text, c.relpersistence::text, \
                             n.nspname::text, c.relname::text, \
                             coalesce(array_agg(n2.nspname || '.' || c2.relname) \
-                                     FILTER (WHERE c2.oid IS NOT NULL), '{}') \
+                                     FILTER (WHERE c2.oid IS NOT NULL), '{}'), \
+                            CASE WHEN c.relkind = 'p' THEN ( \
+                                SELECT coalesce(array_agg(pt.relid::regclass::text), '{}') \
+                                FROM pg_partition_tree(c.oid) pt WHERE pt.isleaf) \
+                            ELSE '{}' END \
                      FROM pg_class c \
                      JOIN pg_namespace n ON n.oid = c.relnamespace \
                      LEFT JOIN pg_inherits i ON i.inhparent = c.oid \
                      LEFT JOIN pg_class c2 ON c2.oid = i.inhrelid \
                      LEFT JOIN pg_namespace n2 ON n2.oid = c2.relnamespace \
                      WHERE c.oid = to_regclass($1) \
-                     GROUP BY c.relkind, c.relpersistence, n.nspname, c.relname",
+                     GROUP BY c.relkind, c.relpersistence, n.nspname, c.relname, c.oid",
                     &[&cfg.as_str()],
                 )
                 .with_context(|| {
@@ -417,11 +431,13 @@ impl PgChangeStream {
             let resolved_schema: String = row.get(2);
             let resolved_table: String = row.get(3);
             let children: Vec<String> = row.get(4);
+            let leaves: Vec<String> = row.get(5);
             let rel = RelationRouting {
                 configured: cfg,
                 relkind: relkind.chars().next().unwrap_or('?'),
                 relpersistence: relpersistence.chars().next().unwrap_or('p'),
                 resolved: (resolved_schema, resolved_table),
+                leaves,
                 children,
             };
             match classify_routing(&rel) {
@@ -1422,6 +1438,7 @@ mod tests {
             // The catalog agrees with the config here, so these cases exercise the
             // relkind arms rather than the identity check above them.
             resolved: ("public".to_string(), "t".to_string()),
+            leaves: children.iter().map(|c| c.to_string()).collect(),
             children: children.iter().map(|c| c.to_string()).collect(),
         };
 
@@ -1435,6 +1452,27 @@ mod tests {
             why.contains("public.t_2026_01"),
             "the refusal must name the partitions, because listing them IS the \
              remediation: {why}"
+        );
+
+        // SUB-PARTITIONED: the remediation must name a LEAF, never the intermediate
+        // partitioned table. `children` there is `ml_2026`, which stores no rows
+        // either and is refused by this same guard on the next run — a dead-end
+        // remediation, found by an adversarial pass over the first version.
+        let sub = RelationRouting {
+            configured: "public.ml",
+            relkind: 'p',
+            relpersistence: 'p',
+            resolved: ("public".to_string(), "ml".to_string()),
+            children: vec!["public.ml_2026".to_string()], // intermediate, unroutable
+            leaves: vec!["public.ml_2026_01".to_string()], // the only relation in the WAL
+        };
+        let RoutingVerdict::Never(why) = classify_routing(&sub) else {
+            panic!("a sub-partitioned parent is still unroutable");
+        };
+        assert!(
+            why.contains("public.ml_2026_01") && !why.contains("public.ml_2026,"),
+            "the remediation must name the LEAF — naming the intermediate sends the \
+             operator to a config this same guard refuses next run: {why}"
         );
 
         // …and with no partitions yet, it is still unroutable — the message just
@@ -1472,6 +1510,7 @@ mod tests {
             // the unquoted name, so the probe reads THIS relation's columns while
             // events spelled `MixedCase` route nowhere.
             resolved: ("public".to_string(), "mixedcase".to_string()),
+            leaves: vec![],
             children: vec![],
         };
         let RoutingVerdict::Never(why) = classify_routing(&mismatched) else {
@@ -1495,6 +1534,7 @@ mod tests {
             relkind: 'r',
             relpersistence: 'p',
             resolved: ("public".to_string(), "orders".to_string()),
+            leaves: vec![],
             children: vec![],
         };
         assert!(
@@ -1508,6 +1548,7 @@ mod tests {
             relkind: 'r',
             relpersistence: 'u',
             resolved: ("public".to_string(), "t".to_string()),
+            leaves: vec![],
             children: vec![],
         };
         let RoutingVerdict::Never(why) = classify_routing(&unlogged) else {

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -3703,6 +3703,97 @@ fn roast_pg_cdc_refuses_a_partitioned_parent_before_acking_the_slot() {
     );
 }
 
+/// A configured MySQL VIEW must be refused at open — the binlog can never name it.
+///
+/// Found by an ADVERSARIAL re-check of a matrix cell this session had written as
+/// `na` ("no MySQL relation emits under a name other than the configured one").
+/// That cell generalized a correct, measured result — a RANGE-partitioned table
+/// DOES capture through a config naming the parent — into a false universal. An
+/// updatable view reproduces the PostgreSQL partitioned-parent shape exactly: the
+/// binlog `Table_map` names the BASE table, routing is byte-exact, and every
+/// change is dropped.
+///
+/// MEASURED before the guard (2026-08-24): 3 rows committed through a view gave
+/// `rows: 0, files: 0, status: success, exit 0`, with the checkpoint advanced
+/// 54945184 -> 54945514 past the commit, and fixing the config recovered NOTHING
+/// from that checkpoint.
+///
+/// Unlike PostgreSQL this is RECOVERABLE — MySQL binlog retention does not depend
+/// on the reader, so the events are still in the log and deleting the checkpoint
+/// re-reads them. The message says so, and this test asserts it does, because
+/// telling an operator to re-snapshot when a checkpoint reset would do is its own
+/// kind of wrong answer.
+#[test]
+#[ignore = "live: requires docker compose --profile cdc mysql-cdc"]
+fn roast_mysql_cdc_refuses_a_view_whose_binlog_identity_is_the_base_table() {
+    let d = tempfile::tempdir().unwrap();
+    let base = unique_name("cdc_vbase");
+    let view = format!("{base}_v");
+    let mut c = conn();
+    c.query_drop(format!("DROP VIEW IF EXISTS {view}")).unwrap();
+    c.query_drop(format!("DROP TABLE IF EXISTS {base}"))
+        .unwrap();
+    c.query_drop(format!("CREATE TABLE {base} (id INT PRIMARY KEY, v INT)"))
+        .unwrap();
+    c.query_drop(format!("CREATE VIEW {view} AS SELECT * FROM {base}"))
+        .unwrap();
+    let _g = Table(base.clone());
+    struct ViewGuard(String);
+    impl Drop for ViewGuard {
+        fn drop(&mut self) {
+            if let Ok(mut c) = mysql::Conn::new(mysql::Opts::from_url(MYSQL_CDC_URL).unwrap()) {
+                use mysql::prelude::Queryable as _;
+                let _ = c.query_drop(format!("DROP VIEW IF EXISTS {}", self.0));
+            }
+        }
+    }
+    let _vg = ViewGuard(view.clone());
+
+    let msg = Rig::mysql_cdc(&view)
+        .checkpoint_path(d.path().join("v.ckpt"))
+        .dest_path(d.path().join("out"))
+        .run_expect_fail();
+    assert!(
+        msg.contains("VIEW") && msg.contains("base table"),
+        "the refusal must name what the relation IS and what to capture instead — \
+         shipping a 0-row success past an advanced checkpoint is the alternative. \
+         Got: {msg}"
+    );
+    assert!(
+        msg.contains("NOT lost"),
+        "MySQL binlog retention is reader-independent, so this is recoverable by \
+         deleting the checkpoint; an operator told to re-snapshot would do work they \
+         do not need. Got: {msg}"
+    );
+    // The refusal must NOT arrive wearing the binlog-grants hint. It is a config
+    // problem, and `create_change_stream` wraps the open call in MYSQL_CDC_HINT —
+    // the same trap the checkpoint validation was hoisted out of, which is why the
+    // routing precheck runs before that wrap rather than inside open.
+    assert!(
+        !msg.contains("REPLICATION SLAVE") && !msg.contains("binlog_format"),
+        "a routing/config refusal must not be prefixed with a permissions hint — an \
+         operator would go read the grants docs for a problem that is not there. \
+         Got: {msg}"
+    );
+
+    // Not too WIDE: the base table itself must still capture normally. Oracle is
+    // the manifest-declared parts re-read, compared to what the source holds.
+    let base_rig = || {
+        Rig::mysql_cdc(&base)
+            .checkpoint_path(d.path().join("b.ckpt"))
+            .dest_path(d.path().join("out_base"))
+    };
+    base_rig().run_ok(); // anchor
+    c.query_drop(format!("INSERT INTO {base} VALUES (1,10),(2,20),(3,30)"))
+        .unwrap();
+    let rows: usize = base_rig().run_and_read().iter().map(|b| b.num_rows()).sum();
+    assert_eq!(
+        rows, 3,
+        "the guard must refuse only what the binlog cannot name — a base table has \
+         to keep working, or the fix is worse than the defect"
+    );
+}
+
 struct CdcDb {
     name: String,
     url: String,

--- a/tests/live/live_cdc.rs
+++ b/tests/live/live_cdc.rs
@@ -3794,6 +3794,94 @@ fn roast_mysql_cdc_refuses_a_view_whose_binlog_identity_is_the_base_table() {
     );
 }
 
+/// The three routing hazards an adversarial pass found in the FIRST version of
+/// this guard, which read only `relkind`.
+///
+/// All three end the same way — a run that reports success while capturing
+/// nothing, or worse — and all three are invisible to a relkind check:
+///
+/// 1. **A folded twin.** The config string is read by two resolvers with different
+///    case rules: the schema probe interpolates it into `SELECT * FROM {table}` and
+///    lets PostgreSQL FOLD it; the sink routes BYTE-EXACT. With both `"MixedCase"`
+///    and `mixedcase` present, MEASURED: exit 0 throughout, writes to `mixedcase`
+///    captured `rows: 0` with no warning, and writes to `"MixedCase"` landed under
+///    the WRONG table's schema — columns `id, other_col, extra`, the real `v`
+///    values absent entirely. Silent column loss on top of silent event loss.
+/// 2. **A 3-part name.** `to_regclass` accepts `db.schema.table` when `db` is the
+///    current database, so the probe resolves while `table_matches` splits on the
+///    FIRST dot and compares `db` against the schema — never matching.
+/// 3. **UNLOGGED.** No WAL at all, so no event can ever exist for it.
+///
+/// Isolated in its OWN database: the guard reads `pg_class`, and a case-collision
+/// fixture on the shared DB would be visible to every parallel test.
+#[test]
+#[ignore = "live: requires docker compose postgres (wal_level=logical)"]
+fn roast_pg_cdc_refuses_a_config_whose_resolved_identity_routing_cannot_match() {
+    let cdc_db = CdcDb::new("cdc_ident");
+    let slot = unique_name("rivet_ident_slot").to_lowercase();
+    let mut c = cdc_db.connect();
+    // The case collision, spelled the way a real schema acquires one: a quoted
+    // relation plus an unquoted sibling. Different COLUMNS on purpose — that is
+    // what makes the wrong-schema write visible.
+    c.batch_execute(
+        "CREATE TABLE \"MixedCase\" (id int, v text); \
+         CREATE TABLE mixedcase (id int, other_col text, extra text); \
+         CREATE UNLOGGED TABLE unlg (id int primary key, v text)",
+    )
+    .unwrap();
+    c.execute(
+        "SELECT pg_create_logical_replication_slot($1, 'test_decoding')",
+        &[&slot],
+    )
+    .unwrap();
+
+    for (cfg, must_say) in [
+        ("MixedCase", "public.mixedcase"),
+        ("rivet.public.mixedcase", "public.mixedcase"),
+        ("public.unlg", "SET LOGGED"),
+    ] {
+        let rig = Rig::pg_cdc(cfg, &slot).source_url(cdc_db.url());
+        let out = run_rivet(&["run", "--config", rig.config_path().to_str().unwrap()]);
+        let said = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(
+            !out.status.success(),
+            "`{cfg}` must be refused — it either captures nothing or writes rows \
+             under another table's schema, silently. Output:\n{said}"
+        );
+        assert!(
+            said.contains(must_say),
+            "the refusal for `{cfg}` must name `{must_say}` — that is the whole \
+             remediation. Output:\n{said}"
+        );
+        // A config problem must NOT arrive wearing the wal_level/REPLICATION hint:
+        // an operator would go read the permissions docs for a problem that is not
+        // there. Same trap the MySQL side was hoisted out of.
+        assert!(
+            !said.contains("wal_level=logical and a role"),
+            "a routing refusal must not be prefixed with the permissions hint. \
+             Output:\n{said}"
+        );
+    }
+
+    // Not too WIDE: an ordinary table on the same database still captures. Oracle
+    // is the manifest-declared parts, compared to what the source holds.
+    c.batch_execute("CREATE TABLE plain_ok (id int primary key, v text)")
+        .unwrap();
+    c.execute("INSERT INTO plain_ok VALUES (1,'a'),(2,'b')", &[])
+        .unwrap();
+    let ok = Rig::pg_cdc("public.plain_ok", &slot).source_url(cdc_db.url());
+    let rows: usize = ok.run_and_read().iter().map(|b| b.num_rows()).sum();
+    assert_eq!(
+        rows, 2,
+        "the guard must refuse only what routing cannot match — an ordinary table \
+         has to keep working, or the fix is worse than the defect"
+    );
+}
+
 struct CdcDb {
     name: String,
     url: String,


### PR DESCRIPTION
A hostile verification pass over this session's work refuted several of my own claims. Two required code. This is that code.

## 1. PostgreSQL: compare the RESOLVED identity, not just `relkind`

The #283 guard reads `relkind` and nothing else. Three configs walk past it:

**A folded twin.** The config string is read by two resolvers with different case rules — the schema probe interpolates it into `SELECT * FROM {table}` and lets PostgreSQL *fold* it; the sink routes *byte-exact*. They agree for an ordinary lowercase name and diverge the moment a folded twin exists, which is legal PostgreSQL.

Measured with both `"MixedCase"(id,v)` and `mixedcase(id,other_col,extra)` present: exit 0 throughout, writes to `mixedcase` captured `rows: 0` with no warning, **and** writes to `"MixedCase"` landed under the *wrong table's schema* — columns `id, other_col, extra`, the real `v` values absent entirely. Silent column loss on top of silent event loss.

My earlier note that mixed case "fails loudly at any spelling" was true only for the single-table case I happened to test.

**A 3-part name.** `to_regclass` accepts `db.schema.table` when `db` is the current database, so the probe resolves while `table_matches` splits on the first dot. Never matches, never warns.

**UNLOGGED.** No WAL at all, so no event can ever exist for it.

One check covers the first two: require `table_matches(cfg, nspname, relname)` against the catalog's own spelling — the *same predicate the router uses*, so the guard asks the router's question rather than a similar one.

## 2. MySQL: refuse a VIEW at open

I wrote that matrix cell as `na` this morning: "no MySQL relation emits under a name other than the configured one". The partitioning half was measured and correct; the universal drawn from it was not, and the counter-example sits inside the row's own stated scope.

Measured: 3 rows committed through an updatable view → `rows: 0, files: 0, status: success, exit 0`, checkpoint advanced `54945184 → 54945514`, config fixed and re-run recovered nothing.

Severity differs from PostgreSQL and the message says so — MySQL binlog retention is reader-independent, so a checkpoint reset recovers them. Telling someone to re-snapshot when a checkpoint delete would do is its own wrong answer.

## 3. Both refusals were wearing the wrong hint

A routing refusal reached the operator prefixed with *"if this is a permissions/setup error: PostgreSQL CDC needs wal_level=logical"* — for a config problem with nothing to do with permissions. Both engines now run the check outside that wrap. Same trap the checkpoint validation was hoisted out of previously.

## Why these were `gap`-shaped and became fixes

I first tried to record the MySQL finding as `gap` — measured, unhandled. The fail-loud ratchet admits **zero** gaps, so that was not a state the ledger would accept. It forced the fix.

Every guard RED-proven against a mutant, and each asserted **not too wide** — an ordinary table on the same database still captures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168uwctCn3W1rP4Kt4kZXvE